### PR TITLE
Wait for all tasks to complete during DFK cleanup

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -714,6 +714,22 @@ class DataFlowKernel(object):
         if not self.cleanup_called:
             self.cleanup()
 
+    def cleanup_wait_for_all_tasks(self):
+        """Waits for all tasks in the task list to be completed, by waiting for their
+        AppFuture to be completed. This method will not necessarily wait for any tasks
+        added after cleanup has started (such as data stageout?)
+        """
+
+        logger.info("Waiting for all remaining tasks to complete")
+        for task_id in self.tasks:
+            # .exception() is a less exception throwing way of
+            # waiting for completion than .result()
+            fut = self.tasks[task_id]['exec_fu']
+            if not fut.done():
+                logger.debug("Waiting for task {} to complete".format(task_id))
+                fut.exception()
+        logger.info("All remaining tasks completed")
+
     def cleanup(self):
         """DataFlowKernel cleanup.
 
@@ -731,6 +747,8 @@ class DataFlowKernel(object):
         if self.cleanup_called:
             raise Exception("attempt to clean up DFK when it has already been cleaned-up")
         self.cleanup_called = True
+
+        self.cleanup_wait_for_all_tasks()
 
         self.log_task_states()
 


### PR DESCRIPTION
This partially addresses #222 #313, enough that this should be usable in practice.

There is a potential race here with tasks that are submitted
after DFK cleanup has begun:

  * a task on a local threaded executor might be running and
    submit such a task

  * I'm unclear if data stageout tasks appear as regular
    tasks

The second of those points is probably the most immediate
to be concerned about.