### PR TITLE
Fixes for #349. Adds extra kwarg defaults extraction to bash_app.

### DIFF
--- a/parsl/app/bash_app.py
+++ b/parsl/app/bash_app.py
@@ -121,7 +121,6 @@ class BashApp(AppBase):
             if sig.parameters[s].default != Parameter.empty:
                 self.kwargs[s] = sig.parameters[s].default
 
-
     def __call__(self, *args, **kwargs):
         """Handle the call to a Bash app.
 

--- a/parsl/tests/test_bash_apps/test_basic.py
+++ b/parsl/tests/test_bash_apps/test_basic.py
@@ -22,8 +22,8 @@ def echo_to_file(inputs=[], outputs=[], stderr='std.err', stdout='std.out'):
 
 
 @App('bash')
-def foo(x, y, stdout=None):
-    return """echo {0} {1}
+def foo(x, y, z=10, stdout=None):
+    return """echo {0} {1} {z}
     """
 
 
@@ -49,7 +49,7 @@ def test_command_format_1():
     if os.path.exists('stdout_file'):
         os.remove(stdout)
 
-    assert contents == '1 4\n', 'Output does not match expected string "1 4", Got: "{0}"'.format(
+    assert contents == '1 4 10\n', 'Output does not match expected string "1 4", Got: "{0}"'.format(
         contents)
     return True
 


### PR DESCRIPTION
We had removed code bits that copied all the kwarg defaults from the app_base earlier to fix issues related to complex python objects that cannot be compared. This logic has now been moved to bash_apps.

Test for this behavior included.