### PR TITLE
Change checkpoint file modes to append. Fixes issue #230.

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -606,7 +606,7 @@ class DataFlowKernel(object):
             pickle.dump(state, f)
 
         count = 0
-        with open(checkpoint_tasks, 'wb+') as f:
+        with open(checkpoint_tasks, 'ab') as f:
             for task_id in self.tasks:
                 if self.tasks[task_id]['app_fu'].done() and \
                    not self.tasks[task_id]['checkpoint']:
@@ -626,7 +626,7 @@ class DataFlowKernel(object):
                     else:
                         t['result'] = r
 
-                    # We are using pickle here since pickle dumps to a file in 'w+'
+                    # We are using pickle here since pickle dumps to a file in 'ab'
                     # mode behave like a incremental log.
                     pickle.dump(t, f)
                     count += 1


### PR DESCRIPTION
Previous behaviour truncated and overwrote the checkpoint
file at each checkpoint, although it was intended to
append.

The previous mode, wb+, means to open the file for both reading and
writing, truncating if necessary - some documentation refers to
this as "updating", which may be the source of confusion.

The new mode, ab, means to open the file for writing, but without
truncating, and positioned initially at the end of the file.