### PR TITLE
Raise an exception rather than use wrong cwd for globus paths (#788)

### DIFF
--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -122,7 +122,7 @@ class DataManager(ParslExecutor):
                         if executor.working_dir:
                             working_dir = os.path.normpath(executor.working_dir)
                         else:
-                            working_dir = os.getcwd()
+                            raise ValueError("executor working_dir must be specified for GlobusScheme")
                         if scheme.endpoint_path and scheme.local_path:
                             endpoint_path = os.path.normpath(scheme.endpoint_path)
                             local_path = os.path.normpath(scheme.local_path)


### PR DESCRIPTION
Prior to this patch, if no execute-side working directory is known for a
globus transfer, the client side current directory is used.

This is very likely to be wrong (unless the execute side and client side
are running on the same filesystem, perhaps), so this patch causes an
exception to be raised asking for more explicit configuration rather
than guessing.