### PR TITLE
[WIP] Add script_path parameter to Launchers, especially SrunLauncher

### DIFF
--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -7,7 +7,7 @@ class Launcher(RepresentationMixin, metaclass=ABCMeta):
     """ Launcher base class to enforce launcher interface
     """
     @abstractmethod
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block, script_path, walltime=None):
         """ Wraps the command with the Launcher calls.
         *MUST* be implemented by the concrete child classes
         """
@@ -18,7 +18,7 @@ class SimpleLauncher(Launcher):
     """ Does no wrapping. Just returns the command as-is
     """
 
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block, script_path, walltime=None):
         """
         Args:
         - command (string): The command string to be launched
@@ -37,7 +37,7 @@ class SingleNodeLauncher(Launcher):
     task_blocks to an integer or to a bash expression the number of invocations
     of the command to be launched can be controlled.
     """
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block, script_path, walltime=None):
         """
         Args:
         - command (string): The command string to be launched
@@ -79,7 +79,7 @@ class GnuParallelLauncher(Launcher):
       target nodes.
     - The provider makes available the $PBS_NODEFILE environment variable
     """
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block, script_path, walltime=None):
         """
         Args:
         - command (string): The command string to be launched
@@ -137,7 +137,7 @@ class MpiExecLauncher(Launcher):
     - mpiexec is installed and can be located in $PATH
     - The provider makes available the $PBS_NODEFILE environment variable
     """
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block, script_path, walltime=None):
         """
         Args:
         - command (string): The command string to be launched
@@ -180,7 +180,7 @@ class SrunLauncher(Launcher):
     def __init__(self):
         pass
 
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block, script_path, walltime=None):
         """
         Args:
         - command (string): The command string to be launched
@@ -218,7 +218,7 @@ class SrunMPILauncher(Launcher):
     at the same time. Workers should be launched with independent Srun calls so as to setup the
     environment for MPI application launch.
     """
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block, script_path, walltime=None):
         """
         Args:
         - command (string): The command string to be launched
@@ -278,7 +278,7 @@ class AprunLauncher(Launcher):
     def __init__(self, overrides=''):
         self.overrides = overrides
 
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block, script_path, walltime=None):
         """
         Args:
         - command (string): The command string to be launched
@@ -312,5 +312,5 @@ echo "Done"
 if __name__ == '__main__':
 
     s = SingleNodeLauncher()
-    wrapped = s("hello", 1, 1)
+    wrapped = s("hello", 1, 1, ".")
     print(wrapped)

--- a/parsl/providers/aws/aws.py
+++ b/parsl/providers/aws/aws.py
@@ -588,7 +588,8 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
         job_name = "parsl.auto.{0}".format(time.time())
         wrapped_cmd = self.launcher(command,
                                     tasks_per_node,
-                                    self.nodes_per_block)
+                                    self.nodes_per_block,
+                                    "./")
         [instance, *rest] = self.spin_up_instance(command=wrapped_cmd, job_name=job_name)
 
         if not instance:

--- a/parsl/providers/cobalt/cobalt.py
+++ b/parsl/providers/cobalt/cobalt.py
@@ -176,7 +176,7 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
                      blocksize, self.nodes_per_block, tasks_per_node)
 
         # Wrap the command
-        job_config["user_script"] = self.launcher(command, tasks_per_node, self.nodes_per_block)
+        job_config["user_script"] = self.launcher(command, tasks_per_node, self.nodes_per_block, script_path)
 
         queue_opt = '-q {}'.format(self.queue) if self.queue is not None else ''
 

--- a/parsl/providers/condor/condor.py
+++ b/parsl/providers/condor/condor.py
@@ -207,7 +207,8 @@ class CondorProvider(RepresentationMixin, ClusterProvider):
         # This is where the command should be wrapped by the launchers.
         wrapped_command = self.launcher(command,
                                         tasks_per_node,
-                                        self.nodes_per_block)
+                                        self.nodes_per_block,
+                                        script_path)
 
         with open(userscript_path, 'w') as f:
             f.write(job_config["worker_init"] + '\n' + wrapped_command)

--- a/parsl/providers/grid_engine/grid_engine.py
+++ b/parsl/providers/grid_engine/grid_engine.py
@@ -89,7 +89,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
             logger.warning("Use of {} launcher is usually appropriate for Slurm providers. "
                            "Recommended options include 'single_node' or 'aprun'.".format(launcher))
 
-    def get_configs(self, command, tasks_per_node):
+    def get_configs(self, command, tasks_per_node, script_path):
         """Compose a dictionary with information for writing the submit script."""
 
         logger.debug("Requesting one block with {} nodes per block and {} tasks per node".format(
@@ -105,7 +105,8 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
 
         job_config["user_script"] = self.launcher(command,
                                                   tasks_per_node,
-                                                  self.nodes_per_block)
+                                                  self.nodes_per_block,
+                                                  script_path)
         return job_config
 
     def submit(self, command, blocksize, tasks_per_node, job_name="parsl.auto"):
@@ -140,7 +141,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
         script_path = "{0}/{1}.submit".format(self.script_dir, job_name)
         script_path = os.path.abspath(script_path)
 
-        job_config = self.get_configs(command, tasks_per_node)
+        job_config = self.get_configs(command, tasks_per_node, script_path)
 
         logger.debug("Writing submit script")
         self._write_submit_script(template_string, script_path, job_name, job_config)

--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -181,7 +181,7 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
         script_path = "{0}/{1}.sh".format(self.script_dir, job_name)
         script_path = os.path.abspath(script_path)
 
-        wrap_command = self.worker_init + '\n' + self.launcher(command, tasks_per_node, self.nodes_per_block)
+        wrap_command = self.worker_init + '\n' + self.launcher(command, tasks_per_node, self.nodes_per_block, script_path)
 
         self._write_submit_script(wrap_command, script_path)
 

--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -179,7 +179,8 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         # Wrap the command
         job_config["user_script"] = self.launcher(command,
                                                   tasks_per_node,
-                                                  self.nodes_per_block)
+                                                  self.nodes_per_block,
+                                                  script_path)
 
         logger.debug("Writing submit script")
         self._write_submit_script(template_string, script_path, job_name, job_config)

--- a/parsl/providers/torque/torque.py
+++ b/parsl/providers/torque/torque.py
@@ -187,7 +187,8 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
         # Wrap the command
         job_config["user_script"] = self.launcher(command,
                                                   tasks_per_node,
-                                                  self.nodes_per_block)
+                                                  self.nodes_per_block,
+                                                  script_path)
 
         logger.debug("Writing submit script")
         self._write_submit_script(template_string, script_path, job_name, job_config)


### PR DESCRIPTION
This means that launchers can create their temporary files in the run
directory, rather than a more arbitrary directory such as pwd.

SrunLauncher is the only launcher that this commit actually changes
to use the script_path, as that was the one used in the motivating
imsim work.

TODO: This raises an issue (possibly also encountered by @gordonwatts
with the ssh provider?) of which file systems are being used for
creating launcher files - the local or the remote.

This is based on work done for imsim.

I've opened issue #730 to record some thoughts separate from this code.