### PR TITLE
Adding debugging info for issue #785

### DIFF
--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -2,9 +2,12 @@
 from functools import wraps
 
 import dill
+import logging
 from tblib import Traceback
 
 from six import reraise
+
+logger = logging.getLogger(__name__)
 
 
 class ParslError(Exception):
@@ -146,7 +149,18 @@ class RemoteExceptionWrapper:
 
     def reraise(self):
 
-        reraise(dill.loads(self.e_type), dill.loads(self.e_value), self.e_traceback.as_traceback())
+        t = dill.loads(self.e_type)
+
+        # the type is logged here before deserialising v and tb
+        # because occasionally there are problems deserialising the
+        # value (see #785, #548) and the fix is related to the
+        # specific exception type.
+        logger.debug("Reraising exception of type {}".format(t))
+
+        v = dill.loads(self.e_value)
+        tb = self.e_traceback.as_traceback()
+
+        reraise(t, v, tb)
 
 
 def wrap_error(func):


### PR DESCRIPTION
This is related to #548, and seems related to the
specific exception class being re-raised - so this
debug information is probably useful to keep around
permanently, to help diagnose the next misbehaving
exception class.