### PR TITLE
Output log message about task submission before we add callback.

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -437,8 +437,8 @@ class DataFlowKernel(object):
             self.db_logger.info("Task Launch", extra=task_log_info)
         exec_fu.retries_left = self._config.retries - \
             self.tasks[task_id]['fail_count']
-        exec_fu.add_done_callback(partial(self.handle_update, task_id))
         logger.info("Task {} launched on executor {}".format(task_id, executor.label))
+        exec_fu.add_done_callback(partial(self.handle_update, task_id))
         return exec_fu
 
     def _add_input_deps(self, executor, args, kwargs):


### PR DESCRIPTION
Previously:
In the case of a fast executed task, the task was complete by the
time we add the callback; in that case, the callback is executed
immediately, before the 'task launched' message.

This commit reverses that to give a more sensible looking log order.

Addresses part of #604.
Please squash merge this.