### PR TITLE
Unwrap ipp errors #110

### DIFF
--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -1,6 +1,5 @@
 """Exceptions raise by Apps."""
 from functools import wraps
-import sys
 
 import dill
 from six import reraise
@@ -29,6 +28,7 @@ class AppException(ParslError):
 
     What this exception contains depends entirely on context
     """
+
 
 class AppBadFormatting(ParslError):
     """An error raised during formatting of a bash function.

--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -25,13 +25,6 @@ class AppException(ParslError):
     What this exception contains depends entirely on context
     """
 
-    def __repr__(self):
-        return "{0} Reason:{1}".format(self.__class__, self.reason)
-
-    def __str__(self):
-        return self.__repr__()
-
-
 class AppBadFormatting(ParslError):
     """An error raised during formatting of a bash function.
 

--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -2,10 +2,8 @@
 from functools import wraps
 
 from six import reraise
-from tblib import Traceback
-
-import tblib.pickling_support
-tblib.pickling_support.install()
+from tblib import pickling_support, Traceback
+pickling_support.install()
 
 
 class ParslError(Exception):

--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -1,8 +1,11 @@
 """Exceptions raise by Apps."""
 from functools import wraps
 
-import dill
 from six import reraise
+from tblib import Traceback
+
+import tblib.pickling_support
+tblib.pickling_support.install()
 
 
 class ParslError(Exception):
@@ -161,19 +164,21 @@ class DependencyError(ParslError):
 
 class RemoteException(ParslError):
     def __init__(self, e_type, e_value, traceback):
-        self.e_type = dill.dumps(e_type)
-        self.e_value = dill.dumps(e_value)
-        self.traceback = dill.dumps(traceback)
+        self.e_type = e_type
+        self.e_value = e_value
+        self.traceback = Traceback(traceback).to_dict()
 
     def reraise(self):
-        reraise(dill.loads(self.e_type), dill.loads(self.e_value), dill.loads(self.traceback))
+        tb = Traceback.from_dict(self.traceback)
+        reraise(self.e_type, self.e_value, tb.as_traceback())
 
 
 def wrap_error(func):
+    import sys
+    from parsl.app.errors import RemoteException
+
     @wraps(func)
     def wrapper(*args, **kwargs):
-        import sys
-        from parsl.app.errors import RemoteException
         try:
             return func(*args, **kwargs)
         except Exception as e:

--- a/parsl/app/python_app.py
+++ b/parsl/app/python_app.py
@@ -5,7 +5,7 @@ tblib.pickling_support.install()
 
 from parsl.app.futures import DataFuture
 from parsl.app.app import AppBase
-from parsl.app.errors import RemoteException, wrap_error
+from parsl.app.errors import wrap_error
 
 
 logger = logging.getLogger(__name__)

--- a/parsl/app/python_app.py
+++ b/parsl/app/python_app.py
@@ -1,7 +1,12 @@
 import logging
 
+import tblib.pickling_support
+tblib.pickling_support.install()
+
 from parsl.app.futures import DataFuture
 from parsl.app.app import AppBase
+from parsl.app.errors import RemoteException, wrap_error
+
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +20,7 @@ class PythonApp(AppBase):
 
         This bit is the same for both bash & python apps.
         """
-        super().__init__(func, executor, walltime=walltime, sites=sites, exec_type="python")
+        super().__init__(wrap_error(func), executor, walltime=walltime, sites=sites, exec_type="python")
         self.fn_hash = fn_hash
         self.cache = cache
 

--- a/parsl/app/python_app.py
+++ b/parsl/app/python_app.py
@@ -1,5 +1,8 @@
 import logging
 
+import tblib.pickling_support
+tblib.pickling_support.install()
+
 from parsl.app.futures import DataFuture
 from parsl.app.app import AppBase
 from parsl.app.errors import wrap_error

--- a/parsl/app/python_app.py
+++ b/parsl/app/python_app.py
@@ -1,8 +1,5 @@
 import logging
 
-import tblib.pickling_support
-tblib.pickling_support.install()
-
 from parsl.app.futures import DataFuture
 from parsl.app.app import AppBase
 from parsl.app.errors import wrap_error

--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -117,9 +117,6 @@ class AppFuture(Future):
                 return super().result(timeout=timeout)
 
         except Exception as e:
-            # logger.debug("[TODO] {} Retries:{}".format(self.parent,
-            #                                           self.parent.retries_left))
-
             if self.parent.retries_left > 0:
                 self._parent_update_event.wait()
                 self._parent_update_event.clear()

--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -129,7 +129,8 @@ class AppFuture(Future):
             else:
                 if isinstance(e, RemoteException):
                     e.reraise()
-                raise
+                else:
+                    raise
 
     def cancel(self):
         if self.parent:

--- a/parsl/executors/ipp.py
+++ b/parsl/executors/ipp.py
@@ -1,7 +1,7 @@
 import os
 import time
 import logging
-from ipyparallel import serialize, Client
+from ipyparallel import Client
 
 from parsl.executors.base import ParslExecutor
 from parsl.executors.errors import *
@@ -192,8 +192,6 @@ sleep infinity
             logger.debug("Starting IpyParallelExecutor with no provider")
 
         self.lb_view = self.executor.load_balanced_view()
-        serialize.use_cloudpickle()
-        self.lb_view.apply(serialize.use_cloudpickle)
         logger.debug("Starting executor")
 
     @property

--- a/parsl/executors/ipp.py
+++ b/parsl/executors/ipp.py
@@ -1,7 +1,7 @@
 import os
 import time
 import logging
-from ipyparallel import Client
+from ipyparallel import serialize, Client
 
 from parsl.executors.base import ParslExecutor
 from parsl.executors.errors import *
@@ -192,6 +192,8 @@ sleep infinity
             logger.debug("Starting IpyParallelExecutor with no provider")
 
         self.lb_view = self.executor.load_balanced_view()
+        serialize.use_cloudpickle()
+        self.lb_view.apply(serialize.use_cloudpickle)
         logger.debug("Starting executor")
 
     @property

--- a/parsl/tests/test_ipp/test_python_apps.py
+++ b/parsl/tests/test_ipp/test_python_apps.py
@@ -46,7 +46,6 @@ def test_simple(n=10):
 
 
 def test_imports(n=10):
-
     start = time.time()
     x = import_echo(n, "hello world")
     print("Result : ", x.result())
@@ -59,7 +58,6 @@ def test_imports(n=10):
 
 
 def test_parallel_for(n=10):
-
     d = {}
     start = time.time()
     for i in range(0, n):
@@ -106,6 +104,4 @@ if __name__ == '__main__':
     x = test_imports()
     x = test_parallel_for()
     # x = test_parallel_for(int(args.count))
-
     # x = test_stdout()
-    # raise_error(0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ipyparallel
 libsubmit>=0.3.2a0
 globus-sdk
-dill
+cloudpickle
 tblib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 ipyparallel
 libsubmit>=0.3.2a0
 globus-sdk
+dill
+tblib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ipyparallel
 libsubmit>=0.3.2a0
 globus-sdk
-cloudpickle
+dill
 tblib


### PR DESCRIPTION
Here's a first take on #110. I'm sure there are much cleaner ways to accomplish this, but I figure that maybe we can review it, then if desired merge and run with it for a while and get a better sense for what else might be required. This provides our own wrapper around remote errors. I had to add two dependencies: `tblib` to get around the fact that tracebacks are not pickleable or dillable and `dill` to get locally defined classes that might not be imported on the local side (which `pickle` can't handle). We may eventually want to remove the wrapper bits from the traceback-- for now I left them in, because sometimes hiding things makes them more confusing. The main changes are 1) now the traceback includes the location the exception happened in addition to the type and 2) now the originally raised exception is re-raised such that the user will get the same exception whether running with threads or IPP. I've added an example and test which raises a `GlobusError` to demonstrate how it works.


**before (note we get the exception name but not where it occurred):**
```
INFO:parsl.dataflow.dflow:Task 0 failed after 0 retry attempts
    return self.__get_result()
  File "/home/annawoodard/.conda/envs/parsl_py36/lib/python3.6/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/home/annawoodard/parsl/parsl/dataflow/dflow.py", line 183, in handle_update
    future.result()
  File "/home/annawoodard/.conda/envs/parsl_py36/lib/python3.6/concurrent/futures/_base.py", line 425, in result
    return self.__get_result()
  File "/home/annawoodard/.conda/envs/parsl_py36/lib/python3.6/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/home/annawoodard/.conda/envs/parsl_py36/lib/python3.6/site-packages/ipyparallel/client/asyncresult.py", line 226, in _resolve_result
    raise r
ipyparallel.error.RemoteError: GlobusError(foobar)
```

**after:**
```
INFO:parsl.dataflow.dflow:Task 0 failed after 0 retry attempts
    future.result()
  File "/home/annawoodard/.conda/envs/parsl_py36/lib/python3.6/concurrent/futures/_base.py", line 425, in result
    return self.__get_result()
  File "/home/annawoodard/.conda/envs/parsl_py36/lib/python3.6/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/home/annawoodard/.conda/envs/parsl_py36/lib/python3.6/site-packages/ipyparallel/client/asyncresult.py", line 226, in _resolve_result
    raise r
parsl.app.errors.RemoteException: (<class 'globus_sdk.exc.GlobusError'>, GlobusError('foobar',), <traceback object at 0x7f363ba75b48>)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test_ipp/test_python_apps.py", line 119, in <module>
    demonstrate_custom_exception()
  File "test_ipp/test_python_apps.py", line 105, in demonstrate_custom_exception
    print(x.result())
  File "/home/annawoodard/parsl/parsl/dataflow/futures.py", line 128, in result
    e.reraise()
  File "/home/annawoodard/parsl/parsl/app/errors.py", line 169, in reraise
    reraise(dill.loads(self.e_type), dill.loads(self.e_value), dill.loads(self.traceback))
  File "/home/annawoodard/.conda/envs/parsl_py36/lib/python3.6/site-packages/six.py", line 692, in reraise
    raise value.with_traceback(tb)
  File "/home/annawoodard/parsl/parsl/app/errors.py", line 178, in wrapper
    return func(*args, **kwargs)
  File "test_ipp/test_python_apps.py", line 40, in custom_exception
    raise GlobusError('foobar')
globus_sdk.exc.GlobusError: foobar
```