### PR TITLE
Make RemoteException more serialisable

### DIFF
--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -2,6 +2,8 @@
 from functools import wraps
 
 import dill
+from tblib import Traceback
+
 from six import reraise
 
 
@@ -135,23 +137,25 @@ class DependencyError(ParslError):
         return "Reason:{0} Missing:{1}".format(self.reason, self.outputs)
 
 
-class RemoteException(ParslError):
+class RemoteExceptionWrapper:
     def __init__(self, e_type, e_value, traceback):
+
         self.e_type = dill.dumps(e_type)
         self.e_value = dill.dumps(e_value)
-        self.traceback = dill.dumps(traceback)
+        self.e_traceback = Traceback(traceback)
 
     def reraise(self):
-        reraise(dill.loads(self.e_type), dill.loads(self.e_value), dill.loads(self.traceback))
+
+        reraise(dill.loads(self.e_type), dill.loads(self.e_value), self.e_traceback.as_traceback())
 
 
 def wrap_error(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         import sys
-        from parsl.app.errors import RemoteException
+        from parsl.app.errors import RemoteExceptionWrapper
         try:
             return func(*args, **kwargs)
         except Exception:
-            return RemoteException(*sys.exc_info())
+            return RemoteExceptionWrapper(*sys.exc_info())
     return wrapper

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -18,7 +18,7 @@ from concurrent.futures import Future
 from functools import partial
 
 import parsl
-from parsl.app.errors import RemoteException
+from parsl.app.errors import RemoteExceptionWrapper
 from parsl.config import Config
 from parsl.data_provider.data_manager import DataManager
 from parsl.data_provider.files import File
@@ -251,7 +251,7 @@ class DataFlowKernel(object):
 
         try:
             res = future.result()
-            if isinstance(res, RemoteException):
+            if isinstance(res, RemoteExceptionWrapper):
                 res.reraise()
 
         except Exception:

--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -10,7 +10,7 @@ from concurrent.futures import Future
 import logging
 import threading
 
-from parsl.app.errors import RemoteException
+from parsl.app.errors import RemoteExceptionWrapper
 
 logger = logging.getLogger(__name__)
 
@@ -54,8 +54,8 @@ class AppFuture(Future):
     retries left, or if it has no retry field. .result(), .exception() and done callbacks
     should give a result as expected when a Future has a result set
 
-    The parent future may return a RemoteException as a result (rather than raising it
-    as an exception) and AppFuture will treat this an an exception for the above
+    The parent future may return a RemoteExceptionWrapper as a result
+    and AppFuture will treat this an an exception for the above
     retry and result handling behaviour.
 
     """
@@ -115,7 +115,7 @@ class AppFuture(Future):
 
             # this is for consistency checking
             if executor_fu != self.parent:
-                if executor_fu.exception() is None and not isinstance(executor_fu.result(), RemoteException):
+                if executor_fu.exception() is None and not isinstance(executor_fu.result(), RemoteExceptionWrapper):
                     # ... then we completed with a value, not an exception or wrapped exception,
                     # but we've got an updated executor future.
                     # This is bad - for example, we've started a retry even though we have a result
@@ -124,7 +124,7 @@ class AppFuture(Future):
 
             try:
                 res = executor_fu.result()
-                if isinstance(res, RemoteException):
+                if isinstance(res, RemoteExceptionWrapper):
                     res.reraise()
                 super().set_result(executor_fu.result())
 


### PR DESCRIPTION
Previously, RemoteExceptions could not be send over the wire because
they contained tracebacks (in the parent exception class, and in the
explicitly added traceback).

This commit:

 * removes the Exception superclass, which was never needed.
 * wraps the traceback using tblib, which allows it to be serialised.
 * renames RemoteException to RemoteExceptionWrapper, as the class
   is not an exception.