### PR TITLE
Increase the number of tasks in htex CI test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
 
     # run simple worker test. this is unlikely to scale due to
     # a stdout/stderr buffering bug in present master.
-    - coverage run --append --source=parsl parsl/tests/manual_tests/test_worker_count.py -c 20
+    - coverage run --append --source=parsl parsl/tests/manual_tests/test_worker_count.py -c 1000
 
     - coverage report
       # prints report of coverage data stored in .coverage


### PR DESCRIPTION
There was previously a bug where this test would fail after a
relatively small number of tasks executed, and so this test
was introduced to CI with a small number of tasks.

This bug was fixed in PR #725, and so a more intensive test can be
run now - this commit makes that change.