### PR TITLE
Log concurrent.future to avoid silent discard of parsl exceptions (#240)

### DIFF
--- a/parsl/__init__.py
+++ b/parsl/__init__.py
@@ -71,6 +71,12 @@ def set_stream_logger(name='parsl', level=logging.DEBUG, format_string=None):
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 
+    # Concurrent.futures errors are also of interest, as exceptions
+    # which propagate out of the top of a callback are logged this way
+    # and then discarded. (see #240)
+    futures_logger = logging.getLogger("concurrent.futures")
+    futures_logger.addHandler(handler)
+
 
 def set_file_logger(filename, name='parsl', level=logging.DEBUG, format_string=None):
     """Add a stream log handler.
@@ -94,6 +100,11 @@ def set_file_logger(filename, name='parsl', level=logging.DEBUG, format_string=N
     formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
     handler.setFormatter(formatter)
     logger.addHandler(handler)
+
+    # see note in set_stream_logger for notes about logging
+    # concurrent.futures
+    futures_logger = logging.getLogger("concurrent.futures")
+    futures_logger.addHandler(handler)
 
 
 class NullHandler(logging.Handler):


### PR DESCRIPTION
This does not fix #240, but should make cases of it more visible, as
stack traces will now show on the regular parsl log stream.