### PR TITLE
Re-enable retry tests

### DIFF
--- a/parsl/tests/test_error_handling/test_retries.py
+++ b/parsl/tests/test_error_handling/test_retries.py
@@ -1,8 +1,6 @@
 import argparse
 import os
 
-import pytest
-
 import parsl
 from parsl.app.app import App
 from parsl.tests.configs.local_threads import config
@@ -48,7 +46,6 @@ def sleep(sleep_dur=0.1):
     return 0
 
 
-@pytest.mark.skip('broken')
 def test_fail_nowait(numtasks=10):
     """Test retries on tasks with no dependencies.
     """
@@ -66,7 +63,6 @@ def test_fail_nowait(numtasks=10):
     print("Done")
 
 
-@pytest.mark.skip('broken')
 def test_fail_delayed(numtasks=10):
     """Test retries on tasks with dependencies.
 
@@ -89,7 +85,6 @@ def test_fail_delayed(numtasks=10):
     print("Done")
 
 
-@pytest.mark.skip('broken')
 def test_retry():
     """Test retries via app that succeeds on the Nth retry.
     """


### PR DESCRIPTION
These tests pass for me.

This testing is necessary to help validate callback-based dependency management in #583 (which *does not* pass these tests at the moment, if they are enabled there)