### PR TITLE
Improve strategy logging

### DIFF
--- a/parsl/dataflow/strategy.py
+++ b/parsl/dataflow/strategy.py
@@ -2,8 +2,6 @@ import logging
 import time
 import math
 
-import tabulate
-
 from parsl.executors.ipp import IPyParallelExecutor
 
 logger = logging.getLogger(__name__)
@@ -164,8 +162,6 @@ class Strategy(object):
             - kind (Not used)
         """
 
-        headers = ['executor', 'active tasks', 'running blocks', 'submitting blocks', 'pending blocks', 'connected engines']
-        data = []
         for label, executor in self.dfk.executors.items():
             if not executor.scaling_enabled:
                 continue
@@ -190,14 +186,12 @@ class Strategy(object):
             active_blocks = running + submitting + pending
             active_slots = active_blocks * tasks_per_node * nodes_per_block
 
-            data.append([
-                label,
-                len(active_tasks),
-                running,
-                submitting,
-                pending,
-                len(executor.executor) if isinstance(executor, IPyParallelExecutor) else 'N/A'
-            ])
+            if isinstance(executor, IPyParallelExecutor):
+                logger.debug('Executor {} has {} active tasks, {}/{}/{} running/submitted/pending blocks, and {} connected engines'.format(
+                    label, len(active_tasks), running, submitting, pending, len(executor.executor)))
+            else:
+                logger.debug('Executor {} has {} active tasks and {}/{}/{} running/submitted/pending blocks'.format(
+                    label, len(active_tasks), running, submitting, pending))
 
             # Case 1
             # No tasks.
@@ -257,7 +251,6 @@ class Strategy(object):
             else:
                 # logger.debug("Strategy: Case 3")
                 pass
-        logger.debug('\n' + tabulate.tabulate(data, headers=headers))
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ ipykernel
 requests
 psutil
 CMRESHandler
+tabulate


### PR DESCRIPTION
Considering a config with two IPP executors `midway-1` and `midway-2`, this changes the logging line in `strategy.py` from
```
2018-08-14 18:01:26 parsl.dataflow.strategy:260 [DEBUG] Tasks: 0 Slots: 0 Parallelism: 1
2018-08-14 18:01:26 parsl.dataflow.strategy:260 [DEBUG] Tasks: 0 Slots: 0 Parallelism: 1
```
to

```
2018-08-14 18:01:26 parsl.dataflow.strategy:260 [DEBUG]  
executor      active tasks    running blocks    submitting blocks    pending blocks    connected engines
----------  --------------  ----------------  -------------------  ----------------  -------------------
midway-1                 0                 0                    0                 1                    0
midway-2                 0                 0                    0                 1                    0
```

Logging a table in this way is a bit heterodox but it seemed like the clearest way to display info when there are multiple executors, and a not-terrible way when there is a single executor. Feedback on whether this makes things clearer or more confusing is appreciated. Another big change here is logging the number of connected engines directly-- hopefully this will close the 'check controller logs, see that it says connected and then ends which means there are actually no connected engines' loop.