### PR TITLE
Record exclusive parameter for RepresentationMixin

### DIFF
--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -93,6 +93,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
                          launcher=launcher)
 
         self.partition = partition
+        self.exclusive = exclusive
         if exclusive:
             self.scheduler_options = "#SBATCH --exclusive\n" + scheduler_options
         else:


### PR DESCRIPTION
Without this, SlurmProviders cannot be printed at
startup, with the below exception.

```
...
  File "/global/homes/b/bxc/.conda/envs/parsl-imsim-nov2018/lib/python3.6/site-packages/parsl/utils.py", line 187, in __repr__
    raise AttributeError(template.format(self.__class__.__name__, arg))
AttributeError: class SlurmProvider uses exclusive in the constructor, but does not define it as an attribute
```
