### PR TITLE
Make DFK shutdown wait for app futures, not exec futures

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -724,7 +724,7 @@ class DataFlowKernel(object):
         for task_id in self.tasks:
             # .exception() is a less exception throwing way of
             # waiting for completion than .result()
-            fut = self.tasks[task_id]['exec_fu']
+            fut = self.tasks[task_id]['app_fu']
             if not fut.done():
                 logger.debug("Waiting for task {} to complete".format(task_id))
                 fut.exception()


### PR DESCRIPTION
This was my original intended behaviour of #610

A task does not always have an exec_fu, and in some cases in
testing, the final wait was failing rather than waiting,
because it could not find an exec_fu to wait for.