### PR TITLE
Parse walltime strings to actual number of minutes

### DIFF
--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -142,7 +142,10 @@ def wtime_to_minutes(time_string):
 
     '''
     hours, mins, seconds = time_string.split(':')
-    return int(hours) * 60 + int(mins) + 1
+    total_mins = int(hours) * 60 + int(mins)
+    if total_mins < 1:
+        logger.warning("Time string '{}' parsed to {} minutes, less than 1".format(time_string, total_mins))
+    return total_mins
 
 
 class RepresentationMixin(object):


### PR DESCRIPTION
Previously, one minute was added, to attempt to deal with
a specific degenerate situation of 0 minutes being specified.

Now, zero minutes will be parsed as 0 minutes, but a warning will
be emitted if the return vales is <1, to nudge the user in the
right direction.