### PR TITLE
[discussion?] change stdout/stderr handling for local jobs

### DIFF
--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -103,8 +103,11 @@ class LocalChannel(Channel, RepresentationMixin):
         try:
             proc = subprocess.Popen(
                 cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                # should this be using a pipe, or sending to existing
+                # stdout/err? What's the best behaviour in the abstract
+                # non-local case?
+                stdout=None,
+                stderr=None,
                 cwd=self.userhome,
                 env=current_env,
                 shell=True,


### PR DESCRIPTION
previously the stdout/stderr went into a pipe which was then ignored
this keeps it on the console, which is also maybe not the best
place but at least it goes somewhere.

This comes from debugging some startup problems on `theta`, alongside PR #896, where failures to start workers result in pretty silent hangs. With LocalChannel and LocalProvider, even though the startup command (`aprun`) was outputting useful diagnostic information to stderr/stdout, that was discarded (specifically, it went into a newly created pipe that was ignored).

This commit is the change I made immediately to get that output, but I'm unclear what the correct behaviour should be in the more general case of other channels and providers: so I'm not clear if this commit is the right fix.
