### PR TITLE
Fix formatting of code blocks in FAQ page

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -284,13 +284,13 @@ How can I start a Jupyter notebook over SSH?
 
 Run
 
-.. code-block::
+.. code-block:: bash
 
     jupyter notebook --no-browser --ip=`/sbin/ip route get 8.8.8.8 | awk '{print $NF;exit}'`
 
 for a Jupyter notebook, or 
 
-.. code-block::
+.. code-block:: bash
 
     jupyter lab --no-browser --ip=`/sbin/ip route get 8.8.8.8 | awk '{print $NF;exit}'`
 


### PR DESCRIPTION
`code-block` requires a language specification, currently those lines are missing from the [HTML FAQ page](https://parsl.readthedocs.io/en/stable/faq.html#how-can-i-start-a-jupyter-notebook-over-ssh)