### PR TITLE
Fix cleannet tests broken by PR #693

### DIFF
--- a/parsl/tests/test_staging/test_docs_1.py
+++ b/parsl/tests/test_staging/test_docs_1.py
@@ -1,11 +1,6 @@
 import pytest
 
-import parsl
 from parsl import App, File
-from parsl.configs.local_threads import config
-
-parsl.clear()
-parsl.load(config)
 
 
 @App('python')

--- a/parsl/tests/test_staging/test_implicit_staging_ftp.py
+++ b/parsl/tests/test_staging/test_implicit_staging_ftp.py
@@ -3,10 +3,6 @@ import pytest
 import parsl
 from parsl.app.app import App
 from parsl.data_provider.files import File
-from parsl.tests.configs.local_threads import config
-
-parsl.clear()
-parsl.load(config)
 
 
 @App('python')


### PR DESCRIPTION
PR #693 made the test framework more aggressive about loading DFKs
in test code when the test framework should be loading DFKs.

As cleannet tests are not run in pytest, this breakage was not
discovered by CI: these now-fixed tests are disabled by the
'-k not cleannet' flag to pytest in CI.