### PR TITLE
Make exex wrap exceptions, and cope with exceptions even when they aren't wrapped

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,3 +65,4 @@ Contributing
 ============
 
 We welcome contributions from the community. Please see our `contributing guide <CONTRIBUTING.rst>`_.
+

--- a/README.rst
+++ b/README.rst
@@ -65,4 +65,3 @@ Contributing
 ============
 
 We welcome contributions from the community. Please see our `contributing guide <CONTRIBUTING.rst>`_.
-

--- a/parsl/executors/extreme_scale/mpi_worker_pool.py
+++ b/parsl/executors/extreme_scale/mpi_worker_pool.py
@@ -402,7 +402,7 @@ def worker(comm, rank):
         try:
             result = execute_task(req['buffer'])
         except Exception as e:
-            result_package = {'task_id': tid, 'exception': serialize_object(e)}
+            result_package = {'task_id': tid, 'exception': serialize_object(RemoteExceptionWrapper(*sys.exc_info()))}
             logger.debug("No result due to exception: {} with result package {}".format(e, result_package))
         else:
             result_package = {'task_id': tid, 'result': serialize_object(result)}

--- a/parsl/executors/extreme_scale/mpi_worker_pool.py
+++ b/parsl/executors/extreme_scale/mpi_worker_pool.py
@@ -16,6 +16,7 @@ import json
 
 from mpi4py import MPI
 
+from parsl.app.errors import RemoteExceptionWrapper
 from parsl.version import VERSION as PARSL_VERSION
 from ipyparallel.serialize import unpack_apply_message  # pack_apply_message,
 from ipyparallel.serialize import serialize_object

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -353,10 +353,15 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                             try:
                                 s, _ = deserialize_object(msg['exception'])
                                 # s should be a RemoteExceptionWrapper... so we can reraise it
-                                try:
-                                    s.reraise()
-                                except Exception as e:
-                                    task_fut.set_exception(e)
+                                if isinstance(s, RemoteExceptionWapper):
+                                    try:
+                                        s.reraise()
+                                    except Exception as e:
+                                        task_fut.set_exception(e)
+                                elif isinstance(s, Exception):
+                                    task_fut.set_exception(s)
+                                else:
+                                    raise ValueError("Unknown exception-like type received: {}".format(type(s)))
                             except Exception as e:
                                 # TODO could be a proper wrapped exception?
                                 task_fut.set_exception(


### PR DESCRIPTION
CI testing of the extreme scale executor are reporting the following error non-deterministically. I think I fixed this in htex before (but I can't find that fix), and I think that we're seeing it with exex recently because exex was only recently added into CI (in 7e54e7d842b3821312eb01ab49d2158375a9bca0 on 23rd May).

This PR adds in handling for the case where the deserialised object is an exception, rather than an exception wrapper, and also ports some of the exception wrapping that I put in htex workers into the equivalent MPI worker code.

```
                        elif 'exception' in msg:
                            try:
                                s, _ = deserialize_object(msg['exception'])
                                # s should be a RemoteExceptionWrapper... so we can reraise it
                                try:
>                                   s.reraise()
E                                   AttributeError: 'FileExistsError' object has no attribute 'reraise'
```