### PR TITLE
Remove implicit wait for outstanding tasks at DFK shutdown.

### DIFF
--- a/parsl/__init__.py
+++ b/parsl/__init__.py
@@ -47,6 +47,7 @@ __all__ = [
 clear = DataFlowKernelLoader.clear
 load = DataFlowKernelLoader.load
 dfk = DataFlowKernelLoader.dfk
+wait_for_current_tasks = DataFlowKernelLoader.wait_for_current_tasks
 
 
 def set_stream_logger(name='parsl', level=logging.DEBUG, format_string=None):

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -786,8 +786,6 @@ class DataFlowKernel(object):
             raise Exception("attempt to clean up DFK when it has already been cleaned-up")
         self.cleanup_called = True
 
-        self.wait_for_current_tasks()
-
         self.log_task_states()
 
         # Checkpointing takes priority over the rest of the tasks
@@ -1014,6 +1012,10 @@ class DataFlowKernelLoader(object):
             cls._dfk = DataFlowKernel(config)
 
         return cls._dfk
+
+    @classmethod
+    def wait_for_current_tasks(cls):
+        dfk().wait_for_current_tasks()
 
     @classmethod
     def dfk(cls):

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1015,7 +1015,11 @@ class DataFlowKernelLoader(object):
 
     @classmethod
     def wait_for_current_tasks(cls):
-        dfk().wait_for_current_tasks()
+        """Waits for all tasks in the task list to be completed, by waiting for their
+        AppFuture to be completed. This method will not necessarily wait for any tasks
+        added after cleanup has started such as data stageout.
+        """
+        cls.dfk().wait_for_current_tasks()
 
     @classmethod
     def dfk(cls):


### PR DESCRIPTION
In practice, this turned out to be awkward when, for example, ctrl-C
was pressed and parsl spent a long time waiting (or sometimes hung).

This commit intends that the same wait code is executed explicitly
at the place in the workflow code that the wait is desired (usually
the end). Ctrl-C and other abnormal exits will not cause this wait
to happen.