### PR TITLE
Make `connected_workers` consistent

### DIFF
--- a/parsl/dataflow/strategy.py
+++ b/parsl/dataflow/strategy.py
@@ -199,11 +199,9 @@ class Strategy(object):
             active_blocks = running + submitting + pending
             active_slots = active_blocks * tasks_per_node * nodes_per_block
 
-            if (isinstance(executor, IPyParallelExecutor) or
-                isinstance(executor, HighThroughputExecutor) or
-                isinstance(executor, ExtremeScaleExecutor)):
-                logger.debug('Executor {} has {} active tasks, {}/{}/{} running/submitted/pending blocks, and {} connected engines'.format(
-                    label, active_tasks, running, submitting, pending, len(executor.connected_workers)))
+            if hasattr(executor, 'connected_workers'):
+                logger.debug('Executor {} has {} active tasks, {}/{}/{} running/submitted/pending blocks, and {} connected workers'.format(
+                    label, active_tasks, running, submitting, pending, executor.connected_workers))
             else:
                 logger.debug('Executor {} has {} active tasks and {}/{}/{} running/submitted/pending blocks'.format(
                     label, active_tasks, running, submitting, pending))

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -435,8 +435,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
 
     @property
     def connected_workers(self):
-        workers = self.command_client.run("MANAGERS")
-        # logger.debug("Got managers: {}".format(workers))
+        workers = self.command_client.run("WORKERS")
         return workers
 
     def _hold_block(self, block_id):

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -438,6 +438,11 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         workers = self.command_client.run("WORKERS")
         return workers
 
+    @property
+    def connected_managers(self):
+        workers = self.command_client.run("MANAGERS")
+        return workers
+
     def _hold_block(self, block_id):
         """ Sends hold command to all managers which are in a specific block
 
@@ -447,7 +452,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
              Block identifier of the block to be put on hold
         """
 
-        managers = self.connected_workers
+        managers = self.connected_managers
 
         for manager in managers:
             if manager['block_id'] == block_id:

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -257,6 +257,11 @@ class Interchange(object):
                         outstanding += len(self._ready_manager_queue[manager]['tasks'])
                     reply = outstanding
 
+                elif command_req == "WORKERS":
+                    num_workers = 0
+                    for manager in self._ready_manager_queue:
+                        num_workers += self._ready_manager_queue[manager]['worker_count']
+                    reply = num_workers
                 elif command_req == "MANAGERS":
                     reply = []
                     for manager in self._ready_manager_queue:

--- a/parsl/executors/ipp.py
+++ b/parsl/executors/ipp.py
@@ -209,7 +209,7 @@ sleep infinity
 
     @property
     def connected_workers(self):
-        return self.executor.ids
+        return len(self.executor.ids)
 
     @property
     def scaling_enabled(self):


### PR DESCRIPTION
This fix makes the `connected_workers` method return the number of connected workers. Note this is needed to more conveniently debug issues (to be posted shortly) with dynamic slot sizes on Condor with @lgray.