### PR TITLE
Factor launch code

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -345,7 +345,6 @@ class DataFlowKernel(object):
                 # Acquire a lock, retest the state, launch
                 with self.task_launch_lock:
                     if self.tasks[task_id]['status'] == States.pending:
-                        self.tasks[task_id]['status'] = States.running  # launch_task also does this though? so maybe unnecessary?
                         exec_fu = self.launch_task(
                             task_id, self.tasks[task_id]['func'], *new_args, **kwargs)
 

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -322,15 +322,21 @@ class DataFlowKernel(object):
             self.launch_if_ready(tid)
         return
 
-    # this should be called by pieces of the DataFlowKernel that think that a task might
-    # now be ready to run (although that task does not have to definitely be ready to run).
-    # For example, if the task has just been created, or a dependency might have been
-    # satisfied
-
-    # IS THIS THREAD SAFE? (probably not)    DOES IT NEED TO BE? (probably)
-    # might be able to take the launch lock around all of this? (which will reduce
-    # performance during lock contention...)
     def launch_if_ready(self, task_id):
+        """
+        launch_if_ready will launch the specified task, if it is ready
+        to run (for example, without dependencies, and in pending state).
+
+        This should be called by any piece of the DataFlowKernel that
+        thinks a task may have become ready to run.
+
+        It is not an error to call launch_if_ready on a task that is not
+        ready to run - launch_if_ready will not incorrectly launch that
+        task.
+
+        launch_if_ready is thread safe, so may be called from any thread
+        or callback.
+        """
         if self._count_deps(self.tasks[task_id]['depends']) == 0:
 
             # We can now launch *task*

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -327,7 +327,12 @@ class DataFlowKernel(object):
 
     # this should be called by pieces of the DataFlowKernel that think that a task might
     # now be ready to run (although that task does not have to definitely be ready to run).
-    # For example, if the task has just been created, or
+    # For example, if the task has just been created, or a dependency might have been
+    # satisfied
+
+    # IS THIS THREAD SAFE? (probably not)    DOES IT NEED TO BE? (probably)
+    # might be able to take the launch lock around all of this? (which will reduce
+    # performance during lock contention...)
     def launch_if_ready(self, task_id):
             logger.info("launch_if_ready for task {}".format(task_id))
             if self._count_deps(self.tasks[task_id]['depends'], task_id) == 0:

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -327,7 +327,7 @@ class DataFlowKernel(object):
 
     # this should be called by pieces of the DataFlowKernel that think that a task might
     # now be ready to run (although that task does not have to definitely be ready to run).
-    # For example, if the task has just been created, or 
+    # For example, if the task has just been created, or
     def launch_if_ready(self, task_id):
             logger.info("launch_if_ready for task {}".format(task_id))
             if self._count_deps(self.tasks[task_id]['depends'], task_id) == 0:
@@ -343,7 +343,7 @@ class DataFlowKernel(object):
                     # Acquire a lock, retest the state, launch
                     with self.task_launch_lock:
                         if self.tasks[task_id]['status'] == States.pending:
-                            self.tasks[task_id]['status'] = States.running # launch_task also does this though?
+                            self.tasks[task_id]['status'] = States.running  # launch_task also does this though? so maybe unnecessary?
                             exec_fu = self.launch_task(
                                 task_id, self.tasks[task_id]['func'], *new_args, **kwargs)
 

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -334,7 +334,6 @@ class DataFlowKernel(object):
     # might be able to take the launch lock around all of this? (which will reduce
     # performance during lock contention...)
     def launch_if_ready(self, task_id):
-            logger.info("launch_if_ready for task {}".format(task_id))
             if self._count_deps(self.tasks[task_id]['depends'], task_id) == 0:
                 # We can now launch *task*
                 new_args, kwargs, exceptions = self.sanitize_and_wrap(task_id,


### PR DESCRIPTION
Prior to this commit, there were two ways in which a task would be launched,
depending on whether there were dependencies pending when the task was
created or not.

These two ways were similar but not identical.

This commit makes a single `launch_if_ready` method which captures one of those
launch behaviours - the case where a launch had been deferred.

This commit also changes the initial submission to always submit as if
dependencies were pending, and then immediately calls `launch_if_ready`.

This makes the code easier to follow, I think, as tidying up the separation
of creating a non-running task first, and then separately visiting it
to decide if it can be run.

There is a (hopefully minor) increased expense in visiting all of the dependencies
twice to see if they are done, on task creation (as launch_if_ready always checks
dependencies, even if task creation has just done so).

This refactoring also means that `launch_if_ready` can be called *anywhere* where
there is a possibility that a task has become ready for launch, without needing
further co-ordination of that launching.