### PR TITLE
Fix data.rst - storage_access should be a list

### DIFF
--- a/docs/userguide/data.rst
+++ b/docs/userguide/data.rst
@@ -132,7 +132,7 @@ In some cases, for example when using a Globus `shared endpoint <https://www.glo
 
         from parsl.config import Config
         from parsl.executors.ipp import IPyParallelExecutor
-        from parsl.data_manager.scheme import GlobusScheme
+        from parsl.data_provider.scheme import GlobusScheme
 
         config = Config(
             executors=[

--- a/docs/userguide/data.rst
+++ b/docs/userguide/data.rst
@@ -138,11 +138,11 @@ In some cases, for example when using a Globus `shared endpoint <https://www.glo
             executors=[
                 IPyParallelExecutor(
                     working_dir="/home/user/parsl_script",
-                    storage_access=GlobusScheme(
+                    storage_access=[GlobusScheme(
                         endpoint_uuid="7d2dc622-2edb-11e8-b8be-0ac6873fc732",
                         endpoint_path="/",
                         local_path="/home/user"
-                    )
+                    )]
                 )
             ]
         )

--- a/parsl/tests/configs/local_threads_globus.py
+++ b/parsl/tests/configs/local_threads_globus.py
@@ -17,7 +17,7 @@ config = Config(
             storage_access=[GlobusScheme(
                 endpoint_uuid=user_opts['globus']['endpoint'],
                 endpoint_path=user_opts['globus']['path']
-            )[,
+            )],
             working_dir=user_opts['globus']['path']
         )
     ],

--- a/parsl/tests/configs/local_threads_globus.py
+++ b/parsl/tests/configs/local_threads_globus.py
@@ -14,10 +14,10 @@ config = Config(
     executors=[
         ThreadPoolExecutor(
             label='local_threads_globus',
-            storage_access=GlobusScheme(
+            storage_access=[GlobusScheme(
                 endpoint_uuid=user_opts['globus']['endpoint'],
                 endpoint_path=user_opts['globus']['path']
-            ),
+            )[,
             working_dir=user_opts['globus']['path']
         )
     ],

--- a/parsl/tests/test_staging/test_implicit_staging_globus.py
+++ b/parsl/tests/test_staging/test_implicit_staging_globus.py
@@ -20,7 +20,7 @@ def sort_strings(inputs=[], outputs=[]):
 
 
 @pytest.mark.local
-def test_implicit_staging_https():
+def test_implicit_staging_globus():
     """Test implicit staging for an ftp file
 
     Create a remote input file (globus) that points to unsorted.txt.
@@ -47,4 +47,4 @@ if __name__ == "__main__":
     if args.debug:
         parsl.set_stream_logger()
 
-    test_implicit_staging_https()
+    test_implicit_staging_globus()


### PR DESCRIPTION
It corrects the 'Data management' documentation page where storage_access in an example should be a list instead of a GlobusSchema object.