### PR TITLE
Measure test coverage during CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,16 @@ script:
     - export PARSL_TESTING="true"
     - pip install -r test-requirements.txt
     - flake8 parsl/
-    - (for test in parsl/tests/test*/test*; do pytest $test --config local ; export X=$? ; echo X is $X ; if [[ "$X" != 0 ]] && [[ "$X" != 5 ]]; then exit 1; fi; done ) ;
+
+      # do this before any testing, but not in-between tests
+    - rm -f .coverage
+
+    - (for test in parsl/tests/test*/test*; do pytest $test --config local --cov=parsl --cov-append --cov-report= ; export X=$? ; echo X is $X ; if [[ "$X" != 0 ]] && [[ "$X" != 5 ]]; then exit 1; fi; done ) ;
       # allow exit code 5; this means pytest did not run a test in the
       # specified file
+
+    - coverage report
+      # prints report of coverage data stored in .coverage
+
     # - pytest parsl/tests --config parsl/tests/configs/local_threads.py
     # - pytest parsl/tests --config parsl/tests/configs/local_ipp.py

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 flake8
 ipyparallel
 pytest>=3.6.0
+pytest-cov
 pytest-xdist
 pytest-ordering
 coverage


### PR DESCRIPTION
This uses coverage.py to measure test coverage of everything under `parsl/` (including the test suites themselves).

It looks like this bug: https://github.com/spack/spack/issues/6887 in coverage.py is being triggered, which I think is harmless.
