### PR TITLE
change permission of job submit file, this is needed on theta

### DIFF
--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -144,6 +144,9 @@ class LocalChannel(Channel, RepresentationMixin):
             except OSError as e:
                 raise FileCopyException(e, self.hostname)
 
+        else:
+            os.chmod(local_dest, 0o777)
+
         return local_dest
 
     def close(self):


### PR DESCRIPTION
Without changing the permission, parsl cannot submit the job on Theta. Not sure 777 is too aggressive though. 