### PR TITLE
Add support for configuring prefetch capacity

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -116,9 +116,9 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         Caps the number of workers launched by the manager. Default: infinity
 
     prefetch_capacity : int
-        Number of tasks that could be prefetched over available worker capacity. Default:100.
+        Number of tasks that could be prefetched over available worker capacity.
         When there are a few tasks (<100) or when tasks are long running, this option should
-        be set to 0 for better load balancing.
+        be set to 0 for better load balancing. Default is 0.
 
     suppress_failure : Bool
         If set, the interchange will suppress failures rather than terminate early. Default: False

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -115,6 +115,11 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
     max_workers : int
         Caps the number of workers launched by the manager. Default: infinity
 
+    prefetch_capacity : int
+        Number of tasks that could be prefetched over available worker capacity. Default:100.
+        When there are a few tasks (<100) or when tasks are long running, this option should
+        be set to 0 for better load balancing.
+
     suppress_failure : Bool
         If set, the interchange will suppress failures rather than terminate early. Default: False
 
@@ -145,12 +150,12 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                  worker_debug: bool = False,
                  cores_per_worker: float = 1.0,
                  max_workers: Union[int, float] = float('inf'),
+                 prefetch_capacity: int = 0,
                  heartbeat_threshold: int = 120,
                  heartbeat_period: int = 30,
                  poll_period: int = 10,
                  suppress_failure: bool = False,
                  managed: bool = True):
-
         logger.debug("Initializing HighThroughputExecutor")
 
         self.label = label
@@ -166,6 +171,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         self.tasks = {}  # type: Dict[str, Future]
         self.cores_per_worker = cores_per_worker
         self.max_workers = max_workers
+        self.prefetch_capacity = prefetch_capacity
 
         self._task_counter = 0
         self.address = address
@@ -180,6 +186,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
 
         if not launch_cmd:
             self.launch_cmd = ("process_worker_pool.py {debug} {max_workers} "
+                               "-p {prefetch_capacity} "
                                "-c {cores_per_worker} "
                                "--poll {poll_period} "
                                "--task_url={task_url} "
@@ -198,6 +205,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         max_workers = "" if self.max_workers == float('inf') else "--max_workers={}".format(self.max_workers)
 
         l_cmd = self.launch_cmd.format(debug=debug_opts,
+                                       prefetch_capacity=self.prefetch_capacity,
                                        task_url=self.worker_task_url,
                                        result_url=self.worker_result_url,
                                        cores_per_worker=self.cores_per_worker,
@@ -505,6 +513,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
              NotImplementedError
         """
         to_kill = self.blocks[:blocks]
+
         if self.provider:
             r = self.provider.cancel(to_kill)
         return r

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -349,6 +349,7 @@ class Interchange(object):
                     # By default we set up to ignore bad nodes/registration messages.
                     self._ready_manager_queue[manager] = {'last': time.time(),
                                                           'free_capacity': 0,
+                                                          'max_capacity': 0,
                                                           'active': True,
                                                           'tasks': []}
                     if reg_flag is True:
@@ -404,11 +405,15 @@ class Interchange(object):
             if interesting_managers and not self.pending_task_queue.empty():
                 shuffled_managers = list(interesting_managers)
                 random.shuffle(shuffled_managers)
+
                 while shuffled_managers and not self.pending_task_queue.empty():  # cf. the if statement above...
                     manager = shuffled_managers.pop()
-                    if (self._ready_manager_queue[manager]['free_capacity'] and
-                        self._ready_manager_queue[manager]['active']):
-                        tasks = self.get_tasks(self._ready_manager_queue[manager]['free_capacity'])
+                    tasks_inflight = len(self._ready_manager_queue[manager]['tasks'])
+                    real_capacity = min(self._ready_manager_queue[manager]['free_capacity'],
+                                        self._ready_manager_queue[manager]['max_capacity'] - tasks_inflight)
+
+                    if (real_capacity and self._ready_manager_queue[manager]['active']):
+                        tasks = self.get_tasks(real_capacity)
                         if tasks:
                             self.task_outgoing.send_multipart([manager, b'', pickle.dumps(tasks)])
                             task_count = len(tasks)

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -48,9 +48,9 @@ class Manager(object):
     def __init__(self,
                  task_q_url="tcp://127.0.0.1:50097",
                  result_q_url="tcp://127.0.0.1:50098",
-                 max_queue_size=10,
                  cores_per_worker=1,
                  max_workers=float('inf'),
+                 prefetch_capacity=100,
                  uid=None,
                  heartbeat_threshold=120,
                  heartbeat_period=30,
@@ -71,6 +71,11 @@ class Manager(object):
         max_workers : int
              caps the maximum number of workers that can be launched.
              default: infinity
+
+        prefetch_capacity : int
+             Number of tasks that could be prefetched over available worker capacity. Default:100.
+             When there are a few tasks (<100) or when tasks are long running, this option should
+             be set to 0 for better load balancing.
 
         heartbeat_threshold : int
              Seconds since the last message from the interchange after which the
@@ -106,6 +111,7 @@ class Manager(object):
 
         cores_on_node = multiprocessing.cpu_count()
         self.max_workers = max_workers
+        self.prefetch_capacity = prefetch_capacity
         self.worker_count = min(max_workers,
                                 math.floor(cores_on_node / cores_per_worker))
         logger.info("Manager will spawn {} workers".format(self.worker_count))
@@ -114,7 +120,7 @@ class Manager(object):
         self.pending_result_queue = multiprocessing.Queue()
         self.ready_worker_queue = multiprocessing.Queue()
 
-        self.max_queue_size = max_queue_size + self.worker_count
+        self.max_queue_size = self.prefetch_capacity + self.worker_count
 
         self.tasks_per_round = 1
 
@@ -129,6 +135,9 @@ class Manager(object):
                'python_v': "{}.{}.{}".format(sys.version_info.major,
                                              sys.version_info.minor,
                                              sys.version_info.micro),
+               'worker_count': self.worker_count,
+               'prefetch_capacity': self.prefetch_capacity,
+               'max_capacity': self.worker_count + self.prefetch_capacity,
                'os': platform.system(),
                'hname': platform.node(),
                'dir': os.getcwd(),
@@ -461,6 +470,8 @@ if __name__ == "__main__":
                         help="REQUIRED: ZMQ url for receiving tasks")
     parser.add_argument("--max_workers", default=float('inf'),
                         help="Caps the maximum workers that can be launched, default:infinity")
+    parser.add_argument("-p", "--prefetch_capacity", default=100,
+                        help="Number of tasks that can be prefetched to the manager. default:100")
     parser.add_argument("--hb_period", default=30,
                         help="Heartbeat period in seconds. Uses manager default unless set")
     parser.add_argument("--hb_threshold", default=120,
@@ -491,12 +502,14 @@ if __name__ == "__main__":
         logger.info("result_url: {}".format(args.result_url))
         logger.info("max_workers: {}".format(args.max_workers))
         logger.info("poll_period: {}".format(args.poll))
+        logger.info("Prefetch capacity: {}".format(args.prefetch_capacity))
 
         manager = Manager(task_q_url=args.task_url,
                           result_q_url=args.result_url,
                           uid=args.uid,
                           cores_per_worker=float(args.cores_per_worker),
                           max_workers=args.max_workers if args.max_workers == float('inf') else int(args.max_workers),
+                          prefetch_capacity=int(args.prefetch_capacity),
                           heartbeat_threshold=int(args.hb_threshold),
                           heartbeat_period=int(args.hb_period),
                           poll_period=int(args.poll))

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -135,7 +135,6 @@ class Manager(object):
                'python_v': "{}.{}.{}".format(sys.version_info.major,
                                              sys.version_info.minor,
                                              sys.version_info.micro),
-               'block_id': self.block_id,
                'worker_count': self.worker_count,
                'prefetch_capacity': self.prefetch_capacity,
                'max_capacity': self.worker_count + self.prefetch_capacity,

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -50,7 +50,7 @@ class Manager(object):
                  result_q_url="tcp://127.0.0.1:50098",
                  cores_per_worker=1,
                  max_workers=float('inf'),
-                 prefetch_capacity=100,
+                 prefetch_capacity=0,
                  uid=None,
                  heartbeat_threshold=120,
                  heartbeat_period=30,
@@ -73,9 +73,9 @@ class Manager(object):
              default: infinity
 
         prefetch_capacity : int
-             Number of tasks that could be prefetched over available worker capacity. Default:100.
+             Number of tasks that could be prefetched over available worker capacity.
              When there are a few tasks (<100) or when tasks are long running, this option should
-             be set to 0 for better load balancing.
+             be set to 0 for better load balancing. Default is 0.
 
         heartbeat_threshold : int
              Seconds since the last message from the interchange after which the
@@ -135,6 +135,7 @@ class Manager(object):
                'python_v': "{}.{}.{}".format(sys.version_info.major,
                                              sys.version_info.minor,
                                              sys.version_info.micro),
+               'block_id': self.block_id,
                'worker_count': self.worker_count,
                'prefetch_capacity': self.prefetch_capacity,
                'max_capacity': self.worker_count + self.prefetch_capacity,
@@ -470,8 +471,8 @@ if __name__ == "__main__":
                         help="REQUIRED: ZMQ url for receiving tasks")
     parser.add_argument("--max_workers", default=float('inf'),
                         help="Caps the maximum workers that can be launched, default:infinity")
-    parser.add_argument("-p", "--prefetch_capacity", default=100,
-                        help="Number of tasks that can be prefetched to the manager. default:100")
+    parser.add_argument("-p", "--prefetch_capacity", default=0,
+                        help="Number of tasks that can be prefetched to the manager. Default is 0.")
     parser.add_argument("--hb_period", default=30,
                         help="Heartbeat period in seconds. Uses manager default unless set")
     parser.add_argument("--hb_threshold", default=120,


### PR DESCRIPTION
This is a squashed cherry pick with a few changes removed
in order to just collect the changes related to prefetch capacity.
It is based on the following commits:

75f9d4eca8ec179564768c74b8c5cd67154ea1d8
5a221f2e8ad581b23e4b4b1ec86d3ee02e41e460
c89f3b2def16023bd08360705e923eeb73815013