### PR TITLE
Testing local

### DIFF
--- a/parsl/tests/checklist.rst
+++ b/parsl/tests/checklist.rst
@@ -1,0 +1,21 @@
+[C] test_aalst_patterns
+[I] test_apps
+[C] test_checkpointing
+[P] test_data / Blocked on issue #200
+[C] test_docker
+[C] test_error_handling
+[C] test_flowcontrol
+[C] test_globus
+[P] test_ipp
+[I] test_scaling
+[P] test_sites
+[C] test_stress
+[C] test_threads
+
+Statuses
+========
+
+* C - Completed
+* P - Partially completed, some tests excluded
+* E - Errored
+* I - Ignored completely

--- a/parsl/tests/cleanup
+++ b/parsl/tests/cleanup
@@ -8,3 +8,4 @@ for dir in */
         cd ..
     done
 
+find . -path '*/runinfo' -type d | xargs rm -rf

--- a/parsl/tests/test_docker/test_docker.py
+++ b/parsl/tests/test_docker/test_docker.py
@@ -1,8 +1,8 @@
 """Testing dockerized apps
 """
-import parsl
+# import parsl
 from parsl import *
-parsl.set_stream_logger()
+# parsl.set_stream_logger()
 import time
 import argparse
 

--- a/parsl/tests/test_docker/test_without_containers.py
+++ b/parsl/tests/test_docker/test_without_containers.py
@@ -1,8 +1,8 @@
 """Testing dockerized apps
 """
-import parsl
+# import parsl
 from parsl import *
-parsl.set_stream_logger()
+# parsl.set_stream_logger()
 import time
 import argparse
 

--- a/parsl/tests/test_flowcontrol/setup.sh
+++ b/parsl/tests/test_flowcontrol/setup.sh
@@ -1,3 +1,0 @@
-echo "This script must be sourced"
-
-export MIDWAY_USERNAM="yadunand"

--- a/parsl/tests/test_flowcontrol/test_bash.py
+++ b/parsl/tests/test_flowcontrol/test_bash.py
@@ -7,7 +7,7 @@ print(libsubmit.__version__)
 
 # parsl.set_stream_logger()
 
-from .local import localIPP
+from parsl.configs.local import localIPP
 dfk = DataFlowKernel(config=localIPP)
 
 
@@ -25,3 +25,7 @@ def test_bash():
     x = bash_app(stdout="{0}.out".format(fname))
     print("Waiting ....")
     print(x.result())
+
+
+if __name__ == "__main__":
+    test_bash()

--- a/parsl/tests/test_flowcontrol/test_python.py
+++ b/parsl/tests/test_flowcontrol/test_python.py
@@ -1,6 +1,6 @@
 from parsl import *
 
-from .local import localIPP
+from parsl.configs.local import localIPP
 localIPP["sites"][0]["execution"]["block"]["initBlocks"] = 0
 dfk = DataFlowKernel(config=localIPP)
 
@@ -25,5 +25,4 @@ def test_python(N=2):
 
 if __name__ == '__main__':
 
-    # parsl.set_stream_logger()
     test_python()

--- a/parsl/tests/test_flowcontrol/test_python_diamond.py
+++ b/parsl/tests/test_flowcontrol/test_python_diamond.py
@@ -1,6 +1,7 @@
 from parsl import *
 import time
-from .local import localIPP
+
+from parsl.configs.local import localIPP
 localIPP["sites"][0]["execution"]["block"]["initBlocks"] = 0
 localIPP["sites"][0]["execution"]["block"]["minBlocks"] = 0
 localIPP["sites"][0]["execution"]["block"]["maxBlocks"] = 4
@@ -32,5 +33,4 @@ def test_python(width=10):
 
 
 if __name__ == "__main__":
-    parsl.set_stream_logger()
     test_python()

--- a/parsl/tests/test_globus/test_#177.py
+++ b/parsl/tests/test_globus/test_#177.py
@@ -1,0 +1,60 @@
+from parsl import *
+from parsl.data_provider.files import File
+import os
+
+config = {
+    "sites": [
+        {
+            "site": "Local_Threads",
+            "auth": {
+                "channel": None
+            },
+            "execution": {
+                "executor": "threads",
+                "provider": None,
+                "maxThreads": 4
+            },
+            "data": {
+                "globus": {
+                    "endpoint_name": os.environ["GLOBUS_ENDPOINT"],
+                    "endpoint_path": os.environ["GLOBUS_EP_PATH"]
+                },
+                "working_dir": os.environ["GLOBUS_EP_PATH"],
+            }
+        }
+    ],
+    "globals": {
+        "lazyErrors": True
+    }
+}
+dfk = DataFlowKernel(config=config)
+
+
+def test_explicit_staging():
+
+    unsorted_file = File(
+        "globus://037f054a-15cf-11e8-b611-0ac6873fc732/unsorted.txt")
+
+    print("File plain ", unsorted_file)
+    print("Filepath before stage_in ", unsorted_file.filepath)
+
+    dfu = unsorted_file.stage_in()
+    dfu.result()
+
+    print("DFU result : ", dfu.result())
+    print(unsorted_file.filepath)
+
+
+if __name__ == "__main__":
+
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--debug", action='store_true',
+                        help="Count of apps to launch")
+    args = parser.parse_args()
+
+    if args.debug:
+        set_stream_logger()
+
+    test_explicit_staging()

--- a/parsl/tests/test_ipp/__init__.py
+++ b/parsl/tests/test_ipp/__init__.py
@@ -3,7 +3,7 @@ import os
 if str(os.environ.get('PARSL_TESTING', False)).lower() != 'true':
     raise RuntimeError("must first run 'export PARSL_TESTING=True'")
 
-
+"""
 def setup_package():
     import subprocess
     import time
@@ -20,3 +20,4 @@ def teardown_package():
     print("Stopping ipcluster")
     time.sleep(2)
     return proc
+"""

--- a/parsl/tests/test_ipp/test_at_scale.py
+++ b/parsl/tests/test_ipp/test_at_scale.py
@@ -1,14 +1,11 @@
 """Testing bash apps
 """
-import parsl
 from parsl import *
 import time
 import argparse
 
-# parsl.set_stream_logger()
-workers = IPyParallelExecutor()
-print("Using ipyparallel workers")
-dfk = DataFlowKernel(executors=[workers])
+from parsl.configs.local import localIPP as config
+dfk = DataFlowKernel(config=config)
 
 
 @App('python', dfk)
@@ -58,6 +55,10 @@ def test_parallel2(n=10):
     print("Total time : ", ttc)
 
     return ttc
+
+
+def test_z_cleanup():
+    dfk.cleanup()
 
 
 if __name__ == '__main__':

--- a/parsl/tests/test_ipp/test_bash_apps.py
+++ b/parsl/tests/test_ipp/test_bash_apps.py
@@ -1,19 +1,14 @@
 """Testing bash apps
 """
-import parsl
 from parsl import *
-
-print("Parsl version: ", parsl.__version__)
 
 import os
 import time
 import shutil
 import argparse
 
-# parsl.set_stream_logger()
-
-workers = IPyParallelExecutor()
-dfk = DataFlowKernel(executors=[workers])
+from parsl.configs.local import localIPP as config
+dfk = DataFlowKernel(config=config)
 
 
 @App('bash', dfk)
@@ -90,6 +85,10 @@ def test_parallel_for(n=10):
                                                                          n, outdir)
     print("[TEST STATUS] test_parallel_for [SUCCESS]")
     return d
+
+
+def test_z_cleanup():
+    dfk.cleanup()
 
 
 if __name__ == '__main__':

--- a/parsl/tests/test_ipp/test_early_attach_bug.py
+++ b/parsl/tests/test_ipp/test_early_attach_bug.py
@@ -14,17 +14,11 @@ among the engine once it has been sent to the the engine's queue.
 
 
 """
-import parsl
 from parsl import *
-
-print("Parsl version: ", parsl.__version__)
-
 import time
 
-# parsl.set_stream_logger()
-
-workers = IPyParallelExecutor()
-dfk = DataFlowKernel(executors=[workers])
+from parsl.configs.local import localIPP as config
+dfk = DataFlowKernel(config=config)
 
 
 @App('python', dfk)
@@ -32,6 +26,10 @@ def sleep_double(x):
     import time
     time.sleep(1)
     return x * 2
+
+
+def test_z_cleanup():
+    dfk.cleanup()
 
 
 if __name__ == "__main__":

--- a/parsl/tests/test_ipp/test_multiline_bash.py
+++ b/parsl/tests/test_ipp/test_multiline_bash.py
@@ -5,8 +5,8 @@ import time
 import shutil
 import argparse
 
-workers = IPyParallelExecutor()
-dfk = DataFlowKernel(executors=[workers])
+from parsl.configs.local import localIPP as config
+dfk = DataFlowKernel(config=config)
 
 
 @App('bash', dfk)

--- a/parsl/tests/test_ipp/test_python_apps.py
+++ b/parsl/tests/test_ipp/test_python_apps.py
@@ -8,9 +8,8 @@ import time
 import argparse
 from nose.tools import nottest
 
-# parsl.set_stream_logger()
-workers = IPyParallelExecutor()
-dfk = DataFlowKernel(executors=[workers])
+from parsl.configs.local import localIPP as config
+dfk = DataFlowKernel(config=config)
 
 
 @App('python', dfk)

--- a/parsl/tests/test_ipp/test_python_fibonacci_iterative.py
+++ b/parsl/tests/test_ipp/test_python_fibonacci_iterative.py
@@ -2,8 +2,8 @@
 from parsl import *
 import argparse
 
-workers = IPyParallelExecutor()
-dfk = DataFlowKernel(executors=[workers])
+from parsl.configs.local import localIPP
+dfk = DataFlowKernel(config=localIPP)
 
 
 @App('python', dfk)

--- a/parsl/tests/test_ipp/test_python_fibonacci_recursive.py
+++ b/parsl/tests/test_ipp/test_python_fibonacci_recursive.py
@@ -1,8 +1,8 @@
 from parsl import *
 import argparse
 
-workers = IPyParallelExecutor()
-dfk = DataFlowKernel(executors=[workers])
+from parsl.configs.local import localIPP as config
+dfk = DataFlowKernel(config=config)
 
 
 @App('python', dfk)

--- a/parsl/tests/test_runner.sh
+++ b/parsl/tests/test_runner.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+#set -e
+echo "##############################################################"
+echo "#### Begin tests "
+python3 -c "import parsl;     print('Parsl version     :', parsl.__version__)"
+python3 -c "import libsubmit; print('Libsubmit version :', libsubmit.__version__)"
+echo "##############################################################"
+
+if [[ ! -e "user_env.sh" ]]
+then
+    echo "WARNING: user_env.sh script missing"
+    echo "ERROR: Cannot proceed"
+    exit -1
+else
+    echo "Loading user_env.sh script"
+    source user_env.sh
+fi
+
+
+###### Defaults ############################################
+echo "Setting to test mode"
+export EXIT_EARLY=true
+export PARSL_TESTING=true
+
+############################################################
+
+wrapper() {
+    echo "#############################################"
+    echo "Running $1"
+    echo "============================================="
+    if [[ "$EXIT_EARLY" == "true" ]]
+    then
+        opts="-x"
+    fi
+    pushd .
+    $1 $opts
+    popd
+    echo "Done $1"
+    echo "============================================="
+}
+
+run_threads() {
+    echo "Running Threads"
+    nosetests -v $1 test_threads
+}
+
+run_threads() {
+    nosetests -v $1 test_threads
+}
+
+run_error_handling() {
+    nosetests -v $1 test_error_handling
+}
+
+run_checkpointing() {
+    for test in test_checkpointing/test*; do
+        nosetests -v $1 $test || exit -2;
+    done;
+}
+run_data() {
+    nosetests -v $1 test_data
+}
+
+run_stress() {
+    cd test_stress
+    nosetests -v $1 .
+}
+
+run_globus() {
+    cd test_globus
+    nosetests -v $1 .
+}
+
+run_flowcontrol() {
+    cd test_flowcontrol
+    for t in test*py
+    do
+        echo "Running $test"
+        python3 $t || exit -2
+    done
+}
+
+run_containers() {
+    echo "This is not standardized"
+    export PATH="/home/yadu/miniconda3/bin:$PATH"
+    source activate parsl_py3.6.4
+    cd test_docker
+    nosetests -v $1 test_docker*
+}
+
+run_ipp() {
+    cd test_ipp
+    failed=0
+    # We run each test one at a time to ensure DFK cleanup
+    for test in test*py;
+    do
+        echo "=====Running test : $test =================="
+        nosetests -v $1 $test;
+        if [[ $? != 0 ]]; then failed=$(($failed+1)) ;fi
+        killall -u $USER ipcontroller -9
+        killall -u $USER ipengine -9
+    done;
+
+}
+
+
+
+test_standard () {
+    wrapper run_threads
+    wrapper run_data
+    wrapper run_checkpointing
+    wrapper run_error_handling
+    ./cleanup
+}
+
+
+test_provisional() {
+    #wrapper run_containers
+    #wrapper run_stress
+    #wrapper run_globus
+    #wrapper run_flowcontrol
+    wrapper run_ipp
+}
+
+#test_standard
+test_provisional
+#wrapper run_ipp
+#wrapper run_globus
+

--- a/parsl/tests/test_stress/test_python_ipp.py
+++ b/parsl/tests/test_stress/test_python_ipp.py
@@ -1,18 +1,28 @@
-"""Testing bash apps
-"""
-import parsl
+''' Testing bash apps
+'''
 from parsl import *
 
 import time
 import argparse
 
-workers = IPyParallelExecutor()
-dfk = DataFlowKernel(executors=[workers])
+from parsl.configs.local import localIPP as config
+dfk = DataFlowKernel(config=config)
 
 
 @App('python', dfk)
 def increment(x):
     return x + 1
+
+
+def test_stress(count=1000):
+    """IPP app launch stress test"""
+    start = time.time()
+    x = {}
+    for i in range(count):
+        x[i] = increment(i)
+    end = time.time()
+    print("Launched {0} tasks in {1} s".format(count, end - start))
+    dfk.cleanup()
 
 
 if __name__ == '__main__':
@@ -27,9 +37,4 @@ if __name__ == '__main__':
     if args.debug:
         parsl.set_stream_logger()
 
-    start = time.time()
-    x = {}
-    for i in range(int(args.count)):
-        x[i] = increment(i)
-    end = time.time()
-    print("Launched {0} tasks in {1} s".format(args.count, end - start))
+    test_stress(count=int(args.count))

--- a/parsl/tests/test_stress/test_python_simple.py
+++ b/parsl/tests/test_stress/test_python_simple.py
@@ -15,6 +15,22 @@ def increment(x):
     return x + 1
 
 
+def test_stress(count=1000):
+    """Threaded app RTT stress test"""
+
+    start = time.time()
+    x = []
+    for i in range(int(count)):
+        fu = increment(i)
+        x.append(fu)
+    end = time.time()
+    print("Launched {0} tasks in {1} s".format(count, end - start))
+
+    [fu.result() for fu in x]
+    end = time.time()
+    print("Completed {0} tasks in {1} s".format(count, end - start))
+
+
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
@@ -27,14 +43,4 @@ if __name__ == '__main__':
     if args.debug:
         parsl.set_stream_logger()
 
-    start = time.time()
-    x = []
-    for i in range(int(args.count)):
-        fu = increment(i)
-        x.append(fu)
-    end = time.time()
-    print("Launched {0} tasks in {1} s".format(args.count, end - start))
-
-    [fu.result() for fu in x]
-    end = time.time()
-    print("Completed {0} tasks in {1} s".format(args.count, end - start))
+    test_stress(count=int(args.count))

--- a/parsl/tests/test_stress/test_python_threads.py
+++ b/parsl/tests/test_stress/test_python_threads.py
@@ -1,0 +1,41 @@
+''' Testing bash apps
+'''
+import parsl
+from parsl import *
+
+import time
+import argparse
+
+from parsl.configs.local import localThreads as config
+dfk = DataFlowKernel(config=config)
+
+
+@App('python', dfk)
+def increment(x):
+    return x + 1
+
+
+def test_stress(count=1000):
+    """Threaded app launch stress test"""
+    start = time.time()
+    x = {}
+    for i in range(count):
+        x[i] = increment(i)
+    end = time.time()
+    print("Launched {0} tasks in {1} s".format(count, end - start))
+    dfk.cleanup()
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-c", "--count", default="100",
+                        help="width of the pipeline")
+    parser.add_argument("-d", "--debug", action='store_true',
+                        help="Count of apps to launch")
+    args = parser.parse_args()
+
+    if args.debug:
+        parsl.set_stream_logger()
+
+    test_stress(count=int(args.count))

--- a/parsl/tests/test_threads/test_configs.py
+++ b/parsl/tests/test_threads/test_configs.py
@@ -1,0 +1,39 @@
+''' Testing python apps
+'''
+
+from parsl import *
+from parsl.configs.local import localThreads
+
+# parsl.set_stream_logger()
+
+dfk = DataFlowKernel(config=localThreads)
+
+
+@App('python', dfk)
+def worker_identify(x, sleep_dur=0.2):
+    import time
+    import os
+    import threading
+    time.sleep(sleep_dur)
+    return {"pid": os.getpid(),
+            "tid": threading.current_thread()}
+
+
+def test_parallel_for(n=8):
+
+    d = []
+    for i in range(0, n):
+        d.extend([worker_identify(i)])
+
+    [item.result() for item in d]
+
+    thread_count = len(set([item.result()['tid'] for item in d]))
+    process_count = len(set([item.result()['pid'] for item in d]))
+    assert thread_count == localThreads["sites"][0]["execution"]["maxThreads"], "Wrong number of threads"
+    assert process_count == 1, "More processes than allowed"
+    return d
+
+
+if __name__ == "__main__":
+
+    test_parallel_for()

--- a/parsl/tests/test_threads/test_ipp_configs.py
+++ b/parsl/tests/test_threads/test_ipp_configs.py
@@ -1,0 +1,36 @@
+''' Testing python apps
+'''
+from parsl import *
+
+from parsl.configs.local import localThreads as config
+dfk = DataFlowKernel(config=config)
+
+
+@App('python', dfk)
+def worker_identify(x, sleep_dur=0.2):
+    import time
+    import threading
+
+    time.sleep(sleep_dur)
+    return threading.current_thread()
+
+
+def test_parallel_for(n=8):
+
+    d = []
+    for i in range(0, n):
+        d.extend([worker_identify(i)])
+
+    thread_count = len(set([item.result() for item in d]))
+    expected = config["sites"][0]["execution"]["maxThreads"]
+
+    assert thread_count == expected, "Got {} Expected {} threads".format(
+        thread_count, expected)
+
+    return d
+
+
+if __name__ == "__main__":
+
+    print(config)
+    test_parallel_for()

--- a/parsl/tests/user_env.sh
+++ b/parsl/tests/user_env.sh
@@ -1,0 +1,19 @@
+# ensure that this script is being sourced
+if [ ${BASH_VERSINFO[0]} -gt 2 -a "${BASH_SOURCE[0]}" = "${0}" ] ; then
+    echo ERROR: script ${BASH_SOURCE[0]} must be executed as: source ${BASH_SOURCE[0]}
+    exit 1
+fi
+
+# Env for Midway
+export MIDWAY_USERNAME="yadunand"
+
+# Env for OSG
+export OSG_USERNAME="yadunand"
+
+# Env for CC_In2P3 French grid
+export CC_IN2P3_USERNAME="yadunand"
+export CC_IN2P3_HOME="yadunand"
+
+# Test globus
+export GLOBUS_ENDPOINT="066539c4-2e0b-11e8-b884-0ac6873fc732"
+export GLOBUS_EP_PATH=$PWD/test_globus


### PR DESCRIPTION
@annawoodard I'm not sure how much this helps in terms of testing work. There's tons of duplication which I haven't been able to trim down.
This PR adds a `test_runner.sh` script that sources a `user_env.sh` script to set some global vars and begin testing of pretty much all the tests we have.
* Some tests will hang, for eg, the ipp version of recursive fibonacci.
* The globus tests will hang if you haven't already started the globusconnect service and done pre-auth.
* Site tests will work only if you have access to the sites and have setup passwordless auth