### PR TITLE
Remove DataManager's duplicated executor list and get it live from DFK

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -155,7 +155,7 @@ class DataFlowKernel(object):
         self._checkpoint_timer = None
         self.checkpoint_mode = config.checkpoint_mode
 
-        data_manager = DataManager(max_threads=config.data_management_max_threads, executors=config.executors)
+        data_manager = DataManager(self, max_threads=config.data_management_max_threads)
         self.executors = {e.label: e for e in config.executors + [data_manager]}
         for executor in self.executors.values():
             executor.run_dir = self.run_dir


### PR DESCRIPTION
This is in support of PR #803 which possibly does not support staging using dynamically added executors without this patch.