### PR TITLE
Allow alternate modes to be specified for bash app stdout and stderr.

### DIFF
--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -51,21 +51,30 @@ def remote_side_bash_executor(func, *args, **kwargs):
     logging.debug("Executable: %s", executable)
 
     # Updating stdout, stderr if values passed at call time.
-    stdout = kwargs.get('stdout')
-    stderr = kwargs.get('stderr')
+
+    def open_std_fd(fdname):
+        # fdname is 'stdout' or 'stderr'
+        stdfspec = kwargs.get(fdname)  # spec is str name or tuple (name, mode)
+        if stdfspec is None:
+            return None
+        elif isinstance(stdfspec, str):
+            fname = stdfspec
+            mode = 'a+'
+        elif isinstance(stdfspec, tuple):
+            if len(stdfspec) != 2:
+                raise pe.BadStdStreamFile("std descriptor %s has incorrect tuple length %s" % (fdname, len(stdfspec)), TypeError('Bad Tuple Length'))
+            fname, mode = stdfspec
+        else:
+            raise pe.BadStdStreamFile("std descriptor %s has unexpected type %s" % (fdname, str(type(stdfspec))), TypeError('Bad Tuple Type'))
+        try:
+            fd = open(fname, mode)
+        except Exception as e:
+            raise pe.BadStdStreamFile(fname, e)
+        return fd
+
+    std_out = open_std_fd('stdout')
+    std_err = open_std_fd('stderr')
     timeout = kwargs.get('walltime')
-    logging.debug("Stdout: %s", stdout)
-    logging.debug("Stderr: %s", stderr)
-
-    try:
-        std_out = open(stdout, 'a+') if stdout else None
-    except Exception as e:
-        raise pe.BadStdStreamFile(stdout, e)
-
-    try:
-        std_err = open(stderr, 'a+') if stderr else None
-    except Exception as e:
-        raise pe.BadStdStreamFile(stderr, e)
 
     returncode = None
     try:

--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -83,7 +83,7 @@ class MissingOutputs(ParslError):
     """
 
     def __init__(self, reason, outputs):
-        super().__init__(reason)
+        super().__init__(reason, outputs)
         self.reason = reason
         self.outputs = outputs
 
@@ -104,7 +104,7 @@ class BadStdStreamFile(ParslError):
     """
 
     def __init__(self, outputs, exception):
-        super().__init__()
+        super().__init__(outputs, exception)
         self._outputs = outputs
         self._exception = exception
 

--- a/parsl/tests/test_bash_apps/test_stdout.py
+++ b/parsl/tests/test_bash_apps/test_stdout.py
@@ -6,10 +6,6 @@ import pytest
 import parsl
 import parsl.app.errors as perror
 from parsl.app.app import App
-from parsl.tests.configs.local_threads import config
-
-parsl.clear()
-dfk = parsl.load(config)
 
 
 @App('bash')
@@ -19,41 +15,103 @@ def echo_to_streams(msg, stderr='std.err', stdout='std.out'):
 
 whitelist = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'configs', '*threads*')
 
+speclist = (
+    '/bad/dir/t.out',
+    ['t3.out', 'w'],
+    ('t4.out', None),
+    (42, 'w'),
+    ('t6.out', 'w', 42),
+    ('t7.out',),
+    ('t8.out', 'badmode')
+)
 
-# @pytest.mark.whitelist(whitelist, reason='broken in IPP')
-@pytest.mark.skip("Broke somewhere between PR #525 and PR #652")
-def test_bad_stdout():
-    """Testing bad stdout file
+testids = [
+    'nonexistent_dir',
+    'list_not_tuple',
+    'null_mode',
+    'not_a_string',
+    '3tuple',
+    '1tuple',
+    'bad_mode'
+]
+
+
+@pytest.mark.parametrize('spec', speclist, ids=testids)
+def test_bad_stdout_specs(spec):
+    """Testing bad stdout spec cases
     """
-    stdout = "/x/test_bad_stdout.stdout"
-    stderr = "test_bad_stdout.stderr"
-    fu = echo_to_streams("Hello world", stderr=stderr, stdout=stdout)
+
+    fn = echo_to_streams("Hello world", stdout=spec, stderr='t.err')
 
     try:
-        fu.result()
+        fn.result()
     except Exception as e:
         assert isinstance(
             e, perror.BadStdStreamFile), "Expected BadStdStreamFile, got :{0}".format(type(e))
+    else:
+        assert False, "Did not raise expected exception BadStdStreamFile"
 
     return
 
 
 # @pytest.mark.whitelist(whitelist, reason='broken in IPP')
-@pytest.mark.skip("Broke somewhere between PR #525 and PR #652")
-def test_bad_stderr():
-    """Testing bad stderr file
-    """
-    stdout = "test_bad_stdout.stdout"
-    stderr = "/x/test_bad_stdout.stderr"
-    fu = echo_to_streams("Hello world", stderr=stderr, stdout=stdout)
+# @pytest.mark.skip("Broke somewhere between PR #525 and PR #652")
+def test_bad_stderr_file():
+
+    """ Testing bad stderr file """
+
+    out = "t2.out"
+    err = "/bad/dir/t2.err"
+
+    fn = echo_to_streams("Hello world", stdout=out, stderr=err)
 
     try:
-        fu.result()
+        fn.result()
     except Exception as e:
         assert isinstance(
             e, perror.BadStdStreamFile), "Expected BadStdStreamFile, got :{0}".format(type(e))
+    else:
+        assert False, "Did not raise expected exception BadStdStreamFile"
 
     return
+
+
+def test_stdout_truncate():
+
+    """ Testing truncation of prior content of stdout """
+
+    out = ('t1.out', 'w')
+    err = 't1.err'
+    os.system('rm -f ' + out[0] + ' ' + err)
+
+    echo_to_streams('hi', stdout=out, stderr=err).result()
+    len1 = len(open(out[0]).readlines())
+
+    echo_to_streams('hi', stdout=out, stderr=err).result()
+    len2 = len(open(out[0]).readlines())
+
+    assert len1 == len2 == 1, "Line count of output files should both be 1, but: len1={} len2={}".format(len1, len2)
+
+    os.system('rm -f ' + out[0] + ' ' + err)
+
+
+def test_stdout_append():
+
+    """ Testing appending to prior content of stdout (default open() mode) """
+
+    out = 't1.out'
+    err = 't1.err'
+    os.system('rm -f ' + out + ' ' + err)
+
+    echo_to_streams('hi', stdout=out, stderr=err).result()
+    len1 = len(open(out).readlines())
+
+    echo_to_streams('hi', stdout=out, stderr=err).result()
+    len2 = len(open(out).readlines())
+
+    assert len1 == 1 and len2 == 2, "Line count of output files should be 1 and 2, but:  len1={} len2={}".format(len1, len2)
+
+    os.system('rm -f ' + out + ' ' + err)
 
 
 if __name__ == '__main__':
@@ -67,6 +125,7 @@ if __name__ == '__main__':
 
     if args.debug:
         parsl.set_stream_logger()
-
-    y = test_bad_stdout()
-    y = test_bad_stderr()
+    y = test_bad_stdout_specs()  # FIXME: Not sure how this should work when tested directly
+    y = test_bad_stderr_file()
+    y = test_stdout_truncate()
+    y = test_stdout_append()


### PR DESCRIPTION
Modes can be specified via a (file,mode) tuple as an alternative
option to a simple filename string.

Default mode remains "a+" for now.  Typical alternative fir simple
file overrwite is ('filename','w')

Also fixes error in exception handling for BadStfFileStream and
MissingOutputs exception.  Problem was that the exception superclass
needs to be initialized withthe same member variables as the
subclassed execption in order for it to pickle correctly in the
"remote" execution context.

Other exceptions have similar issues, but were not corrected, pending
review of the proposed fix.

The app_stdout.py pytest was extended to test the new options, and
corrected to initialize correctly (by not attempting to clear and
reset the dfk, which seemed to causing this test to file.

Note that only the local execution tests were tested at the time of
this commit.