### PR TITLE
Remove comparison to `Parameter.empty`

### DIFF
--- a/parsl/app/app.py
+++ b/parsl/app/app.py
@@ -4,7 +4,7 @@ The APP class encapsulates a generic leaf task that can be executed asynchronous
 
 """
 import logging
-from inspect import signature, Parameter
+from inspect import signature
 
 # Logging moved here in the PEP8 conformance fixes.
 logger = logging.getLogger(__name__)
@@ -44,10 +44,6 @@ class AppBase (object):
         self.cache = cache
 
         sig = signature(func)
-        self.kwargs = {}
-        for s in sig.parameters:
-            if sig.parameters[s].default != Parameter.empty:
-                self.kwargs[s] = sig.parameters[s].default
 
         self.stdout = sig.parameters['stdout'].default if 'stdout' in sig.parameters else None
         self.stderr = sig.parameters['stderr'].default if 'stderr' in sig.parameters else None

--- a/parsl/tests/test_no_comparison_arg.py
+++ b/parsl/tests/test_no_comparison_arg.py
@@ -1,0 +1,46 @@
+'''
+Regression test for #226.
+'''
+from parsl import *
+
+config = {
+    "sites": [
+        {
+            "site": "local_threads",
+            "auth": {
+                "channel": None
+            },
+            "execution": {
+                "executor": "threads",
+                "provider": None,
+                "maxThreads": 10,
+            }
+        }
+    ]
+}
+dfk = DataFlowKernel(config=config)
+
+
+class Foo(object):
+    def __init__(self, x):
+        self.x = x
+
+    def __eq__(self, value):
+        raise NotImplementedError
+
+
+bar = Foo(1)
+
+
+@App('python', dfk)
+def get_foo_x(b=bar):
+    return b.x
+
+
+def test_no_comparison_arg():
+    res = get_foo_x().result()
+    assert res == 1, 'Expected 1, returned {}'.format(res)
+
+
+if __name__ == '__main__':
+    test_no_comparison_arg()


### PR DESCRIPTION
This check fails for classes which do not have `__eq__` implemented. I
do not think we actually need to do the check, so I am removing it.
Fixes #226.

Note I'm currently re-organizing the tests, so I'm just dropping the regression test in the top testing directory for now.