### PR TITLE
Fix vis datetime precision #979

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -114,7 +114,7 @@ class DataFlowKernel(object):
                     self.workflow_name = fname
                     break
 
-        self.workflow_version = str(self.time_began)
+        self.workflow_version = str(self.time_began.replace(microsecond=0))
         if self.monitoring is not None and self.monitoring.workflow_version is not None:
             self.workflow_version = self.monitoring.workflow_version
 

--- a/parsl/monitoring/visualization/templates/app.html
+++ b/parsl/monitoring/visualization/templates/app.html
@@ -9,9 +9,9 @@
 
 <ul>
     <li><b>Workflow name:</b>  <a href="/workflow/{{ workflow_details['run_id'] }}">{{ workflow_details['workflow_name'] }}<a/></li>
-    <li><b>Started:</b>  {{ workflow_details['time_began'] }}</li>
-    <li><b>Completed:</b>  {{ workflow_details['time_completed'] }}</li>
-    <li><b>Workflow duration:</b>  {{ workflow_details['workflow_duration'] }} s</li>
+    <li><b>Started:</b>  {{ workflow_details['time_began'] | timeformat }}</li>
+    <li><b>Completed:</b>  {{ workflow_details['time_completed'] | timeformat }}</li>
+    <li><b>Workflow duration:</b>  {{ workflow_details['workflow_duration'] | timeformat }}</li>
     <li><b>Owner:</b>  {{ workflow_details['user'] }}</li>
     <li><b>host:</b>  {{ workflow_details['host'] }}</li>
     <li><b>rundir:</b>  {{ workflow_details['rundir'] }}</li>
@@ -47,8 +47,8 @@
         {% endif %}
         </td>
         <td>{{ t['task_executor'] }}</td>
-        <td>{{ t['task_time_submitted'] }}</td>
-        <td> {{ t['task_time_returned'] }}</td>
+        <td>{{ t['task_time_submitted'] | timeformat }}</td>
+        <td> {{ t['task_time_returned'] | timeformat }}</td>
       </tr>
     {% endfor %}
     </tbody>

--- a/parsl/monitoring/visualization/templates/dag.html
+++ b/parsl/monitoring/visualization/templates/dag.html
@@ -8,9 +8,9 @@
 <hr>
 
 <ul>
-    <li><b>Started:</b>  {{ workflow_details['time_began'] }}</li>
-    <li><b>Completed:</b>  {{ workflow_details['time_completed'] }}</li>
-    <li><b>Workflow duration:</b>  {{ workflow_details['workflow_duration'] }} s</li>
+    <li><b>Started:</b>  {{ workflow_details['time_began'] | timeformat }}</li>
+    <li><b>Completed:</b>  {{ workflow_details['time_completed'] | timeformat }}</li>
+    <li><b>Workflow duration:</b>  {{ workflow_details['workflow_duration'] | timeformat }}</li>
     <li><b>Owner:</b>  {{ workflow_details['user'] }}</li>
     <li><b>host:</b>  {{ workflow_details['host'] }}</li>
     <li><b>rundir:</b>  {{ workflow_details['rundir'] }}</li>

--- a/parsl/monitoring/visualization/templates/resource_usage.html
+++ b/parsl/monitoring/visualization/templates/resource_usage.html
@@ -8,9 +8,9 @@
 <hr>
 
 <ul>
-    <li><b>Started:</b>  {{ workflow_details['time_began'] }}</li>
-    <li><b>Completed:</b>  {{ workflow_details['time_completed'] }}</li>
-    <li><b>Workflow duration:</b>  {{ workflow_details['workflow_duration'] }} s</li>
+    <li><b>Started:</b>  {{ workflow_details['time_began'] | timeformat }}</li>
+    <li><b>Completed:</b>  {{ workflow_details['time_completed'] | timeformat }}</li>
+    <li><b>Workflow duration:</b>  {{ workflow_details['workflow_duration'] | timeformat }}</li>
     <li><b>Owner:</b>  {{ workflow_details['user'] }}</li>
     <li><b>host:</b>  {{ workflow_details['host'] }}</li>
     <li><b>rundir:</b>  {{ workflow_details['rundir'] }}</li>

--- a/parsl/monitoring/visualization/templates/task.html
+++ b/parsl/monitoring/visualization/templates/task.html
@@ -10,9 +10,9 @@
     <div class="col">
 <ul>
     <li><b>Workflow name:</b>  <a href="/workflow/{{ workflow_details['run_id'] }}">{{ workflow_details['workflow_name'] }}<a/></li>
-    <li><b>Started:</b>  {{ workflow_details['time_began'] }}</li>
-    <li><b>Completed:</b>  {{ workflow_details['time_completed'] }}</li>
-    <li><b>Workflow duration:</b>  {{ workflow_details['workflow_duration'] }} s</li>
+    <li><b>Started:</b>  {{ workflow_details['time_began'] | timeformat }}</li>
+    <li><b>Completed:</b>  {{ workflow_details['time_completed'] | timeformat }}</li>
+    <li><b>Workflow duration:</b>  {{ workflow_details['workflow_duration']| timeformat }}</li>
     <li><b>Owner:</b>  {{ workflow_details['user'] }}</li>
     <li><b>task_func_name:</b>   <a href="/workflow/{{ workflow_details['run_id'] }}/app/{{ task_details['task_func_name'] }}">{{ task_details['task_func_name'] }}</a></li>
     <li><b>task_id:</b>  {{ task_details['task_id'] }}</li>
@@ -25,8 +25,8 @@
             None
         {% endif %}
     </li>
-    <li><b>task_time_submitted:</b>  {{ task_details['task_time_submitted'] }}</li>
-    <li><b>task_time_returned:</b>  {{ task_details['task_time_returned'] }}</li>
+    <li><b>task_time_submitted:</b>  {{ task_details['task_time_submitted'] | timeformat }}</li>
+    <li><b>task_time_returned:</b>  {{ task_details['task_time_returned'] | timeformat }}</li>
     <li><b>task_inputs:</b>  {{ task_details['task_inputs'] }}</li>
     <li><b>task_outputs:</b>  {{ task_details['task_outputs'] }}</li>
     <li><b>task_stdin:</b>  {{ task_details['task_stdin'] }}</li>
@@ -46,7 +46,7 @@
             <tbody>
               {% for t in task_status %}
                   <tr>
-                <td>{{ t.timestamp }}</td>
+                <td>{{ t.timestamp | timeformat }}</td>
                 <td>{{ t.task_status_name }}</td>
               </tr>
             {% endfor %}

--- a/parsl/monitoring/visualization/templates/workflow.html
+++ b/parsl/monitoring/visualization/templates/workflow.html
@@ -12,9 +12,9 @@
         <h5>Workflow Summary</h5>
 
         <ul>
-            <li><b>Started:</b>  {{ workflow_details['time_began'] }}</li>
-            <li><b>Completed:</b>  {{ workflow_details['time_completed'] }}</li>
-            <li><b>Workflow duration:</b>  {{ workflow_details['workflow_duration'] }} s</li>
+            <li><b>Started:</b>  {{ workflow_details['time_began'] | timeformat}}</li>
+            <li><b>Completed:</b>  {{ workflow_details['time_completed'] | timeformat }}</li>
+            <li><b>Workflow duration:</b>  {{ workflow_details['workflow_duration'] | timeformat }}</li>
             <li><b>Owner:</b>  {{ workflow_details['user'] }}</li>
             <li><b>host:</b>  {{ workflow_details['host'] }}</li>
             <li><b>rundir:</b>  {{ workflow_details['rundir'] }}</li>

--- a/parsl/monitoring/visualization/templates/workflows_summary.html
+++ b/parsl/monitoring/visualization/templates/workflows_summary.html
@@ -24,7 +24,7 @@
         <td>{{ w.workflow_version }}</td>
         <td>{{ w.user }}</td>
         <td>{{ w.status }}</td>
-        <td>{{ w.workflow_duration }}</td>
+        <td>{{ w.workflow_duration | timeformat }}</td>
         <td>
              <span class="task task-complete">{{ w['tasks_completed_count'] }}</span>
              <span class="task task-failed">{{ w['tasks_failed_count'] }}</span>

--- a/parsl/monitoring/visualization/views.py
+++ b/parsl/monitoring/visualization/views.py
@@ -9,6 +9,21 @@ from parsl.monitoring.visualization.plots.default.workflow_resource_plots import
 
 dummy = True
 
+import datetime
+
+
+def format_time(value):
+    if value is not None:
+        if isinstance(value, float):
+            return str(datetime.timedelta(seconds=round(value)))
+        else:
+            return value.replace(microsecond=0)
+    else:
+        return value
+
+
+app.jinja_env.filters['timeformat'] = format_time
+
 
 @app.route('/')
 def index():

--- a/parsl/monitoring/visualization/views.py
+++ b/parsl/monitoring/visualization/views.py
@@ -16,8 +16,10 @@ def format_time(value):
     if value is not None:
         if isinstance(value, float):
             return str(datetime.timedelta(seconds=round(value)))
-        else:
+        elif isinstance(value, datetime.datetime):
             return value.replace(microsecond=0)
+        else:
+            return "Incorrect time format found (neither float nor datetime.datetime object)"
     else:
         return value
 

--- a/parsl/monitoring/visualization/views.py
+++ b/parsl/monitoring/visualization/views.py
@@ -13,15 +13,14 @@ import datetime
 
 
 def format_time(value):
-    if value is not None:
-        if isinstance(value, float):
-            return str(datetime.timedelta(seconds=round(value)))
-        elif isinstance(value, datetime.datetime):
-            return value.replace(microsecond=0)
-        else:
-            return "Incorrect time format found (neither float nor datetime.datetime object)"
-    else:
+    if value is None:
         return value
+    elif isinstance(value, float):
+        return str(datetime.timedelta(seconds=round(value)))
+    elif isinstance(value, datetime.datetime):
+        return value.replace(microsecond=0)
+    else:
+        return "Incorrect time format found (neither float nor datetime.datetime object)"
 
 
 app.jinja_env.filters['timeformat'] = format_time


### PR DESCRIPTION
this PR 

1. converts workflow_duration from `86401.12432s` to `1 day, 00:00:01`
2. trims the microseconds for `workflow_version`
3. displays the datetime object without microseconds on viz server.

fix #979 