### PR TITLE
Heartbeat fix #633

### DIFF
--- a/parsl/executors/extreme_scale/mpi_worker_pool.py
+++ b/parsl/executors/extreme_scale/mpi_worker_pool.py
@@ -25,6 +25,7 @@ TASK_REQUEST_TAG = 11
 
 LOOP_SLOWDOWN = 0.0  # in seconds
 
+HEARTBEAT_CODE = (2 ** 32) - 1
 
 class Manager(object):
     """ Orchestrates the flow of tasks and results to and from the workers
@@ -90,7 +91,7 @@ class Manager(object):
     def heartbeat(self):
         """ Send heartbeat to the incoming task queue
         """
-        heartbeat = (0).to_bytes(4, "little")
+        heartbeat = (HEARTBEAT_CODE).to_bytes(4, "little")
         r = self.task_incoming.send(heartbeat)
         logger.debug("Return from heartbeat : {}".format(r))
 

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -16,7 +16,7 @@ from parsl.version import VERSION as PARSL_VERSION
 from ipyparallel.serialize import serialize_object
 
 LOOP_SLOWDOWN = 0.0  # in seconds
-
+HEARTBEAT_CODE = (2 ** 32) - 1
 
 class ShutdownRequest(Exception):
     ''' Exception raised when any async component receives a ShutdownRequest
@@ -200,6 +200,7 @@ class Interchange(object):
                 msg = self.task_incoming.recv_pyobj()
             except zmq.Again:
                 # We just timed out while attempting to receive
+                logger.debug("[TASK_PULL_THREAD] {} tasks in internal queue".format(self.pending_task_queue.qsize()))
                 continue
 
             if msg == 'STOP':
@@ -319,7 +320,10 @@ class Interchange(object):
                     tasks_requested = int.from_bytes(message[1], "little")
                     logger.debug("[MAIN] Manager {} requested {} tasks".format(manager, tasks_requested))
                     self._ready_manager_queue[manager]['last'] = time.time()
-                    self._ready_manager_queue[manager]['free_capacity'] = tasks_requested
+                    if tasks_requested == HEARTBEAT_CODE:
+                        logger.debug("[MAIN] Manager {} sends heartbeat".format(manager))
+                    else:
+                        self._ready_manager_queue[manager]['free_capacity'] = tasks_requested
 
             # If we had received any requests, check if there are tasks that could be passed
             for manager in self._ready_manager_queue:

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -107,9 +107,11 @@ class Interchange(object):
             client_address, client_ports[0], client_ports[1], client_ports[2]))
         self.context = zmq.Context()
         self.task_incoming = self.context.socket(zmq.DEALER)
+        self.task_incoming.set_hwm(0)
         self.task_incoming.RCVTIMEO = 10  # in milliseconds
         self.task_incoming.connect("tcp://{}:{}".format(client_address, client_ports[0]))
         self.results_outgoing = self.context.socket(zmq.DEALER)
+        self.results_outgoing.set_hwm(0)
         self.results_outgoing.connect("tcp://{}:{}".format(client_address, client_ports[1]))
 
         self.command_channel = self.context.socket(zmq.REP)
@@ -123,7 +125,9 @@ class Interchange(object):
         self.worker_port_range = worker_port_range
 
         self.task_outgoing = self.context.socket(zmq.ROUTER)
+        self.task_outgoing.set_hwm(0)
         self.results_incoming = self.context.socket(zmq.ROUTER)
+        self.results_incoming.set_hwm(0)
 
         if self.worker_ports:
             self.worker_task_port = self.worker_ports[0]

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -25,8 +25,9 @@ from ipyparallel.serialize import serialize_object
 RESULT_TAG = 10
 TASK_REQUEST_TAG = 11
 
-LOOP_SLOWDOWN = 0.0  # in seconds
+LOOP_SLOWDOWN = 0.01  # in seconds
 
+HEARTBEAT_CODE = (2 ** 32) - 1
 
 class Manager(object):
     """ Manager manages task execution by the workers
@@ -110,7 +111,7 @@ class Manager(object):
     def heartbeat(self):
         """ Send heartbeat to the incoming task queue
         """
-        heartbeat = (0).to_bytes(4, "little")
+        heartbeat = (HEARTBEAT_CODE).to_bytes(4, "little")
         r = self.task_incoming.send(heartbeat)
         logger.debug("Return from heartbeat: {}".format(r))
 

--- a/parsl/executors/high_throughput/zmq_pipes.py
+++ b/parsl/executors/high_throughput/zmq_pipes.py
@@ -62,6 +62,7 @@ class TasksOutgoing(object):
         """
         self.context = zmq.Context()
         self.zmq_socket = self.context.socket(zmq.DEALER)
+        self.zmq_socket.set_hwm(0)
         self.port = self.zmq_socket.bind_to_random_port("tcp://{}".format(ip_address),
                                                         min_port=port_range[0],
                                                         max_port=port_range[1])
@@ -110,6 +111,7 @@ class ResultsIncoming(object):
         """
         self.context = zmq.Context()
         self.results_receiver = self.context.socket(zmq.DEALER)
+        self.results_receiver.set_hwm(0)
         self.port = self.results_receiver.bind_to_random_port("tcp://{}".format(ip_address),
                                                               min_port=port_range[0],
                                                               max_port=port_range[1])


### PR DESCRIPTION
Fixes a potential stalling issue that in part causes #633.
* Adds a cleaner way to report heartbeats
* Adds high water marks to the ROUTER, DEALER sockets ensuring that packets don't get dropped.