### PR TITLE
Separate exec and app completion code more.

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -233,11 +233,12 @@ class DataFlowKernel(object):
         """
         return self._config
 
-    def handle_exec_update(self, task_id, future, memo_cbk=False):
-        """This function is called only as a callback from a task being done.
+    def handle_exec_update(self, task_id, future):
+        """This function is called only as a callback from an execution
+        attempt reaching a final state (either successfully or failing).
 
-        Move done task from runnable -> done
-        Move newly doable tasks from pending -> runnable , and launch
+        It will launch retries if necessary, and update the task
+        structure.
 
         Args:
              task_id (string) : Task id which is a uuid string
@@ -248,7 +249,6 @@ class DataFlowKernel(object):
              memo_cbk(Bool) : Indicates that the call is coming from a memo update,
              that does not require additional memo updates.
         """
-        final_state_flag = False
 
         try:
             res = future.result()
@@ -282,7 +282,6 @@ class DataFlowKernel(object):
                 logger.info("Task {} failed after {} retry attempts".format(task_id,
                                                                             self._config.retries))
                 self.tasks[task_id]['status'] = States.failed
-                final_state_flag = True
                 self.tasks_failed_count += 1
 
                 self.tasks[task_id]['time_returned'] = time.time()
@@ -292,7 +291,6 @@ class DataFlowKernel(object):
 
         else:
             self.tasks[task_id]['status'] = States.done
-            final_state_flag = True
             self.tasks_completed_count += 1
 
             logger.info("Task {} completed".format(task_id))
@@ -308,19 +306,27 @@ class DataFlowKernel(object):
 
         return
 
-    ## this expects status = States.done if the app was successful...
-    ## but i don't believe it is true that the handle_exec_callback has definitely
-    ## fired at this point (we might have fired a callback that sets the app callback, and
-    ## be walking through the app callbacks now)
-    ## if this race happens the wrong way:
-    ## * file stageouts won't be launched - becaues we wont' see the task as done, and instead
-    ##   assume it failed (in this function)
-    ## * in checkpoint, we might make that same assumption and not checkpoint stuff.
-
-    ## however we can probably ask the app_future if it is done as an exception or not now 
-    ## - weirdness with wrapped exceptions should have disappered by the time it becomes an
-    ## app exception.
     def handle_app_update(self, task_id, future, memo_cbk=False):
+        """This function is called as a callback when an AppFuture
+        is in its final state.
+
+        It will trigger post-app processing such as checkpointing
+        and stageout.
+
+        Args:
+             task_id (string) : Task id
+             future (Future) : The relevant app future (which should be
+                 consistent with the task structure 'app_fu' entry
+
+        KWargs:
+             memo_cbk(Bool) : Indicates that the call is coming from a memo update,
+             that does not require additional memo updates.
+        """
+
+        if not self.tasks[task_id]['app_fu'].done():
+            logger.error("Internal consistency error: app_fu is not done for task {}".format(task_id))
+        if not self.tasks[task_id]['app_fu'] == future:
+            logger.error("Internal consistency error: callback future is not the app_fu in task structure, for task {}".format(task_id))
 
         if not memo_cbk:
             # Update the memoizer with the new result if this is not a
@@ -342,7 +348,6 @@ class DataFlowKernel(object):
                 f = dfu.file_obj
                 if isinstance(f, File) and f.is_remote():
                     f.stage_out(self.tasks[task_id]['executor'])
-
 
         return
 
@@ -436,7 +441,7 @@ class DataFlowKernel(object):
         hit, memo_fu = self.memoizer.check_memo(task_id, self.tasks[task_id])
         if hit:
             logger.info("Reusing cached result for task {}".format(task_id))
-            self.handle_exec_update(task_id, memo_fu, memo_cbk=True)
+            self.handle_exec_update(task_id, memo_fu)
             self.handle_app_update(task_id, memo_fu, memo_cbk=True)
             return memo_fu
 
@@ -786,10 +791,6 @@ class DataFlowKernel(object):
             self.logging_server.terminate()
             self.logging_server.join()
         logger.info("DFK cleanup complete")
-
-    ## this checks if task is in status = States.done (opposed to States.failed)
-    ## but at the moment, in handle_app_update, I don't think it is necessarily true
-    ## that the exec level callbacks have fired yet to set state to done...
 
     def checkpoint(self, tasks=None):
         """Checkpoint the dfk incrementally to a checkpoint file.


### PR DESCRIPTION
[I probably want to test this in some more depth for a few days before merging]

This PR splits the `handle_update` callback into two separate callbacks: `handle_exec_update` which is intended to run when an executor future is done; and `handle_app_update` which is intended to run when an app future is done.

Inside `handle_update` previously, it was not definitely true that the relevant app future was done (in the `future.done()` sense); but some code potentially assumed that was so (checkpointing and stage out).

Tasks which are related to executor completion (handling retries and completion logging) are handled in `handle_exec_update` and do not rely on either the task `['status']` field or app future being done.

Tasks which are related to app completion (memoization and stage out) are performed in `handle_app_update`. The mechanism used to determine if an app is done is also changed in those operations, to observe the relevant app future directly rather than rely on `['status']` being set.

This is intended to resolve #604 which detects an inconsistency/possible race condition; and to move the codebase further towards using the style suggested in #103 