### PR TITLE
Remove most complexity from AppFuture __repr__

### DIFF
--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -171,27 +171,7 @@ class AppFuture(Future):
         return self._outputs
 
     def __repr__(self):
-        if self.parent:
-            with self.parent._condition:
-                if self.parent._state == FINISHED:
-                    if self.parent._exception:
-                        return '<%s at %#x state=%s raised %s>' % (
-                            self.__class__.__name__,
-                            id(self),
-                            _STATE_TO_DESCRIPTION_MAP[self.parent._state],
-                            self.parent._exception.__class__.__name__)
-                    else:
-                        return '<%s at %#x state=%s returned %s>' % (
-                            self.__class__.__name__,
-                            id(self),
-                            _STATE_TO_DESCRIPTION_MAP[self.parent._state],
-                            self.parent._result.__class__.__name__)
-                return '<%s at %#x state=%s>' % (
-                    self.__class__.__name__,
-                    id(self),
-                    _STATE_TO_DESCRIPTION_MAP[self.parent._state])
-        else:
-            return '<%s at %#x state=%s>' % (
-                self.__class__.__name__,
-                id(self),
-                _STATE_TO_DESCRIPTION_MAP[self._state])
+        return '<%s at %#x parent=%s>' % (
+            self.__class__.__name__,
+            id(self),
+            self.parent.__repr__())

--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -171,7 +171,7 @@ class AppFuture(Future):
         return self._outputs
 
     def __repr__(self):
-        return '<%s at %#x parent=%s>' % (
+        return '<%s super=%s parent=%s>' % (
             self.__class__.__name__,
-            id(self),
+            super().__repr__(),
             self.parent.__repr__())


### PR DESCRIPTION
Almost the same output, but with more detail,
comes from asking super() and parent for their
own `__repr__` and concatenating them.

The previous code relied heavily on the parent
state, which is not so directly tied to AppFuture
state nowadays: for example, an AppFuture may
have failed with an exception while the parent
future has returned a successful result of
a `RemoteExceptionWrapper`.

```
<AppFuture super=<AppFuture at 0x7fa7a0d08a20 state=finished raised AppTimeout> parent=<Future at 0x7fa7a0d08cc0 state=finished returned RemoteExceptionWrapper>>
```