### PR TITLE
Closes #475. Now printing globus schemes should print nicely.

### DIFF
--- a/parsl/data_provider/scheme.py
+++ b/parsl/data_provider/scheme.py
@@ -1,5 +1,7 @@
+from parsl.utils import RepresentationMixin
 
-class GlobusScheme(object):
+
+class GlobusScheme(RepresentationMixin):
     """Specification for accessing data on a remote executor via Globus.
 
     Parameters


### PR DESCRIPTION
Simple inheritance change to close #475.