### PR TITLE
Broaden error message when interchange error has no task id

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -309,7 +309,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                             raise BadMessage("Message received does not contain 'task_id' field")
 
                         if tid == -1 and 'exception' in msg:
-                            logger.warning("Executor shutting down due to version mismatch in interchange")
+                            logger.warning("Executor shutting down due to exception from interchange")
                             self._executor_exception, _ = deserialize_object(msg['exception'])
                             logger.exception("Exception: {}".format(self._executor_exception))
                             # Set bad state to prevent new tasks from being submitted


### PR DESCRIPTION
Previously, any exception thrown from the interchange that was not
associated with an identified task was reported as a version mismatch.

That is not the only reason an exception might be thrown.