### PR TITLE
Do not log traceback if version check fails

### DIFF
--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -25,7 +25,7 @@ def get_version():
         status = 'dirty' if diff else 'clean'
         version = '{v}-{head}-{status}'.format(v=VERSION, head=head, status=status)
     except Exception as e:
-        logger.exception("Unable to determine code state")
+        pass
 
     return version
 


### PR DESCRIPTION
This is confusing. If the version is the vanilla version instead of in
the format '{v}-{head}-{status}', we can assume that the check failed.
There is no need to show the user the traceback, as that makes it appear
like there was a fatal error. Fixes #326 and fixes #327.