### PR TITLE
Fix changes introduced upgrade to flake8 3.7.1

### DIFF
--- a/parsl/app/app.py
+++ b/parsl/app/app.py
@@ -110,9 +110,9 @@ def App(apptype, data_flow_kernel=None, walltime=60, cache=False, executors='all
 
     logger.warning("The 'App' decorator will be deprecated in Parsl 0.8. Please use 'python_app' or 'bash_app' instead.")
 
-    if apptype is 'python':
+    if apptype == 'python':
         app_class = PythonApp
-    elif apptype is 'bash':
+    elif apptype == 'bash':
         app_class = BashApp
     else:
         raise InvalidAppTypeError("Invalid apptype requested {}; must be 'python' or 'bash'".format(apptype))

--- a/parsl/app/app.py
+++ b/parsl/app/app.py
@@ -118,11 +118,11 @@ def App(apptype, data_flow_kernel=None, walltime=60, cache=False, executors='all
         raise InvalidAppTypeError("Invalid apptype requested {}; must be 'python' or 'bash'".format(apptype))
 
     def wrapper(f):
-            return app_class(f,
-                             data_flow_kernel=data_flow_kernel,
-                             walltime=walltime,
-                             cache=cache,
-                             executors=executors)
+        return app_class(f,
+                         data_flow_kernel=data_flow_kernel,
+                         walltime=walltime,
+                         cache=cache,
+                         executors=executors)
     return wrapper
 
 

--- a/parsl/config.py
+++ b/parsl/config.py
@@ -69,11 +69,11 @@ class Config(RepresentationMixin):
                 logger.debug('The requested `checkpoint_period={}` will have no effect because `checkpoint_mode=None`'.format(
                     checkpoint_period)
                 )
-            elif checkpoint_mode is not 'periodic':
+            elif checkpoint_mode != 'periodic':
                 logger.debug("Requested checkpoint period of {} only has an effect with checkpoint_mode='periodic'".format(
                     checkpoint_period)
                 )
-        if checkpoint_mode is 'periodic' and checkpoint_period is None:
+        if checkpoint_mode == 'periodic' and checkpoint_period is None:
             checkpoint_period = "00:30:00"
         self.checkpoint_period = checkpoint_period
         self.data_management_max_threads = data_management_max_threads

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -335,7 +335,7 @@ class DataFlowKernel(object):
             # result from a memo lookup and the task has reached a terminal state.
             self.memoizer.update_memo(task_id, self.tasks[task_id], future)
 
-            if self.checkpoint_mode is 'task_exit':
+            if self.checkpoint_mode == 'task_exit':
                 self.checkpoint(tasks=[task_id])
 
         # Submit _*_stage_out tasks for output data futures that correspond with remote files

--- a/parsl/executors/ipp_controller.py
+++ b/parsl/executors/ipp_controller.py
@@ -69,7 +69,7 @@ class Controller(RepresentationMixin):
         if self.mode == "manual":
             return
 
-        if self.ipython_dir is not '~/.ipython':
+        if self.ipython_dir != '~/.ipython':
             self.ipython_dir = os.path.abspath(os.path.expanduser(self.ipython_dir))
 
         if self.log:
@@ -82,9 +82,9 @@ class Controller(RepresentationMixin):
         try:
             opts = [
                 'ipcontroller',
-                '' if self.ipython_dir is '~/.ipython' else '--ipython-dir={}'.format(self.ipython_dir),
+                '' if self.ipython_dir == '~/.ipython' else '--ipython-dir={}'.format(self.ipython_dir),
                 self.interfaces if self.interfaces is not None else '--ip=*',
-                '' if self.profile is 'default' else '--profile={0}'.format(self.profile),
+                '' if self.profile == 'default' else '--profile={0}'.format(self.profile),
                 '--reuse' if self.reuse else '',
                 '--location={}'.format(self.public_ip) if self.public_ip else '',
                 '--port={}'.format(self.port) if self.port is not None else ''


### PR DESCRIPTION
This will introduce a potential behaviour change: previously, `is`
was used to compare strings; now `==` is used to compare strings.

Where the strings have been interned (which I hope has been always),
then the behaviour should be the same; but there are potential cases
(at least abstractly) where `is` was returning false for strings that
were ==-equal, and `is not` was returning true for string that were
==-equal. So if you've bisected a problem back to this commit,
check that out!