### PR TITLE
Serialise checkpointing with a lock

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -81,6 +81,8 @@ class DataFlowKernel(object):
         logger.info("Parsl version: {}".format(get_version()))
         logger.info("Libsubmit version: {}".format(libsubmit.__version__))
 
+        self.checkpoint_lock = threading.Lock()
+
         # Update config with defaults
         self._config = update_config(config, self.rundir)
 
@@ -613,71 +615,70 @@ class DataFlowKernel(object):
             By default the checkpoints are written to the RUNDIR of the current
             run under RUNDIR/checkpoints/{tasks.pkl, dfk.pkl}
         """
-
-        checkpoint_queue = None
-        if tasks:
-            checkpoint_queue = tasks
-        else:
-            checkpoint_queue = self.tasks
-
-        checkpoint_dir = '{0}/checkpoint'.format(self.rundir)
-        checkpoint_dfk = checkpoint_dir + '/dfk.pkl'
-        checkpoint_tasks = checkpoint_dir + '/tasks.pkl'
-
-        if not os.path.exists(checkpoint_dir):
-            try:
-                os.makedirs(checkpoint_dir)
-            except FileExistsError as e:
-                pass
-
-        with open(checkpoint_dfk, 'wb') as f:
-            state = {'config': self.config,
-                     'rundir': self.rundir,
-                     'task_count': self.task_count
-                     }
-            pickle.dump(state, f)
-
-        count = 0
-
-        with open(checkpoint_tasks, 'ab') as f:
-            for task_id in checkpoint_queue:
-                if not self.tasks[task_id]['checkpoint'] and \
-                   self.tasks[task_id]['status'] == States.done:
-
-                    hashsum = self.tasks[task_id]['hashsum']
-                    if not hashsum:
-                        continue
-                    t = {'hash': hashsum,
-                         'exception': None,
-                         'result': None}
-                    try:
-                        # Asking for the result will raise an exception if
-                        # the app had failed. Should we even checkpoint these?
-                        # TODO : Resolve this question ?
-                        r = self.memoizer.hash_lookup(hashsum).result()
-                    except Exception as e:
-                        t['exception'] = e
-                    else:
-                        t['result'] = r
-
-                    # We are using pickle here since pickle dumps to a file in 'ab'
-                    # mode behave like a incremental log.
-                    pickle.dump(t, f)
-                    count += 1
-                    self.tasks[task_id]['checkpoint'] = True
-                    logger.debug("Task {} checkpointed".format(task_id))
-
-        self.checkpointed_tasks += count
-
-        if count == 0:
-            if self.checkpointed_tasks == 0:
-                logger.warn("No tasks checkpointed, please ensure caching is enabled")
+        with self.checkpoint_lock:
+            checkpoint_queue = None
+            if tasks:
+                checkpoint_queue = tasks
             else:
-                logger.debug("No tasks checkpointed")
-        else:
-            logger.info("Done checkpointing {} tasks".format(count))
+                checkpoint_queue = self.tasks
 
-        return checkpoint_dir
+            checkpoint_dir = '{0}/checkpoint'.format(self.rundir)
+            checkpoint_dfk = checkpoint_dir + '/dfk.pkl'
+            checkpoint_tasks = checkpoint_dir + '/tasks.pkl'
+
+            if not os.path.exists(checkpoint_dir):
+                try:
+                    os.makedirs(checkpoint_dir)
+                except FileExistsError as e:
+                    pass
+
+            with open(checkpoint_dfk, 'wb') as f:
+                state = {'config': self.config,
+                         'rundir': self.rundir,
+                         'task_count': self.task_count
+                         }
+                pickle.dump(state, f)
+
+            count = 0
+
+            with open(checkpoint_tasks, 'ab') as f:
+                for task_id in checkpoint_queue:
+                    if not self.tasks[task_id]['checkpoint'] and \
+                       self.tasks[task_id]['status'] == States.done:
+                        hashsum = self.tasks[task_id]['hashsum']
+                        if not hashsum:
+                            continue
+                        t = {'hash': hashsum,
+                             'exception': None,
+                             'result': None}
+                        try:
+                            # Asking for the result will raise an exception if
+                            # the app had failed. Should we even checkpoint these?
+                            # TODO : Resolve this question ?
+                            r = self.memoizer.hash_lookup(hashsum).result()
+                        except Exception as e:
+                            t['exception'] = e
+                        else:
+                            t['result'] = r
+
+                        # We are using pickle here since pickle dumps to a file in 'ab'
+                        # mode behave like a incremental log.
+                        pickle.dump(t, f)
+                        count += 1
+                        self.tasks[task_id]['checkpoint'] = True
+                        logger.debug("Task {} checkpointed".format(task_id))
+
+            self.checkpointed_tasks += count
+
+            if count == 0:
+                if self.checkpointed_tasks == 0:
+                    logger.warn("No tasks checkpointed, please ensure caching is enabled")
+                else:
+                    logger.debug("No tasks checkpointed")
+            else:
+                logger.info("Done checkpointing {} tasks".format(count))
+
+            return checkpoint_dir
 
     def _load_checkpoints(self, checkpointDirs):
         """Load a checkpoint file into a lookup table.


### PR DESCRIPTION
Prior to this, parsl/tests/test_checkpointing/test_regression_233.py
was failing on benc's laptop fairly regularly - within 10 iterations of

while pytest parsl/tests/test_checkpointing/test_regression_233.py; do echo TICK ; done