### PR TITLE
Reduce verbosity of test_worker_count

### DIFF
--- a/parsl/tests/manual_tests/test_worker_count.py
+++ b/parsl/tests/manual_tests/test_worker_count.py
@@ -14,7 +14,6 @@ EXPECTED_WORKERS = math.floor(CORES / CORES_PER_WORKER)
 from htex_local import config
 config.executors[0].cores_per_worker = CORES_PER_WORKER
 config.executors[0].provider.init_blocks = 1
-parsl.set_stream_logger()
 
 # from htex_midway import config
 # from htex_swan import config


### PR DESCRIPTION
This test was the main cause of travis logs exceeding travis' maximum
log length of 10000 lines, as it outputed roughly 5 lines per task.

This PR leaves the full CI run at about 5000 lines of output.