### PR TITLE
[WIP] experimenting with travis CI folds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,8 @@ script:
     # This uses all of the configurations and tests as the base from which to
     # run mypy checks - these are likely to capture most of the code used in
     # parsl
-    - travis_fold start parsl.mypy ; echo MYPY FOLD HERE
-    - (for test in parsl/tests/configs/*.py parsl/tests/test*/test*; do MYPYPATH=$(pwd)/mypy-stubs mypy $test ; export MypyReturnCode=$? ; echo mypy return code is $MypyReturnCode ; if [[ "$MypyReturnCode" != 0 ]] ; then exit 1; fi; done ) 
+    - travis_fold start parsl.mypy ; Folded parsl.mypy output ; (for test in parsl/tests/configs/*.py parsl/tests/test*/test*; do MYPYPATH=$(pwd)/mypy-stubs mypy $test ; export MypyReturnCode=$? ; echo mypy return code is $MypyReturnCode ; if [[ "$MypyReturnCode" != 0 ]] ; then exit 1; fi; done ) && travis_fold end parsl.mypy
 
-    - travis_fold end parsl.mypy
     - rm -f .coverage
 
     - travis_fold start parsl.htex

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,9 @@ script:
     - export PARSL_TESTING="true"
     - pip install -r test-requirements.txt
     - travis_fold end parsl.setup
+    - travis_fold start parsl.flake8
     - flake8 parsl/
+    - travis_fold end parsl.flake8
 
     # This uses all of the configurations and tests as the base from which to
     # run mypy checks - these are likely to capture most of the code used in
@@ -49,25 +51,35 @@ script:
     - travis_fold end parsl.mypy
     - rm -f .coverage
 
+    - travis_fold start parsl.htex
     - (for test in parsl/tests/test*/test*; do pytest $test -k "not cleannet" --config parsl/tests/configs/htex_local.py --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
+    - travis_fold end parsl.htex
+    - travis_fold start parsl.threads
     - (for test in parsl/tests/test*/test*; do pytest $test -k "not cleannet" --config parsl/tests/configs/local_threads.py --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
       # allow exit code 5; this means pytest did not run a test in the
       # specified file
+    - travis_fold end parsl.threads
 
     # these tests run with specific configs loaded within the tests themselves.
     # This mode is enabled with: --config local
+    - travis_fold start parsl.local
     - (for test in parsl/tests/test*/test* parsl/tests/sites/test*; do pytest $test -k "not cleannet" --config local --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
+    - travis_fold end parsl.local
 
     # run simple worker test. this is unlikely to scale due to
     # a stdout/stderr buffering bug in present master.
     - coverage run --append --source=parsl parsl/tests/manual_tests/test_worker_count.py -c 1000
 
     # run specific integration tests that need their own configuration
+    - travis_fold start parsl.integration
     - pytest parsl/tests/integration/test_retries.py -k "not cleannet" --config local --cov=parsl --cov-append --cov-report=
     - pytest parsl/tests/integration/test_parsl_load_default_config.py -k "not cleannet" --config local --cov=parsl --cov-append --cov-report=
+    - travis_fold end parsl.integration
   
+    - travis_fold start parsl.coverage
     - coverage report
       # prints report of coverage data stored in .coverage
+    - travis_fold end parsl.coverage
 
     # - pytest parsl/tests --config parsl/tests/configs/local_threads.py
     # - pytest parsl/tests --config parsl/tests/configs/local_ipp.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,34 +32,48 @@ os:
 
 # command to run tests
 script:
+    - echo "travis_fold:start:setup"
     - export PARSL_TESTING="true"
     - pip install -r test-requirements.txt
+    - echo "travis_fold:end:setup"
+    - echo "travis_fold:start:flake8"
     - flake8 parsl/
+    - echo "travis_fold:end:flake8"
 
     # This uses all of the configurations and tests as the base from which to
     # run mypy checks - these are likely to capture most of the code used in
     # parsl
+    - echo "travis_fold:start:mypy"
     - (for test in parsl/tests/configs/*.py parsl/tests/test*/test*; do MYPYPATH=$(pwd)/mypy-stubs mypy $test ; export MypyReturnCode=$? ; echo mypy return code is $MypyReturnCode ; if [[ "$MypyReturnCode" != 0 ]] ; then exit 1; fi; done ) ;
 
       # do this before any testing, but not in-between tests
+    - echo "travis_fold:end:mypy"
     - rm -f .coverage
 
+    - echo "travis_fold:start:htex_local"
     - (for test in parsl/tests/test*/test*; do pytest $test -k "not cleannet" --config parsl/tests/configs/htex_local.py --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
+    - echo "travis_fold:end:htex_local"
+    - echo "travis_fold:start:local_threads"
     - (for test in parsl/tests/test*/test*; do pytest $test -k "not cleannet" --config parsl/tests/configs/local_threads.py --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
+    - echo "travis_fold:end:local_threads"
       # allow exit code 5; this means pytest did not run a test in the
       # specified file
 
     # these tests run with specific configs loaded within the tests themselves.
     # This mode is enabled with: --config local
+    - echo "travis_fold:start:local sites"
     - (for test in parsl/tests/test*/test* parsl/tests/sites/test*; do pytest $test -k "not cleannet" --config local --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
 
+    - echo "travis_fold:end:local sites"
     # run simple worker test. this is unlikely to scale due to
     # a stdout/stderr buffering bug in present master.
     - coverage run --append --source=parsl parsl/tests/manual_tests/test_worker_count.py -c 1000
 
     # run specific integration tests that need their own configuration
+    - echo "travis_fold:start:integrations"
     - pytest parsl/tests/integration/test_retries.py -k "not cleannet" --config local --cov=parsl --cov-append --cov-report=
     - pytest parsl/tests/integration/test_parsl_load_default_config.py -k "not cleannet" --config local --cov=parsl --cov-append --cov-report=
+    - echo "travis_fold:end:integrations"
   
     - coverage report
       # prints report of coverage data stored in .coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,8 @@ script:
     - export PARSL_TESTING="true"
     - pip install -r test-requirements.txt
     - travis_fold end parsl.setup
-    - travis_fold start parsl.flake8
-    - flake8 parsl/
-    - travis_fold end parsl.flake8
+
+    - travis_fold start parsl.flake8 ; flake8 parsl/ && travis_fold end parsl.flake8
 
     # This uses all of the configurations and tests as the base from which to
     # run mypy checks - these are likely to capture most of the code used in

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
     # This uses all of the configurations and tests as the base from which to
     # run mypy checks - these are likely to capture most of the code used in
     # parsl
-    - travis_fold start parsl.mypy
+    - echo -en "travis_fold:start:parsl.mypy\r"
     - (for test in parsl/tests/configs/*.py parsl/tests/test*/test*; do MYPYPATH=$(pwd)/mypy-stubs mypy $test ; export MypyReturnCode=$? ; echo mypy return code is $MypyReturnCode ; if [[ "$MypyReturnCode" != 0 ]] ; then exit 1; fi; done ) ;
 
       # do this before any testing, but not in-between tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,10 @@ script:
     # This uses all of the configurations and tests as the base from which to
     # run mypy checks - these are likely to capture most of the code used in
     # parsl
-    - ( echo -e "travis_fold:start:parsl.mypy\rMYPY" ; (for test in parsl/tests/configs/*.py parsl/tests/test*/test*; do MYPYPATH=$(pwd)/mypy-stubs mypy $test ; export MypyReturnCode=$? ; echo mypy return code is $MypyReturnCode ; if [[ "$MypyReturnCode" != 0 ]] ; then exit 1; fi; done ) ; travis_fold end parsl.mypy )
+    - travis_fold start parsl.mypy ; echo MYPY FOLD HERE
+    - (for test in parsl/tests/configs/*.py parsl/tests/test*/test*; do MYPYPATH=$(pwd)/mypy-stubs mypy $test ; export MypyReturnCode=$? ; echo mypy return code is $MypyReturnCode ; if [[ "$MypyReturnCode" != 0 ]] ; then exit 1; fi; done ) 
+
+    - travis_fold end parsl.mypy
     - rm -f .coverage
 
     - travis_fold start parsl.htex

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,48 +32,39 @@ os:
 
 # command to run tests
 script:
-    - echo "travis_fold:start:setup"
+    - export -f travis_fold
+    - travis_fold start parsl.setup
     - export PARSL_TESTING="true"
     - pip install -r test-requirements.txt
-    - echo "travis_fold:end:setup"
-    - echo "travis_fold:start:flake8"
+    - travis_fold end parsl.setup
     - flake8 parsl/
-    - echo "travis_fold:end:flake8"
 
     # This uses all of the configurations and tests as the base from which to
     # run mypy checks - these are likely to capture most of the code used in
     # parsl
-    - echo "travis_fold:start:mypy"
+    - travis_fold start parsl.mypy
     - (for test in parsl/tests/configs/*.py parsl/tests/test*/test*; do MYPYPATH=$(pwd)/mypy-stubs mypy $test ; export MypyReturnCode=$? ; echo mypy return code is $MypyReturnCode ; if [[ "$MypyReturnCode" != 0 ]] ; then exit 1; fi; done ) ;
 
       # do this before any testing, but not in-between tests
-    - echo "travis_fold:end:mypy"
+    - travis_fold end parsl.mypy
     - rm -f .coverage
 
-    - echo "travis_fold:start:htex_local"
     - (for test in parsl/tests/test*/test*; do pytest $test -k "not cleannet" --config parsl/tests/configs/htex_local.py --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
-    - echo "travis_fold:end:htex_local"
-    - echo "travis_fold:start:local_threads"
     - (for test in parsl/tests/test*/test*; do pytest $test -k "not cleannet" --config parsl/tests/configs/local_threads.py --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
-    - echo "travis_fold:end:local_threads"
       # allow exit code 5; this means pytest did not run a test in the
       # specified file
 
     # these tests run with specific configs loaded within the tests themselves.
     # This mode is enabled with: --config local
-    - echo "travis_fold:start:local sites"
     - (for test in parsl/tests/test*/test* parsl/tests/sites/test*; do pytest $test -k "not cleannet" --config local --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
 
-    - echo "travis_fold:end:local sites"
     # run simple worker test. this is unlikely to scale due to
     # a stdout/stderr buffering bug in present master.
     - coverage run --append --source=parsl parsl/tests/manual_tests/test_worker_count.py -c 1000
 
     # run specific integration tests that need their own configuration
-    - echo "travis_fold:start:integrations"
     - pytest parsl/tests/integration/test_retries.py -k "not cleannet" --config local --cov=parsl --cov-append --cov-report=
     - pytest parsl/tests/integration/test_parsl_load_default_config.py -k "not cleannet" --config local --cov=parsl --cov-append --cov-report=
-    - echo "travis_fold:end:integrations"
   
     - coverage report
       # prints report of coverage data stored in .coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,9 @@ script:
 
     # run simple worker test. this is unlikely to scale due to
     # a stdout/stderr buffering bug in present master.
+    - travis_fold start parsl.manytasks
     - coverage run --append --source=parsl parsl/tests/manual_tests/test_worker_count.py -c 1000
+    - travis_fold end parsl.manytasks
 
     # run specific integration tests that need their own configuration
     - travis_fold start parsl.integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,41 +44,29 @@ script:
     # This uses all of the configurations and tests as the base from which to
     # run mypy checks - these are likely to capture most of the code used in
     # parsl
-    - travis_fold start parsl.mypy ; Folded parsl.mypy output ; (for test in parsl/tests/configs/*.py parsl/tests/test*/test*; do MYPYPATH=$(pwd)/mypy-stubs mypy $test ; export MypyReturnCode=$? ; echo mypy return code is $MypyReturnCode ; if [[ "$MypyReturnCode" != 0 ]] ; then exit 1; fi; done ) && travis_fold end parsl.mypy
+    - travis_fold start parsl.mypy ; echo mypy tests ; (for test in parsl/tests/configs/*.py parsl/tests/test*/test*; do MYPYPATH=$(pwd)/mypy-stubs mypy $test ; export MypyReturnCode=$? ; echo mypy return code is $MypyReturnCode ; if [[ "$MypyReturnCode" != 0 ]] ; then exit 1; fi; done ) && travis_fold end parsl.mypy
 
     - rm -f .coverage
 
-    - travis_fold start parsl.htex
-    - (for test in parsl/tests/test*/test*; do pytest $test -k "not cleannet" --config parsl/tests/configs/htex_local.py --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
-    - travis_fold end parsl.htex
-    - travis_fold start parsl.threads
-    - (for test in parsl/tests/test*/test*; do pytest $test -k "not cleannet" --config parsl/tests/configs/local_threads.py --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
+    - travis_fold start parsl.htex ; echo pytest with high throughput executor ;  (for test in parsl/tests/test*/test*; do pytest $test -k "not cleannet" --config parsl/tests/configs/htex_local.py --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) && travis_fold end parsl.htex
+
+    - travis_fold start parsl.threads ; echo pytest with local thread executor ; (for test in parsl/tests/test*/test*; do pytest $test -k "not cleannet" --config parsl/tests/configs/local_threads.py --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) && travis_fold end parsl.threads
       # allow exit code 5; this means pytest did not run a test in the
       # specified file
-    - travis_fold end parsl.threads
 
     # these tests run with specific configs loaded within the tests themselves.
     # This mode is enabled with: --config local
-    - travis_fold start parsl.local
-    - (for test in parsl/tests/test*/test* parsl/tests/sites/test*; do pytest $test -k "not cleannet" --config local --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
-    - travis_fold end parsl.local
+    - travis_fold start parsl.local ; echo pytest with specific configurations ; (for test in parsl/tests/test*/test* parsl/tests/sites/test*; do pytest $test -k "not cleannet" --config local --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) && travis_fold end parsl.local
 
     # run simple worker test. this is unlikely to scale due to
     # a stdout/stderr buffering bug in present master.
-    - travis_fold start parsl.manytasks
-    - coverage run --append --source=parsl parsl/tests/manual_tests/test_worker_count.py -c 1000
-    - travis_fold end parsl.manytasks
+    - travis_fold start parsl.manytasks ; echo many task test ; coverage run --append --source=parsl parsl/tests/manual_tests/test_worker_count.py -c 1000 && travis_fold end parsl.manytasks
 
     # run specific integration tests that need their own configuration
-    - travis_fold start parsl.integration
-    - pytest parsl/tests/integration/test_retries.py -k "not cleannet" --config local --cov=parsl --cov-append --cov-report=
-    - pytest parsl/tests/integration/test_parsl_load_default_config.py -k "not cleannet" --config local --cov=parsl --cov-append --cov-report=
-    - travis_fold end parsl.integration
+    - travis_fold start parsl.integration ; echo integration pytests that need their own configuration && pytest parsl/tests/integration/test_retries.py -k "not cleannet" --config local --cov=parsl --cov-append --cov-report= && pytest parsl/tests/integration/test_parsl_load_default_config.py -k "not cleannet" --config local --cov=parsl --cov-append --cov-report= && travis_fold end parsl.integration
   
-    - travis_fold start parsl.coverage
-    - coverage report
+    - travis_fold start parsl.coverage ; echo Coverage report ; coverage report && travis_fold end parsl.coverage
       # prints report of coverage data stored in .coverage
-    - travis_fold end parsl.coverage
 
     # - pytest parsl/tests --config parsl/tests/configs/local_threads.py
     # - pytest parsl/tests --config parsl/tests/configs/local_ipp.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,7 @@ script:
     # This uses all of the configurations and tests as the base from which to
     # run mypy checks - these are likely to capture most of the code used in
     # parsl
-    - echo -en "travis_fold:start:parsl.mypy\r"
-    - (for test in parsl/tests/configs/*.py parsl/tests/test*/test*; do MYPYPATH=$(pwd)/mypy-stubs mypy $test ; export MypyReturnCode=$? ; echo mypy return code is $MypyReturnCode ; if [[ "$MypyReturnCode" != 0 ]] ; then exit 1; fi; done ) ;
-
-      # do this before any testing, but not in-between tests
-    - travis_fold end parsl.mypy
+    - ( echo -e "travis_fold:start:parsl.mypy\rMYPY" ; (for test in parsl/tests/configs/*.py parsl/tests/test*/test*; do MYPYPATH=$(pwd)/mypy-stubs mypy $test ; export MypyReturnCode=$? ; echo mypy return code is $MypyReturnCode ; if [[ "$MypyReturnCode" != 0 ]] ; then exit 1; fi; done ) ; travis_fold end parsl.mypy )
     - rm -f .coverage
 
     - travis_fold start parsl.htex


### PR DESCRIPTION
The travis web UI allows sections of the log to be folded - for example, travis does this automatically for git checkouts.

This PR adds in calls to wrap each verbose parsl test section in a fold, so that successfully completed sections of a log are folded into a single line.