### PR TITLE
Fix incorrect logging statement which would throw an exception.

### DIFF
--- a/parsl/dataflow/memoization.py
+++ b/parsl/dataflow/memoization.py
@@ -151,7 +151,7 @@ class Memoizer(object):
 
         if task['hashsum'] in self.memo_lookup_table:
             logger.info('Updating appCache entry with latest %s:%s call' %
-                        task[task_id]['func_name'], task_id)
+                        (task['func_name'], task_id))
             self.memo_lookup_table[task['hashsum']] = r
         else:
             self.memo_lookup_table[task['hashsum']] = r


### PR DESCRIPTION
There were two problems:

1. Task was treated as a collection of tasks, not a single task.
2. The % formatting was not properly bracketed

This code was throwing an exception when encountered, which is
elsewhere silently discarded, and would instead manifest as a hang
in execution.