### PR TITLE
Prevent htex logs from becoming huge when sending blobs as arguments.

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -503,7 +503,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
 
         # handle people sending blobs gracefully
         args_to_print = args
-        if logging.getEffectiveLevel() >= logging.DEBUG:
+        if logger.getEffectiveLevel() >= logging.DEBUG:
             args_to_print = tuple([arg if len(repr(arg)) < 100 else (repr(arg)[:100] + '...') for arg in args])
         logger.debug("Pushing function {} to queue with args {}".format(func, args_to_print))
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -502,7 +502,9 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         task_id = self._task_counter
 
         # handle people sending blobs gracefully
-        args_to_print = tuple([arg if len(repr(arg)) < 100 else (repr(arg)[:100] + '...') for arg in args])
+        args_to_print = args
+        if logging.getEffectiveLevel() >= logging.DEBUG:
+            args_to_print = tuple([arg if len(repr(arg)) < 100 else (repr(arg)[:100] + '...') for arg in args])
         logger.debug("Pushing function {} to queue with args {}".format(func, args_to_print))
 
         self.tasks[task_id] = Future()

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -501,7 +501,9 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         self._task_counter += 1
         task_id = self._task_counter
 
-        logger.debug("Pushing function {} to queue with args {}".format(func, args))
+        # handle people sending blobs gracefully
+        args_to_print = tuple([arg if len(repr(arg)) < 100 else (repr(arg)[:100] + '...') for arg in args])
+        logger.debug("Pushing function {} to queue with args {}".format(func, args_to_print))
 
         self.tasks[task_id] = Future()
 


### PR DESCRIPTION
Truncate long arguments in logs for htex, this was causing logs to explode in size and also become useless.