### PR TITLE
Remove line which was preventing stdout redirect

### DIFF
--- a/parsl/providers/torque/template.py
+++ b/parsl/providers/torque/template.py
@@ -3,7 +3,6 @@ template_string = '''#!/bin/bash
 #PBS -S /bin/bash
 #PBS -N ${jobname}
 #PBS -m n
-#PBS -k eo
 #PBS -l walltime=$walltime
 #PBS -l nodes=${nodes_per_block}:ppn=${tasks_per_node}
 #PBS -o ${submit_script_dir}/${jobname}.submit.stdout


### PR DESCRIPTION
I think this line tries to send stdout and stderr to the same file. I'm
not really sure why removing it causes the later specification of the
stdout and stderr lines to be respected, but we don't want them in the
same file in any case. Fixes #647.