### PR TITLE
Attempt to enforce the presence of a label on ExecutionProviders

### DIFF
--- a/parsl/providers/aws/aws.py
+++ b/parsl/providers/aws/aws.py
@@ -117,7 +117,7 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
             raise OptionalModuleMissing(['boto3'], "AWS Provider requires the boto3 module.")
 
         self.image_id = image_id
-        self.label = 'ec2'
+        self._label = 'ec2'
         self.init_blocks = init_blocks
         self.min_blocks = min_blocks
         self.max_blocks = max_blocks
@@ -691,6 +691,10 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
     @property
     def scaling_enabled(self):
         return True
+
+    @property
+    def label(self):
+        return self._label
 
     @property
     def current_capacity(self):

--- a/parsl/providers/cluster_provider.py
+++ b/parsl/providers/cluster_provider.py
@@ -58,7 +58,7 @@ class ClusterProvider(ExecutionProvider):
                  cmd_timeout=10):
 
         self._scaling_enabled = True
-        self.label = label
+        self._label = label
         self.channel = channel
         self.nodes_per_block = nodes_per_block
         self.init_blocks = init_blocks
@@ -199,3 +199,7 @@ class ClusterProvider(ExecutionProvider):
         { minsize, maxsize, current_requested }
         """
         return self.provisioned_blocks
+
+    @property
+    def label(self):
+        return self._label

--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -272,3 +272,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
     @property
     def channels_required(self):
         return False
+
+    @property
+    def label(self):
+        return "kubernetes"

--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -56,7 +56,7 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
                  cmd_timeout=30,
                  parallelism=1):
         self.channel = channel
-        self.label = 'local'
+        self._label = 'local'
         self.provisioned_blocks = 0
         self.nodes_per_block = nodes_per_block
         self.launcher = launcher
@@ -246,6 +246,10 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
     @property
     def current_capacity(self):
         return len(self.resources)
+
+    @property
+    def label(self):
+        return self._label
 
 
 if __name__ == "__main__":

--- a/parsl/providers/provider_base.py
+++ b/parsl/providers/provider_base.py
@@ -90,3 +90,8 @@ class ExecutionProvider(metaclass=ABCMeta):
         '''
 
         pass
+
+    @abstractproperty
+    def label(self):
+        ''' Provides the label for this provider '''
+        pass


### PR DESCRIPTION
Previously, there was no requirement that an ExecutionProvider have
a label, yet some code assumes there always is a label.

This modifies all providers which are ExecutionProviders to have
such a property (although I have not tested them all).

Some providers in this directory are not ExecutionProviders, and I
have not touched those: googlecloud, jetstream.

This commit also introduces a potential bugfix when using the kubernetes
provider, which did not implement a label property.

This commit makes mypy happy that labels are used properly.