### PR TITLE
Yadu htex linger

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,5 +13,5 @@
 # https://github.com/PyCQA/pycodestyle/issues/386
 # W504: Raised by flake8 even when it is followed
 ignore = D203, E124, E126, F403, F405, F811, E402, E129, W605, W504
-max-line-length = 160
+max-line-length = 300
 exclude = parsl/executors/serialize/, test_import_fail.py

--- a/parsl/executors/extreme_scale/executor.py
+++ b/parsl/executors/extreme_scale/executor.py
@@ -107,6 +107,15 @@ class ExtremeScaleExecutor(HighThroughputExecutor, RepresentationMixin):
 
     ranks_per_node : int
         Specify the ranks to be launched per node.
+
+    heartbeat_threshold : int
+        Seconds since the last message from the counterpart in the communication pair:
+        (interchange, manager) after which the counterpart is assumed to be un-available. Default:120s
+
+    heartbeat_period : int
+        Number of seconds after which a heartbeat message indicating liveness is sent to the
+        counterpart (interchange, manager). Default:30s
+
     """
 
     def __init__(self,
@@ -121,6 +130,8 @@ class ExtremeScaleExecutor(HighThroughputExecutor, RepresentationMixin):
                  working_dir=None,
                  worker_debug=False,
                  ranks_per_node=1,
+                 heartbeat_threshold=120,
+                 heartbeat_period=30,
                  managed=True):
 
         super().__init__(label=label,
@@ -133,6 +144,8 @@ class ExtremeScaleExecutor(HighThroughputExecutor, RepresentationMixin):
                          storage_access=storage_access,
                          working_dir=working_dir,
                          worker_debug=worker_debug,
+                         heartbeat_threshold=heartbeat_threshold,
+                         heartbeat_period=heartbeat_period,
                          managed=managed)
 
         if not _mpi_enabled:
@@ -146,7 +159,7 @@ class ExtremeScaleExecutor(HighThroughputExecutor, RepresentationMixin):
         logger.debug("Initializing ExtremeScaleExecutor")
 
         if not launch_cmd:
-            self.launch_cmd = """mpiexec -np {ranks_per_node} mpi_worker_pool.py {debug} --task_url={task_url} --result_url={result_url} --logdir={logdir}"""
+            self.launch_cmd = """mpiexec -np {ranks_per_node} mpi_worker_pool.py {debug} --task_url={task_url} --result_url={result_url} --logdir={logdir} --hb_period={heartbeat_period} --hb_threshold={heartbeat_threshold}"""
         self.worker_debug = worker_debug
 
     def initialize_scaling(self):
@@ -159,6 +172,8 @@ class ExtremeScaleExecutor(HighThroughputExecutor, RepresentationMixin):
                                        # This is here only to support the exex mpiexec call
                                        ranks_per_node=self.ranks_per_node,
                                        nodes_per_block=self.provider.nodes_per_block,
+                                       heartbeat_period=self.heartbeat_period,
+                                       heartbeat_threshold=self.heartbeat_threshold,
                                        logdir="{}/{}".format(self.run_dir, self.label))
         self.launch_cmd = l_cmd
         logger.debug("Launch command: {}".format(self.launch_cmd))

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -105,6 +105,14 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
     cores_per_worker : float
         cores to be assigned to each worker. Oversubscription is possible
         by setting cores_per_worker < 1.0. Default=1
+
+    heartbeat_threshold : int
+        Seconds since the last message from the counterpart in the communication pair:
+        (interchange, manager) after which the counterpart is assumed to be un-available. Default:120s
+
+    heartbeat_period : int
+        Number of seconds after which a heartbeat message indicating liveness is sent to the
+        counterpart (interchange, manager). Default:30s
     """
 
     def __init__(self,
@@ -119,6 +127,8 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                  working_dir=None,
                  worker_debug=False,
                  cores_per_worker=1.0,
+                 heartbeat_threshold=120,
+                 heartbeat_period=30,
                  managed=True):
 
         logger.debug("Initializing HighThroughputExecutor")
@@ -141,10 +151,12 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         self.worker_ports = worker_ports
         self.worker_port_range = worker_port_range
         self.interchange_port_range = interchange_port_range
+        self.heartbeat_threshold = heartbeat_threshold
+        self.heartbeat_period = heartbeat_period
         self.run_dir = '.'
 
         if not launch_cmd:
-            self.launch_cmd = """process_worker_pool.py {debug} -c {cores_per_worker} --task_url={task_url} --result_url={result_url} --logdir={logdir}"""
+            self.launch_cmd = """process_worker_pool.py {debug} -c {cores_per_worker} --task_url={task_url} --result_url={result_url} --logdir={logdir} --hb_period={heartbeat_period} --hb_threshold={heartbeat_threshold}"""
 
     def initialize_scaling(self):
         """ Compose the launch command and call the scale_out
@@ -158,6 +170,8 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                                        result_url=self.worker_result_url,
                                        cores_per_worker=self.cores_per_worker,
                                        nodes_per_block=self.provider.nodes_per_block,
+                                       heartbeat_period=self.heartbeat_period,
+                                       heartbeat_threshold=self.heartbeat_threshold,
                                        logdir="{}/{}".format(self.run_dir, self.label))
         self.launch_cmd = l_cmd
         logger.debug("Launch command: {}".format(self.launch_cmd))
@@ -319,6 +333,8 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                                           "worker_ports": self.worker_ports,
                                           "worker_port_range": self.worker_port_range,
                                           "logdir": "{}/{}".format(self.run_dir, self.label),
+                                          "heartbeat_period": self.heartbeat_period,
+                                          "heartbeat_threshold": self.heartbeat_threshold,
                                           "logging_level": logging.DEBUG if self.worker_debug else logging.INFO
                                   },
         )

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -52,6 +52,7 @@ class Manager(object):
                  max_queue_size=10,
                  cores_per_worker=1,
                  uid=None,
+                 heartbeat_threshold=120,
                  heartbeat_period=30):
         """
         Parameters
@@ -66,16 +67,30 @@ class Manager(object):
              cores to be assigned to each worker. Oversubscription is possible
              by setting cores_per_worker < 1.0. Default=1
 
+        heartbeat_threshold : int
+             Seconds since the last message from the interchange after which the
+             interchange is assumed to be un-available, and the manager initiates shutdown. Default:120s
+
+             Number of seconds since the last message from the interchange after which the worker
+             assumes that the interchange is lost and the manager shuts down. Default:120
+
+        heartbeat_period : int
+             Number of seconds after which a heartbeat message is sent to the interchange
+
         """
         logger.info("Manager started")
 
         self.context = zmq.Context()
         self.task_incoming = self.context.socket(zmq.DEALER)
         self.task_incoming.setsockopt(zmq.IDENTITY, uid.encode('utf-8'))
+        # Linger is set to 0, so that the manager can exit even when there might be
+        # messages in the pipe
+        self.task_incoming.setsockopt(zmq.LINGER, 0)
         self.task_incoming.connect(task_q_url)
 
         self.result_outgoing = self.context.socket(zmq.DEALER)
         self.result_outgoing.setsockopt(zmq.IDENTITY, uid.encode('utf-8'))
+        self.result_outgoing.setsockopt(zmq.LINGER, 0)
         self.result_outgoing.connect(result_q_url)
         logger.info("Manager connected")
 
@@ -94,6 +109,7 @@ class Manager(object):
         self.tasks_per_round = 1
 
         self.heartbeat_period = heartbeat_period
+        self.heartbeat_threshold = heartbeat_threshold
 
     def create_reg_message(self):
         """ Creates a registration message to identify the worker to the interchange
@@ -134,6 +150,7 @@ class Manager(object):
         logger.debug("Sending registration message: {}".format(msg))
         self.task_incoming.send(msg)
         last_beat = time.time()
+        last_interchange_contact = time.time()
         task_recv_counter = 0
 
         poll_timer = 1
@@ -161,10 +178,16 @@ class Manager(object):
                 poll_timer = 1
                 _, pkl_msg = self.task_incoming.recv_multipart()
                 tasks = pickle.loads(pkl_msg)
+                last_interchange_contact = time.time()
+
                 if tasks == 'STOP':
                     logger.critical("[TASK_PULL_THREAD] Received stop request")
                     kill_event.set()
                     break
+
+                elif tasks == HEARTBEAT_CODE:
+                    logger.debug("Got heartbeat from interchange")
+
                 else:
                     task_recv_counter += len(tasks)
                     logger.debug("[TASK_PULL_THREAD] Got tasks: {} of {}".format([t['task_id'] for t in tasks],
@@ -174,11 +197,19 @@ class Manager(object):
                         self.pending_task_queue.put(task)
                         # logger.debug("[TASK_PULL_THREAD] Ready tasks: {}".format(
                         #    [i['task_id'] for i in self.pending_task_queue]))
+
             else:
                 logger.debug("[TASK_PULL_THREAD] No incoming tasks")
                 # Limit poll duration to heartbeat_period
                 # heartbeat_period is in s vs poll_timer in ms
                 poll_timer = min(self.heartbeat_period * 1000, poll_timer * 2)
+
+                # Only check if no messages were received.
+                if time.time() > last_interchange_contact + self.heartbeat_threshold:
+                    logger.critical("[TASK_PULL_THREAD] Missing contact with interchange beyond heartbeat_threshold")
+                    kill_event.set()
+                    logger.critical("[TASK_PULL_THREAD] Exiting")
+                    break
 
     def push_results(self, kill_event):
         """ Listens on the pending_result_queue and sends out results via 0mq
@@ -212,6 +243,8 @@ class Manager(object):
             except Exception as e:
                 logger.exception("[RESULT_PUSH_THREAD] Got an exception: {}".format(e))
 
+        logger.critical("[RESULT_PUSH_THREAD] Exiting")
+
     def start(self):
         """ Start the worker processes.
 
@@ -230,6 +263,7 @@ class Manager(object):
                                                          ))
             p.start()
             self.procs[worker_id] = p
+
         logger.debug("Manager synced with workers")
 
         self._task_puller_thread = threading.Thread(target=self.pull_tasks,
@@ -239,23 +273,28 @@ class Manager(object):
         self._task_puller_thread.start()
         self._result_pusher_thread.start()
 
-        abort_flag = False
-
         logger.info("Loop start")
 
         # TODO : Add mechanism in this loop to stop the worker pool
         # This might need a multiprocessing event to signal back.
-        while not abort_flag:
+        while not self._kill_event.is_set():
             time.sleep(0.1)
+        logger.critical("[MAIN] Received kill event, terminating worker processes")
 
+        self._task_puller_thread.join()
+        self._result_pusher_thread.join()
         for proc_id in self.procs:
             self.procs[proc_id].terminate()
+            self.procs[proc_id].join()
+            logger.critical("Terminating worker {}:{}".format(self.procs[proc_id],
+                                                              self.procs[proc_id].is_alive()))
 
-        # self._task_puller_thread.join()
-        # self._result_pusher_thread.join()
+        self.task_incoming.close()
+        self.result_outgoing.close()
+        self.context.term()
         delta = time.time() - start
         logger.info("process_worker_pool ran for {} seconds".format(delta))
-        sys.exit(0)
+        return
 
 
 def execute_task(bufs):
@@ -406,6 +445,10 @@ if __name__ == "__main__":
                         help="Number of cores assigned to each worker process. Default=1.0")
     parser.add_argument("-t", "--task_url", required=True,
                         help="REQUIRED: ZMQ url for receiving tasks")
+    parser.add_argument("--hb_period", default=None,
+                        help="Heartbeat period in seconds. Uses manager default unless set")
+    parser.add_argument("--hb_threshold", default=None,
+                        help="Heartbeat threshold in seconds. Uses manager default unless set")
     parser.add_argument("-r", "--result_url", required=True,
                         help="REQUIRED: ZMQ url for posting results")
 
@@ -421,6 +464,7 @@ if __name__ == "__main__":
                           0,
                           level=logging.DEBUG if args.debug is True else logging.INFO)
 
+        set_stream_logger()
         logger.info("Python version: {}".format(sys.version))
         logger.info("Debug logging: {}".format(args.debug))
         logger.info("Log dir: {}".format(args.logdir))
@@ -429,15 +473,23 @@ if __name__ == "__main__":
         logger.info("task_url: {}".format(args.task_url))
         logger.info("result_url: {}".format(args.result_url))
 
+        optionals = {}
+        if args.hb_period:
+            optionals['heartbeat_period'] = int(args.hb_period)
+        if args.hb_threshold:
+            optionals['heartbeat_threshold'] = int(args.hb_threshold)
+
         manager = Manager(task_q_url=args.task_url,
                           result_q_url=args.result_url,
                           uid=args.uid,
-                          cores_per_worker=float(args.cores_per_worker))
+                          cores_per_worker=float(args.cores_per_worker),
+                          **optionals)
         manager.start()
+
     except Exception as e:
         logger.critical("process_worker_pool exiting from an exception")
         logger.exception("Caught error: {}".format(e))
         raise
     else:
         logger.info("process_worker_pool exiting")
-        print("PROCESS_WORKER_POOL exiting.")
+        print("PROCESS_WORKER_POOL exiting")


### PR DESCRIPTION
This PR allows for the managers to determine liveness of the interchange via heartbeats and adds support for configuring the duration after which the managers should abort.

Includes fixes that improve manager exit handling w.r.t ZMQ linger behavior.

We should have this go into 0.7.0 a0