### PR TITLE
(for discussion) Move boilerplate for last checkpoint into code from docs into helper

### DIFF
--- a/docs/userguide/checkpoints.rst
+++ b/docs/userguide/checkpoints.rst
@@ -97,13 +97,13 @@ Loading a checkpoint
 
 To load a checkpoint the user must select which checkpoint file to resume from. 
 As mentioned above, checkpoint files are stored in the ``runinfo/RUNID/checkpoint`` directory.
-The example below shows how to resume from the most recent checkpoint:
+The example below shows how to resume using from all available checkpoints:
 
 .. code-block:: python
 
     from parsl import *
     from parsl.configs.local import localThreads as config
-    from parsl.utils import get_last_checkpoint
+    from parsl.utils import get_all_checkpoints
 
     dfk = DataFlowKernel(config=config,
-                         checkpointFiles=parsl.get_last_checkpoint())
+                         checkpointFiles=parsl.get_all_checkpoints())

--- a/docs/userguide/checkpoints.rst
+++ b/docs/userguide/checkpoints.rst
@@ -103,12 +103,9 @@ The example below shows how to resume from the most recent checkpoint:
 
 .. code-block:: python
 
-    import os
     from parsl import *
     from parsl.configs.local import localThreads as config
-
-    last_runid = sorted(os.listdir('runinfo/'))[-1]
-    last_checkpoint = os.path.abspath('runinfo/{0}/checkpoint'.format(last_runid))
+    from parsl.utils import get_last_checkpoint
 
     dfk = DataFlowKernel(config=config,
-                         checkpointFiles=[last_checkpoint])
+                         checkpointFiles=parsl.get_last_checkpoint())

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -24,3 +24,37 @@ def get_version():
         logger.exception("Unable to determine code state")
 
     return version
+
+def get_last_checkpoint():
+  """Finds the checkpoint from the last run, if one exists.
+
+  Note that checkpoints are incremental, and this helper will not find
+  previous checkpoints from earlier than the most recent run. It probably
+  should be made to do so.
+
+  Returns:
+     - a list suitable for checkpointFiles parameter of DataFlowKernel
+       constructor, with 0 or 1 elements
+   
+  """
+  print("BENC: get last checkpoint")
+
+  if(not(os.path.isdir('runinfo/'))):
+    print("BENC: rundir does not exists")
+    return []
+
+  dirs = sorted(os.listdir('runinfo/'))
+
+  if(len(dirs) == 0):
+    print("BENC: no run directories in runinfo")
+    return []
+
+  last_runid = dirs[-1]
+  last_checkpoint = os.path.abspath('runinfo/{0}/checkpoint'.format(last_runid))
+
+  if(not(os.path.isdir(last_checkpoint))):
+    return []
+
+  print("BENC: returning checkpoint", last_checkpoint)
+  return [last_checkpoint]
+

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -37,10 +37,8 @@ def get_all_checkpoints():
        constructor
    
   """
-  print("BENC: get last checkpoint")
 
   if(not(os.path.isdir('runinfo/'))):
-    print("BENC: rundir does not exists")
     return []
 
   dirs = sorted(os.listdir('runinfo/'))
@@ -55,7 +53,6 @@ def get_all_checkpoints():
       checkpoints.append(checkpoint)
 
 
-  print("BENC: returning checkpoints", checkpoints)
   return checkpoints
 
 def get_last_checkpoint():
@@ -70,16 +67,13 @@ def get_last_checkpoint():
        constructor, with 0 or 1 elements
    
   """
-  print("BENC: get last checkpoint")
 
   if(not(os.path.isdir('runinfo/'))):
-    print("BENC: rundir does not exists")
     return []
 
   dirs = sorted(os.listdir('runinfo/'))
 
   if(len(dirs) == 0):
-    print("BENC: no run directories in runinfo")
     return []
 
   last_runid = dirs[-1]
@@ -88,6 +82,5 @@ def get_last_checkpoint():
   if(not(os.path.isdir(last_checkpoint))):
     return []
 
-  print("BENC: returning checkpoint", last_checkpoint)
   return [last_checkpoint]
 

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -25,62 +25,62 @@ def get_version():
 
     return version
 
+
 def get_all_checkpoints():
-  """Finds the checkpoints from all last runs.
+    """Finds the checkpoints from all last runs.
 
-  Note that checkpoints are incremental, and this helper will not find
-  previous checkpoints from earlier than the most recent run. It probably
-  should be made to do so.
+    Note that checkpoints are incremental, and this helper will not find
+    previous checkpoints from earlier than the most recent run. It probably
+    should be made to do so.
 
-  Returns:
-     - a list suitable for the checkpointFiles parameter of DataFlowKernel
-       constructor
-   
-  """
+    Returns:
+       - a list suitable for the checkpointFiles parameter of DataFlowKernel
+         constructor
 
-  if(not(os.path.isdir('runinfo/'))):
-    return []
+    """
 
-  dirs = sorted(os.listdir('runinfo/'))
+    if(not(os.path.isdir('runinfo/'))):
+        return []
 
-  checkpoints = []
+    dirs = sorted(os.listdir('runinfo/'))
 
-  for runid in dirs:
-  
-    checkpoint = os.path.abspath('runinfo/{0}/checkpoint'.format(runid))
+    checkpoints = []
 
-    if(os.path.isdir(checkpoint)):
-      checkpoints.append(checkpoint)
+    for runid in dirs:
 
+        checkpoint = os.path.abspath('runinfo/{0}/checkpoint'.format(runid))
 
-  return checkpoints
+        if(os.path.isdir(checkpoint)):
+            checkpoints.append(checkpoint)
+
+    return checkpoints
+
 
 def get_last_checkpoint():
-  """Finds the checkpoint from the last run, if one exists.
+    """Finds the checkpoint from the last run, if one exists.
 
-  Note that checkpoints are incremental, and this helper will not find
-  previous checkpoints from earlier than the most recent run. It probably
-  should be made to do so.
+    Note that checkpoints are incremental, and this helper will not find
+    previous checkpoints from earlier than the most recent run. It probably
+    should be made to do so.
 
-  Returns:
+    Returns:
      - a list suitable for checkpointFiles parameter of DataFlowKernel
        constructor, with 0 or 1 elements
-   
-  """
 
-  if(not(os.path.isdir('runinfo/'))):
-    return []
+    """
 
-  dirs = sorted(os.listdir('runinfo/'))
+    if(not(os.path.isdir('runinfo/'))):
+        return []
 
-  if(len(dirs) == 0):
-    return []
+    dirs = sorted(os.listdir('runinfo/'))
 
-  last_runid = dirs[-1]
-  last_checkpoint = os.path.abspath('runinfo/{0}/checkpoint'.format(last_runid))
+    if(len(dirs) == 0):
+        return []
 
-  if(not(os.path.isdir(last_checkpoint))):
-    return []
+    last_runid = dirs[-1]
+    last_checkpoint = os.path.abspath('runinfo/{0}/checkpoint'.format(last_runid))
 
-  return [last_checkpoint]
+    if(not(os.path.isdir(last_checkpoint))):
+        return []
 
+    return [last_checkpoint]

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -25,6 +25,39 @@ def get_version():
 
     return version
 
+def get_all_checkpoints():
+  """Finds the checkpoints from all last runs.
+
+  Note that checkpoints are incremental, and this helper will not find
+  previous checkpoints from earlier than the most recent run. It probably
+  should be made to do so.
+
+  Returns:
+     - a list suitable for the checkpointFiles parameter of DataFlowKernel
+       constructor
+   
+  """
+  print("BENC: get last checkpoint")
+
+  if(not(os.path.isdir('runinfo/'))):
+    print("BENC: rundir does not exists")
+    return []
+
+  dirs = sorted(os.listdir('runinfo/'))
+
+  checkpoints = []
+
+  for runid in dirs:
+  
+    checkpoint = os.path.abspath('runinfo/{0}/checkpoint'.format(runid))
+
+    if(os.path.isdir(checkpoint)):
+      checkpoints.append(checkpoint)
+
+
+  print("BENC: returning checkpoints", checkpoints)
+  return checkpoints
+
 def get_last_checkpoint():
   """Finds the checkpoint from the last run, if one exists.
 


### PR DESCRIPTION
(not for pushing to master)

The docs previously contained example code that can be pasted, but
as it is non-trivial, it is better placed as a helper function.

This commit also enhances that code to deal with the case where
no checkpoints exist yet - for example, on a first run.

However, this PR does not find all the needed checkpoints, I think, because they are made incrementally, and this will only find the most recent increment (?)