### PR TITLE
Managers to report block_id on registration

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -514,7 +514,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                 r = None
         return r
 
-    def scale_in(self, blocks, block_ids=[]):
+    def scale_in(self, blocks=None, block_ids=[]):
         """Scale in the number of active blocks by specified amount.
 
         The scale in method here is very rude. It doesn't give the workers
@@ -533,14 +533,18 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         Raises:
              NotImplementedError
         """
-        for block_id in block_ids:
-            self._hold_block(block_id)
 
         if block_ids:
-            to_kill = [self.blocks.pop(bid) for bid in block_ids]
+            block_ids_to_kill = block_ids
         else:
-            to_kill = [self.blocks.pop(bid) for bid in list(self.blocks.keys())[:blocks]]
+            block_ids_to_kill = list(self.blocks.keys())[:blocks]
 
+        # Hold the block
+        for block_id in block_ids_to_kill:
+            self._hold_block(block_id)
+
+        # Now kill via provider
+        to_kill = [self.blocks.pop(bid) for bid in block_ids_to_kill]
         if self.provider:
             r = self.provider.cancel(to_kill)
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -500,15 +500,15 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         r = []
         for i in range(blocks):
             if self.provider:
-                external_block_id = len(self.blocks)
+                external_block_id = str(len(self.blocks))
                 launch_cmd = self.launch_cmd.format(block_id=external_block_id)
                 internal_block = self.provider.submit(launch_cmd, 1, 1)
                 logger.debug("Launched block {}->{}".format(external_block_id, internal_block))
                 if not internal_block:
                     raise(ScalingFailed(self.provider.label,
                                         "Attempts to provision nodes via provider has failed"))
-                r.extend([str(external_block_id)])
-                self.blocks[str(external_block_id)] = internal_block
+                r.extend([external_block_id])
+                self.blocks[external_block_id] = internal_block
             else:
                 logger.error("No execution provider available")
                 r = None
@@ -533,7 +533,6 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         Raises:
              NotImplementedError
         """
-        logger.debug("YADU: SCALE_IN, self.blocks: {}".format(self.blocks))
         for block_id in block_ids:
             self._hold_block(block_id)
 
@@ -542,7 +541,6 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         else:
             to_kill = [self.blocks.pop(bid) for bid in list(self.blocks.keys())[:blocks]]
 
-        logger.debug("YADU: SCALE_IN, trying to scale_in: {}".format(to_kill))
         if self.provider:
             r = self.provider.cancel(to_kill)
 

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -260,9 +260,11 @@ class Interchange(object):
                 elif command_req == "MANAGERS":
                     reply = []
                     for manager in self._ready_manager_queue:
-                        resp = (manager.decode('utf-8'),
-                                len(self._ready_manager_queue[manager]['tasks']),
-                                self._ready_manager_queue[manager]['active'])
+                        resp = {'manager': manager.decode('utf-8'),
+                                'block_id': self._ready_manager_queue[manager]['block_id'],
+                                'worker_count': self._ready_manager_queue[manager]['worker_count'],
+                                'tasks': len(self._ready_manager_queue[manager]['tasks']),
+                                'active': self._ready_manager_queue[manager]['active']}
                         reply.append(resp)
 
                 elif command_req.startswith("HOLD_WORKER"):

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -351,6 +351,7 @@ class Interchange(object):
                     # By default we set up to ignore bad nodes/registration messages.
                     self._ready_manager_queue[manager] = {'last': time.time(),
                                                           'free_capacity': 0,
+                                                          'block_id': None,
                                                           'active': True,
                                                           'tasks': []}
                     if reg_flag is True:

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -495,6 +495,7 @@ if __name__ == "__main__":
         logger.info("Debug logging: {}".format(args.debug))
         logger.info("Log dir: {}".format(args.logdir))
         logger.info("Manager ID: {}".format(args.uid))
+        logger.info("Block ID: {}".format(args.block_id))
         logger.info("cores_per_worker: {}".format(args.cores_per_worker))
         logger.info("task_url: {}".format(args.task_url))
         logger.info("result_url: {}".format(args.result_url))
@@ -504,6 +505,7 @@ if __name__ == "__main__":
         manager = Manager(task_q_url=args.task_url,
                           result_q_url=args.result_url,
                           uid=args.uid,
+                          block_id=args.block_id,
                           cores_per_worker=float(args.cores_per_worker),
                           max_workers=args.max_workers if args.max_workers == float('inf') else int(args.max_workers),
                           heartbeat_threshold=int(args.hb_threshold),

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -52,6 +52,7 @@ class Manager(object):
                  cores_per_worker=1,
                  max_workers=float('inf'),
                  uid=None,
+                 block_id=None,
                  heartbeat_threshold=120,
                  heartbeat_period=30,
                  poll_period=10):
@@ -63,6 +64,9 @@ class Manager(object):
 
         uid : str
              string unique identifier
+
+        block_id : str
+             Block identifier that maps managers to the provider blocks they belong to.
 
         cores_per_worker : float
              cores to be assigned to each worker. Oversubscription is possible
@@ -103,6 +107,7 @@ class Manager(object):
         logger.info("Manager connected")
 
         self.uid = uid
+        self.block_id = block_id
 
         cores_on_node = multiprocessing.cpu_count()
         self.max_workers = max_workers
@@ -455,6 +460,8 @@ if __name__ == "__main__":
                         help="Process worker pool log directory")
     parser.add_argument("-u", "--uid", default=str(uuid.uuid4()).split('-')[-1],
                         help="Unique identifier string for Manager")
+    parser.add_argument("-b", "--block_id", default=None,
+                        help="Block identifier for Manager")
     parser.add_argument("-c", "--cores_per_worker", default="1.0",
                         help="Number of cores assigned to each worker process. Default=1.0")
     parser.add_argument("-t", "--task_url", required=True,

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -134,6 +134,8 @@ class Manager(object):
                'python_v': "{}.{}.{}".format(sys.version_info.major,
                                              sys.version_info.minor,
                                              sys.version_info.micro),
+               'worker_count': self.worker_count,
+               'block_id': self.block_id,
                'os': platform.system(),
                'hname': platform.node(),
                'dir': os.getcwd(),


### PR DESCRIPTION
Support for identifying managers by block_id, and putting managers in a block on hold

Managers are given a block identifier at initialization that is reported back at registration.
This allows the executor to track tasks/worker slots at the block level.
The executor also has a _hold_block() function that puts all managers in a block on hold
preventing further task scheduling, and making it safe to terminate the block.

(cherry picked from commit dc94c0223bccd0159813e8425f787f624790bbae)

Extracted from #826 .