### PR TITLE
Potential bugfix for add_done_callback on AppFutures

### DIFF
--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -175,7 +175,7 @@ class AppFuture(Future):
         if self.parent:
             return self.parent.add_done_callback(fn)
         else:
-            return None
+            return super().add_done_callback(fn)
 
     @property
     def outputs(self):


### PR DESCRIPTION
If a callback was added to an AppFuture before it had a parent assigned,
that callback was silently discarded.

This commit changes that so that the callback behaviour is delegated to
the (Future) superclass - similar to how result() processing is so
delegated.