### PR TITLE
Fix incorrect assignment rather than invocation of set_result

### DIFF
--- a/parsl/app/futures.py
+++ b/parsl/app/futures.py
@@ -66,7 +66,7 @@ class DataFuture(Future):
 
         if fut is None:
             logger.debug("Setting result to filepath since no future was passed")
-            self.set_result = self.file_obj
+            self.set_result(self.file_obj)
 
         else:
             if isinstance(fut, Future):


### PR DESCRIPTION
Before this commit, set_result changed from being a method to
being a file object in the case that no parent AppFuture was
supplied; fortunately in that case, set_result was never
actually invoked, and the superclass Future result was never
actually used.