### PR TITLE
Change visualization --external to --listen

### DIFF
--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -68,5 +68,5 @@ This binds your local machine's port 50000 to the remote cluster's port 8080. Th
 .. warning:: Below is an alternative to host the viz_server, which may violate the cluster's security policy. Please check with your cluster admin before doing this.
 If the cluster allows you to host a web server on its public IP address with a specific port (i.e., open to Internet via `public_IP:55555`), you can run::
 
-   $ parsl-visualize -e --port 55555 sqlite:///<absolute-path-to-db>
+   $ parsl-visualize --listen 0.0.0.0 --port 55555 sqlite:///<absolute-path-to-db>
 

--- a/parsl/monitoring/visualization/app.py
+++ b/parsl/monitoring/visualization/app.py
@@ -13,8 +13,8 @@ def cli_run():
                         help='Port at which the monitoring Viz Server is hosted. Default: 8080')
     parser.add_argument("-d", "--debug", action='store_true',
                         help="Enable debug logging")
-    parser.add_argument("-e", "--external", action='store_true',
-                        help="Enable hosting on Internet")
+    parser.add_argument("-l", "--listen", type=str, default="127.0.0.1", metavar="ADDRESS",
+                        help="Choose address to listen for connections on. Default: 127.0.0.1. Choose 0.0.0.0 to listen on all addresses.")
     args = parser.parse_args()
 
     app = Flask(__name__)
@@ -26,10 +26,7 @@ def cli_run():
         db.create_all()
         from parsl.monitoring.visualization import views
         views.dummy = False
-        host = '127.0.0.1'
-        if args.external:
-            host = '0.0.0.0'
-        app.run(host=host, port=args.port, debug=args.debug)
+        app.run(host=args.listen, port=args.port, debug=args.debug)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This allows arbitrary IP addresses to be bound for listening, rather
than only allowing a choice between 0.0.0.0 and 127.0.0.1

This fits more in line with how most server software allows listening
address to be chosen (see apache httpd, BIND, postgres).

As a side effect, that also allows the visualization code to listen on
IPv6.

This should fix issue #1023