### PR TITLE
Describe code state more precisely in the logging

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -20,6 +20,7 @@ from parsl.dataflow.memoization import Memoizer
 from parsl.dataflow.config_defaults import update_config
 from parsl.data_provider.data_manager import DataManager
 from parsl.execution_provider.provider_factory import ExecProviderFactory as EPF
+from parsl.utils import get_version
 
 # from parsl.dataflow.start_controller import Controller
 # Exceptions
@@ -72,7 +73,7 @@ class DataFlowKernel(object):
         parsl.set_file_logger("{}/parsl.log".format(self.rundir),
                               level=logging.DEBUG)
 
-        logger.info("Parsl version: {}".format(parsl.__version__))
+        logger.info("Parsl version: {}".format(get_version()))
         logger.info("Libsubmit version: {}".format(libsubmit.__version__))
 
         # Update config with defaults

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -5,15 +5,16 @@ import shlex
 import parsl
 from parsl.version import VERSION
 
+
 def get_version():
     if 'site-packages' in __file__:
         version = parsl.__version__
     else:
-            version = '{major}-{head}-{status}'.format(major=VERSION, head=head, status=status)
         git_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), '.git')
         env = {'GIT_DIR': git_dir}
         cmd = shlex.split('git rev-parse --short HEAD')
         head = subprocess.check_output(cmd, env=env).strip().decode('utf-8')
         diff = subprocess.check_output(shlex.split('git diff HEAD'), env=env)
         status = 'dirty' if diff else 'clean'
+        version = '{v}-{head}-{status}'.format(v=VERSION, head=head, status=status)
     return version

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -9,15 +9,11 @@ def get_version():
     if 'site-packages' in __file__:
         version = parsl.__version__
     else:
-        start = os.getcwd()
-        os.chdir(os.path.dirname(__file__))
-        try:
-            head = subprocess.check_output(shlex.split('git rev-parse --short HEAD')).strip().decode('utf-8')
-            diff = subprocess.check_output(shlex.split('git diff'))
-            status = 'dirty' if diff else 'clean'
             version = '{major}-{head}-{status}'.format(major=VERSION, head=head, status=status)
-        except subprocess.CalledProcessError:
-            version = VERSION
-        finally:
-            os.chdir(start)
+        git_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), '.git')
+        env = {'GIT_DIR': git_dir}
+        cmd = shlex.split('git rev-parse --short HEAD')
+        head = subprocess.check_output(cmd, env=env).strip().decode('utf-8')
+        diff = subprocess.check_output(shlex.split('git diff HEAD'), env=env)
+        status = 'dirty' if diff else 'clean'
     return version

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -11,17 +11,16 @@ logger = logging.getLogger(__name__)
 
 def get_version():
     version = parsl.__version__
-    if 'site-packages' not in __file__:
-        work_tree = os.path.dirname(os.path.dirname(__file__))
-        git_dir = os.path.join(work_tree, '.git')
-        env = {'GIT_WORK_TREE': work_tree, 'GIT_DIR': git_dir}
-        try:
-            cmd = shlex.split('git rev-parse --short HEAD')
-            head = subprocess.check_output(cmd, env=env).strip().decode('utf-8')
-            diff = subprocess.check_output(shlex.split('git diff HEAD'), env=env)
-            status = 'dirty' if diff else 'clean'
-            version = '{v}-{head}-{status}'.format(v=VERSION, head=head, status=status)
-        except Exception as e:
-            logger.exception("Unable to determine code state")
+    work_tree = os.path.dirname(os.path.dirname(__file__))
+    git_dir = os.path.join(work_tree, '.git')
+    env = {'GIT_WORK_TREE': work_tree, 'GIT_DIR': git_dir}
+    try:
+        cmd = shlex.split('git rev-parse --short HEAD')
+        head = subprocess.check_output(cmd, env=env).strip().decode('utf-8')
+        diff = subprocess.check_output(shlex.split('git diff HEAD'), env=env)
+        status = 'dirty' if diff else 'clean'
+        version = '{v}-{head}-{status}'.format(v=VERSION, head=head, status=status)
+    except Exception as e:
+        logger.exception("Unable to determine code state")
 
     return version

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -1,20 +1,27 @@
+import logging
 import os
-import subprocess
 import shlex
+import subprocess
 
 import parsl
 from parsl.version import VERSION
 
+logger = logging.getLogger(__name__)
+
 
 def get_version():
-    if 'site-packages' in __file__:
-        version = parsl.__version__
-    else:
-        git_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), '.git')
-        env = {'GIT_DIR': git_dir}
-        cmd = shlex.split('git rev-parse --short HEAD')
-        head = subprocess.check_output(cmd, env=env).strip().decode('utf-8')
-        diff = subprocess.check_output(shlex.split('git diff HEAD'), env=env)
-        status = 'dirty' if diff else 'clean'
-        version = '{v}-{head}-{status}'.format(v=VERSION, head=head, status=status)
+    version = parsl.__version__
+    if 'site-packages' not in __file__:
+        work_tree = os.path.dirname(os.path.dirname(__file__))
+        git_dir = os.path.join(work_tree, '.git')
+        env = {'GIT_WORK_TREE': work_tree, 'GIT_DIR': git_dir}
+        try:
+            cmd = shlex.split('git rev-parse --short HEAD')
+            head = subprocess.check_output(cmd, env=env).strip().decode('utf-8')
+            diff = subprocess.check_output(shlex.split('git diff HEAD'), env=env)
+            status = 'dirty' if diff else 'clean'
+            version = '{v}-{head}-{status}'.format(v=VERSION, head=head, status=status)
+        except Exception as e:
+            logger.exception("Unable to determine code state")
+
     return version

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -1,0 +1,23 @@
+import os
+import subprocess
+import shlex
+
+import parsl
+from parsl.version import VERSION
+
+def get_version():
+    if 'site-packages' in __file__:
+        version = parsl.__version__
+    else:
+        start = os.getcwd()
+        os.chdir(os.path.dirname(__file__))
+        try:
+            head = subprocess.check_output(shlex.split('git rev-parse --short HEAD')).strip().decode('utf-8')
+            diff = subprocess.check_output(shlex.split('git diff'))
+            status = 'dirty' if diff else 'clean'
+            version = '{major}-{head}-{status}'.format(major=VERSION, head=head, status=status)
+        except subprocess.CalledProcessError:
+            version = VERSION
+        finally:
+            os.chdir(start)
+    return version


### PR DESCRIPTION
Users that have installed pip with `pip install parsl` will continue to
just see the Parsl version. Developers will additionally see the hash of
the last commit and `dirty` or `clean`, depending on if there are
uncommitted changes. Fixes #242.