### PR TITLE
Switch from `enforce` to `typeguard` as it is more maintained

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 plugins = sqlmypy
 
-[mypy-enforce.*]
+[mypy-typeguard.*]
 ignore_missing_imports = True
 
 [mypy-non_existent.*]

--- a/parsl/config.py
+++ b/parsl/config.py
@@ -1,5 +1,5 @@
-import enforce
 import logging
+import typeguard
 
 from typing import List, Optional
 
@@ -10,8 +10,6 @@ from parsl.dataflow.error import ConfigurationError
 from parsl.monitoring import MonitoringHub
 
 logger = logging.getLogger(__name__)
-
-enforce.config({'mode': 'covariant'})
 
 
 class Config(RepresentationMixin):
@@ -54,7 +52,7 @@ class Config(RepresentationMixin):
         information used for reporting to our funding agencies. Default is False.
     """
 
-    @enforce.runtime_validation
+    @typeguard.typechecked
     def __init__(self,
                  executors: Optional[List[ParslExecutor]] = None,
                  app_cache: bool = True,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-enforce
 pyzmq>=17.1.2
+typeguard
 ipyparallel
 globus-sdk
 dill


### PR DESCRIPTION
After doing some futher work to get runtime type checking on some more common functions (which exists in the `benc-more-type-annotations` branch), I ended up switching to `typeguard`, away from `enforce`, because I was encountering problems with `enforce` on some annotations, and it has a most recent commit much futher in the past than `typeguard`.

The syntax for annotations is unchanged, but the decorator to use is from `typeguard` now.