### PR TITLE
Make it so mypy can make basic check of codebase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,11 @@ script:
     - pip install -r test-requirements.txt
     - flake8 parsl/
 
+    # This uses all of the configurations and tests as the base from which to
+    # run mypy checks - these are likely to capture most of the code used in
+    # parsl
+    - (for test in parsl/tests/configs/*.py parsl/tests/test*/test*; do mypy $test ; export MypyReturnCode=$? ; echo mypy return code is $MypyReturnCode ; if [[ "$MypyReturnCode" != 0 ]] ; then exit 1; fi; done ) ;
+
       # do this before any testing, but not in-between tests
     - rm -f .coverage
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,102 @@
+[mypy]
+plugins = sqlmypy
+
+[mypy-sqlalchemy_utils.*]
+ignore_missing_imports = True
+
+[mypy-pytest.*]
+ignore_missing_imports = True
+
+[mypy-dill.*]
+ignore_missing_imports = True
+
+[mypy-numpy.*]
+ignore_missing_imports = True
+
+[mypy-copyreg.*]
+ignore_missing_imports = True
+
+[mypy-tblib.*]
+ignore_missing_imports = True
+
+[mypy-globus_sdk.*]
+ignore_missing_imports = True
+
+[mypy-psutil.*]
+ignore_missing_imports = True
+
+[mypy-cPickle.*]
+ignore_missing_imports = True
+
+[mypy-cloudpickle.*]
+ignore_missing_imports = True
+
+[mypy-copy_reg.*]
+ignore_missing_imports = True
+
+[mypy-ipyparallel.*]
+ignore_missing_imports = True
+
+[mypy-ipython_genutils.*]
+ignore_missing_imports = True
+
+[mypy-cmreslogging.handlers.*]
+ignore_missing_imports = True
+
+[mypy-paramiko.*]
+ignore_missing_imports = True
+
+[mypy-kubernetes.*]
+ignore_missing_imports = True
+
+[mypy-novaclient.*]
+ignore_missing_imports = True
+
+[mypy-jetstream.*]
+ignore_missing_imports = True
+
+[mypy-azure.*]
+ignore_missing_imports = True
+
+# !
+[mypy-libsubmit.azure.azure_deployer.*]
+ignore_missing_imports = True
+
+[mypy-googleapiclient.*]
+ignore_missing_imports = True
+
+[mypy-boto3.*]
+ignore_missing_imports = True
+
+[mypy-botocore.*]
+ignore_missing_imports = True
+
+[mypy-tornado.*]
+ignore_missing_imports = True
+
+[mypy-sqlalchemy.*]
+ignore_missing_imports = True
+
+[mypy-zmq.*]
+ignore_missing_imports = True
+
+[mypy-mpi4py.*]
+ignore_missing_imports = True
+
+[mypy-dash.*]
+ignore_missing_imports = True
+
+[mypy-dash_core_components.*]
+ignore_missing_imports = True
+
+[mypy-dash_html_components.*]
+ignore_missing_imports = True
+
+[mypy-flask.*]
+ignore_missing_imports = True
+
+[mypy-plotly.*]
+ignore_missing_imports = True
+
+[mypy-pandas.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,9 @@
 [mypy]
 plugins = sqlmypy
 
+[mypy-non_existent.*]
+ignore_missing_imports = True
+
 [mypy-sqlalchemy_utils.*]
 ignore_missing_imports = True
 

--- a/parsl/app/futures.py
+++ b/parsl/app/futures.py
@@ -220,7 +220,7 @@ if __name__ == "__main__":
         for item in nums:
             testfile.write("{0}\n".format(item))
 
-    foo = Future()
+    foo = Future()  # type: Future[str]
     df = DataFuture(foo, './shuffled.txt')
     dx = DataFuture(foo, '~/shuffled.txt')
 

--- a/parsl/dataflow/usage_tracking/usage.py
+++ b/parsl/dataflow/usage_tracking/usage.py
@@ -241,14 +241,3 @@ class UsageTracker (object):
         """We terminate (SIGTERM) the processes added to the self.procs list """
         for proc in self.procs:
             proc.terminate()
-
-
-if __name__ == '__main__':
-
-    from parsl import *
-
-    set_stream_logger()
-    workers = ThreadPoolExecutor(max_workers=4)
-    dfk = DataFlowKernel(executors=[workers])
-
-    dfk.cleanup()

--- a/parsl/executors/serialize/canning.py
+++ b/parsl/executors/serialize/canning.py
@@ -291,11 +291,11 @@ class CannedBytes(CannedObject):
 
 
 class CannedBuffer(CannedBytes):
-    wrap = buffer
+    wrap = buffer  # type: ignore
 
 
 class CannedMemoryView(CannedBytes):
-    wrap = memoryview
+    wrap = memoryview  # type: ignore
 
 #-------------------------------------------------------------------------------
 # Functions

--- a/parsl/executors/serialize/serialize.py
+++ b/parsl/executors/serialize/serialize.py
@@ -8,7 +8,7 @@ try:
     pickle = cPickle
 except:
     cPickle = None
-    import pickle
+    import pickle  # type: ignore
 _stdlib_pickle = pickle
 
 try:

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -12,10 +12,12 @@ from parsl.utils import RepresentationMixin
 
 from parsl.monitoring.message_type import MessageType
 
+from typing import Optional
+
 try:
     from parsl.monitoring.db_manager import dbm_starter
 except Exception as e:
-    _db_manager_excepts = e
+    _db_manager_excepts = e  # type: Optional[Exception]
 else:
     _db_manager_excepts = None
 

--- a/parsl/tests/configs/user_opts.py
+++ b/parsl/tests/configs/user_opts.py
@@ -5,6 +5,8 @@ The fields must be configured separately for each user. To disable any associate
 out the entry.
 """
 
+from typing import Any, Dict
+
 # PUBLIC_IP = "52.86.208.63" # "128.135.250.229"
 # MIDWAY_USERNAME = "yadunand"
 # OSG_USERNAME = "yadunand"
@@ -89,4 +91,4 @@ user_opts = {
     #     'endpoint': 'fixme',
     #     'path': 'fixme'
     # }
-}
+}  # type: Dict[str, Any]

--- a/parsl/tests/test_python_apps/test_memoize_2.py
+++ b/parsl/tests/test_python_apps/test_memoize_2.py
@@ -18,29 +18,6 @@ def random_uuid(x):
 
 
 @pytest.mark.local
-def test_python_memoization(n=4):
-    """Testing python memoization disable via config
-    """
-    x = random_uuid(0)
-
-    for i in range(0, n):
-        foo = random_uuid(0)
-        assert foo.result() != x.result(
-        ), "Memoized results were used when memoization was disabled"
-
-
-dfk.cleanup()
-parsl.clear()
-dfk = DataFlowKernel(config)
-
-
-@App('python', dfk)
-def random_uuid(x):
-    import uuid
-    return str(uuid.uuid4())
-
-
-@pytest.mark.local
 def test_python_memoization(n=2):
     """Testing python memoization disable via DFK call
     """

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,4 +11,5 @@ nbsphinx
 sphinx_rtd_theme
 sqlalchemy
 sqlalchemy_utils
-
+mypy
+# sqlalchemy-stubs 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,4 +12,4 @@ sphinx_rtd_theme
 sqlalchemy
 sqlalchemy_utils
 mypy
-# sqlalchemy-stubs 
+sqlalchemy-stubs


### PR DESCRIPTION
This PR fixes all of the errors that happen when trying to make mypy tests against the configuration and test files; and then makes that check happen in CI.

On my laptop, this additional testing takes 1m25s of realtime.

