### PR TITLE
Htex python version check #857

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -371,7 +371,10 @@ class Interchange(object):
                                 logger.warning("[MAIN] Sent failure reports, unregistering manager")
                             else:
                                 logger.debug("[MAIN] Suppressing shutdown due to version incompatibility")
-
+                        else:
+                            logger.info("[MAIN] Manager {} has compatible Parsl version {}".format(manager, msg['parsl_v']))
+                            logger.info("[MAIN] Manager {} has compatible Python version {}".format(manager,
+                                                                                                    msg['python_v'].rsplit(".", 1)[0]))
                     else:
                         # Registration has failed.
                         if self.suppress_failure is False:

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -357,7 +357,7 @@ class Interchange(object):
                         self._ready_manager_queue[manager].update(msg)
                         logger.info("[MAIN] Registration info for manager {}: {}".format(manager, msg))
 
-                        if (msg['python_v'] != self.current_platform['python_v'] or
+                        if (msg['python_v'].rsplit(".", 1)[0] != self.current_platform['python_v'].rsplit(".", 1)[0] or
                             msg['parsl_v'] != self.current_platform['parsl_v']):
                             logger.warn("[MAIN] Manager {} has incompatible version info with the interchange".format(manager))
 


### PR DESCRIPTION
This PR changes python version check in HTEX interchange from micro to minor level, e.g., now python 3.6.6 is compatible with python 3.6.8.

Fixes #857 