### PR TITLE
Restrict the versions of pytest

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 flake8
 ipyparallel
-pytest>=3.6.0
+pytest>=3.6.0,<4.1.0
 pytest-cov
 pytest-xdist
 pytest-ordering


### PR DESCRIPTION
parsl/test/conftest.py looks like it is incompatible
with changes introduced in pytest commit 847eacea which
is released in 4.1.0

That commit incompatibly changes the parameter format for runner.CallInfo