### PR TITLE
Fix state machine in local provider

### DIFF
--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -98,10 +98,12 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
 
                 if poll_code is None:
                     self.resources[job_id]['status'] = 'RUNNING'
-                elif poll_code == 0 and self.resources[job_id]['status'] != 'RUNNING':
+                elif poll_code == 0:
                     self.resources[job_id]['status'] = 'COMPLETED'
-                elif poll_code < 0 and self.resources[job_id]['status'] != 'RUNNING':
+                elif poll_code != 0:
                     self.resources[job_id]['status'] = 'FAILED'
+                else:
+                    logger.error("Internal consistency error: unexpected case in local provider state machine")
 
             elif self.resources[job_id]['remote_pid']:
 


### PR DESCRIPTION
Previously, no state transition happened for completed processes: any
process labelled as RUNNING would not trigger any of the state transitions.

This commit removes the incorrect non-RUNNING restriction on transitions
to COMPLETED or FAILED.

This commit also extends the FAILED transition to happen with any non-zero
return code, not just negative ones: this means that a FAILED transition
should happen when a process exits with a failing return code.

This commit also adds in a error statement when none of these state
transitions fire.

Prior to this commit, some failures to launch would manifest as hangs
waiting for the launched code to start, as the failure would be ignored.

After this commit, those failures to launch result in a COMPLETED
or FAILED state, and so for example the HighThroughputExecutor loops
attempting to start new workers repeatedly - still a hang, but a
hopefully more debuggable hang.