### PR TITLE
Pin pytest-xdist as newer versions are incompatible with pinned pytest

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ flake8
 ipyparallel
 pytest>=3.6.0,<4.1.0
 pytest-cov
-pytest-xdist
+pytest-xdist==1.26.1
 pytest-ordering
 pandas
 coverage


### PR DESCRIPTION
This broke in CI roughly when pytest-xdist when from around 1.26.1 to 1.28