### PR TITLE
Call cleanup after each test

### DIFF
--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -130,7 +130,9 @@ def load_dfk(config):
             module.config['globals'] = {}
         module.config['globals']['runDir'] = get_rundir()  # Give unique rundir; needed running with -n=X where X > 1.
         parsl.clear()
-        parsl.load(module.config)
+        dfk = parsl.load(module.config)
+    yield
+    parsl.dfk().cleanup()
 
 
 @pytest.fixture(autouse=True)

--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -131,8 +131,10 @@ def load_dfk(config):
         module.config['globals']['runDir'] = get_rundir()  # Give unique rundir; needed running with -n=X where X > 1.
         parsl.clear()
         dfk = parsl.load(module.config)
-    yield
-    parsl.dfk().cleanup()
+        yield
+        dfk.cleanup()
+    else:
+        yield
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
This improves the situation for #298. I see far fewer peak ipengine
processes, but still more than I would expect if cleanup was working as
expected after each test.