### PR TITLE
Print path to stdout and stderr for failed tasks

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -248,13 +248,7 @@ class DataFlowKernel(object):
                 res.reraise()
 
         except Exception:
-            message = "Task {} failed".format(task_id)
-            if self.tasks[task_id]['app_fu'].stdout is not None:
-                message += "\n standard output available at {}".format(self.tasks[task_id]['app_fu'].stdout)
-            if self.tasks[task_id]['app_fu'].stderr is not None:
-                message += "\n standard error available at {}".format(self.tasks[task_id]['app_fu'].stderr)
-
-            logger.exception(message)
+            logger.exception("Task {} failed".format(task_id))
 
             # We keep the history separately, since the future itself could be
             # tossed.
@@ -286,6 +280,11 @@ class DataFlowKernel(object):
 
             logger.info("Task {} completed".format(task_id))
             self.tasks[task_id]['time_returned'] = datetime.datetime.now()
+
+        if self.tasks[task_id]['app_fu'].stdout is not None:
+            logger.info("Standard output for task {} available at {}".format(task_id, self.tasks[task_id]['app_fu'].stdout))
+        if self.tasks[task_id]['app_fu'].stderr is not None:
+            logger.info("Standard error for task {} available at {}".format(task_id, self.tasks[task_id]['app_fu'].stderr))
 
         if self.monitoring:
             task_log_info = self._create_task_log_info(task_id, 'lazy')

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -248,7 +248,13 @@ class DataFlowKernel(object):
                 res.reraise()
 
         except Exception:
-            logger.exception("Task {} failed".format(task_id))
+            message = "Task {} failed".format(task_id)
+            if self.tasks[task_id]['app_fu'].stdout is not None:
+                message += "\n standard output available at {}".format(self.tasks[task_id]['app_fu'].stdout)
+            if self.tasks[task_id]['app_fu'].stderr is not None:
+                message += "\n standard error available at {}".format(self.tasks[task_id]['app_fu'].stderr)
+
+            logger.exception(message)
 
             # We keep the history separately, since the future itself could be
             # tossed.


### PR DESCRIPTION
This prints path to stdout and stderr for failed tasks. Note that this might not be as helpful in situations where there is no shared filesystem. But we have various issues describing that and related problems, and I think it's ok to keep it factorized out. In any case, this is consistent with what is saved in the monitoring DB.