### PR TITLE
Set the Future-result of a DataFuture to the correct result

### DIFF
--- a/parsl/app/futures.py
+++ b/parsl/app/futures.py
@@ -39,7 +39,7 @@ class DataFuture(Future):
             if e:
                 super().set_exception(e)
             else:
-                super().set_result(parent_fu.result())
+                super().set_result(self.file_obj)
         return
 
     def __init__(self, fut, file_obj, parent=None, tid=None):


### PR DESCRIPTION
Prior to this, the superclass Future implementation was given
a result that was inconsistent with the values returned by
(for example) DataFuture custom implementations of result().

This leads to fragility and potential inconsistency about what
a DataFuture's result value actually is.

This change makes that value always be the wrapped File object,
which is the result that the custom implementations attempt to
return.