### PR TITLE
Use more cross-version-compatible `getfullargspec`

### DIFF
--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -172,7 +172,7 @@ class RepresentationMixin(object):
     __max_width__ = 80
 
     def __repr__(self):
-        argspec = inspect.getargspec(self.__init__)
+        argspec = inspect.getfullargspec(self.__init__)
         if len(argspec.args) > 1:
             defaults = dict(zip(reversed(argspec.args), reversed(argspec.defaults)))
         else:


### PR DESCRIPTION
THe old `getargspec` did not work as expected on python3.5
and some parsl configs could not be rendered properly,
most urgently at the point that the DFK tries to log the
config that it has been initialised with, preventing use
of those configs on python 3.5