### PR TITLE
Fair task distribution

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -5,6 +5,7 @@ import zmq
 import os
 import sys
 import platform
+import random
 import time
 import pickle
 import logging
@@ -331,7 +332,9 @@ class Interchange(object):
                         self._ready_manager_queue[manager]['free_capacity'] = tasks_requested
 
             # If we had received any requests, check if there are tasks that could be passed
-            for manager in self._ready_manager_queue:
+            shuffled_managers = random.shuffle(list(self._ready_manager_queue.keys()))
+            # for manager in self._ready_manager_queue:
+            for manager in shuffled_managers:
                 if (self._ready_manager_queue[manager]['free_capacity'] and
                     self._ready_manager_queue[manager]['active']):
                     tasks = self.get_tasks(self._ready_manager_queue[manager]['free_capacity'])


### PR DESCRIPTION
The current model of manager selection is heavily biased by the dict.keys sorting. The rate at which tasks are received is not much greater that the rate at which tasks could be distributed. So this bias leads to the managers earlier in sorting receiving most (or all) tasks.

This PR adds a random shuffle to give managers a fairer chance at getting sent tasks.

Some sleeps added by mistake from testing are also removed.