### PR TITLE
Prefetch limits

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -164,7 +164,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
             raise ConfigurationError('Multiple storage access schemes are not supported')
         self.working_dir = working_dir
         self.managed = managed
-        self.blocks = []
+        self.blocks = {}
         self.tasks = {}
         self.cores_per_worker = cores_per_worker
         self.max_workers = max_workers
@@ -189,6 +189,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                                "--task_url={task_url} "
                                "--result_url={result_url} "
                                "--logdir={logdir} "
+                               "--block_id={{block_id}} "
                                "--hb_period={heartbeat_period} "
                                "--hb_threshold={heartbeat_threshold} ")
 
@@ -427,14 +428,30 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
     @property
     def outstanding(self):
         outstanding_c = self.command_client.run("OUTSTANDING_C")
-        logger.debug("Got outstanding count: {}".format(outstanding_c))
+        # logger.debug("Got outstanding count: {}".format(outstanding_c))
         return outstanding_c
 
     @property
     def connected_workers(self):
         workers = self.command_client.run("MANAGERS")
-        logger.debug("Got managers: {}".format(workers))
+        # logger.debug("Got managers: {}".format(workers))
         return workers
+
+    def _hold_block(self, block_id):
+        """ Sends hold command to all managers which are in a specific block
+
+        Parameters
+        ----------
+        block_id : str
+             Block identifier of the block to be put on hold
+        """
+
+        managers = self.connected_workers
+
+        for manager in managers:
+            if manager['block_id'] == block_id:
+                logger.debug("[HOLD_BLOCK]: Sending hold to manager:{}".format(manager['manager']))
+                self.hold_worker(manager['manager'])
 
     def submit(self, func, *args, **kwargs):
         """Submits work to the the outgoing_q.
@@ -489,30 +506,52 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         r = []
         for i in range(blocks):
             if self.provider:
-                block = self.provider.submit(self.launch_cmd, 1, 1)
-                logger.debug("Launched block {}:{}".format(i, block))
-                if not block:
+                external_block_id = len(self.blocks)
+                launch_cmd = self.launch_cmd.format(block_id=external_block_id)
+                internal_block = self.provider.submit(launch_cmd, 1, 1)
+                logger.debug("Launched block {}->{}".format(external_block_id, internal_block))
+                if not internal_block:
                     raise(ScalingFailed(self.provider.label,
                                         "Attempts to provision nodes via provider has failed"))
-                self.blocks.extend([block])
+                r.extend([str(external_block_id)])
+                self.blocks[str(external_block_id)] = internal_block
             else:
                 logger.error("No execution provider available")
                 r = None
         return r
 
-    def scale_in(self, blocks):
+    def scale_in(self, blocks, block_ids=[]):
         """Scale in the number of active blocks by specified amount.
 
         The scale in method here is very rude. It doesn't give the workers
         the opportunity to finish current tasks or cleanup. This is tracked
         in issue #530
 
+        Parameters
+        ----------
+
+        blocks : int
+             Number of blocks to terminate and scale_in by
+
+        block_ids : list
+             List of specific block ids to terminate. Optional
+
         Raises:
              NotImplementedError
         """
-        to_kill = self.blocks[:blocks]
+        logger.debug("YADU: SCALE_IN, self.blocks: {}".format(self.blocks))
+        for block_id in block_ids:
+            self._hold_block(block_id)
+
+        if block_ids:
+            to_kill = [self.blocks.pop(bid) for bid in block_ids]
+        else:
+            to_kill = [self.blocks.pop(bid) for bid in list(self.blocks.keys())[:blocks]]
+
+        logger.debug("YADU: SCALE_IN, trying to scale_in: {}".format(to_kill))
         if self.provider:
             r = self.provider.cancel(to_kill)
+
         return r
 
     def status(self):
@@ -520,7 +559,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
 
         status = []
         if self.provider:
-            status = self.provider.status(self.blocks)
+            status = self.provider.status(self.blocks.values())
 
         return status
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -506,15 +506,15 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         r = []
         for i in range(blocks):
             if self.provider:
-                external_block_id = len(self.blocks)
+                external_block_id = str(len(self.blocks))
                 launch_cmd = self.launch_cmd.format(block_id=external_block_id)
                 internal_block = self.provider.submit(launch_cmd, 1, 1)
                 logger.debug("Launched block {}->{}".format(external_block_id, internal_block))
                 if not internal_block:
                     raise(ScalingFailed(self.provider.label,
                                         "Attempts to provision nodes via provider has failed"))
-                r.extend([str(external_block_id)])
-                self.blocks[str(external_block_id)] = internal_block
+                r.extend([external_block_id])
+                self.blocks[external_block_id] = internal_block
             else:
                 logger.error("No execution provider available")
                 r = None

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -146,7 +146,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                  worker_debug=False,
                  cores_per_worker=1.0,
                  max_workers=float('inf'),
-                 prefetch_capacity=100,
+                 prefetch_capacity=0,
                  heartbeat_threshold=120,
                  heartbeat_period=30,
                  poll_period=10,

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -112,6 +112,11 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
     max_workers : int
         Caps the number of workers launched by the manager. Default: infinity
 
+    prefetch_capacity : int
+        Number of tasks that could be prefetched over available worker capacity. Default:100.
+        When there are a few tasks (<100) or when tasks are long running, this option should
+        be set to 0 for better load balancing.
+
     suppress_failure : Bool
         If set, the interchange will suppress failures rather than terminate early. Default: False
 
@@ -141,6 +146,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                  worker_debug=False,
                  cores_per_worker=1.0,
                  max_workers=float('inf'),
+                 prefetch_capacity=100,
                  heartbeat_threshold=120,
                  heartbeat_period=30,
                  poll_period=10,
@@ -162,6 +168,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         self.tasks = {}
         self.cores_per_worker = cores_per_worker
         self.max_workers = max_workers
+        self.prefetch_capacity = prefetch_capacity
 
         self._task_counter = 0
         self.address = address
@@ -176,6 +183,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
 
         if not launch_cmd:
             self.launch_cmd = ("process_worker_pool.py {debug} {max_workers} "
+                               "-p {prefetch_capacity} "
                                "-c {cores_per_worker} "
                                "--poll {poll_period} "
                                "--task_url={task_url} "
@@ -193,7 +201,9 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         debug_opts = "--debug" if self.worker_debug else ""
         max_workers = "" if self.max_workers == float('inf') else "--max_workers={}".format(self.max_workers)
 
+        logger.debug("YADU : {}/{}".format(self.run_dir, self.label))
         l_cmd = self.launch_cmd.format(debug=debug_opts,
+                                       prefetch_capacity=self.prefetch_capacity,
                                        task_url=self.worker_task_url,
                                        result_url=self.worker_result_url,
                                        cores_per_worker=self.cores_per_worker,

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -202,7 +202,6 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         debug_opts = "--debug" if self.worker_debug else ""
         max_workers = "" if self.max_workers == float('inf') else "--max_workers={}".format(self.max_workers)
 
-        logger.debug("YADU : {}/{}".format(self.run_dir, self.label))
         l_cmd = self.launch_cmd.format(debug=debug_opts,
                                        prefetch_capacity=self.prefetch_capacity,
                                        task_url=self.worker_task_url,
@@ -539,7 +538,6 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         Raises:
              NotImplementedError
         """
-        logger.debug("YADU: SCALE_IN, self.blocks: {}".format(self.blocks))
         for block_id in block_ids:
             self._hold_block(block_id)
 
@@ -548,7 +546,6 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         else:
             to_kill = [self.blocks.pop(bid) for bid in list(self.blocks.keys())[:blocks]]
 
-        logger.debug("YADU: SCALE_IN, trying to scale_in: {}".format(to_kill))
         if self.provider:
             r = self.provider.cancel(to_kill)
 

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -258,9 +258,11 @@ class Interchange(object):
                 elif command_req == "MANAGERS":
                     reply = []
                     for manager in self._ready_manager_queue:
-                        resp = (manager.decode('utf-8'),
-                                len(self._ready_manager_queue[manager]['tasks']),
-                                self._ready_manager_queue[manager]['active'])
+                        resp = {'manager': manager.decode('utf-8'),
+                                'block_id': self._ready_manager_queue[manager]['block_id'],
+                                'worker_count': self._ready_manager_queue[manager]['worker_count'],
+                                'tasks': len(self._ready_manager_queue[manager]['tasks']),
+                                'active': self._ready_manager_queue[manager]['active']}
                         reply.append(resp)
 
                 elif command_req.startswith("HOLD_WORKER"):

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -347,6 +347,7 @@ class Interchange(object):
                     # By default we set up to ignore bad nodes/registration messages.
                     self._ready_manager_queue[manager] = {'last': time.time(),
                                                           'free_capacity': 0,
+                                                          'max_capacity': 0,
                                                           'active': True,
                                                           'tasks': []}
                     if reg_flag is True:
@@ -402,11 +403,15 @@ class Interchange(object):
             if interesting_managers and not self.pending_task_queue.empty():
                 shuffled_managers = list(interesting_managers)
                 random.shuffle(shuffled_managers)
+
                 while shuffled_managers and not self.pending_task_queue.empty():  # cf. the if statement above...
                     manager = shuffled_managers.pop()
-                    if (self._ready_manager_queue[manager]['free_capacity'] and
-                        self._ready_manager_queue[manager]['active']):
-                        tasks = self.get_tasks(self._ready_manager_queue[manager]['free_capacity'])
+                    tasks_inflight = len(self._ready_manager_queue[manager]['tasks'])
+                    real_capacity = min(self._ready_manager_queue[manager]['free_capacity'],
+                                        self._ready_manager_queue[manager]['max_capacity'] - tasks_inflight)
+
+                    if (real_capacity and self._ready_manager_queue[manager]['active']):
+                        tasks = self.get_tasks(real_capacity)
                         if tasks:
                             self.task_outgoing.send_multipart([manager, b'', pickle.dumps(tasks)])
                             task_count = len(tasks)

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -51,6 +51,7 @@ class Manager(object):
                  max_queue_size=10,
                  cores_per_worker=1,
                  max_workers=float('inf'),
+                 prefetch_capacity=100,
                  uid=None,
                  heartbeat_threshold=120,
                  heartbeat_period=30,
@@ -71,6 +72,11 @@ class Manager(object):
         max_workers : int
              caps the maximum number of workers that can be launched.
              default: infinity
+
+        prefetch_capacity : int
+             Number of tasks that could be prefetched over available worker capacity. Default:100.
+             When there are a few tasks (<100) or when tasks are long running, this option should
+             be set to 0 for better load balancing.
 
         heartbeat_threshold : int
              Seconds since the last message from the interchange after which the
@@ -106,6 +112,7 @@ class Manager(object):
 
         cores_on_node = multiprocessing.cpu_count()
         self.max_workers = max_workers
+        self.prefetch_capacity = prefetch_capacity
         self.worker_count = min(max_workers,
                                 math.floor(cores_on_node / cores_per_worker))
         logger.info("Manager will spawn {} workers".format(self.worker_count))
@@ -129,6 +136,10 @@ class Manager(object):
                'python_v': "{}.{}.{}".format(sys.version_info.major,
                                              sys.version_info.minor,
                                              sys.version_info.micro),
+               'block_id': self.block_id,
+               'worker_count': self.worker_count,
+               'prefetch_capacity': self.prefetch_capacity,
+               'max_capacity': self.worker_count + self.prefetch_capacity,
                'os': platform.system(),
                'hname': platform.node(),
                'dir': os.getcwd(),
@@ -461,6 +472,8 @@ if __name__ == "__main__":
                         help="REQUIRED: ZMQ url for receiving tasks")
     parser.add_argument("--max_workers", default=float('inf'),
                         help="Caps the maximum workers that can be launched, default:infinity")
+    parser.add_argument("-p", "--prefetch_capacity", default=100,
+                        help="Number of tasks that can be prefetched to the manager. default:100")
     parser.add_argument("--hb_period", default=30,
                         help="Heartbeat period in seconds. Uses manager default unless set")
     parser.add_argument("--hb_threshold", default=120,
@@ -491,12 +504,16 @@ if __name__ == "__main__":
         logger.info("result_url: {}".format(args.result_url))
         logger.info("max_workers: {}".format(args.max_workers))
         logger.info("poll_period: {}".format(args.poll))
+        logger.info("Block ID: {}".format(args.block_id))
+        logger.info("Prefetch capacity: {}".format(args.prefetch_capacity))
 
         manager = Manager(task_q_url=args.task_url,
                           result_q_url=args.result_url,
                           uid=args.uid,
                           cores_per_worker=float(args.cores_per_worker),
                           max_workers=args.max_workers if args.max_workers == float('inf') else int(args.max_workers),
+                          prefetch_capacity=int(args.prefetch_capacity),
+                          block_id=args.block_id,
                           heartbeat_threshold=int(args.hb_threshold),
                           heartbeat_period=int(args.hb_period),
                           poll_period=int(args.poll))

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -48,7 +48,6 @@ class Manager(object):
     def __init__(self,
                  task_q_url="tcp://127.0.0.1:50097",
                  result_q_url="tcp://127.0.0.1:50098",
-                 max_queue_size=10,
                  cores_per_worker=1,
                  max_workers=float('inf'),
                  prefetch_capacity=100,
@@ -126,7 +125,7 @@ class Manager(object):
         self.pending_result_queue = multiprocessing.Queue()
         self.ready_worker_queue = multiprocessing.Queue()
 
-        self.max_queue_size = max_queue_size + self.worker_count
+        self.max_queue_size = self.prefetch_capacity + self.worker_count
 
         self.tasks_per_round = 1
 

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -53,6 +53,7 @@ class Manager(object):
                  max_workers=float('inf'),
                  prefetch_capacity=100,
                  uid=None,
+                 block_id=None,
                  heartbeat_threshold=120,
                  heartbeat_period=30,
                  poll_period=10):
@@ -64,6 +65,9 @@ class Manager(object):
 
         uid : str
              string unique identifier
+
+        block_id : str
+             Block identifier that maps managers to the provider blocks they belong to.
 
         cores_per_worker : float
              cores to be assigned to each worker. Oversubscription is possible
@@ -109,6 +113,7 @@ class Manager(object):
         logger.info("Manager connected")
 
         self.uid = uid
+        self.block_id = block_id
 
         cores_on_node = multiprocessing.cpu_count()
         self.max_workers = max_workers
@@ -466,6 +471,8 @@ if __name__ == "__main__":
                         help="Process worker pool log directory")
     parser.add_argument("-u", "--uid", default=str(uuid.uuid4()).split('-')[-1],
                         help="Unique identifier string for Manager")
+    parser.add_argument("-b", "--block_id", default=None,
+                        help="Block identifier for Manager")
     parser.add_argument("-c", "--cores_per_worker", default="1.0",
                         help="Number of cores assigned to each worker process. Default=1.0")
     parser.add_argument("-t", "--task_url", required=True,


### PR DESCRIPTION
This PR brings two separate features from branch `htex_strategy`:
* Support for specifying a `prefetch_capacity` that limits the # of tasks that can be fetched over the available worker capacity on the managers.
* Support for identifying managers with block_ids, and identification via a registration message to the interchange.