### PR TITLE
Allow default dfk #50

### DIFF
--- a/docs/devguide/dev_docs.rst
+++ b/docs/devguide/dev_docs.rst
@@ -88,7 +88,7 @@ Exceptions
 
 .. autoclass:: parsl.app.errors.DependencyError
 
-.. autoclass:: parsl.dataflow.error.DataFlowExceptions
+.. autoclass:: parsl.dataflow.error.DataFlowException
 
 .. autoclass:: parsl.dataflow.error.DuplicateTaskError
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -10,6 +10,7 @@ Reference Guide
     parsl.app.app.App
     parsl.app.futures.DataFuture
     parsl.dataflow.futures.AppFuture
+    parsl.dataflow.dflow.DataFlowKernelLoader
     parsl.data_provider.files.File
 
 .. autosummary::

--- a/docs/stubs/parsl.dataflow.dflow.DataFlowKernelLoader.rst
+++ b/docs/stubs/parsl.dataflow.dflow.DataFlowKernelLoader.rst
@@ -1,0 +1,24 @@
+parsl.dataflow.dflow.DataFlowKernelLoader
+=========================================
+
+.. currentmodule:: parsl.dataflow.dflow
+
+.. autoclass:: DataFlowKernelLoader
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~DataFlowKernelLoader.dfk
+      ~DataFlowKernelLoader.load
+      ~DataFlowKernelLoader.set_default
+   
+   
+
+   
+   
+   

--- a/docs/userguide/examples/config.py
+++ b/docs/userguide/examples/config.py
@@ -1,0 +1,18 @@
+local_threads = {
+    "sites": [
+        {
+            "site": "local_threads",
+            "auth": {
+                "channel": None
+            },
+            "execution": {
+                "executor": "threads",
+                "provider": None,
+                "maxThreads": 4
+            }
+        }
+    ],
+    "globals": {
+        "lazyErrors": True
+    }
+}

--- a/docs/userguide/examples/library.py
+++ b/docs/userguide/examples/library.py
@@ -1,0 +1,5 @@
+from parsl import App
+
+@App('python')
+def increment(x):
+    return x + 1

--- a/docs/userguide/examples/run_increment.py
+++ b/docs/userguide/examples/run_increment.py
@@ -1,0 +1,9 @@
+import parsl
+from config import local_threads
+from library import increment
+
+parsl.load(local_threads)
+
+for i in range(5):
+    print('{} + 1 = {}'.format(i, increment(i).result()))
+

--- a/docs/userguide/importing.rst
+++ b/docs/userguide/importing.rst
@@ -1,0 +1,36 @@
+.. _codebases
+
+Importing Parsl apps
+--------------------
+
+It may be convenient to define Parsl apps separately from the definition of the
+:class:`~pars.dataflow.dflow.DataFlowKernel`, or in libraries of apps which are
+intended to be imported by other modules. For this reason, the
+:class:`~parsl.dataflow.dflow.DataFlowKernel` is an optional argument to the
+:func:`~parsl.app.app.App` decorator. If the
+:class:`~pars.dataflow.dflow.DataFlowKernel` is not passed to the
+:func:`~parsl.app.app.App` decorator, a configuration must be loaded using
+:meth:`parsl.load <parsl.DataFlowKernelLoader.load>` prior to calling the app.
+
+The configuration can be defined in the Parsl script, or elsewhere before being imported.
+As an example of the latter, consider a file called ``config.py`` which contains the
+following definition:
+
+.. literalinclude:: examples/config.py
+
+In a separate file called ``library.py``, we define:
+
+.. literalinclude:: examples/library.py
+
+Putting these together in a third file called ``run_increment.py``, we load the
+configuration from ``config.py`` before calling the ``increment`` app:
+
+.. literalinclude:: examples/run_increment.py
+
+Which produces the following output::
+
+    0 + 1 = 1
+    1 + 1 = 2
+    2 + 1 = 3
+    3 + 1 = 4
+    4 + 1 = 5

--- a/docs/userguide/index.rst
+++ b/docs/userguide/index.rst
@@ -14,5 +14,6 @@ User guide
    app_caching
    checkpoints
    configuring
+   importing
    usage_tracking
    containers

--- a/parsl/__init__.py
+++ b/parsl/__init__.py
@@ -31,7 +31,7 @@ from parsl.executors.threads import ThreadPoolExecutor
 from parsl.executors.ipp import IPyParallelExecutor
 from parsl.data_provider.files import File
 
-from parsl.dataflow.dflow import DataFlowKernel
+from parsl.dataflow.dflow import DataFlowKernel, DataFlowKernelLoader
 from parsl.app.app_factory import AppFactoryFactory
 APP_FACTORY_FACTORY = AppFactoryFactory('central')
 
@@ -42,6 +42,9 @@ __all__ = [
     'App', 'DataFlowKernel', 'File', 'ThreadPoolExecutor',
     'IPyParallelExecutor', 'set_stream_logger', 'set_file_logger'
 ]
+
+load = DataFlowKernelLoader.load
+dfk = DataFlowKernelLoader.dfk
 
 
 def set_stream_logger(name='parsl', level=logging.DEBUG, format_string=None):

--- a/parsl/app/app.py
+++ b/parsl/app/app.py
@@ -30,7 +30,7 @@ class AppBase(object):
              - cache (Bool) : Enable caching of this app ?
 
         Returns:
-             - APP object.
+             - App object.
 
         """
         self.__name__ = func.__name__

--- a/parsl/app/app.py
+++ b/parsl/app/app.py
@@ -87,10 +87,11 @@ def App(apptype, executor, walltime=60, cache=False, sites='all'):
     """
     from parsl import APP_FACTORY_FACTORY
 
-    def Exec(f):
-        return APP_FACTORY_FACTORY.make(apptype, executor, f,
+    def wrapper(f):
+        return APP_FACTORY_FACTORY.make(apptype, f,
+                                        executor=executor,
                                         sites=sites,
                                         cache=cache,
                                         walltime=walltime)
 
-    return Exec
+    return wrapper

--- a/parsl/app/app.py
+++ b/parsl/app/app.py
@@ -16,14 +16,15 @@ class AppBase(object):
 
     """
 
-    def __init__(self, func, executor, walltime=60, sites='all', cache=False, exec_type="bash"):
-        """Constructor for the APP object.
+    def __init__(self, func, executor=None, walltime=60, sites='all', cache=False, exec_type="bash"):
+        """Construct the App object.
 
         Args:
              - func (function): Takes the function to be made into an App
-             - executor (executor): Executor for the execution resource
 
         Kwargs:
+             - executor (Executor): Executor for the execution resource. This can be omitted only
+               after calling :meth:`parsl.dataflow.dflow.DataFlowKernelLoader.load`.
              - walltime (int) : Walltime in seconds for the app execution
              - sites (str|list) : List of site names that this app could execute over. default is 'all'
              - exec_type (string) : App type (bash|python)
@@ -67,14 +68,15 @@ def app_wrapper(func):
     return wrapper
 
 
-def App(apptype, executor, walltime=60, cache=False, sites='all'):
+def App(apptype, executor=None, walltime=60, cache=False, sites='all'):
     """The App decorator function.
 
     Args:
         - apptype (string) : Apptype can be bash|python
-        - executor (Executor) : Executor object wrapping threads/process pools etc.
 
     Kwargs:
+        - executor (Executor): Executor for the execution resource. This can be omitted only
+          after calling :meth:`parsl.dataflow.dflow.DataFlowKernelLoader.load`.
         - walltime (int) : Walltime for app in seconds,
              default=60
         - sites (str|List) : List of site names on which the app could execute

--- a/parsl/app/app_factory.py
+++ b/parsl/app/app_factory.py
@@ -14,15 +14,15 @@ logger = logging.getLogger(__name__)
 class AppFactory(object):
     """AppFactory streamlines creation of apps."""
 
-    def __init__(self, app_class, executor, func, cache=False, sites='all', walltime=60):
+    def __init__(self, app_class, func, executor=None, cache=False, sites='all', walltime=60):
         """Construct an AppFactory for a particular app_class.
 
         Args:
             - app_class(Class) : An app class
-            - executor(Executor) : An executor object which will handle app execution
             - func(Function) : The function to execute
 
         Kwargs:
+            - executor(Executor) : An executor object which will handle app execution
             - walltime(int) : Walltime in seconds, default=60
             - sites (str|list) : List of site names that this app could execute over. default is 'all'
             - cache (Bool) : Enable caching of app.
@@ -68,7 +68,7 @@ class AppFactory(object):
         """
         # Create and call the new App object
         app_obj = self.app_class(self.func,
-                                 self.executor,
+                                 executor=self.executor,
                                  sites=self.sites,
                                  walltime=self.walltime,
                                  cache=self.cache,
@@ -106,7 +106,7 @@ class AppFactoryFactory(object):
         self.apps = {'bash': BashApp,
                      'python': PythonApp}
 
-    def make(self, kind, executor, func, **kwargs):
+    def make(self, kind, func, executor=None, **kwargs):
         """Creates a new App of the kind specified.
 
         Args:
@@ -127,8 +127,8 @@ class AppFactoryFactory(object):
         """
         if kind in self.apps:
             return AppFactory(self.apps[kind],
-                              executor,
                               func,
+                              executor=executor,
                               **kwargs)
 
         else:

--- a/parsl/app/bash_app.py
+++ b/parsl/app/bash_app.py
@@ -2,6 +2,7 @@ import logging
 
 from parsl.app.futures import DataFuture
 from parsl.app.app import AppBase
+from parsl.dataflow.dflow import DataFlowKernelLoader
 
 logger = logging.getLogger(__name__)
 
@@ -100,13 +101,13 @@ def remote_side_bash_executor(func, *args, **kwargs):
 
 class BashApp(AppBase):
 
-    def __init__(self, func, executor, walltime=60, cache=False,
+    def __init__(self, func, executor=None, walltime=60, cache=False,
                  sites='all', fn_hash=None):
         """Initialize the super.
 
         This bit is the same for both bash & python apps.
         """
-        super().__init__(func, executor, walltime=60, sites=sites, exec_type="bash")
+        super().__init__(func, executor=executor, walltime=60, sites=sites, exec_type="bash")
         self.fn_hash = fn_hash
         self.cache = cache
 
@@ -128,6 +129,9 @@ class BashApp(AppBase):
         """
         # Update kwargs in the app definition with one's passed in at calltime
         self.kwargs.update(kwargs)
+
+        if self.executor is None:
+            self.executor = DataFlowKernelLoader.dfk()
 
         app_fut = self.executor.submit(remote_side_bash_executor, self.func, *args,
                                        parsl_sites=self.sites,

--- a/parsl/app/python_app.py
+++ b/parsl/app/python_app.py
@@ -6,6 +6,7 @@ tblib.pickling_support.install()
 from parsl.app.futures import DataFuture
 from parsl.app.app import AppBase
 from parsl.app.errors import wrap_error
+from parsl.dataflow.dflow import DataFlowKernelLoader
 
 
 logger = logging.getLogger(__name__)
@@ -14,13 +15,13 @@ logger = logging.getLogger(__name__)
 class PythonApp(AppBase):
     """Extends AppBase to cover the Python App."""
 
-    def __init__(self, func, executor, walltime=60, cache=False,
+    def __init__(self, func, executor=None, walltime=60, cache=False,
                  sites='all', fn_hash=None):
         """Initialize the super.
 
         This bit is the same for both bash & python apps.
         """
-        super().__init__(wrap_error(func), executor, walltime=walltime, sites=sites, exec_type="python")
+        super().__init__(wrap_error(func), executor=executor, walltime=walltime, sites=sites, exec_type="python")
         self.fn_hash = fn_hash
         self.cache = cache
 
@@ -39,6 +40,8 @@ class PythonApp(AppBase):
                    App_fut
 
         """
+        if self.executor is None:
+            self.executor = DataFlowKernelLoader.dfk()
         app_fut = self.executor.submit(self.func, *args,
                                        parsl_sites=self.sites,
                                        fn_hash=self.fn_hash,

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -736,3 +736,36 @@ class DataFlowKernel(object):
             raise BadCheckpoint("checkpointDirs expects a list of checkpoints")
 
         return self._load_checkpoints(checkpointDirs)
+
+
+class DataFlowKernelLoader(object):
+    """Manage which DataFlowKernel is active.
+
+    This is a singleton class containing only class methods. You should not
+    need to instantiate this class.
+    """
+
+    _dfk = None
+
+    @classmethod
+    def load(cls, config):
+        """Load a DataFlowKernel.
+
+        Args:
+            - config (dict) : Configuration to load. This config will be passed to a
+              new DataFlowKernel instantiation which will be set as the active DataFlowKernel.
+        Returns:
+            - DataFlowKernel : The loaded DataFlowKernel object.
+        """
+        if cls._dfk is not None:
+            raise RuntimeError('Config has already been loaded')
+        cls._dfk = DataFlowKernel(config=config)
+
+        return cls._dfk
+
+    @classmethod
+    def dfk(cls):
+        """Return the currently-loaded DataFlowKernel."""
+        if cls._dfk is None:
+            raise RuntimeError('Must first load config')
+        return cls._dfk

--- a/parsl/dataflow/error.py
+++ b/parsl/dataflow/error.py
@@ -1,4 +1,4 @@
-class DataFlowExceptions(Exception):
+class DataFlowException(Exception):
     """Base class for all exceptions.
 
     Only to be invoked when only a more specific error is not available.
@@ -6,19 +6,24 @@ class DataFlowExceptions(Exception):
     """
 
 
-class DuplicateTaskError(DataFlowExceptions):
+class ConfigurationError(DataFlowException):
+    """Raised when the DataFlowKernel receives an invalid configuration.
+    """
+
+
+class DuplicateTaskError(DataFlowException):
     """Raised by the DataFlowKernel when it finds that a job with the same task-id has been launched before.
     """
 
 
-class MissingFutError(DataFlowExceptions):
+class MissingFutError(DataFlowException):
     """Raised when a particular future is not found within the dataflowkernel's datastructures.
 
     Deprecated.
     """
 
 
-class BadCheckpoint(DataFlowExceptions):
+class BadCheckpoint(DataFlowException):
     """Error raised at the end of app execution due to missing output files.
 
     Args:
@@ -39,7 +44,7 @@ class BadCheckpoint(DataFlowExceptions):
         return self.__repr__()
 
 
-class DependencyError(DataFlowExceptions):
+class DependencyError(DataFlowException):
     """Error raised at the end of app execution due to missing output files.
 
     Args:

--- a/parsl/tests/test_threads/test_factory.py
+++ b/parsl/tests/test_threads/test_factory.py
@@ -23,11 +23,11 @@ def app_3(x):
 
 def test_factory():
     appff = AppFactoryFactory('main')
-    app_f = appff.make('bash', workers, app_2, walltime=60)
+    app_f = appff.make('bash', app_2, workers, walltime=60)
     assert isinstance(
         app_f, AppFactory), "AppFactoryFactory made the wrong type"
 
-    app_f_2 = appff.make('python', workers, app_3, walltime=60)
+    app_f_2 = appff.make('python', app_3, workers, walltime=60)
     assert isinstance(
         app_f_2, AppFactory), "AppFactoryFactory made the wrong type"
 


### PR DESCRIPTION
This PR adds a singleton class for loading the DFK which allows for more natural importing of apps. These changes were necessary in order to allow the testing framework to swap DFKs in and out such that we can factorize the testing code and the testing configurations, and cycle through such that each test is run on each configuration. Note it is possible to load a DFK either from a file containing a configuration or from a local DFK instance; I have only documented the latter way in the docstring, trying to keep things simple for now. Here is a preview of the new documentation:

<img width="967" alt="screen shot 2018-05-01 at 10 26 50 am" src="https://user-images.githubusercontent.com/5114833/39481499-4a34e9f2-4d31-11e8-9a47-f5c53505285b.png">
