### PR TITLE
Split up example configs and testing configs - fix #459

### DIFF
--- a/docs/userguide/configuring.rst
+++ b/docs/userguide/configuring.rst
@@ -31,7 +31,7 @@ Comet (SDSC)
 
 The following snippet shows an example configuration for executing remotely on San Diego Supercomputer Center's **Comet** supercomputer. The example uses an `SSHChannel` to connect remotely to Comet, the `SlurmProvider` to interface with the Slurm scheduler used by Comet and the `SrunLauncher` to launch workers.
 
-.. literalinclude:: ../../parsl/tests/configs/comet_ipp_multinode.py
+.. literalinclude:: ../../parsl/configs/comet_ipp_multinode.py
 
 
 Cori (NERSC)
@@ -41,7 +41,7 @@ Cori (NERSC)
 
 The following snippet shows an example configuration for accessing NERSC's **Cori** supercomputer. This example uses the IPythonParallel executor and connects to Cori's Slurm scheduler. It uses a remote SSH channel that allows the IPythonParallel controller to be hosted on the script's submission machine (e.g., a PC).  It is configured to request 2 nodes configured with 1 TaskBlock per node. Finally it includes override information to request a particular node type (Haswell) and to configure a specific Python environment on the worker nodes using Anaconda.
 
-.. literalinclude:: ../../parsl/tests/configs/cori_ipp_multinode.py
+.. literalinclude:: ../../parsl/configs/cori_ipp_multinode.py
 
 
 Theta (ALCF)
@@ -53,7 +53,7 @@ The following snippet shows an example configuration for executing on Argonne Le
 This example uses the `IPythonParallel` executor and connects to Theta's Cobalt scheduler using the `CobaltProvider`. This configuration
 assumes that the script is being executed on the login nodes of Theta.
 
-.. literalinclude:: ../../parsl/tests/configs/theta_local_ipp_multinode.py
+.. literalinclude:: ../../parsl/configs/theta_local_ipp_multinode.py
 
 
 Cooley (ALCF)
@@ -65,7 +65,7 @@ The following snippet shows an example configuration for executing remotely on A
 The example uses an `SSHInteractiveLoginChannel` to connect remotely to Cooley using ALCF's 2FA token.
 The configuration uses the `CobaltProvider` to interface with Cooley's scheduler.
 
-.. literalinclude:: ../../parsl/tests/configs/cooley_ssh_il_single_node.py
+.. literalinclude:: ../../parsl/configs/cooley_ssh_il_single_node.py
 
 Swan (Cray)
 -----------
@@ -76,7 +76,7 @@ The following snippet shows an example configuration for executing remotely on S
 The example uses an `SSHChannel` to connect remotely Swan, uses the `TorqueProvider` to interface with the scheduler and the `AprunLauncher`
 to launch workers on the machine
 
-.. literalinclude:: ../../parsl/tests/configs/swan_ipp_multinode.py
+.. literalinclude:: ../../parsl/configs/swan_ipp_multinode.py
 
 
 CC-IN2P3
@@ -88,7 +88,7 @@ The snippet below shows an example configuration for executing from a login node
 The configuration uses the `LocalProvider` to run on a login node primarily to avoid GSISSH, which Parsl does not support yet.
 This system uses Grid Engine which Parsl interfaces with using the `GridEngineProvider`.
 
-.. literalinclude:: ../../parsl/tests/configs/cc_in2p3_local_single_node.py
+.. literalinclude:: ../../parsl/configs/cc_in2p3_local_single_node.py
 
 Midway (RCC, UChicago)
 ----------------------
@@ -100,7 +100,7 @@ The snippet below shows an example configuration for executing remotely on Midwa
 The configuration uses the `SSHProvider` to connect remotely to Midway, uses the `SlurmProvider` to interface
 with the scheduler, and uses the `SrunProvider` to launch workers.
 
-.. literalinclude:: ../../parsl/tests/configs/midway_ipp_multinode.py
+.. literalinclude:: ../../parsl/configs/midway_ipp_multinode.py
 
 
 Open Science Grid
@@ -113,7 +113,7 @@ The snippet below shows an example configuration for executing remotely on OSG.
 The configuration uses the `SSHProvider` to connect remotely to OSG, uses the `CondorProvider` to interface
 with the scheduler.
 
-.. literalinclude:: ../../parsl/tests/configs/osg_ipp_multinode.py
+.. literalinclude:: ../../parsl/configs/osg_ipp_multinode.py
 
 Amazon Web Services
 -------------------
@@ -129,7 +129,7 @@ The snippet below shows an example configuration for provisioning nodes from the
 The first run would configure a Virtual Private Cloud and other networking and security infrastructure that will be
 re-used in subsequent runs. The configuration uses the `AWSProvider` to connect to AWS
 
-.. literalinclude:: ../../parsl/tests/configs/ec2_single_node.py
+.. literalinclude:: ../../parsl/configs/ec2_single_node.py
 
 
 Further help

--- a/parsl/configs/beagle_single_node.py
+++ b/parsl/configs/beagle_single_node.py
@@ -1,0 +1,42 @@
+"""
+================== Block
+| ++++++++++++++ | Node
+| |            | |
+| |    Task    | |             . . .
+| |            | |
+| ++++++++++++++ |
+==================
+"""
+from parsl.channels import SSHChannel
+from parsl.providers import TorqueProvider
+from parsl.launchers import AprunLauncher
+
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='beagle_multinode_mpi',
+            provider=TorqueProvider(
+                'debug',
+                channel=SSHChannel(
+                    hostname='login4.beagle.ci.uchicago.edu',
+                    username='USERNAME',     # Please replace USERNAME with your username
+                    script_dir='/lustre/beagle2/USERNAME/parsl_scripts',    # Please replace USERNAME with your username
+                ),
+                nodes_per_block=1,
+                tasks_per_node=1,
+                init_blocks=1,
+                max_blocks=1,
+                launcher=AprunLauncher,
+                overrides='OVERRIDES',     # Please replace OVERRIDES with your overrides
+            )
+        )
+
+    ],
+)

--- a/parsl/configs/cc_in2p3_local_single_node.py
+++ b/parsl/configs/cc_in2p3_local_single_node.py
@@ -1,0 +1,36 @@
+"""
+================== Block
+| ++++++++++++++ | Node
+| |            | |
+| |    Task    | |             . . .
+| |            | |
+| ++++++++++++++ |
+==================
+"""
+from parsl.channels import LocalChannel
+from parsl.providers import GridEngineProvider
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='cc_in2p3_local_single_node',
+            provider=GridEngineProvider(
+                channel=LocalChannel(),
+                nodes_per_block=1,
+                tasks_per_node=1,
+                init_blocks=1,
+                max_blocks=1,
+                walltime="00:20:00",
+                overrides='OVERRIDES',     # Please replace OVERRIDES with your overrides
+            ),
+            engine_debug_level='DEBUG',
+        )
+
+    ],
+)

--- a/parsl/configs/comet_ipp_multinode.py
+++ b/parsl/configs/comet_ipp_multinode.py
@@ -1,0 +1,36 @@
+from parsl.channels import SSHChannel
+from parsl.providers import SlurmProvider
+from parsl.launchers import SrunLauncher
+
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.ipp_controller import Controller
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='comet_ipp_multinode',
+            provider=SlurmProvider(
+                'debug',
+                channel=SSHChannel(
+                    hostname='comet.sdsc.xsede.org',
+                    username='USERNAME',     # Please replace USERNAME with your username
+                    script_dir='/home/USERNAME/parsl_scripts',    # Please replace USERNAME with your username
+                ),
+                launcher=SrunLauncher(),
+                overrides='OVERRIDES',     # Please replace OVERRIDES with your overrides
+                walltime="00:10:00",
+                init_blocks=1,
+                max_blocks=1,
+                nodes_per_block=2,
+                tasks_per_node=1,
+            ),
+            controller=Controller(public_ip='PUBLIC_IP'),    # Please replace PUBLIC_IP with your public ip
+        )
+
+    ],
+)

--- a/parsl/configs/cooley_local_single_node.py
+++ b/parsl/configs/cooley_local_single_node.py
@@ -1,0 +1,33 @@
+# Untested
+
+from parsl.providers import CobaltProvider
+from parsl.launchers import SingleNodeLauncher
+
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.ipp_controller import Controller
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='cooley_local_single_node',
+            provider=CobaltProvider(
+                launcher=SingleNodeLauncher(),
+                nodes_per_block=1,
+                tasks_per_node=1,
+                init_blocks=1,
+                max_blocks=1,
+                walltime="00:05:00",
+                overrides='OVERRIDES',     # Please replace OVERRIDES with your overrides
+                queue='debug',
+                account='ALCF_ALLOCATION',    # Please replace ALCF_ALLOCATION with your ALCF allocation
+            ),
+            controller=Controller(public_ip="10.230.100.210")
+        )
+
+    ],
+)

--- a/parsl/configs/cooley_ssh-il_single_node.py
+++ b/parsl/configs/cooley_ssh-il_single_node.py
@@ -1,0 +1,35 @@
+# Untested
+from parsl.channels import SSHInteractiveLoginChannel
+from parsl.providers import CobaltProvider
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.ipp_controller import Controller
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='cooley_ssh_il_local_single_node',
+            provider=CobaltProvider(
+                channel=SSHInteractiveLoginChannel(
+                    hostname='cooleylogin1.alcf.anl.gov',
+                    username='USERNAME',     # Please replace USERNAME with your username
+                    script_dir='/home/USERNAME/parsl_scripts/',    # Please replace USERNAME with your username
+                ),
+                nodes_per_block=1,
+                tasks_per_node=1,
+                init_blocks=1,
+                max_blocks=1,
+                walltime="00:05:00",
+                overrides='OVERRIDES',     # Please replace OVERRIDES with your overrides
+                queue='debug',
+                account='ALCF_ALLOCATION',    # Please replace ALCF_ALLOCATION with your ALCF allocation
+            ),
+            controller=Controller(public_ip='PUBLIC_IP'),    # Please replace PUBLIC_IP with your public ip
+        )
+
+    ],
+)

--- a/parsl/configs/cooley_ssh_il_single_node.py
+++ b/parsl/configs/cooley_ssh_il_single_node.py
@@ -1,0 +1,38 @@
+# Untested
+from parsl.channels import SSHInteractiveLoginChannel
+from parsl.providers import CobaltProvider
+from parsl.launchers import SingleNodeLauncher
+
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.ipp_controller import Controller
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='cooley_ssh_il_local_single_node',
+            provider=CobaltProvider(
+                channel=SSHInteractiveLoginChannel(
+                    hostname='cooley.alcf.anl.gov',
+                    username='USERNAME',     # Please replace USERNAME with your username
+                    script_dir='/home/USERNAME/parsl_scripts/',    # Please replace USERNAME with your username
+                ),
+                nodes_per_block=1,
+                tasks_per_node=1,
+                init_blocks=1,
+                max_blocks=1,
+                walltime="00:05:00",
+                overrides='OVERRIDES',     # Please replace OVERRIDES with your overrides
+                queue='pubnet-debug',
+                account='ALCF_ALLOCATION',    # Please replace ALCF_ALLOCATION with your ALCF allocation
+                launcher=SingleNodeLauncher(),
+            ),
+            controller=Controller(public_ip='PUBLIC_IP'),    # Please replace PUBLIC_IP with your public ip
+        )
+
+    ],
+)

--- a/parsl/configs/cori_ipp_multinode.py
+++ b/parsl/configs/cori_ipp_multinode.py
@@ -1,0 +1,45 @@
+"""
+    Block {Min:0, init:1, Max:1}
+====================================
+| ++++++++++++++ || ++++++++++++++ |
+| |    Node    | || |    Node    | |
+| |            | || |            | |
+| | Task  Task | || | Task  Task | |
+| |            | || |            | |
+| ++++++++++++++ || ++++++++++++++ |
+====================================
+"""
+from parsl.providers import SlurmProvider
+from parsl.channels import SSHChannel
+from parsl.launchers import SrunLauncher
+
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.ipp_controller import Controller
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='cori_ipp_multinode',
+            provider=SlurmProvider(
+                'debug',
+                channel=SSHChannel(
+                    hostname='cori.nersc.gov',
+                    username='USERNAME',     # Please replace USERNAME with your username
+                    script_dir='/global/homes/y/USERNAME/parsl_scripts',    # Please replace USERNAME with your username
+                ),
+                nodes_per_block=2,
+                tasks_per_node=2,
+                init_blocks=1,
+                max_blocks=1,
+                overrides='OVERRIDES',     # Please replace OVERRIDES with your overrides
+                launcher=SrunLauncher,
+            ),
+            controller=Controller(public_ip='PUBLIC_IP'),    # Please replace PUBLIC_IP with your public ip
+        )
+    ],
+)

--- a/parsl/configs/cori_ipp_single_node.py
+++ b/parsl/configs/cori_ipp_single_node.py
@@ -1,0 +1,41 @@
+"""
+================== Block
+| ++++++++++++++ | Node
+| |            | |
+| |    Task    | |             . . .
+| |            | |
+| ++++++++++++++ |
+==================
+"""
+from parsl.providers import SlurmProvider
+from parsl.channels import SSHChannel
+
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.ipp_controller import Controller
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='cori_ipp_single_node',
+            provider=SlurmProvider(
+                'debug',
+                channel=SSHChannel(
+                    hostname='cori.nersc.gov',
+                    username='USERNAME',     # Please replace USERNAME with your username
+                    script_dir='/global/homes/y/USERNAME/parsl_scripts',    # Please replace USERNAME with your username
+                ),
+                nodes_per_block=1,
+                tasks_per_node=1,
+                init_blocks=1,
+                max_blocks=1,
+                overrides='OVERRIDES',     # Please replace OVERRIDES with your overrides
+            ),
+            controller=Controller(public_ip='PUBLIC_IP'),    # Please replace PUBLIC_IP with your public ip
+        )
+    ],
+)

--- a/parsl/configs/ec2_bad_spot.py
+++ b/parsl/configs/ec2_bad_spot.py
@@ -12,7 +12,7 @@ config = Config(
         IPyParallelExecutor(
             label='ec2_bad_spot',
             provider=AWSProvider(
-                'image_id',    # Please replace image_id with your image id, e.g., 'ami-82f4dae7' 
+                'image_id',    # Please replace image_id with your image id, e.g., 'ami-82f4dae7'
                 region='us-east-1',    # Please replace region with your region
                 key_name='KEY',    # Please replace KEY with your key name
                 profile="default",

--- a/parsl/configs/ec2_bad_spot.py
+++ b/parsl/configs/ec2_bad_spot.py
@@ -12,9 +12,9 @@ config = Config(
         IPyParallelExecutor(
             label='ec2_bad_spot',
             provider=AWSProvider(
-                'image_id',    # Please replace image_id with your image id, e.g., 'ami-82f4dae7'      
-                region='us-east-1',    # Please replace region with your region   
-                key_name='KEY',    # Please replace KEY with your key name   
+                'image_id',    # Please replace image_id with your image id, e.g., 'ami-82f4dae7' 
+                region='us-east-1',    # Please replace region with your region
+                key_name='KEY',    # Please replace KEY with your key name
                 profile="default",
                 state_file='awsproviderstate.json',
                 spot_max_bid='0.001',

--- a/parsl/configs/ec2_bad_spot.py
+++ b/parsl/configs/ec2_bad_spot.py
@@ -1,0 +1,31 @@
+from parsl.providers import AWSProvider
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.ipp_controller import Controller
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='ec2_bad_spot',
+            provider=AWSProvider(
+                'image_id',    # Please replace image_id with your image id, e.g., 'ami-82f4dae7'      
+                region='us-east-1',    # Please replace region with your region   
+                key_name='KEY',    # Please replace KEY with your key name   
+                profile="default",
+                state_file='awsproviderstate.json',
+                spot_max_bid='0.001',
+                nodes_per_block=1,
+                tasks_per_node=1,
+                init_blocks=1,
+                max_blocks=1,
+                min_blocks=0,
+                walltime='00:25:00',
+            ),
+            controller=Controller(public_ip='PUBLIC_IP'),    # Please replace PUBLIC_IP with your public ip
+        )
+    ],
+)

--- a/parsl/configs/ec2_single_node.py
+++ b/parsl/configs/ec2_single_node.py
@@ -26,9 +26,9 @@ config = Config(
         IPyParallelExecutor(
             label='ec2_single_node',
             provider=AWSProvider(
-                'image_id',    # Please replace image_id with your image id, e.g., 'ami-82f4dae7'                
-                region='us-east-1',    # Please replace region with your region   
-                key_name='KEY',    # Please replace KEY with your key name   
+                'image_id',    # Please replace image_id with your image id, e.g., 'ami-82f4dae7'
+                region='us-east-1',    # Please replace region with your region
+                key_name='KEY',    # Please replace KEY with your key name
                 profile="default",
                 state_file='awsproviderstate.json',
                 nodes_per_block=1,

--- a/parsl/configs/ec2_single_node.py
+++ b/parsl/configs/ec2_single_node.py
@@ -1,0 +1,44 @@
+"""Config for EC2.
+
+Block {Min:0, init:1, Max:1}
+==================
+| ++++++++++++++ |
+| |    Node    | |
+| |            | |
+| | Task  Task | |
+| |            | |
+| ++++++++++++++ |
+==================
+
+"""
+from parsl.providers import AWSProvider
+
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.ipp_controller import Controller
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='ec2_single_node',
+            provider=AWSProvider(
+                'image_id',    # Please replace image_id with your image id, e.g., 'ami-82f4dae7'                
+                region='us-east-1',    # Please replace region with your region   
+                key_name='KEY',    # Please replace KEY with your key name   
+                profile="default",
+                state_file='awsproviderstate.json',
+                nodes_per_block=1,
+                tasks_per_node=2,
+                init_blocks=1,
+                max_blocks=1,
+                min_blocks=0,
+                walltime='01:00:00',
+            ),
+            controller=Controller(public_ip='PUBLIC_IP'),    # Please replace PUBLIC_IP with your public ip
+        )
+    ],
+)

--- a/parsl/configs/ec2_spot.py
+++ b/parsl/configs/ec2_spot.py
@@ -12,9 +12,9 @@ config = Config(
         IPyParallelExecutor(
             label='ec2_spot',
             provider=AWSProvider(
-                'image_id',    # Please replace image_id with your image id, e.g., 'ami-82f4dae7'                
-                region='us-east-1',    # Please replace region with your region   
-                key_name='KEY',    # Please replace KEY with your key name   
+                'image_id',    # Please replace image_id with your image id, e.g., 'ami-82f4dae7'
+                region='us-east-1',    # Please replace region with your region
+                key_name='KEY',    # Please replace KEY with your key name
                 profile="default",
                 state_file='awsproviderstate.json',
                 spot_max_bid='1.0',

--- a/parsl/configs/ec2_spot.py
+++ b/parsl/configs/ec2_spot.py
@@ -1,0 +1,31 @@
+from parsl.providers import AWSProvider
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.ipp_controller import Controller
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='ec2_spot',
+            provider=AWSProvider(
+                'image_id',    # Please replace image_id with your image id, e.g., 'ami-82f4dae7'                
+                region='us-east-1',    # Please replace region with your region   
+                key_name='KEY',    # Please replace KEY with your key name   
+                profile="default",
+                state_file='awsproviderstate.json',
+                spot_max_bid='1.0',
+                nodes_per_block=1,
+                tasks_per_node=1,
+                init_blocks=1,
+                max_blocks=1,
+                min_blocks=0,
+                walltime='00:25:00',
+            ),
+            controller=Controller(public_ip='PUBLIC_IP'),    # Please replace PUBLIC_IP with your public ip
+        )
+    ],
+)

--- a/parsl/configs/exex_local.py
+++ b/parsl/configs/exex_local.py
@@ -1,0 +1,23 @@
+from parsl.providers import LocalProvider
+from parsl.channels import LocalChannel
+from parsl.launchers import SimpleLauncher
+
+from parsl.config import Config
+from parsl.executors import ExtremeScaleExecutor
+
+config = Config(
+    executors=[
+        ExtremeScaleExecutor(
+            label="Extreme_Local",
+            worker_debug=True,
+            provider=LocalProvider(
+                channel=LocalChannel(),
+                init_blocks=1,
+                max_blocks=1,
+                tasks_per_node=4,
+                launcher=SimpleLauncher(),
+            )
+        )
+    ],
+    strategy=None,
+)

--- a/parsl/configs/htex_local.py
+++ b/parsl/configs/htex_local.py
@@ -1,0 +1,24 @@
+from parsl.providers import LocalProvider
+from parsl.channels import LocalChannel
+from parsl.launchers import SimpleLauncher
+
+from parsl.config import Config
+from parsl.executors import HighThroughputExecutor
+
+config = Config(
+    executors=[
+        HighThroughputExecutor(
+            label="htex_Local",
+            worker_debug=True,
+            cores_per_worker=1,
+            provider=LocalProvider(
+                channel=LocalChannel(),
+                init_blocks=1,
+                max_blocks=1,
+                tasks_per_node=1,  # For HighThroughputExecutor, this option should in most cases be 1
+                launcher=SimpleLauncher(),
+            ),
+        )
+    ],
+    strategy=None,
+)

--- a/parsl/configs/local_ipp_docker.py
+++ b/parsl/configs/local_ipp_docker.py
@@ -1,0 +1,20 @@
+import pytest
+import shutil
+
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+
+if shutil.which('docker') is None:
+    pytest.skip('docker not installed', allow_module_level=True)
+
+print("Creating config")
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='local_ipp_docker',
+            engine_dir='engines',
+            # container_image='parslbase_v0.1'
+        )
+    ],
+    lazy_errors=True
+)

--- a/parsl/configs/local_ipp_multisite.py
+++ b/parsl/configs/local_ipp_multisite.py
@@ -1,0 +1,33 @@
+"""The following config uses two IPP executors designed for python apps which may
+not show any performance improvements on local threads. This also allows you to
+send work to two separate remote executors, or to two separate partitions.
+"""
+from parsl.config import Config
+from parsl.providers import LocalProvider
+from parsl.executors.ipp import IPyParallelExecutor
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='local_ipp_1',
+            engine_dir='engines',
+            provider=LocalProvider(
+                nodes_per_block=1,
+                tasks_per_node=1,
+                walltime="00:15:00",
+                init_blocks=4,
+            )
+        ),
+        IPyParallelExecutor(
+            label='local_ipp_2',
+            engine_dir='engines',
+            provider=LocalProvider(
+                nodes_per_block=1,
+                tasks_per_node=1,
+                walltime="00:15:00",
+                init_blocks=2,
+            )
+        )
+
+    ],
+)

--- a/parsl/configs/local_ipp_reuse.py
+++ b/parsl/configs/local_ipp_reuse.py
@@ -1,0 +1,14 @@
+""" Use the following config with caution.
+"""
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.ipp_controller import Controller
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='local_ipp_reuse',
+        ),
+    ],
+    controller=Controller(reuse=True),
+)

--- a/parsl/configs/local_threads_checkpoint.py
+++ b/parsl/configs/local_threads_checkpoint.py
@@ -1,0 +1,10 @@
+from parsl.config import Config
+from parsl.executors.threads import ThreadPoolExecutor
+
+config = Config(
+    executors=[
+        ThreadPoolExecutor(
+            label='local_threads_checkpoint',
+        )
+    ],
+)

--- a/parsl/configs/local_threads_checkpoint_dfk_exit.py
+++ b/parsl/configs/local_threads_checkpoint_dfk_exit.py
@@ -1,0 +1,11 @@
+from parsl.config import Config
+from parsl.executors.threads import ThreadPoolExecutor
+
+config = Config(
+    executors=[
+        ThreadPoolExecutor(
+            label='local_threads_checkpoint_dfk_exit',
+        )
+    ],
+    checkpoint_mode='dfk_exit',
+)

--- a/parsl/configs/local_threads_checkpoint_periodic.py
+++ b/parsl/configs/local_threads_checkpoint_periodic.py
@@ -1,0 +1,12 @@
+from parsl.config import Config
+from parsl.executors.threads import ThreadPoolExecutor
+
+config = Config(
+    executors=[
+        ThreadPoolExecutor(
+            label='local_threads_checkpoint_periodic',
+        )
+    ],
+    checkpoint_mode='periodic',
+    checkpoint_period='00:00:05',
+)

--- a/parsl/configs/local_threads_checkpoint_task_exit.py
+++ b/parsl/configs/local_threads_checkpoint_task_exit.py
@@ -1,0 +1,11 @@
+from parsl.config import Config
+from parsl.executors.threads import ThreadPoolExecutor
+
+config = Config(
+    executors=[
+        ThreadPoolExecutor(
+            label='local_threads_checkpoint_task_exit',
+        )
+    ],
+    checkpoint_mode='task_exit',
+)

--- a/parsl/configs/local_threads_globus.py
+++ b/parsl/configs/local_threads_globus.py
@@ -1,0 +1,20 @@
+from parsl.config import Config
+from parsl.data_provider.scheme import GlobusScheme
+from parsl.executors.threads import ThreadPoolExecutor
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        ThreadPoolExecutor(
+            label='local_threads_globus',
+            storage_access=[GlobusScheme(
+                endpoint_uuid='UUID',    # Please replace UUID with your uuid
+                endpoint_path='PATH'    # Please replace PATH with your path
+            )],
+            working_dir='PATH'    # Please replace PATH with your path
+        )
+    ],
+)

--- a/parsl/configs/local_threads_ipp.py
+++ b/parsl/configs/local_threads_ipp.py
@@ -1,0 +1,26 @@
+"""The following config uses threads say for local lightweight apps and IPP workers for
+heavy weight applications.
+
+The app decorator has a parameter `executors=[<list of executors>]` to specify the executor to which
+apps should be directed.
+"""
+from parsl.providers import LocalProvider
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.threads import ThreadPoolExecutor
+
+config = Config(
+    executors=[
+        ThreadPoolExecutor(max_threads=4, label='local_threads'),
+        IPyParallelExecutor(
+            label='local_ipp',
+            engine_dir='engines',
+            provider=LocalProvider(
+                walltime="00:05:00",
+                nodes_per_block=1,
+                tasks_per_node=1,
+                init_blocks=4
+            )
+        )
+    ],
+)

--- a/parsl/configs/local_threads_no_cache.py
+++ b/parsl/configs/local_threads_no_cache.py
@@ -1,0 +1,9 @@
+from parsl.config import Config
+from parsl.executors.threads import ThreadPoolExecutor
+
+config = Config(
+    executors=[
+        ThreadPoolExecutor(max_threads=4),
+    ],
+    app_cache=False,
+)

--- a/parsl/configs/midway_ipp.py
+++ b/parsl/configs/midway_ipp.py
@@ -1,0 +1,34 @@
+from parsl.channels import SSHChannel
+from parsl.providers import SlurmProvider
+
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.ipp_controller import Controller
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            provider=SlurmProvider(
+                'westmere',
+                channel=SSHChannel(
+                    hostname='swift.rcc.uchicago.edu',
+                    username='USERNAME',     # Please replace USERNAME with your username
+                    script_dir='/scratch/midway2/USERNAME/parsl_scripts',    # Please replace USERNAME with your username
+                ),
+                init_blocks=1,
+                min_blocks=1,
+                max_blocks=2,
+                nodes_per_block=1,
+                tasks_per_node=4,
+                parallelism=0.5,
+                overrides='OVERRIDES',     # Please replace OVERRIDES with your overrides
+            ),
+            label='midway_ipp',
+            controller=Controller(public_ip='PUBLIC_IP'),    # Please replace PUBLIC_IP with your public ip
+        )
+    ]
+)

--- a/parsl/configs/midway_ipp_multicore.py
+++ b/parsl/configs/midway_ipp_multicore.py
@@ -1,0 +1,36 @@
+from parsl.channels import SSHChannel
+from parsl.providers import SlurmProvider
+from parsl.launchers import SingleNodeLauncher
+
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.ipp_controller import Controller
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='midway_ipp_multicore',
+            provider=SlurmProvider(
+                'westmere',
+                channel=SSHChannel(
+                    hostname='swift.rcc.uchicago.edu',
+                    username='USERNAME',     # Please replace USERNAME with your username
+                    script_dir='/scratch/midway2/USERNAME/parsl_scripts',    # Please replace USERNAME with your username
+                ),
+                overrides='OVERRIDES',     # Please replace OVERRIDES with your overrides
+                nodes_per_block=1,
+                tasks_per_node=4,
+                walltime="00:05:00",
+                init_blocks=1,
+                max_blocks=1,
+                launcher=SingleNodeLauncher(),
+            ),
+            controller=Controller(public_ip='PUBLIC_IP'),    # Please replace PUBLIC_IP with your public ip
+        )
+
+    ],
+)

--- a/parsl/configs/midway_ipp_multinode.py
+++ b/parsl/configs/midway_ipp_multinode.py
@@ -1,0 +1,36 @@
+from parsl.channels import SSHChannel
+from parsl.providers import SlurmProvider
+from parsl.launchers import SrunLauncher
+
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.ipp_controller import Controller
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='midway_ipp_multinode',
+            provider=SlurmProvider(
+                'westmere',
+                channel=SSHChannel(
+                    hostname='swift.rcc.uchicago.edu',
+                    username='USERNAME',     # Please replace USERNAME with your username
+                    script_dir='/scratch/midway2/USERNAME/parsl_scripts',    # Please replace USERNAME with your username
+                ),
+                launcher=SrunLauncher(),
+                overrides='OVERRIDES',     # Please replace OVERRIDES with your overrides
+                walltime="00:05:00",
+                init_blocks=1,
+                max_blocks=1,
+                nodes_per_block=2,
+                tasks_per_node=1,
+            ),
+            controller=Controller(public_ip='PUBLIC_IP'),    # Please replace PUBLIC_IP with your public ip
+        )
+
+    ],
+)

--- a/parsl/configs/osg_ipp_multinode.py
+++ b/parsl/configs/osg_ipp_multinode.py
@@ -1,0 +1,32 @@
+from parsl.executors.ipp_controller import Controller
+from parsl.channels.ssh.ssh import SSHChannel
+from parsl.providers.condor.condor import Condor
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='osg_remote_ipp',
+            provider=Condor(
+                channel=SSHChannel(
+                    hostname='login.osgconnect.net',
+                    username='USERNAME',     # Please replace USERNAME with your username
+                    script_dir='/home/USERNAME/parsl_scripts',    # Please replace USERNAME with your username
+                ),
+                nodes_per_block=1,
+                tasks_per_node=1,
+                init_blocks=4,
+                max_blocks=4,
+                overrides='Requirements = OSGVO_OS_STRING == "RHEL 6" && Arch == "X86_64" &&  HAS_MODULES == True',
+                worker_setup='WORKER_SETUP',     # Please replace WORKER_SETUP with your worker setup
+                walltime="01:00:00"
+            ),
+            controller=Controller(public_ip='PUBLIC_IP'),    # Please replace PUBLIC_IP with your public ip
+        )
+    ],
+)

--- a/parsl/configs/swan_ipp.py
+++ b/parsl/configs/swan_ipp.py
@@ -1,0 +1,42 @@
+"""
+================== Block
+| ++++++++++++++ | Node
+| |            | |
+| |    Task    | |             . . .
+| |            | |
+| ++++++++++++++ |
+==================
+"""
+from parsl.channels import SSHChannel
+from parsl.launchers import AprunLauncher
+from parsl.providers import TorqueProvider
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.ipp_controller import Controller
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='swan_ipp',
+            provider=TorqueProvider(
+                channel=SSHChannel(
+                    hostname='swan.cray.com',
+                    username='USERNAME',     # Please replace USERNAME with your username
+                    script_dir='/home/users/USERNAME/parsl_scripts',    # Please replace USERNAME with your username
+                ),
+                nodes_per_block=1,
+                tasks_per_node=1,
+                init_blocks=1,
+                max_blocks=1,
+                launcher=AprunLauncher(),
+                overrides='OVERRIDES',     # Please replace OVERRIDES with your overrides
+            ),
+            controller=Controller(public_ip='PUBLIC_IP'),    # Please replace PUBLIC_IP with your public ip
+        )
+
+    ],
+)

--- a/parsl/configs/swan_ipp_multinode.py
+++ b/parsl/configs/swan_ipp_multinode.py
@@ -1,0 +1,46 @@
+"""
+    Block
+====================================
+| ++++++++++++++ || ++++++++++++++ |
+| |    Node    | || |    Node    | |
+| |            | || |            | |
+| | Task  Task | || | Task  Task | |
+| |            | || |            | |
+| ++++++++++++++ || ++++++++++++++ |
+====================================
+"""
+from parsl.channels import SSHChannel
+from parsl.launchers import AprunLauncher
+from parsl.providers import TorqueProvider
+
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.ipp_controller import Controller
+
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='swan_ipp',
+            provider=TorqueProvider(
+                channel=SSHChannel(
+                    hostname='swan.cray.com',
+                    username='USERNAME',     # Please replace USERNAME with your username
+                    script_dir='/home/users/USERNAME/parsl_scripts',    # Please replace USERNAME with your username
+                ),
+                nodes_per_block=2,
+                tasks_per_node=2,
+                init_blocks=1,
+                max_blocks=1,
+                launcher=AprunLauncher(),
+                overrides='OVERRIDES',     # Please replace OVERRIDES with your overrides
+            ),
+            controller=Controller(public_ip='PUBLIC_IP'),    # Please replace PUBLIC_IP with your public ip
+        )
+
+    ],
+)

--- a/parsl/configs/theta_local_ipp_multinode.py
+++ b/parsl/configs/theta_local_ipp_multinode.py
@@ -1,0 +1,33 @@
+from parsl.providers import CobaltProvider
+from parsl.launchers import AprunLauncher
+
+from parsl.config import Config
+from parsl.executors.ipp import IPyParallelExecutor
+from parsl.executors.ipp_controller import Controller
+
+# This is an example config, make sure to
+#        replace the specific values below with the literal values
+#          (e.g., 'USERNAME' -> 'your_username')
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='theta_local_ipp_multinode',
+            provider=CobaltProvider(
+                queue="debug-flat-quad",
+                launcher=AprunLauncher(),
+                walltime="00:30:00",
+                nodes_per_block=2,
+                tasks_per_node=1,
+                init_blocks=1,
+                max_blocks=1,
+                overrides='OVERRIDES',     # Please replace OVERRIDES with your overrides
+                account='ALCF_ALLOCATION',    # Please replace ALCF_ALLOCATION with your ALCF allocation
+                cmd_timeout=60
+            ),
+            controller=Controller(public_ip='PUBLIC_IP'),    # Please replace PUBLIC_IP with your public ip
+        )
+
+    ],
+
+)

--- a/parsl/configs/theta_local_mpi_executor.py
+++ b/parsl/configs/theta_local_mpi_executor.py
@@ -1,0 +1,43 @@
+from libsubmit.providers import CobaltProvider
+from libsubmit.launchers import SimpleLauncher
+
+from parsl.config import Config
+from parsl.executors.mpix import MPIExecutor
+
+IP = 'PUBLIC_IP',    # Please replace PUBLIC_IP with your public ip
+JOB_URL = "tcp://{}:50005".format(IP)
+RESULT_URL = "tcp://{}:50006".format(IP)
+
+config = Config(
+    executors=[
+        MPIExecutor(
+            label="local_ipp",
+            jobs_q_url=JOB_URL,
+            results_q_url=RESULT_URL,
+            launch_cmd='which python3; \
+aprun -b -cc depth -j 1 -n $(($COBALT_PARTSIZE * {tasks_per_node})) -N {tasks_per_node} \
+python3 /home/yadunand/parsl/parsl/executors/mpix/fabric.py -d --task_url={task_url} --result_url={result_url}',
+            provider=CobaltProvider(
+                queue="debug-flat-quad",
+                # queue="default",
+                launcher=SimpleLauncher(),
+                walltime="00:30:00",
+                nodes_per_block=2,
+                tasks_per_node=32,
+                init_blocks=1,
+                max_blocks=1,
+                overrides="""module load intelpython35/2017.0.035
+source activate parsl_intel_py3.5
+module swap cray-mpich cray-mpich-abi
+export LD_LIBRARY_PATH=${CRAY_LD_LIBRARY_PATH}:$LD_LIBRARY_PATH
+
+ulimit -c unlimited
+
+export OMP_NUM_THREADS=16""",
+                account='CSC249ADCD01',    # Please replace CSC249ADCD01 with your ALCF allocation
+                cmd_timeout=60
+            ),
+        )
+    ],
+    strategy=None,
+)


### PR DESCRIPTION
   * copy the configs in `/parsl/test/configs` and place the new copies in `/parsl/configs`
   * replace `user_opts` in the new config files with new values and add comments to indicate users to replace them
   * remove `parsl.tests.utils import get_rundir` and `run_dir=get_rundir()` from the config files
   * link the code in `docs/userguide/configuring.rst` to the new config files
   * fix #459