### PR TITLE
Fix RepresentationMixin vs @typechecked

### DIFF
--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -175,7 +175,12 @@ class RepresentationMixin(object):
     __max_width__ = 80
 
     def __repr__(self):
-        argspec = inspect.getfullargspec(self.__init__)
+        init = self.__init__
+
+        if hasattr(init, '__wrapped__'):
+            init = init.__wrapped__
+
+        argspec = inspect.getfullargspec(init)
         if len(argspec.args) > 1:
             defaults = dict(zip(reversed(argspec.args), reversed(argspec.defaults)))
         else:


### PR DESCRIPTION
Applying `@typechecked` to a function means that function does not
have the metadata needed for `RepresentationMixin` to work properly.

`@typechecked` uses `functools.update_wrapper()`, which makes the original
undecorated function available as a `__wrapped__` attribute on the
decorated function.

This commit makes `RepresentationMixin` inspect that
`__init__.__wrapped__` function for metadata if it exists, in preference
to the top level `__init__`.

This makes `RepresentationMixin` work properly with `@typechecked`
functions.