### PR TITLE
Deal with spurious callback exceptions.

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -441,8 +441,14 @@ class DataFlowKernel(object):
         hit, memo_fu = self.memoizer.check_memo(task_id, self.tasks[task_id])
         if hit:
             logger.info("Reusing cached result for task {}".format(task_id))
-            self.handle_exec_update(task_id, memo_fu)
-            self.handle_app_update(task_id, memo_fu, memo_cbk=True)
+            try:
+                self.handle_exec_update(task_id, memo_fu)
+            except Exception as e:
+                logger.error("handle_exec_update raised an exception {} which will be ignored".format(e))
+            try:
+                self.handle_app_update(task_id, memo_fu, memo_cbk=True)
+            except Exception as e:
+                logger.error("handle_app_update raised an exception {} which will be ignored".format(e))
             return memo_fu
 
         executor_label = self.tasks[task_id]["executor"]
@@ -460,7 +466,10 @@ class DataFlowKernel(object):
         exec_fu.retries_left = self._config.retries - \
             self.tasks[task_id]['fail_count']
         logger.info("Task {} launched on executor {}".format(task_id, executor.label))
-        exec_fu.add_done_callback(partial(self.handle_exec_update, task_id))
+        try:
+            exec_fu.add_done_callback(partial(self.handle_update, task_id))
+        except Exception as e:
+            logger.error("add_done_callback got an exception {} which will be ignored".format(e))
         return exec_fu
 
     def _add_input_deps(self, executor, args, kwargs):
@@ -681,7 +690,10 @@ class DataFlowKernel(object):
             def callback_adapter(dep_fut):
                 self.launch_if_ready(task_id)
 
-            d.add_done_callback(callback_adapter)
+            try:
+                d.add_done_callback(callback_adapter)
+            except Exception as e:
+                logger.error("add_done_callback got an exception {} which will be ignored".format(e))
 
         self.launch_if_ready(task_id)
 

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -255,7 +255,7 @@ class DataFlowKernel(object):
             if isinstance(res, RemoteException):
                 res.reraise()
 
-        except Exception as e:
+        except Exception:
             logger.exception("Task {} failed".format(task_id))
 
             # We keep the history separately, since the future itself could be
@@ -269,7 +269,7 @@ class DataFlowKernel(object):
                 if self.monitoring_config is not None:
                     task_log_info = self._create_task_log_info(task_id, 'eager')
                     self.db_logger.info("Task Fail", extra=task_log_info)
-                raise e
+                return
 
             if self.tasks[task_id]['fail_count'] <= self._config.retries:
                 self.tasks[task_id]['status'] = States.pending

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -467,7 +467,7 @@ class DataFlowKernel(object):
             self.tasks[task_id]['fail_count']
         logger.info("Task {} launched on executor {}".format(task_id, executor.label))
         try:
-            exec_fu.add_done_callback(partial(self.handle_update, task_id))
+            exec_fu.add_done_callback(partial(self.handle_exec_update, task_id))
         except Exception as e:
             logger.error("add_done_callback got an exception {} which will be ignored".format(e))
         return exec_fu

--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -157,7 +157,12 @@ class AppFuture(Future):
         """
         # with self._parent_update_lock:
         self.parent = fut
-        fut.add_done_callback(self.parent_callback)
+
+        try:
+            fut.add_done_callback(self.parent_callback)
+        except Exception as e:
+            logger.error("add_done_callback got an exception {} which will be ignored".format(e))
+
         self._parent_update_event.set()
 
     def cancel(self):


### PR DESCRIPTION
Exceptions were appearing in strange places with lazyFail=False.

On investigation, two unexpected things were happening. Each of the two commits on this branch fixes one of those things:

* handle_update was throwing an exception in the case on a non-lazy fail, rather than `return`ing. In general, it doesn't make sense for a callback to throw an exception as there is no where for the exception to go. One commit on this branch replaces that explicit raise with a `return`.

EXCEPT:

* if a callback fires straight away when added to a future, and that callback throws an exception, then (sometimes?) the exception propagates to up through add_done_callback call and out into the code containing that. That gives a race condition where sometimes a failing task (if it fails fast enough) will cause an exception there, and sometimes not (if it fails too slowly); in the latter case, the exception disappears into the void.

The second commit on this branch puts explicit try/catch-log-discard blocks round places where handle_update is called, to give "exceptions in callback handles don't come out of add_done_callback calls" behaviour (as I thought was originally happening).

Either of these commits would be sufficient to solve the specific problem I was experiencing with lazy fail exceptions, but both together make things a bit more resilient in general.