### PR TITLE
Remove some n^2 scaling in interchange

### DIFF
--- a/parsl/__init__.py
+++ b/parsl/__init__.py
@@ -93,7 +93,7 @@ def set_file_logger(filename, name='parsl', level=logging.DEBUG, format_string=N
        -  None
     """
     if format_string is None:
-        format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+        format_string = "%(asctime)s %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
 
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)

--- a/parsl/__init__.py
+++ b/parsl/__init__.py
@@ -93,7 +93,7 @@ def set_file_logger(filename, name='parsl', level=logging.DEBUG, format_string=N
        -  None
     """
     if format_string is None:
-        format_string = "%(asctime)s %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+        format_string = "%(asctime)s %(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
 
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)

--- a/parsl/__init__.py
+++ b/parsl/__init__.py
@@ -93,7 +93,7 @@ def set_file_logger(filename, name='parsl', level=logging.DEBUG, format_string=N
        -  None
     """
     if format_string is None:
-        format_string = "%(asctime)s %(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+        format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
 
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -394,21 +394,12 @@ class Interchange(object):
 
             # If we had received any requests, check if there are tasks that could be passed
 
-            # even rendering the list here is maybe expensive, even if not written out
-            # logger.debug("Managers: {}".format(self._ready_manager_queue))
-            logger.debug("Managers count: {}".format(len(self._ready_manager_queue)))
-            logger.debug("Interesting managers count: {}".format(len(interesting_managers)))
+            logger.debug("Managers count (total/interesting): {}/{}".format(len(self._ready_manager_queue),
+                                                                            len(interesting_managers)))
 
-            # some managers will still be interesting after this pass... accumulate them here
             if interesting_managers and not self.pending_task_queue.empty():
-                logger.debug("[MAIN] entering _ready_manager_queue section")
-                logger.debug("[MAIN]   copying manager list to shuffle")
                 shuffled_managers = list(interesting_managers)
-                logger.debug("[MAIN]   shuffling list")
                 random.shuffle(shuffled_managers)
-                logger.debug("[MAIN]   shuffled list")
-                # logger.debug("Shuffled : {}".format(shuffled_managers))
-                # for manager in self._ready_manager_queue:
                 while shuffled_managers and not self.pending_task_queue.empty():  # cf. the if statement above...
                     manager = shuffled_managers.pop()
                     if (self._ready_manager_queue[manager]['free_capacity'] and

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -493,7 +493,7 @@ def start_file_logger(filename, name='interchange', level=logging.DEBUG, format_
         None.
     """
     if format_string is None:
-        format_string = "%(asctime)s %(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+        format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
 
     global logger
     logger = logging.getLogger(name)
@@ -539,7 +539,7 @@ if __name__ == '__main__':
 
     # Setup logging
     global logger
-    format_string = "%(asctime)s %(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+    format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
 
     logger = logging.getLogger("interchange")
     logger.setLevel(logging.DEBUG)

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -365,7 +365,7 @@ class Interchange(object):
                 logger.debug("[MAIN]   shuffled list")
                 # logger.debug("Shuffled : {}".format(shuffled_managers))
                 # for manager in self._ready_manager_queue:
-                for manager in shuffled_managers: # this for loop should only really proceed as long as there are also tasks in queue? otherwise this is still quite expensive to process if we're allocating just around single task this main-loop iteration?
+                for manager in shuffled_managers: # TODO: this for loop should only really proceed as long as there are also tasks in queue? otherwise this is still quite expensive to process if we're allocating just around single task this main-loop iteration?
                     if (self._ready_manager_queue[manager]['free_capacity'] and
                         self._ready_manager_queue[manager]['active']):
                         tasks = self.get_tasks(self._ready_manager_queue[manager]['free_capacity'])

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -400,7 +400,6 @@ class Interchange(object):
             logger.debug("Interesting managers count: {}".format(len(interesting_managers)))
 
             # some managers will still be interesting after this pass... accumulate them here
-            new_interesting_managers = set()
             if interesting_managers and not self.pending_task_queue.empty():
                 logger.debug("[MAIN] entering _ready_manager_queue section")
                 logger.debug("[MAIN]   copying manager list to shuffle")
@@ -410,11 +409,8 @@ class Interchange(object):
                 logger.debug("[MAIN]   shuffled list")
                 # logger.debug("Shuffled : {}".format(shuffled_managers))
                 # for manager in self._ready_manager_queue:
-                for manager in shuffled_managers:
-                    # TODO: this for loop should only really proceed as long as
-                    # there are also tasks in queue? otherwise this is still
-                    # quite expensive to process if we're allocating just
-                    # around single task this main-loop iteration?
+                while shuffled_managers and not self.pending_task_queue.empty(): # cf. the if statement above...
+                    manager = shuffled_managers.pop()
                     if (self._ready_manager_queue[manager]['free_capacity'] and
                         self._ready_manager_queue[manager]['active']):
                         tasks = self.get_tasks(self._ready_manager_queue[manager]['free_capacity'])
@@ -429,11 +425,13 @@ class Interchange(object):
                             logger.info("[MAIN] Sent tasks: {} to manager {}".format(tids, manager))
                             if self._ready_manager_queue[manager]['free_capacity'] > 0:
                                 logger.info("[MAIN] Manager {} still has free_capacity {}".format(manager, self._ready_manager_queue[manager]['free_capacity']))
-                                new_interesting_managers.add(manager)
+                                # ... so keep it in the interesting_managers list
+                            else:
+                                logger.info("[MAIN] Manager {} is now saturated".format(manager))
+                                interesting_managers.remove(manager)
                     else:
-                        pass
+                        interesting_managers.remove(manager)
                         # logger.debug("Nothing to send to manager {}".format(manager))
-                interesting_managers = new_interesting_managers
                 logger.debug("[MAIN] leaving _ready_manager_queue section, with {} managers still interesting".format(len(interesting_managers)))
             else:
                 logger.debug("[MAIN] either no interesting managers or no tasks, so skipping manager pass")

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -493,7 +493,7 @@ def start_file_logger(filename, name='interchange', level=logging.DEBUG, format_
         None.
     """
     if format_string is None:
-        format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+        format_string = "%(asctime)s %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
 
     global logger
     logger = logging.getLogger(name)
@@ -539,7 +539,7 @@ if __name__ == '__main__':
 
     # Setup logging
     global logger
-    format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+    format_string = "%(asctime)s %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
 
     logger = logging.getLogger("interchange")
     logger.setLevel(logging.DEBUG)

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -355,7 +355,7 @@ class Interchange(object):
             logger.debug("Interesting managers count: {}".format(len(interesting_managers)))
 
             # some managers will still be interesting after this pass... accumulate them here
-            new_interesting_managers=set()
+            new_interesting_managers = set()
             if interesting_managers and not self.pending_task_queue.empty():
                 logger.debug("[MAIN] entering _ready_manager_queue section")
                 logger.debug("[MAIN]   copying manager list to shuffle")
@@ -365,7 +365,11 @@ class Interchange(object):
                 logger.debug("[MAIN]   shuffled list")
                 # logger.debug("Shuffled : {}".format(shuffled_managers))
                 # for manager in self._ready_manager_queue:
-                for manager in shuffled_managers: # TODO: this for loop should only really proceed as long as there are also tasks in queue? otherwise this is still quite expensive to process if we're allocating just around single task this main-loop iteration?
+                for manager in shuffled_managers:
+                    # TODO: this for loop should only really proceed as long as
+                    # there are also tasks in queue? otherwise this is still
+                    # quite expensive to process if we're allocating just
+                    # around single task this main-loop iteration?
                     if (self._ready_manager_queue[manager]['free_capacity'] and
                         self._ready_manager_queue[manager]['active']):
                         tasks = self.get_tasks(self._ready_manager_queue[manager]['free_capacity'])
@@ -383,7 +387,7 @@ class Interchange(object):
                                 new_interesting_managers.add(manager)
                     else:
                         pass
-                        # logger.debug("Nothing to send to manager {}".format(manager)) 
+                        # logger.debug("Nothing to send to manager {}".format(manager))
                 interesting_managers = new_interesting_managers
                 logger.debug("[MAIN] leaving _ready_manager_queue section, with {} managers still interesting".format(len(interesting_managers)))
             else:
@@ -447,7 +451,6 @@ def start_file_logger(filename, name='interchange', level=logging.DEBUG, format_
     """
     if format_string is None:
         format_string = "%(asctime)s %(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
-
 
     global logger
     logger = logging.getLogger(name)

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -454,7 +454,7 @@ def start_file_logger(filename, name='interchange', level=logging.DEBUG, format_
     logger.setLevel(level)
     handler = logging.FileHandler(filename)
     handler.setLevel(level)
-    formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S,uuu')
+    formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 
@@ -497,7 +497,7 @@ if __name__ == '__main__':
     logger.setLevel(logging.DEBUG)
     handler = logging.StreamHandler()
     handler.setLevel('DEBUG' if args.debug is True else 'INFO')
-    formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S,uuu')
+    formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -409,7 +409,7 @@ class Interchange(object):
                 logger.debug("[MAIN]   shuffled list")
                 # logger.debug("Shuffled : {}".format(shuffled_managers))
                 # for manager in self._ready_manager_queue:
-                while shuffled_managers and not self.pending_task_queue.empty(): # cf. the if statement above...
+                while shuffled_managers and not self.pending_task_queue.empty():  # cf. the if statement above...
                     manager = shuffled_managers.pop()
                     if (self._ready_manager_queue[manager]['free_capacity'] and
                         self._ready_manager_queue[manager]['active']):


### PR DESCRIPTION
Prior to this PR, the interchange inspects every worker registration for every task message received.

This means when allocating n tasks to n workers, this is O(n^2)

In practice with imsim in production this was producing noticeable slowdowns.

This PR changes the behaviour so that a set of interesting workers is maintained, and only interesting workers are inspected when allocating a task. Interesting workers are the workers which have available capacity.

In the imsim work which motivated this PR, there are on the order of 2000 workers, and a larger number of long running (many hour) jobs. Testing and thinking-about should happen for different workloads (for exmaple, the case where workers are starved of work, and when jobs are very short.