### PR TITLE
HTEX error suppression

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -106,6 +106,12 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         cores to be assigned to each worker. Oversubscription is possible
         by setting cores_per_worker < 1.0. Default=1
 
+    max_workers : int
+        Caps the number of workers launched by the manager. Default: 99999
+
+    suppress_failure : Bool
+        If set, the interchange will suppress failures rather than terminate early. Default: False
+
     heartbeat_threshold : int
         Seconds since the last message from the counterpart in the communication pair:
         (interchange, manager) after which the counterpart is assumed to be un-available. Default:120s
@@ -127,8 +133,10 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                  working_dir=None,
                  worker_debug=False,
                  cores_per_worker=1.0,
+                 max_workers=99999,
                  heartbeat_threshold=120,
                  heartbeat_period=30,
+                 suppress_failure=False,
                  managed=True):
 
         logger.debug("Initializing HighThroughputExecutor")
@@ -145,6 +153,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         self.blocks = []
         self.tasks = {}
         self.cores_per_worker = cores_per_worker
+        self.max_workers = max_workers
 
         self._task_counter = 0
         self.address = address
@@ -153,10 +162,11 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         self.interchange_port_range = interchange_port_range
         self.heartbeat_threshold = heartbeat_threshold
         self.heartbeat_period = heartbeat_period
+        self.suppress_failure = suppress_failure
         self.run_dir = '.'
 
         if not launch_cmd:
-            self.launch_cmd = ("process_worker_pool.py {debug} "
+            self.launch_cmd = ("process_worker_pool.py {debug} {max_workers} "
                                "-c {cores_per_worker} "
                                "--task_url={task_url} "
                                "--result_url={result_url} "
@@ -171,10 +181,13 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         executor specific oddities.
         """
         debug_opts = "--debug" if self.worker_debug else ""
+        max_workers = "" if self.max_workers == 99999 else "--max_workers={}".format(self.max_workers)
+
         l_cmd = self.launch_cmd.format(debug=debug_opts,
                                        task_url=self.worker_task_url,
                                        result_url=self.worker_result_url,
                                        cores_per_worker=self.cores_per_worker,
+                                       max_workers=max_workers,
                                        nodes_per_block=self.provider.nodes_per_block,
                                        heartbeat_period=self.heartbeat_period,
                                        heartbeat_threshold=self.heartbeat_threshold,
@@ -339,6 +352,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                                           "worker_ports": self.worker_ports,
                                           "worker_port_range": self.worker_port_range,
                                           "logdir": "{}/{}".format(self.run_dir, self.label),
+                                          "suppress_failure": self.suppress_failure,
                                           "heartbeat_threshold": self.heartbeat_threshold,
                                           "logging_level": logging.DEBUG if self.worker_debug else logging.INFO
                                   },

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -140,7 +140,7 @@ class Interchange(object):
         self.command_channel.connect("tcp://{}:{}".format(client_address, client_ports[2]))
         logger.info("Connected to client")
 
-        self.pending_task_queue = queue.Queue(maxsize=10 ^ 6)
+        self.pending_task_queue = queue.Queue(maxsize=10 ** 6)
 
         self.worker_ports = worker_ports
         self.worker_port_range = worker_port_range
@@ -170,7 +170,7 @@ class Interchange(object):
 
         self._task_queue = []
         self._ready_manager_queue = {}
-        self.max_task_queue_size = 10 ^ 5
+        self.max_task_queue_size = 10 ** 5
 
         self.heartbeat_threshold = heartbeat_threshold
 

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -43,6 +43,19 @@ class ManagerLost(Exception):
         return "Task failure due to loss of worker {}".format(self.worker_id)
 
 
+class BadRegistration(Exception):
+    ''' A new Manager tried to join the executor with a BadRegistration message
+    '''
+    def __init__(self, worker_id, critical=False):
+        self.worker_id = worker_id
+        self.tstamp = time.time()
+        self.handled = "critical" if critical is True else "suppressed"
+
+    def __repr__(self):
+        return "Manager:{} caused a {} failure".format(self.worker_id,
+                                                       self.handled)
+
+
 class Interchange(object):
     """ Interchange is a task orchestrator for distributed systems.
 
@@ -64,6 +77,7 @@ class Interchange(object):
                  heartbeat_threshold=60,
                  logdir=".",
                  logging_level=logging.INFO,
+                 suppress_failures=False,
              ):
         """
         Parameters
@@ -93,6 +107,9 @@ class Interchange(object):
         logging_level : int
              Logging level as defined in the logging module. Default: logging.INFO (20)
 
+        suppress_failures : Bool
+             When set to True, the interchange will attempt to suppress failures. Default: False
+
         """
         self.logdir = logdir
         try:
@@ -105,6 +122,7 @@ class Interchange(object):
 
         self.client_address = client_address
         self.interchange_address = interchange_address
+        self.suppress_failures = suppress_failures
 
         logger.info("Attempting connection to client at {} on ports: {},{},{}".format(
             client_address, client_ports[0], client_ports[1], client_ports[2]))
@@ -304,24 +322,52 @@ class Interchange(object):
                 manager = message[0]
 
                 if manager not in self._ready_manager_queue:
-                    msg = json.loads(message[1].decode('utf-8'))
-                    logger.info("[MAIN] Adding manager: {} to ready queue".format(manager))
+                    reg_flag = False
+
+                    try:
+                        msg = json.loads(message[1].decode('utf-8'))
+                        reg_flag = True
+                    except Exception:
+                        logger.warning("[MAIN] Got a non-json registration message from manager:{}".format(
+                            manager))
+                        logger.debug("[MAIN] Message :\n{}\n".format(message[0]))
+
+                    # By default we set up to ignore bad nodes/registration messages.
                     self._ready_manager_queue[manager] = {'last': time.time(),
                                                           'free_capacity': 0,
                                                           'active': True,
                                                           'tasks': []}
-                    self._ready_manager_queue[manager].update(msg)
-                    logger.info("Registration info for manager {}: {}".format(manager, msg))
-                    if (msg['python_v'] != self.current_platform['python_v'] or
-                        msg['parsl_v'] != self.current_platform['parsl_v']):
-                        logger.warn("Manager {} has incompatible version info with the interchange".format(manager))
-                        logger.debug("Setting kill event")
-                        self._kill_event.set()
-                        e = ManagerLost(manager)
-                        result_package = {'task_id': -1, 'exception': serialize_object(e)}
-                        pkl_package = pickle.dumps(result_package)
-                        self.results_outgoing.send(pkl_package)
-                        logger.warning("[MAIN] Sent failure reports, unregistering manager")
+                    if reg_flag is True:
+                        logger.info("[MAIN] Adding manager: {} to ready queue".format(manager))
+                        self._ready_manager_queue[manager].update(msg)
+                        logger.info("[MAIN] Registration info for manager {}: {}".format(manager, msg))
+
+                        if (msg['python_v'] != self.current_platform['python_v'] or
+                            msg['parsl_v'] != self.current_platform['parsl_v']):
+                            logger.warn("[MAIN] Manager {} has incompatible version info with the interchange".format(manager))
+
+                            if self.suppress_failures is False:
+                                logger.debug("Setting kill event")
+                                self._kill_event.set()
+                                e = ManagerLost(manager)
+                                result_package = {'task_id': -1, 'exception': serialize_object(e)}
+                                pkl_package = pickle.dumps(result_package)
+                                self.results_outgoing.send(pkl_package)
+                                logger.warning("[MAIN] Sent failure reports, unregistering manager")
+                            else:
+                                logger.debug("[MAIN] Suppressing shutdown due to version incompatibility")
+
+                    else:
+                        # Registration has failed.
+                        if self.suppress_failures is False:
+                            self._kill_event.set()
+                            e = BadRegistration(manager, critical=True)
+                            result_package = {'task_id': -1, 'exception': serialize_object(e)}
+                            pkl_package = pickle.dumps(result_package)
+                            self.results_outgoing.send(pkl_package)
+                        else:
+                            logger.debug("[MAIN] Suppressing bad registration from manager:{}".format(
+                                manager))
 
                 else:
                     tasks_requested = int.from_bytes(message[1], "little")
@@ -445,6 +491,8 @@ if __name__ == '__main__':
                         help="REQUIRED: ZMQ url for posting results")
     parser.add_argument("--worker_ports", default=None,
                         help="OPTIONAL, pair of workers ports to listen on, eg --worker_ports=50001,50005")
+    parser.add_argument("--suppress_failures", action='store_true',
+                        help="Enables suppression of failures")
     parser.add_argument("-d", "--debug", action='store_true',
                         help="Count of apps to launch")
 
@@ -465,6 +513,8 @@ if __name__ == '__main__':
     logger.debug("Starting Interchange")
 
     optionals = {}
+    optionals['suppress_failures'] = args.suppress_failures
+
     if args.worker_ports:
         optionals['worker_ports'] = [int(i) for i in args.worker_ports.split(',')]
     ic = Interchange(**optionals)

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -77,7 +77,7 @@ class Interchange(object):
                  heartbeat_threshold=60,
                  logdir=".",
                  logging_level=logging.INFO,
-                 suppress_failures=False,
+                 suppress_failure=False,
              ):
         """
         Parameters
@@ -107,7 +107,7 @@ class Interchange(object):
         logging_level : int
              Logging level as defined in the logging module. Default: logging.INFO (20)
 
-        suppress_failures : Bool
+        suppress_failure : Bool
              When set to True, the interchange will attempt to suppress failures. Default: False
 
         """
@@ -122,7 +122,7 @@ class Interchange(object):
 
         self.client_address = client_address
         self.interchange_address = interchange_address
-        self.suppress_failures = suppress_failures
+        self.suppress_failure = suppress_failure
 
         logger.info("Attempting connection to client at {} on ports: {},{},{}".format(
             client_address, client_ports[0], client_ports[1], client_ports[2]))
@@ -346,7 +346,7 @@ class Interchange(object):
                             msg['parsl_v'] != self.current_platform['parsl_v']):
                             logger.warn("[MAIN] Manager {} has incompatible version info with the interchange".format(manager))
 
-                            if self.suppress_failures is False:
+                            if self.suppress_failure is False:
                                 logger.debug("Setting kill event")
                                 self._kill_event.set()
                                 e = ManagerLost(manager)
@@ -359,7 +359,7 @@ class Interchange(object):
 
                     else:
                         # Registration has failed.
-                        if self.suppress_failures is False:
+                        if self.suppress_failure is False:
                             self._kill_event.set()
                             e = BadRegistration(manager, critical=True)
                             result_package = {'task_id': -1, 'exception': serialize_object(e)}
@@ -491,7 +491,7 @@ if __name__ == '__main__':
                         help="REQUIRED: ZMQ url for posting results")
     parser.add_argument("--worker_ports", default=None,
                         help="OPTIONAL, pair of workers ports to listen on, eg --worker_ports=50001,50005")
-    parser.add_argument("--suppress_failures", action='store_true',
+    parser.add_argument("--suppress_failure", action='store_true',
                         help="Enables suppression of failures")
     parser.add_argument("-d", "--debug", action='store_true',
                         help="Count of apps to launch")
@@ -513,7 +513,7 @@ if __name__ == '__main__':
     logger.debug("Starting Interchange")
 
     optionals = {}
-    optionals['suppress_failures'] = args.suppress_failures
+    optionals['suppress_failure'] = args.suppress_failure
 
     if args.worker_ports:
         optionals['worker_ports'] = [int(i) for i in args.worker_ports.split(',')]

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -108,7 +108,7 @@ class Manager(object):
         logger.info("Manager will spawn {} workers".format(self.worker_count))
 
         self.pending_task_queue = multiprocessing.Queue(maxsize=self.worker_count + max_queue_size)
-        self.pending_result_queue = multiprocessing.Queue(maxsize=10 ^ 4)
+        self.pending_result_queue = multiprocessing.Queue(maxsize=10 ** 4)
         self.ready_worker_queue = multiprocessing.Queue(maxsize=self.worker_count + 1)
 
         self.max_queue_size = max_queue_size + self.worker_count

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -51,6 +51,7 @@ class Manager(object):
                  result_q_url="tcp://127.0.0.1:50098",
                  max_queue_size=10,
                  cores_per_worker=1,
+                 max_workers=99999,
                  uid=None,
                  heartbeat_threshold=120,
                  heartbeat_period=30):
@@ -66,6 +67,10 @@ class Manager(object):
         cores_per_worker : float
              cores to be assigned to each worker. Oversubscription is possible
              by setting cores_per_worker < 1.0. Default=1
+
+        max_workers : int
+             caps the maximum number of workers that can be launched.
+             default: 99999
 
         heartbeat_threshold : int
              Seconds since the last message from the interchange after which the
@@ -97,7 +102,9 @@ class Manager(object):
         self.uid = uid
 
         cores_on_node = multiprocessing.cpu_count()
-        self.worker_count = math.floor(cores_on_node / cores_per_worker)
+        self.max_workers = max_workers
+        self.worker_count = min(max_workers,
+                                math.floor(cores_on_node / cores_per_worker))
         logger.info("Manager will spawn {} workers".format(self.worker_count))
 
         self.pending_task_queue = multiprocessing.Queue(maxsize=self.worker_count + max_queue_size)
@@ -444,6 +451,8 @@ if __name__ == "__main__":
                         help="Number of cores assigned to each worker process. Default=1.0")
     parser.add_argument("-t", "--task_url", required=True,
                         help="REQUIRED: ZMQ url for receiving tasks")
+    parser.add_argument("--max_workers", default=99999,
+                        help="Caps the maximum workers that can be launched, default:99999")
     parser.add_argument("--hb_period", default=30,
                         help="Heartbeat period in seconds. Uses manager default unless set")
     parser.add_argument("--hb_threshold", default=120,
@@ -471,11 +480,13 @@ if __name__ == "__main__":
         logger.info("cores_per_worker: {}".format(args.cores_per_worker))
         logger.info("task_url: {}".format(args.task_url))
         logger.info("result_url: {}".format(args.result_url))
+        logger.info("max_workers: {}".format(args.max_workers))
 
         manager = Manager(task_q_url=args.task_url,
                           result_q_url=args.result_url,
                           uid=args.uid,
                           cores_per_worker=float(args.cores_per_worker),
+                          max_workers=int(args.max_workers),
                           heartbeat_threshold=int(args.hb_threshold),
                           heartbeat_period=int(args.hb_period))
         manager.start()


### PR DESCRIPTION
The branch is poorly named. Here are the changes that are included in this PR:

* `suppress_failure` option added to Interchange that ignores *some* errors.
    When enabled, a message from a worker deemed lost is simply allowed to continue operation.
* `max_workers` option caps the # of workers launched by the managers on the remote side. Primarily for debugging.
* Fixes to operators (^ replaced with **) to make larger queues as expected.