### PR TITLE
Allow strings in `DataFuture` initialization

### DIFF
--- a/parsl/app/futures.py
+++ b/parsl/app/futures.py
@@ -74,7 +74,7 @@ class DataFuture(Future):
         """
         super().__init__()
         self._tid = tid
-        if isinstance(file_obj, str):
+        if isinstance(file_obj, str) and not isinstance(file_obj, File):
             self.file_obj = File(file_obj)
         else:
             self.file_obj = file_obj


### PR DESCRIPTION
Now that `File` is subclassed from `str`, `isinstance(File, str)`
will always evaluate as True. Fixes #185.