### PR TITLE
fix stderr for monitoring

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -188,7 +188,7 @@ class DataFlowKernel(object):
         task_log_info['tasks_completed_count'] = self.tasks_completed_count
         task_log_info['task_inputs'] = str(self.tasks[task_id]['kwargs'].get('inputs', None))
         task_log_info['task_outputs'] = str(self.tasks[task_id]['kwargs'].get('outputs', None))
-        task_log_info['task_stdin'] = self.tasks[task_id]['kwargs'].get('stdin', None)
+        task_log_info['task_stderr'] = self.tasks[task_id]['kwargs'].get('stderr', None)
         task_log_info['task_stdout'] = self.tasks[task_id]['kwargs'].get('stdout', None)
         task_log_info['task_depends'] = None
         if self.tasks[task_id]['depends'] is not None:

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -188,8 +188,9 @@ class DataFlowKernel(object):
         task_log_info['tasks_completed_count'] = self.tasks_completed_count
         task_log_info['task_inputs'] = str(self.tasks[task_id]['kwargs'].get('inputs', None))
         task_log_info['task_outputs'] = str(self.tasks[task_id]['kwargs'].get('outputs', None))
-        task_log_info['task_stderr'] = self.tasks[task_id]['kwargs'].get('stderr', None)
+        task_log_info['task_stdin'] = self.tasks[task_id]['kwargs'].get('stdin', None)
         task_log_info['task_stdout'] = self.tasks[task_id]['kwargs'].get('stdout', None)
+        task_log_info['task_stderr'] = self.tasks[task_id]['kwargs'].get('stderr', None)
         task_log_info['task_depends'] = None
         if self.tasks[task_id]['depends'] is not None:
             task_log_info['task_depends'] = ",".join([str(t._tid) for t in self.tasks[task_id]['depends']])

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -131,7 +131,7 @@ class Database(object):
         task_memoize = Column('task_memoize', Text, nullable=False)
         task_inputs = Column('task_inputs', Text, nullable=True)
         task_outputs = Column('task_outputs', Text, nullable=True)
-        task_stdin = Column('task_stdin', Text, nullable=True)
+        task_stderr = Column('task_stderr', Text, nullable=True)
         task_stdout = Column('task_stdout', Text, nullable=True)
         __table_args__ = (
             PrimaryKeyConstraint('task_id', 'run_id'),

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -131,8 +131,9 @@ class Database(object):
         task_memoize = Column('task_memoize', Text, nullable=False)
         task_inputs = Column('task_inputs', Text, nullable=True)
         task_outputs = Column('task_outputs', Text, nullable=True)
-        task_stderr = Column('task_stderr', Text, nullable=True)
+        task_stdin = Column('task_stdin', Text, nullable=True)
         task_stdout = Column('task_stdout', Text, nullable=True)
+        task_stderr = Column('task_stderr', Text, nullable=True)
         __table_args__ = (
             PrimaryKeyConstraint('task_id', 'run_id'),
         )

--- a/parsl/monitoring/visualization/models.py
+++ b/parsl/monitoring/visualization/models.py
@@ -56,7 +56,7 @@ class Task(db.Model):
     task_memoize = db.Column('task_memoize', db.Text, nullable=False)
     task_inputs = db.Column('task_inputs', db.Text, nullable=True)
     task_outputs = db.Column('task_outputs', db.Text, nullable=True)
-    task_stdin = db.Column('task_stdin', db.Text, nullable=True)
+    task_stderr = db.Column('task_stderr', db.Text, nullable=True)
     task_stdout = db.Column('task_stdout', db.Text, nullable=True)
     __table_args__ = (
         db.PrimaryKeyConstraint('task_id', 'run_id'),

--- a/parsl/monitoring/visualization/models.py
+++ b/parsl/monitoring/visualization/models.py
@@ -56,8 +56,9 @@ class Task(db.Model):
     task_memoize = db.Column('task_memoize', db.Text, nullable=False)
     task_inputs = db.Column('task_inputs', db.Text, nullable=True)
     task_outputs = db.Column('task_outputs', db.Text, nullable=True)
-    task_stderr = db.Column('task_stderr', db.Text, nullable=True)
+    task_stdin = db.Column('task_stdin', db.Text, nullable=True)
     task_stdout = db.Column('task_stdout', db.Text, nullable=True)
+    task_stderr = db.Column('task_stderr', db.Text, nullable=True)
     __table_args__ = (
         db.PrimaryKeyConstraint('task_id', 'run_id'),
     )

--- a/parsl/monitoring/visualization/templates/task.html
+++ b/parsl/monitoring/visualization/templates/task.html
@@ -29,7 +29,7 @@
     <li><b>task_time_returned:</b>  {{ task_details['task_time_returned'] | timeformat }}</li>
     <li><b>task_inputs:</b>  {{ task_details['task_inputs'] }}</li>
     <li><b>task_outputs:</b>  {{ task_details['task_outputs'] }}</li>
-    <li><b>task_stdin:</b>  {{ task_details['task_stdin'] }}</li>	
+    <li><b>task_stdin:</b>  {{ task_details['task_stdin'] }}</li>
     <li><b>task_stdout:</b>  {{ task_details['task_stdout'] }}</li>
     <li><b>task_stderr:</b>  {{ task_details['task_stderr'] }}</li>
 </ul>

--- a/parsl/monitoring/visualization/templates/task.html
+++ b/parsl/monitoring/visualization/templates/task.html
@@ -29,6 +29,7 @@
     <li><b>task_time_returned:</b>  {{ task_details['task_time_returned'] | timeformat }}</li>
     <li><b>task_inputs:</b>  {{ task_details['task_inputs'] }}</li>
     <li><b>task_outputs:</b>  {{ task_details['task_outputs'] }}</li>
+    <li><b>task_stdin:</b>  {{ task_details['task_stdin'] }}</li>	
     <li><b>task_stdout:</b>  {{ task_details['task_stdout'] }}</li>
     <li><b>task_stderr:</b>  {{ task_details['task_stderr'] }}</li>
 </ul>

--- a/parsl/monitoring/visualization/templates/task.html
+++ b/parsl/monitoring/visualization/templates/task.html
@@ -29,8 +29,8 @@
     <li><b>task_time_returned:</b>  {{ task_details['task_time_returned'] | timeformat }}</li>
     <li><b>task_inputs:</b>  {{ task_details['task_inputs'] }}</li>
     <li><b>task_outputs:</b>  {{ task_details['task_outputs'] }}</li>
-    <li><b>task_stdin:</b>  {{ task_details['task_stdin'] }}</li>
     <li><b>task_stdout:</b>  {{ task_details['task_stdout'] }}</li>
+    <li><b>task_stderr:</b>  {{ task_details['task_stderr'] }}</li>
 </ul>
     </div>
     <div class="col">


### PR DESCRIPTION
Minor fixes for stderr for monitoring
partially for #987

[Discussion?] Issue #987 mentions only `File` type inputs/outputs should be logged. But currently, the monitoring logs any types of inputs, and only the outputs that are already specified when the app is submitted (actually only `str` type as a file path I think).
Do you think the monitoring should be kept in current version right now?