### PR TITLE
Renaming parsl-visualize to visualize and adding extras to 'all'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     scripts = ['parsl/executors/high_throughput/process_worker_pool.py',
                'parsl/executors/extreme_scale/mpi_worker_pool.py'],
     extras_require = {
-        'parsl-visualize': ['dash', 'dash-html-components', 'dash-core-components', 'pandas'],
+        'visualize': ['dash', 'dash-html-components', 'dash-core-components', 'pandas'],
         'db_logging' : ['CMRESHandler', 'psutil', 'sqlalchemy'],
         'aws' : ['boto3'],
         # Jetstream is deprecated since the interface has not been maintained.
@@ -31,6 +31,7 @@ setup(
         'docs' : ['nbsphinx', 'sphinx_rtd_theme'],
         'google_cloud' : ['google-auth', 'google-api-python-client'],
         'all' : ['CMRESHandler', 'psutil', 'sqlalchemy',
+                 'dash', 'dash-html-components', 'dash-core-components', 'pandas'],
                  'boto3',
                  'mpi4py',
                  'nbsphinx', 'sphinx_rtd_theme',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'docs' : ['nbsphinx', 'sphinx_rtd_theme'],
         'google_cloud' : ['google-auth', 'google-api-python-client'],
         'all' : ['CMRESHandler', 'psutil', 'sqlalchemy',
-                 'dash', 'dash-html-components', 'dash-core-components', 'pandas'],
+                 'dash', 'dash-html-components', 'dash-core-components', 'pandas',
                  'boto3',
                  'mpi4py',
                  'nbsphinx', 'sphinx_rtd_theme',


### PR DESCRIPTION
Renames the pip optional extra keyword from parsl-visualize -> visualize
Adds visualize options to "all" keyword