### PR TITLE
add constraints in strategy to cap the maximum blocks

### DIFF
--- a/parsl/dataflow/strategy.py
+++ b/parsl/dataflow/strategy.py
@@ -259,6 +259,7 @@ class Strategy(object):
                     # logger.debug("Strategy: Case.2b")
                     excess = math.ceil((active_tasks * parallelism) - active_slots)
                     excess_blocks = math.ceil(float(excess) / (tasks_per_node * nodes_per_block))
+                    excess_blocks = min(excess_blocks, max_blocks - active_blocks)
                     logger.debug("Requesting {} more blocks".format(excess_blocks))
                     executor.scale_out(excess_blocks)
 
@@ -266,7 +267,8 @@ class Strategy(object):
                 # Case 4
                 # Check if slots are being lost quickly ?
                 logger.debug("Requesting single slot")
-                executor.scale_out(1)
+                if active_blocks < max_blocks:
+                    executor.scale_out(1)
             # Case 3
             # tasks ~ slots
             else:


### PR DESCRIPTION
Currently the strategy does not properly set the maximum blocks. This PR should fix multiple similar issues, e.g., #868, #704