### PR TITLE
Adding nbsphinx to test-requirements for readthedocs.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,3 +8,4 @@ pandas
 coverage
 mock>=1.0.0
 nbsphinx
+sphinx_rtd_theme

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,3 +7,4 @@ coverage
 pandas
 coverage
 mock>=1.0.0
+nbsphinx


### PR DESCRIPTION
Readthedocs will now switch to using test-requirements.txt instead of requirements.txt