### PR TITLE
Pip all option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setup(
     extras_require = {
         'db_logging' : ['CMRESHandler', 'psutil', 'sqlalchemy'],
         'aws' : ['boto3'],
-        'jetstream' : ['python-novaclient'],
+        # Jetstream is deprecated since the interface has not been maintained.
+        # 'jetstream' : ['python-novaclient'],
         'extreme_scale' : ['mpi4py'],
         'docs' : ['nbsphinx', 'sphinx_rtd_theme'],
         'google_cloud' : ['google-auth', 'google-api-python-client']

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,13 @@ setup(
         # 'jetstream' : ['python-novaclient'],
         'extreme_scale' : ['mpi4py'],
         'docs' : ['nbsphinx', 'sphinx_rtd_theme'],
-        'google_cloud' : ['google-auth', 'google-api-python-client']
+        'google_cloud' : ['google-auth', 'google-api-python-client'],
+        'all' : ['CMRESHandler', 'psutil', 'sqlalchemy',
+                 'boto3',
+                 'mpi4py',
+                 'nbsphinx', 'sphinx_rtd_theme',
+                 'google-auth', 'google-api-python-client']
+
         },
     classifiers = [
         # Maturity


### PR DESCRIPTION
Fixes #665 

Please note that python-novaclient required for jetstream is removed from setup since it isn't maintained.