### PR TITLE
Tighten cases of File.filepath()

### DIFF
--- a/parsl/data_provider/files.py
+++ b/parsl/data_provider/files.py
@@ -90,8 +90,10 @@ class File(str):
                 return self.local_path
             else:
                 return self.filename
-
-        return self.path
+        elif self.scheme in ['file']:
+            return self.path
+        else:
+            raise Exception('Cannot return filepath for unknown scheme {}'.format(self.scheme))
 
     def stage_in(self, executor):
         """Transport file from the input source to the executor.


### PR DESCRIPTION
This throws an exception for unknown URI schemes
rather than defaulting to the file: behaviour,
to give more resilience when adding new schemes.