### PR TITLE
Fix standalone stdout test modified in PR 797

### DIFF
--- a/parsl/tests/test_bash_apps/test_stdout.py
+++ b/parsl/tests/test_bash_apps/test_stdout.py
@@ -6,6 +6,7 @@ import pytest
 import parsl
 import parsl.app.errors as perror
 from parsl.app.app import App
+from parsl.tests.configs.local_threads import config
 
 
 @App('bash')
@@ -125,7 +126,12 @@ if __name__ == '__main__':
 
     if args.debug:
         parsl.set_stream_logger()
-    y = test_bad_stdout_specs()  # FIXME: Not sure how this should work when tested directly
+
+    parsl.load(config)
+
+    # test_bad_stdout_specs is omitted because it is called in a
+    # more complicated parameterised fashion by pytest.
+
     y = test_bad_stderr_file()
     y = test_stdout_truncate()
     y = test_stdout_append()


### PR DESCRIPTION
PR #797 correctly removed the global DFK initialisation, but
should have added a DFK initialisation into the `__main__`
block so that a DFK is available in non-pytest mode. This
commit adds that.

PR #797 also added an incorrect invocation of the parameterised
test_bad_stdout_specs. This commit removes that.