### PR TITLE
Make DFK initialisation not module-global in dynamic executor test

### DIFF
--- a/parsl/tests/sites/test_dynamic_executor.py
+++ b/parsl/tests/sites/test_dynamic_executor.py
@@ -6,9 +6,6 @@ from parsl.app.app import python_app
 
 import pytest
 
-parsl.clear()
-dfk = parsl.load()
-
 
 @python_app(executors=['threads'])
 def sleeper(dur=0):
@@ -42,6 +39,8 @@ def add(dur=0.01):
 
 @pytest.mark.local
 def test_dynamic_executor():
+    parsl.clear()
+    dfk = parsl.load()
     tasks = [sleeper() for i in range(5)]
     results = [i.result() for i in tasks]
     print("Done with initial test. The results are", results)


### PR DESCRIPTION
The test module is imported on the remote side by canning code,
as part of uncanning some lambda expression (I'm not sure
exactly which one).

This was causing a DFK to be loaded on the remote side, because
the DFK was being loaded as a module-level global.

Initialising two DFKs close in time seems to result in a race
condition creating working directories.