### PR TITLE
Updating block semantics #557

### DIFF
--- a/parsl/dataflow/strategy.py
+++ b/parsl/dataflow/strategy.py
@@ -177,7 +177,15 @@ class Strategy(object):
             # FIXME probably more of this logic should be moved to the provider
             min_blocks = executor.provider.min_blocks
             max_blocks = executor.provider.max_blocks
-            tasks_per_node = executor.provider.tasks_per_node
+            if isinstance(executor, IPyParallelExecutor):
+                tasks_per_node = executor.workers_per_node
+            elif isinstance(executor, HighThroughputExecutor):
+                # This is probably wrong calculation, we need this to come from the executor
+                # since we can't know slots ahead of time.
+                tasks_per_node = 1
+            elif isinstance(executor, ExtremeScaleExecutor):
+                tasks_per_node = executor.ranks_per_node
+
             nodes_per_block = executor.provider.nodes_per_block
             parallelism = executor.provider.parallelism
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -146,6 +146,31 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         if not launch_cmd:
             self.launch_cmd = """process_worker_pool.py {debug} -c {cores_per_worker} --task_url={task_url} --result_url={result_url} --logdir={logdir}"""
 
+    def initialize_scaling(self):
+        """ Compose the launch command and call the scale_out
+
+        This should be implemented in the child classes to take care of
+        executor specific oddities.
+        """
+        debug_opts = "--debug" if self.worker_debug else ""
+        l_cmd = self.launch_cmd.format(debug=debug_opts,
+                                       task_url=self.worker_task_url,
+                                       result_url=self.worker_result_url,
+                                       cores_per_worker=self.cores_per_worker,
+                                       nodes_per_block=self.provider.nodes_per_block,
+                                       logdir="{}/{}".format(self.run_dir, self.label))
+        self.launch_cmd = l_cmd
+        logger.debug("Launch command: {}".format(self.launch_cmd))
+
+        self._scaling_enabled = self.provider.scaling_enabled
+        logger.debug("Starting HighThroughputExecutor with provider:\n%s", self.provider)
+        if hasattr(self.provider, 'init_blocks'):
+            try:
+                self.scale_out(blocks=self.provider.init_blocks)
+            except Exception as e:
+                logger.error("Scaling out failed: {}".format(e))
+                raise e
+
     def start(self):
         """Create the Interchange process and connect to it.
         """
@@ -164,34 +189,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         logger.debug("Created management thread: {}".format(self._queue_management_thread))
 
         if self.provider:
-            debug_opts = "--debug" if self.worker_debug else ""
-            l_cmd = self.launch_cmd.format(debug=debug_opts,
-                                           task_url=self.worker_task_url,
-                                           result_url=self.worker_result_url,
-                                           cores_per_worker=self.cores_per_worker,
-                                           # This is here only to support the exex mpiexec call
-                                           tasks_per_node=self.provider.tasks_per_node,
-                                           nodes_per_block=self.provider.nodes_per_block,
-                                           logdir="{}/{}".format(self.run_dir, self.label))
-            self.launch_cmd = l_cmd
-            logger.debug("Launch command: {}".format(self.launch_cmd))
-
-            self._scaling_enabled = self.provider.scaling_enabled
-            logger.debug("Starting HighThroughputExecutor with provider:\n%s", self.provider)
-            if hasattr(self.provider, 'init_blocks'):
-                try:
-                    for i in range(self.provider.init_blocks):
-                        block = self.provider.submit(self.launch_cmd, 1)
-                        logger.debug("Launched block {}:{}".format(i, block))
-                        if not block:
-                            raise(ScalingFailed(self.provider.label,
-                                                "Attempts to provision nodes via provider has failed"))
-                        self.blocks.extend([block])
-
-                except Exception as e:
-                    logger.error("Scaling out failed: {}".format(e))
-                    raise e
-
+            self.initialize_scaling()
         else:
             self._scaling_enabled = False
             logger.debug("Starting HighThroughputExecutor with no provider")
@@ -422,18 +420,23 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         return self._scaling_enabled
 
     def scale_out(self, blocks=1):
-        """Scales out the number of active workers by 1.
+        """Scales out the number of blocks by "blocks"
 
         Raises:
              NotImplementedError
         """
-        if self.provider:
-            r = self.provider.submit(self.launch_cmd, 1)
-            self.blocks.extend([r])
-        else:
-            logger.error("No execution provider available")
-            r = None
-
+        r = []
+        for i in range(blocks):
+            if self.provider:
+                block = self.provider.submit(self.launch_cmd, 1, 1)
+                logger.debug("Launched block {}:{}".format(i, block))
+                if not block:
+                    raise(ScalingFailed(self.provider.label,
+                                        "Attempts to provision nodes via provider has failed"))
+                self.blocks.extend([block])
+            else:
+                logger.error("No execution provider available")
+                r = None
         return r
 
     def scale_in(self, blocks):

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -59,7 +59,7 @@ class Interchange(object):
                  client_ports=(50055, 50056, 50057),
                  worker_ports=None,
                  worker_port_range=(54000, 55000),
-                 heartbeat_period=60,
+                 heartbeat_threshold=60,
                  logdir=".",
                  logging_level=logging.INFO,
              ):
@@ -82,8 +82,8 @@ class Interchange(object):
              The interchange picks ports at random from the range which will be used by workers.
              This is overridden when the worker_ports option is set. Defauls: (54000, 55000)
 
-        heartbeat_period : int
-             Heartbeat period expected from workers (seconds). Default: 10s
+        heartbeat_threshold : int
+             Number of seconds since the last heartbeat after which worker is considered lost.
 
         logdir : str
              Parsl log directory paths. Logs and temp files go here. Default: '.'
@@ -152,7 +152,7 @@ class Interchange(object):
         self._ready_manager_queue = {}
         self.max_task_queue_size = 10 ^ 5
 
-        self.heartbeat_thresh = heartbeat_period * 2
+        self.heartbeat_threshold = heartbeat_threshold
 
         self.current_platform = {'parsl_v': PARSL_VERSION,
                                  'python_v': "{}.{}.{}".format(sys.version_info.major,
@@ -361,7 +361,7 @@ class Interchange(object):
                     logger.debug("[MAIN] Current tasks: {}".format(self._ready_manager_queue[manager]['tasks']))
 
             bad_managers = [manager for manager in self._ready_manager_queue if
-                            time.time() - self._ready_manager_queue[manager]['last'] > self.heartbeat_thresh]
+                            time.time() - self._ready_manager_queue[manager]['last'] > self.heartbeat_threshold]
             for manager in bad_managers:
                 logger.debug("[MAIN] Last: {} Current: {}".format(self._ready_manager_queue[manager]['last'], time.time()))
                 logger.warning("[MAIN] Too many heartbeats missed for manager {}".format(manager))

--- a/parsl/executors/ipp.py
+++ b/parsl/executors/ipp.py
@@ -39,6 +39,8 @@ class IPyParallelExecutor(ParslExecutor, RepresentationMixin):
         Label for this executor instance.
     controller : :class:`~parsl.executors.ipp_controller.Controller`
         Which Controller instance to use. Default is `Controller()`.
+    workers_per_node : int
+        Number of workers to be launched per node. Default=1
     container_image : str
         Launch tasks in a container using this docker image. If set to None, no container is used.
         Default is None.
@@ -72,6 +74,7 @@ class IPyParallelExecutor(ParslExecutor, RepresentationMixin):
                  engine_dir=None,
                  storage_access=None,
                  engine_debug_level=None,
+                 workers_per_node=1,
                  managed=True):
         self.provider = provider
         self.label = label
@@ -80,6 +83,7 @@ class IPyParallelExecutor(ParslExecutor, RepresentationMixin):
         self.engine_debug_level = engine_debug_level
         self.container_image = container_image
         self.engine_dir = engine_dir
+        self.workers_per_node = workers_per_node
         self.storage_access = storage_access if storage_access is not None else []
         if len(self.storage_access) > 1:
             raise ConfigurationError('Multiple storage access schemes are not yet supported')
@@ -119,14 +123,7 @@ class IPyParallelExecutor(ParslExecutor, RepresentationMixin):
         logger.debug("Starting IPyParallelExecutor with provider:\n%s", self.provider)
         if hasattr(self.provider, 'init_blocks'):
             try:
-                for i in range(self.provider.init_blocks):
-                    engine = self.provider.submit(self.launch_cmd, 1)
-                    logger.debug("Launched block: {0}:{1}".format(i, engine))
-                    if not engine:
-                        raise(ScalingFailed(self.provider.label,
-                                            "Attempt to provision nodes via provider has failed"))
-                    self.engines.extend([engine])
-
+                self.scale_out(blocks=self.provider.init_blocks)
             except Exception as e:
                 logger.error("Scaling out failed: %s" % e)
                 raise e
@@ -229,15 +226,25 @@ sleep infinity
         """
         return self.lb_view.apply_async(*args, **kwargs)
 
-    def scale_out(self, *args, **kwargs):
+    def scale_out(self, blocks=1):
         """Scales out the number of active workers by 1.
 
         This method is notImplemented for threads and will raise the error if called.
 
+        Parameters:
+            blocks : int
+               Number of blocks to be provisioned.
         """
-        if self.provider:
-            r = self.provider.submit(self.launch_cmd, *args, **kwargs)
-            self.engines.extend([r])
+        r = []
+        for i in range(blocks):
+            if self.provider:
+                block = self.provider.submit(self.launch_cmd, 1, self.workers_per_node)
+                logger.debug("Launched block {}:{}".format(i, block))
+                if not block:
+                    raise(ScalingFailed(self.provider.label,
+                                        "Attempts to provision nodes via provider has failed"))
+                self.engines.extend([block])
+                r.extend([block])
         else:
             logger.error("No execution provider available")
             r = None

--- a/parsl/providers/aws/aws.py
+++ b/parsl/providers/aws/aws.py
@@ -54,8 +54,6 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
         Path to json file that contains 'AWSAccessKeyId' and 'AWSSecretKey'.
     nodes_per_block : int
         This is always 1 for ec2. Nodes to provision per block.
-    tasks_per_node : int
-        Tasks to run per node.
     profile : str
         Profile to be used from the standard aws config file ~/.aws/config.
     nodes_per_block : int
@@ -98,7 +96,6 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
                  init_blocks=1,
                  min_blocks=0,
                  max_blocks=10,
-                 tasks_per_node=1,
                  nodes_per_block=1,
                  parallelism=1,
 
@@ -124,7 +121,6 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
         self.init_blocks = init_blocks
         self.min_blocks = min_blocks
         self.max_blocks = max_blocks
-        self.tasks_per_node = tasks_per_node
         self.nodes_per_block = nodes_per_block
         self.max_nodes = max_blocks * nodes_per_block
         self.parallelism = parallelism
@@ -567,7 +563,7 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
 
         return all_states
 
-    def submit(self, command='sleep 1', blocksize=1, job_name="parsl.auto"):
+    def submit(self, command='sleep 1', blocksize=1, tasks_per_node=1, job_name="parsl.auto"):
         """Submit the command onto a freshly instantiated AWS EC2 instance.
 
         Submit returns an ID that corresponds to the task that was just submitted.
@@ -578,6 +574,8 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
             Command to be invoked on the remote side.
         blocksize : int
             Number of blocks requested.
+        tasks_per_node : int (default=1)
+            Number of command invocations to be launched per node
         job_name : str
             Prefix for the job name.
 
@@ -589,7 +587,7 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
 
         job_name = "parsl.auto.{0}".format(time.time())
         wrapped_cmd = self.launcher(command,
-                                    self.tasks_per_node,
+                                    tasks_per_node,
                                     self.nodes_per_block)
         [instance, *rest] = self.spin_up_instance(command=wrapped_cmd, job_name=job_name)
 

--- a/parsl/providers/cluster_provider.py
+++ b/parsl/providers/cluster_provider.py
@@ -49,7 +49,6 @@ class ClusterProvider(ExecutionProvider):
                  label,
                  channel,
                  nodes_per_block,
-                 tasks_per_node,
                  init_blocks,
                  min_blocks,
                  max_blocks,
@@ -61,9 +60,7 @@ class ClusterProvider(ExecutionProvider):
         self._scaling_enabled = True
         self.label = label
         self.channel = channel
-        self.tasks_per_block = nodes_per_block * tasks_per_node
         self.nodes_per_block = nodes_per_block
-        self.tasks_per_node = tasks_per_node
         self.init_blocks = init_blocks
         self.min_blocks = min_blocks
         self.max_blocks = max_blocks
@@ -127,14 +124,15 @@ class ClusterProvider(ExecutionProvider):
 
         return True
 
-    def submit(self, cmd_string, blocksize, job_name="parsl.auto"):
+    def submit(self, cmd_string, blocksize, tasks_per_node, job_name="parsl.auto"):
         ''' The submit method takes the command string to be executed upon
         instantiation of a resource most often to start a pilot (such as IPP engine
         or even Swift-T engines).
 
         Args :
-             - cmd_string (str) : The bash command string to be executed.
+             - cmd_string (str) : The bash command string to be executed
              - blocksize (int) : Blocksize to be requested
+             - tasks_per_node (int) : command invocations to be launched per node
 
         KWargs:
              - job_name (str) : Human friendly name to be assigned to the job request

--- a/parsl/providers/googlecloud/googlecloud.py
+++ b/parsl/providers/googlecloud/googlecloud.py
@@ -1,6 +1,7 @@
 import atexit
 import logging
 import os
+from parsl.launchers import SingleNodeLauncher
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,7 @@ class GoogleCloudProvider():
                  init_blocks=1,
                  min_blocks=0,
                  max_blocks=10,
+                 launcher=SingleNodeLauncher(),
                  parallelism=1):
         self.project_id = project_id
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = key_file
@@ -100,19 +102,21 @@ class GoogleCloudProvider():
         self.max_blocks = max_blocks
         self.parallelism = parallelism
         self.num_instances = 0
+        self.launcher = launcher
 
         # Dictionary that keeps track of jobs, keyed on job_id
         self.resources = {}
         self.provisioned_blocks = 0
         atexit.register(self.bye)
 
-    def submit(self, command="", blocksize=1, job_name="parsl.auto"):
+    def submit(self, command, blocksize, tasks_per_node, job_name="parsl.auto"):
         ''' The submit method takes the command string to be executed upon
         instantiation of a resource most often to start a pilot.
 
         Args :
              - command (str) : The bash command string to be executed.
              - blocksize (int) : Blocksize to be requested
+             - tasks_per_node (int) : command invocations to be launched per node
 
         KWargs:
              - job_name (str) : Human friendly name to be assigned to the job request
@@ -123,7 +127,11 @@ class GoogleCloudProvider():
         Raises:
              - ExecutionProviderException or its subclasses
         '''
-        instance, name = self.create_instance(command=command)
+        wrapped_cmd = self.launcher(command,
+                                    tasks_per_node,
+                                    1)
+
+        instance, name = self.create_instance(command=wrapped_cmd)
         self.provisioned_blocks += 1
         self.resources[name] = {"job_id": name, "status": translate_table[instance['status']]}
         return name

--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -28,8 +28,6 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         :class:`~parsl.channels.LocalChannel` (the default),
         :class:`~parsl.channels.SSHChannel`, or
         :class:`~parsl.channels.SSHInteractiveLoginChannel`.
-    tasks_per_node : int
-        Tasks to run per node.
     nodes_per_block : int
         Nodes to provision per block.
     init_blocks : int
@@ -58,7 +56,6 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
                  image,
                  namespace='default',
                  channel=None,
-                 tasks_per_node=1,
                  nodes_per_block=1,
                  init_blocks=4,
                  min_blocks=0,
@@ -77,7 +74,6 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         self.namespace = namespace
         self.image = image
         self.channel = channel
-        self.tasks_per_node = tasks_per_node
         self.nodes_per_block = nodes_per_block
         self.init_blocks = init_blocks
         self.min_blocks = min_blocks
@@ -94,11 +90,13 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         # Dictionary that keeps track of jobs, keyed on job_id
         self.resources = {}
 
-    def submit(self, cmd_string, blocksize, job_name="parsl.auto"):
+    def submit(self, cmd_string, blocksize, tasks_per_node, job_name="parsl.auto"):
         """ Submit a job
         Args:
              - cmd_string  :(String) - Name of the container to initiate
              - blocksize   :(float) - Number of replicas
+             - tasks_per_node (int) : command invocations to be launched per node
+
         Kwargs:
              - job_name (String): Name for job, must be unique
         Returns:

--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -46,7 +46,6 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
 
     def __init__(self,
                  channel=LocalChannel(),
-                 tasks_per_node=1,
                  nodes_per_block=1,
                  launcher=SingleNodeLauncher(),
                  init_blocks=4,
@@ -58,7 +57,6 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
         self.label = 'local'
         self.provisioned_blocks = 0
         self.nodes_per_block = nodes_per_block
-        self.tasks_per_node = tasks_per_node
         self.launcher = launcher
         self.init_blocks = init_blocks
         self.min_blocks = min_blocks
@@ -127,7 +125,7 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
 
         return True
 
-    def submit(self, command, blocksize, job_name="parsl.auto"):
+    def submit(self, command, blocksize, tasks_per_node, job_name="parsl.auto"):
         ''' Submits the command onto an Local Resource Manager job of blocksize parallel elements.
         Submit returns an ID that corresponds to the task that was just submitted.
 
@@ -143,6 +141,7 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
         Args:
              - command  :(String) Commandline invocation to be made on the remote side.
              - blocksize   :(float) - Not really used for local
+             - tasks_per_node (int) : command invocations to be launched per node
 
         Kwargs:
              - job_name (String): Name for job, must be unique
@@ -159,7 +158,7 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
         script_path = "{0}/{1}.sh".format(self.script_dir, job_name)
         script_path = os.path.abspath(script_path)
 
-        wrap_command = self.launcher(command, self.tasks_per_node, self.nodes_per_block)
+        wrap_command = self.launcher(command, tasks_per_node, self.nodes_per_block)
 
         self._write_submit_script(wrap_command, script_path)
 
@@ -177,7 +176,6 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
         Returns :
         [True/False...] : If the cancel operation fails the entire list will be False.
         '''
-
         for job in job_ids:
             logger.debug("Terminating job/proc_id : {0}".format(job))
             # Here we are assuming that for local, the job_ids are the process id's

--- a/parsl/providers/provider_base.py
+++ b/parsl/providers/provider_base.py
@@ -23,14 +23,15 @@ class ExecutionProvider(metaclass=ABCMeta):
      """
 
     @abstractmethod
-    def submit(self, command, blocksize, job_name="parsl.auto"):
+    def submit(self, command, blocksize, tasks_per_node, job_name="parsl.auto"):
         ''' The submit method takes the command string to be executed upon
         instantiation of a resource most often to start a pilot (such as IPP engine
         or even Swift-T engines).
 
         Args :
-             - command (str) : The bash command string to be executed.
+             - command (str) : The bash command string to be executed
              - blocksize (int) : Blocksize to be requested
+             - tasks_per_node (int) : command invocations to be launched per node
 
         KWargs:
              - job_name (str) : Human friendly name to be assigned to the job request

--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -43,8 +43,6 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         :class:`~parsl.channels.SSHInteractiveLoginChannel`.
     nodes_per_block : int
         Nodes to provision per block.
-    tasks_per_node : int
-        Tasks to run per node.
     min_blocks : int
         Minimum number of blocks to maintain.
     max_blocks : int
@@ -70,7 +68,6 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
                  partition,
                  channel=LocalChannel(),
                  nodes_per_block=1,
-                 tasks_per_node=1,
                  init_blocks=1,
                  min_blocks=0,
                  max_blocks=10,
@@ -84,7 +81,6 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         super().__init__(label,
                          channel,
                          nodes_per_block,
-                         tasks_per_node,
                          init_blocks,
                          min_blocks,
                          max_blocks,
@@ -129,7 +125,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
             if self.resources[missing_job]['status'] in ['PENDING', 'RUNNING']:
                 self.resources[missing_job]['status'] = 'COMPLETED'
 
-    def submit(self, command, blocksize, job_name="parsl.auto"):
+    def submit(self, command, blocksize, tasks_per_node, job_name="parsl.auto"):
         """Submit the command as a slurm job of blocksize parallel elements.
 
         Parameters
@@ -138,9 +134,10 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
             Command to be made on the remote side.
         blocksize : int
             Not implemented.
+        tasks_per_node : int
+            Command invocations to be launched per node
         job_name : str
             Name for the job (must be unique).
-
         Returns
         -------
         None or str
@@ -161,7 +158,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         job_config = {}
         job_config["submit_script_dir"] = self.channel.script_dir
         job_config["nodes"] = self.nodes_per_block
-        job_config["tasks_per_node"] = self.tasks_per_node
+        job_config["tasks_per_node"] = tasks_per_node
         job_config["walltime"] = wtime_to_minutes(self.walltime)
         job_config["scheduler_options"] = self.scheduler_options
         job_config["worker_init"] = self.worker_init
@@ -170,7 +167,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
 
         # Wrap the command
         job_config["user_script"] = self.launcher(command,
-                                                  self.tasks_per_node,
+                                                  tasks_per_node,
                                                   self.nodes_per_block)
 
         logger.debug("Writing submit script")

--- a/parsl/providers/torque/torque.py
+++ b/parsl/providers/torque/torque.py
@@ -42,8 +42,6 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
         Torque queue to request blocks from.
     nodes_per_block : int
         Nodes to provision per block.
-    tasks_per_node : int
-        Tasks to run per node.
     init_blocks : int
         Number of blocks to provision at the start of the run. Default is 1.
     min_blocks : int
@@ -73,7 +71,6 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
                  scheduler_options='',
                  worker_init='',
                  nodes_per_block=1,
-                 tasks_per_node=1,
                  init_blocks=1,
                  min_blocks=0,
                  max_blocks=100,
@@ -84,7 +81,6 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
         super().__init__(label,
                          channel,
                          nodes_per_block,
-                         tasks_per_node,
                          init_blocks,
                          min_blocks,
                          max_blocks,
@@ -131,7 +127,7 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
             if self.resources[missing_job]['status'] in ['PENDING', 'RUNNING']:
                 self.resources[missing_job]['status'] = translate_table['E']
 
-    def submit(self, command, blocksize, job_name="parsl.auto"):
+    def submit(self, command, blocksize, tasks_per_node, job_name="parsl.auto"):
         ''' Submits the command onto an Local Resource Manager job of blocksize parallel elements.
         Submit returns an ID that corresponds to the task that was just submitted.
 
@@ -146,6 +142,7 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
         Args:
              - command  :(String) Commandline invocation to be made on the remote side.
              - blocksize   :(float)
+             - tasks_per_node (int) : command invocations to be launched per node
 
         Kwargs:
              - job_name (String): Name for job, must be unique
@@ -173,15 +170,15 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
         script_path = os.path.abspath(script_path)
 
         logger.debug("Requesting blocksize:%s nodes_per_block:%s tasks_per_node:%s", blocksize, self.nodes_per_block,
-                     self.tasks_per_node)
+                     tasks_per_node)
 
         job_config = {}
         # TODO : script_path might need to change to accommodate script dir set via channels
         job_config["submit_script_dir"] = self.channel.script_dir
         job_config["nodes"] = self.nodes_per_block
-        job_config["task_blocks"] = self.nodes_per_block * self.tasks_per_node
+        job_config["task_blocks"] = self.nodes_per_block * tasks_per_node
         job_config["nodes_per_block"] = self.nodes_per_block
-        job_config["tasks_per_node"] = self.tasks_per_node
+        job_config["tasks_per_node"] = tasks_per_node
         job_config["walltime"] = self.walltime
         job_config["scheduler_options"] = self.scheduler_options
         job_config["worker_init"] = self.worker_init
@@ -189,7 +186,7 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
 
         # Wrap the command
         job_config["user_script"] = self.launcher(command,
-                                                  self.tasks_per_node,
+                                                  tasks_per_node,
                                                   self.nodes_per_block)
 
         logger.debug("Writing submit script")

--- a/parsl/tests/configs/beagle_single_node.py
+++ b/parsl/tests/configs/beagle_single_node.py
@@ -26,6 +26,7 @@ config = Config(
     executors=[
         IPyParallelExecutor(
             label='beagle_multinode_mpi',
+            workers_per_node=1,
             provider=TorqueProvider(
                 'debug',
                 channel=SSHChannel(
@@ -34,7 +35,6 @@ config = Config(
                     script_dir="/lustre/beagle2/{}/parsl_scripts".format(user_opts['beagle']['username'])
                 ),
                 nodes_per_block=1,
-                tasks_per_node=1,
                 init_blocks=1,
                 max_blocks=1,
                 launcher=AprunLauncher(),

--- a/parsl/tests/configs/cc_in2p3_local_single_node.py
+++ b/parsl/tests/configs/cc_in2p3_local_single_node.py
@@ -24,10 +24,10 @@ config = Config(
     executors=[
         IPyParallelExecutor(
             label='cc_in2p3_local_single_node',
+            workers_per_node=1,
             provider=GridEngineProvider(
                 channel=LocalChannel(),
                 nodes_per_block=1,
-                tasks_per_node=1,
                 init_blocks=1,
                 max_blocks=1,
                 walltime="00:20:00",

--- a/parsl/tests/configs/comet_ipp_multinode.py
+++ b/parsl/tests/configs/comet_ipp_multinode.py
@@ -18,6 +18,7 @@ config = Config(
     executors=[
         IPyParallelExecutor(
             label='comet_ipp_multinode',
+            workers_per_node=1,
             provider=SlurmProvider(
                 'debug',
                 channel=SSHChannel(
@@ -32,7 +33,6 @@ config = Config(
                 init_blocks=1,
                 max_blocks=1,
                 nodes_per_block=2,
-                tasks_per_node=1,
             ),
             controller=Controller(public_ip=user_opts['public_ip']),
         )

--- a/parsl/tests/configs/cooley_local_single_node.py
+++ b/parsl/tests/configs/cooley_local_single_node.py
@@ -19,10 +19,10 @@ config = Config(
     executors=[
         IPyParallelExecutor(
             label='cooley_local_single_node',
+            workers_per_node=1,
             provider=CobaltProvider(
                 launcher=SingleNodeLauncher(),
                 nodes_per_block=1,
-                tasks_per_node=1,
                 init_blocks=1,
                 max_blocks=1,
                 walltime="00:05:00",

--- a/parsl/tests/configs/cooley_ssh-il_single_node.py
+++ b/parsl/tests/configs/cooley_ssh-il_single_node.py
@@ -17,6 +17,7 @@ config = Config(
     executors=[
         IPyParallelExecutor(
             label='cooley_ssh_il_local_single_node',
+            workers_per_node=1,
             provider=CobaltProvider(
                 channel=SSHInteractiveLoginChannel(
                     hostname='cooleylogin1.alcf.anl.gov',
@@ -24,7 +25,6 @@ config = Config(
                     script_dir="/home/{}/parsl_scripts/".format(user_opts['cooley']['username'])
                 ),
                 nodes_per_block=1,
-                tasks_per_node=1,
                 init_blocks=1,
                 max_blocks=1,
                 walltime="00:05:00",

--- a/parsl/tests/configs/cooley_ssh_il_single_node.py
+++ b/parsl/tests/configs/cooley_ssh_il_single_node.py
@@ -19,6 +19,7 @@ config = Config(
     executors=[
         IPyParallelExecutor(
             label='cooley_ssh_il_local_single_node',
+            workers_per_node=1,
             provider=CobaltProvider(
                 channel=SSHInteractiveLoginChannel(
                     hostname='cooley.alcf.anl.gov',
@@ -26,7 +27,6 @@ config = Config(
                     script_dir="/home/{}/parsl_scripts/".format(user_opts['cooley']['username'])
                 ),
                 nodes_per_block=1,
-                tasks_per_node=1,
                 init_blocks=1,
                 max_blocks=1,
                 walltime="00:05:00",

--- a/parsl/tests/configs/cori_ipp_multinode.py
+++ b/parsl/tests/configs/cori_ipp_multinode.py
@@ -29,6 +29,7 @@ config = Config(
     executors=[
         IPyParallelExecutor(
             label='cori_ipp_multinode',
+            workers_per_node=2,
             provider=SlurmProvider(
                 'debug',
                 channel=SSHChannel(
@@ -37,7 +38,6 @@ config = Config(
                     script_dir=user_opts['cori']['script_dir']
                 ),
                 nodes_per_block=2,
-                tasks_per_node=2,
                 init_blocks=1,
                 max_blocks=1,
                 scheduler_options=user_opts['cori']['scheduler_options'],

--- a/parsl/tests/configs/cori_ipp_single_node.py
+++ b/parsl/tests/configs/cori_ipp_single_node.py
@@ -26,6 +26,7 @@ config = Config(
     executors=[
         IPyParallelExecutor(
             label='cori_ipp_single_node',
+            workers_per_node=1,
             provider=SlurmProvider(
                 'debug',
                 channel=SSHChannel(
@@ -34,7 +35,6 @@ config = Config(
                     script_dir=user_opts['cori']['script_dir']
                 ),
                 nodes_per_block=1,
-                tasks_per_node=1,
                 init_blocks=1,
                 max_blocks=1,
                 scheduler_options=user_opts['cori']['scheduler_options'],

--- a/parsl/tests/configs/ec2_bad_spot.py
+++ b/parsl/tests/configs/ec2_bad_spot.py
@@ -15,6 +15,7 @@ config = Config(
     executors=[
         IPyParallelExecutor(
             label='ec2_bad_spot',
+            workers_per_node=1,
             provider=AWSProvider(
                 user_opts['ec2']['image_id'],
                 region=user_opts['ec2']['region'],
@@ -23,7 +24,6 @@ config = Config(
                 state_file='awsproviderstate.json',
                 spot_max_bid='0.001',
                 nodes_per_block=1,
-                tasks_per_node=1,
                 init_blocks=1,
                 max_blocks=1,
                 min_blocks=0,

--- a/parsl/tests/configs/ec2_single_node.py
+++ b/parsl/tests/configs/ec2_single_node.py
@@ -29,6 +29,7 @@ config = Config(
     executors=[
         IPyParallelExecutor(
             label='ec2_single_node',
+            workers_per_node=2,
             provider=AWSProvider(
                 user_opts['ec2']['image_id'],
                 region=user_opts['ec2']['region'],
@@ -36,7 +37,6 @@ config = Config(
                 profile="default",
                 state_file='awsproviderstate.json',
                 nodes_per_block=1,
-                tasks_per_node=2,
                 init_blocks=1,
                 max_blocks=1,
                 min_blocks=0,

--- a/parsl/tests/configs/ec2_spot.py
+++ b/parsl/tests/configs/ec2_spot.py
@@ -23,7 +23,6 @@ config = Config(
                 state_file='awsproviderstate.json',
                 spot_max_bid='1.0',
                 nodes_per_block=1,
-                tasks_per_node=1,
                 init_blocks=1,
                 max_blocks=1,
                 min_blocks=0,

--- a/parsl/tests/configs/exex_local.py
+++ b/parsl/tests/configs/exex_local.py
@@ -10,11 +10,12 @@ config = Config(
         ExtremeScaleExecutor(
             label="Extreme_Local",
             worker_debug=True,
+            ranks_per_node=4,
             provider=LocalProvider(
                 channel=LocalChannel(),
                 init_blocks=1,
                 max_blocks=1,
-                tasks_per_node=4,
+                # tasks_per_node=4,
                 launcher=SimpleLauncher(),
             )
         )

--- a/parsl/tests/configs/exex_local.py
+++ b/parsl/tests/configs/exex_local.py
@@ -15,7 +15,6 @@ config = Config(
                 channel=LocalChannel(),
                 init_blocks=1,
                 max_blocks=1,
-                # tasks_per_node=4,
                 launcher=SimpleLauncher(),
             )
         )

--- a/parsl/tests/configs/htex_local.py
+++ b/parsl/tests/configs/htex_local.py
@@ -15,7 +15,7 @@ config = Config(
                 channel=LocalChannel(),
                 init_blocks=1,
                 max_blocks=1,
-                tasks_per_node=1,  # For HighThroughputExecutor, this option should in most cases be 1
+                # tasks_per_node=1,  # For HighThroughputExecutor, this option should in most cases be 1
                 launcher=SimpleLauncher(),
             ),
         )

--- a/parsl/tests/configs/htex_local.py
+++ b/parsl/tests/configs/htex_local.py
@@ -15,7 +15,6 @@ config = Config(
                 channel=LocalChannel(),
                 init_blocks=1,
                 max_blocks=1,
-                # tasks_per_node=1,  # For HighThroughputExecutor, this option should in most cases be 1
                 launcher=SimpleLauncher(),
             ),
         )

--- a/parsl/tests/configs/local_ipp_multisite.py
+++ b/parsl/tests/configs/local_ipp_multisite.py
@@ -14,7 +14,6 @@ config = Config(
             engine_dir='engines',
             provider=LocalProvider(
                 nodes_per_block=1,
-                tasks_per_node=1,
                 walltime="00:15:00",
                 init_blocks=4,
             )
@@ -24,7 +23,6 @@ config = Config(
             engine_dir='engines',
             provider=LocalProvider(
                 nodes_per_block=1,
-                tasks_per_node=1,
                 walltime="00:15:00",
                 init_blocks=2,
             )

--- a/parsl/tests/configs/local_threads_ipp.py
+++ b/parsl/tests/configs/local_threads_ipp.py
@@ -16,10 +16,10 @@ config = Config(
         IPyParallelExecutor(
             label='local_ipp',
             engine_dir='engines',
+            workers_per_node=1,
             provider=LocalProvider(
                 walltime="00:05:00",
                 nodes_per_block=1,
-                tasks_per_node=1,
                 init_blocks=4
             )
         )

--- a/parsl/tests/configs/midway_ipp_multicore.py
+++ b/parsl/tests/configs/midway_ipp_multicore.py
@@ -18,6 +18,7 @@ config = Config(
     executors=[
         IPyParallelExecutor(
             label='midway_ipp_multicore',
+            workers_per_node=4,
             provider=SlurmProvider(
                 'westmere',
                 channel=SSHChannel(
@@ -28,7 +29,6 @@ config = Config(
                 scheduler_options=user_opts['midway']['scheduler_options'],
                 worker_init=user_opts['midway']['worker_init'],
                 nodes_per_block=1,
-                tasks_per_node=4,
                 walltime="00:05:00",
                 init_blocks=1,
                 max_blocks=1,

--- a/parsl/tests/configs/midway_ipp_multinode.py
+++ b/parsl/tests/configs/midway_ipp_multinode.py
@@ -32,7 +32,6 @@ config = Config(
                 init_blocks=1,
                 max_blocks=1,
                 nodes_per_block=2,
-                tasks_per_node=1,
             ),
             controller=Controller(public_ip=user_opts['public_ip']),
         )

--- a/parsl/tests/configs/osg_ipp_multinode.py
+++ b/parsl/tests/configs/osg_ipp_multinode.py
@@ -23,7 +23,6 @@ config = Config(
                     script_dir=user_opts['osg']['script_dir']
                 ),
                 nodes_per_block=1,
-                tasks_per_node=1,
                 init_blocks=4,
                 max_blocks=4,
                 scheduler_options='Requirements = OSGVO_OS_STRING == "RHEL 6" && Arch == "X86_64" &&  HAS_MODULES == True',

--- a/parsl/tests/configs/swan_ipp.py
+++ b/parsl/tests/configs/swan_ipp.py
@@ -33,7 +33,6 @@ config = Config(
                     script_dir=user_opts['swan']['script_dir'],
                 ),
                 nodes_per_block=1,
-                tasks_per_node=1,
                 init_blocks=1,
                 max_blocks=1,
                 launcher=AprunLauncher(),

--- a/parsl/tests/configs/swan_ipp_multinode.py
+++ b/parsl/tests/configs/swan_ipp_multinode.py
@@ -30,6 +30,7 @@ config = Config(
     executors=[
         IPyParallelExecutor(
             label='swan_ipp',
+            workers_per_node=2,
             provider=TorqueProvider(
                 channel=SSHChannel(
                     hostname='swan.cray.com',
@@ -37,7 +38,6 @@ config = Config(
                     script_dir=user_opts['swan']['script_dir'],
                 ),
                 nodes_per_block=2,
-                tasks_per_node=2,
                 init_blocks=1,
                 max_blocks=1,
                 launcher=AprunLauncher(),

--- a/parsl/tests/configs/theta_local_ipp_multinode.py
+++ b/parsl/tests/configs/theta_local_ipp_multinode.py
@@ -17,12 +17,12 @@ config = Config(
     executors=[
         IPyParallelExecutor(
             label='theta_local_ipp_multinode',
+            workers_per_node=1,
             provider=CobaltProvider(
                 queue="debug-flat-quad",
                 launcher=AprunLauncher(),
                 walltime="00:30:00",
                 nodes_per_block=2,
-                tasks_per_node=1,
                 init_blocks=1,
                 max_blocks=1,
                 scheduler_options=user_opts['theta']['scheduler_options'],

--- a/parsl/tests/manual_tests/htex_local.py
+++ b/parsl/tests/manual_tests/htex_local.py
@@ -16,10 +16,10 @@ config = Config(
                 channel=LocalChannel(),
                 init_blocks=1,
                 max_blocks=1,
-                tasks_per_node=1,  # For HighThroughputExecutor, this option should in most cases be 1
+                # tasks_per_node=1,  # For HighThroughputExecutor, this option should in most cases be 1
                 launcher=SingleNodeLauncher(),
             ),
         )
     ],
-    # strategy=None,
+    strategy=None,
 )

--- a/parsl/tests/manual_tests/test_basic.py
+++ b/parsl/tests/manual_tests/test_basic.py
@@ -3,7 +3,7 @@ import time
 
 import parsl
 # Tested. Confirmed. Local X Local X SingleNodeLauncher
-# from parsl.tests.configs.local_ipp import config
+from parsl.tests.configs.local_ipp import config
 
 # Tested. Confirmed. ssh X Slurm X SingleNodeLauncher
 # from parsl.tests.configs.midway_ipp import config
@@ -38,8 +38,7 @@ import parsl
 
 # from parsl.tests.configs.comet_ipp_multinode import config
 
-# from mpix_local import config
-from parsl.tests.configs.htex_local import config
+# from parsl.tests.configs.htex_local import config
 # from parsl.tests.configs.exex_local import config
 parsl.set_stream_logger()
 


### PR DESCRIPTION
This PR moves the `tasks_per_node` kwarg from the provider definition to the executors so as to add flexibility in how worker counts can be specified by the user. The executors now call provider.submit() with the `tasks_per_node` kwarg at runtime.

Fixes #557 

This PR requires extensive testing and updates to example configs. I'm putting this up for review while testing is going on in parallel.