### PR TITLE
Ad hoc cluster #670

### DIFF
--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -224,15 +224,16 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
         for job in job_ids:
             logger.debug("Terminating job/proc_id : {0}".format(job))
             # Here we are assuming that for local, the job_ids are the process id's
-            if self.resouces[job]['proc'] :
+            if self.resources[job]['proc'] :
                 proc = self.resources[job]['proc']
                 os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
                 self.resources[job]['status'] = 'CANCELLED'
-            elif self.resource[job]['remote_pid']:
-                cmd = "kill -- -$(ps -o pgid={} | grep -o '[0-9]*')".format(self.resource[job]['remote_pid'])
+
+            elif self.resources[job]['remote_pid']:
+                cmd = "kill -- -$(ps -o pgid={} | grep -o '[0-9]*')".format(self.resources[job]['remote_pid'])
                 retcode, stdout, stderr = self.channel.execute_wait(cmd, self.cmd_timeout)
                 if retcode != 0:
-                    logger.warning("Failed to kill PID:{} and child processes on {}".format(self.resource[job]['remote_pid'],
+                    logger.warning("Failed to kill PID:{} and child processes on {}".format(self.resources[job]['remote_pid'],
                                                                                             self.label))
 
         rets = [True for i in job_ids]

--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -224,7 +224,7 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
         for job in job_ids:
             logger.debug("Terminating job/proc_id : {0}".format(job))
             # Here we are assuming that for local, the job_ids are the process id's
-            if self.resources[job]['proc'] :
+            if self.resources[job]['proc']:
                 proc = self.resources[job]['proc']
                 os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
                 self.resources[job]['status'] = 'CANCELLED'

--- a/parsl/tests/configs/htex_ad_hoc_cluster.py
+++ b/parsl/tests/configs/htex_ad_hoc_cluster.py
@@ -1,6 +1,5 @@
 from parsl.providers import LocalProvider
 from parsl.channels import SSHChannel
-from parsl.launchers import SingleNodeLauncher
 from parsl.executors import HighThroughputExecutor
 
 from parsl.config import Config

--- a/parsl/tests/configs/htex_ad_hoc_cluster.py
+++ b/parsl/tests/configs/htex_ad_hoc_cluster.py
@@ -1,0 +1,30 @@
+from parsl.providers import LocalProvider
+from parsl.channels import SSHChannel
+from parsl.launchers import SingleNodeLauncher
+from parsl.executors import HighThroughputExecutor
+
+from parsl.config import Config
+
+username = "yadunand"
+remotes = ['midway2-login1.rcc.uchicago.edu', 'midway2-login2.rcc.uchicago.edu']
+
+config = Config(
+    executors=[
+        HighThroughputExecutor(
+            label='remote_ipp_{}'.format(m),
+            cores_per_worker=4,
+            worker_debug=False,
+            address="128.135.112.73",
+            provider=LocalProvider(
+                init_blocks=1,
+                nodes_per_block=1,
+                parallelism=0.5,
+                worker_init="source /scratch/midway2/yadunand/parsl_env_setup.sh",
+                channel=SSHChannel(hostname=m,
+                                   username=username,
+                                   script_dir="/scratch/midway2/{}/parsl_tests/".format(username)
+                )
+            )
+        ) for m in remotes
+    ],
+)

--- a/parsl/tests/configs/htex_ad_hoc_cluster.py
+++ b/parsl/tests/configs/htex_ad_hoc_cluster.py
@@ -10,7 +10,7 @@ remotes = ['midway2-login1.rcc.uchicago.edu', 'midway2-login2.rcc.uchicago.edu']
 config = Config(
     executors=[
         HighThroughputExecutor(
-            label='remote_ipp_{}'.format(m),
+            label='remote_htex_{}'.format(m),
             cores_per_worker=4,
             worker_debug=False,
             address="128.135.112.73",

--- a/parsl/tests/configs/ipp_ad_hoc_cluster.py
+++ b/parsl/tests/configs/ipp_ad_hoc_cluster.py
@@ -1,6 +1,5 @@
 from parsl.providers import LocalProvider
 from parsl.channels import SSHChannel
-from parsl.launchers import SingleNodeLauncher
 from parsl.executors.ipp_controller import Controller
 from parsl.executors.ipp import IPyParallelExecutor
 

--- a/parsl/tests/configs/ipp_ad_hoc_cluster.py
+++ b/parsl/tests/configs/ipp_ad_hoc_cluster.py
@@ -1,0 +1,31 @@
+from parsl.providers import LocalProvider
+from parsl.channels import SSHChannel
+from parsl.launchers import SingleNodeLauncher
+from parsl.executors.ipp_controller import Controller
+from parsl.executors.ipp import IPyParallelExecutor
+
+from parsl.config import Config
+
+username = "yadunand"
+remotes = ['midway2-login1.rcc.uchicago.edu', 'midway2-login2.rcc.uchicago.edu']
+
+config = Config(
+    executors=[
+        IPyParallelExecutor(
+            label='remote_ipp_{}'.format(m),
+            workers_per_node=2,  # Replaces provider.tasks_per_node
+            engine_debug_level="DEBUG",
+            controller=Controller(public_ip="128.135.112.73"),
+            provider=LocalProvider(
+                init_blocks=1,
+                nodes_per_block=1,
+                parallelism=0.5,
+                worker_init="source /scratch/midway2/yadunand/parsl_env_setup.sh",
+                channel=SSHChannel(hostname=m,
+                                   username=username,
+                                   script_dir="/scratch/midway2/{}/parsl_tests/".format(username)
+                )
+            ),
+        ) for m in remotes
+    ],
+)


### PR DESCRIPTION
The LocalProvider was not generalized enough to work with both the local and ssh channels.

This PR adds support for the LocalProvider + SSHChannel combination allowing users to launch pilots on ad-hoc clusters. There are still issues with cancelling remote workers due to issues with killing nested process trees safely. For now, ipp workers will timeout in a few minutes and cleanup automatically while HTEX workers linger around.

PR also adds example configs.

Fixes #670 