### PR TITLE
Change test FTP server address

### DIFF
--- a/parsl/tests/test_staging/test_implicit_staging_ftp.py
+++ b/parsl/tests/test_staging/test_implicit_staging_ftp.py
@@ -26,7 +26,7 @@ def test_implicit_staging_ftp():
     Create a remote input file (ftp) that points to file_test_cpt.txt.
     """
 
-    unsorted_file = File('ftp://ftp.cs.brown.edu/pub/info/README')
+    unsorted_file = File('ftp://www.iana.org/pub/mirror/rirstats/arin/ARIN-STATS-FORMAT-CHANGE.txt')
 
     # Create a local file for output data
     sorted_file = File('sorted.txt')


### PR DESCRIPTION
Changes ftp server used by the ftp staging test from ftp://ftp.cs.brown.edu which it turned out to be not too reliable to ftp://ftp.iana.org/.