### PR TITLE
Make worker-side logs more accessible and useful

### DIFF
--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -24,7 +24,9 @@ def remote_side_bash_executor(func, *args, **kwargs):
 
     logbase = kwargs.pop("remote_side_bash_executor_log_base")
 
-    logging.basicConfig(filename='{0}/bashexec.{1}.log'.format(logbase, time.time()), level=logging.DEBUG)
+    format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+
+    logging.basicConfig(filename='{0}/bashexec.{1}.log'.format(logbase, time.time()), level=logging.DEBUG, format=format_string)
 
     # start_t = time.time()
 

--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -22,7 +22,9 @@ def remote_side_bash_executor(func, *args, **kwargs):
     import logging
     import parsl.app.errors as pe
 
-    logging.basicConfig(filename='/tmp/bashexec.{0}.log'.format(time.time()), level=logging.DEBUG)
+    logbase = kwargs.pop("remote_side_bash_executor_log_base")
+
+    logging.basicConfig(filename='{0}/bashexec.{1}.log'.format(logbase, time.time()), level=logging.DEBUG)
 
     # start_t = time.time()
 
@@ -162,6 +164,7 @@ class BashApp(AppBase):
                              executors=self.executors,
                              fn_hash=self.func_hash,
                              cache=self.cache,
+                             remote_side_bash_executor_log_base=dfk.config.remote_side_bash_executor_log_base,
                              **self.kwargs)
 
         out_futs = [DataFuture(app_fut, o, tid=app_fut.tid)

--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -7,9 +7,6 @@ from parsl.app.futures import DataFuture
 from parsl.app.app import AppBase
 from parsl.dataflow.dflow import DataFlowKernelLoader
 
-logger = logging.getLogger(__name__)
-
-
 def remote_side_bash_executor(func, *args, **kwargs):
     """Execute the bash app type function and return the command line string.
 
@@ -21,12 +18,21 @@ def remote_side_bash_executor(func, *args, **kwargs):
     import subprocess
     import logging
     import parsl.app.errors as pe
+    from parsl import set_file_logger
 
     logbase = kwargs.pop("remote_side_bash_executor_log_base")
 
     format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
 
-    logging.basicConfig(filename='{0}/bashexec.{1}.log'.format(logbase, time.time()), level=logging.DEBUG, format=format_string)
+    # make this name unique per invocation so that each invocation can
+    # log to its own file
+
+    t = time.time()
+    logname = __name__ + "." + str(t)
+    logger = logging.getLogger(logname)
+
+    parsl.set_file_logger(filename='{0}/bashexec.{1}.log'.format(logbase, t), name = logname, level=logging.DEBUG, format_string = format_string)
+
 
     # start_t = time.time()
 
@@ -50,10 +56,10 @@ def remote_side_bash_executor(func, *args, **kwargs):
     except IndexError as e:
         raise pe.AppBadFormatting("App formatting failed for app '{}' with IndexError: {}".format(func_name, e))
     except Exception as e:
-        logging.error("Caught exception during formatting of app '{}': {}".format(func_name, e))
+        logger.error("Caught exception during formatting of app '{}': {}".format(func_name, e))
         raise e
 
-    logging.debug("Executable: %s", executable)
+    logger.debug("Executable: %s", executable)
 
     # Updating stdout, stderr if values passed at call time.
 

--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -1,4 +1,3 @@
-import logging
 from functools import update_wrapper
 from inspect import signature, Parameter
 
@@ -6,6 +5,7 @@ from parsl.app.errors import wrap_error
 from parsl.app.futures import DataFuture
 from parsl.app.app import AppBase
 from parsl.dataflow.dflow import DataFlowKernelLoader
+
 
 def remote_side_bash_executor(func, *args, **kwargs):
     """Execute the bash app type function and return the command line string.
@@ -31,8 +31,7 @@ def remote_side_bash_executor(func, *args, **kwargs):
     logname = __name__ + "." + str(t)
     logger = logging.getLogger(logname)
 
-    parsl.set_file_logger(filename='{0}/bashexec.{1}.log'.format(logbase, t), name = logname, level=logging.DEBUG, format_string = format_string)
-
+    set_file_logger(filename='{0}/bashexec.{1}.log'.format(logbase, t), name=logname, level=logging.DEBUG, format_string=format_string)
 
     # start_t = time.time()
 

--- a/parsl/config.py
+++ b/parsl/config.py
@@ -65,7 +65,8 @@ class Config(RepresentationMixin):
                  run_dir: str = 'runinfo',
                  strategy: Optional[str] = 'simple',
                  monitoring: Optional[MonitoringHub] = None,
-                 usage_tracking: bool = False):
+                 usage_tracking: bool = False,
+                 remote_side_bash_executor_log_base: str = "/tmp/"):
         if executors is None:
             executors = [ThreadPoolExecutor()]
         self.executors = executors
@@ -90,6 +91,7 @@ class Config(RepresentationMixin):
         self.run_dir = run_dir
         self.strategy = strategy
         self.usage_tracking = usage_tracking
+        self.remote_side_bash_executor_log_base = remote_side_bash_executor_log_base
         self.monitoring = monitoring
 
     @property

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -449,7 +449,7 @@ class DataFlowKernel(object):
             executable = self.monitoring.monitor_wrapper(executable, task_id,
                                                          self.monitoring.monitoring_hub_url,
                                                          self.run_id,
-                                                         self.monitoring.resource_monitoring_interval)
+                                                         self.monitoring.resource_monitoring_interval, self.config.remote_side_bash_executor_log_base)
 
         with self.submitter_lock:
             exec_fu = executor.submit(executable, *args, **kwargs)

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -416,6 +416,7 @@ def monitor(pid, task_id, monitoring_hub_url, run_id, logbase, sleep_dur=10):
     first_msg = True
 
     while True:
+        logging.debug("start of monitoring loop")
         try:
             d = {"psutil_process_" + str(k): v for k, v in pm.as_dict().items() if k in simple}
             d["run_id"] = run_id
@@ -424,7 +425,9 @@ def monitor(pid, task_id, monitoring_hub_url, run_id, logbase, sleep_dur=10):
             d['hostname'] = platform.node()
             d['first_msg'] = first_msg
             d['timestamp'] = datetime.datetime.now()
+            logging.debug("getting children")
             children = pm.children(recursive=True)
+            logging.debug("got children")
             d["psutil_cpu_count"] = psutil.cpu_count()
             d['psutil_process_memory_virtual'] = pm.memory_info().vms
             d['psutil_process_memory_resident'] = pm.memory_info().rss
@@ -454,6 +457,8 @@ def monitor(pid, task_id, monitoring_hub_url, run_id, logbase, sleep_dur=10):
                     d['psutil_process_disk_read'] += 0
 
         finally:
+            logging.debug("sending message")
             radio.send(MessageType.TASK_INFO, task_id, d)
+            logging.debug("sleeping")
             time.sleep(sleep_dur)
             first_msg = False

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -389,18 +389,20 @@ def hub_starter(comm_q, priority_msgs, resource_msgs, stop_q, *args, **kwargs):
 
 
 def monitor(pid, task_id, monitoring_hub_url, run_id, logbase, sleep_dur=10):
-    """Internal
-    Monitors the Parsl task's resources by pointing psutil to the task's pid and watching it and its children.
-    """
-    import psutil
-    import platform
+  """Internal
+  Monitors the Parsl task's resources by pointing psutil to the task's pid and watching it and its children.
+  """
+  import psutil
+  import platform
 
-    import logging
-    import time
+  import logging
+  import time
 
-    format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
-    logging.basicConfig(filename='{0}/monitor.{task_id}.{pid}.log'.format(logbase, task_id=task_id, pid=pid), level=logging.DEBUG, format=format_string)
-    logging.debug("start of monitor")
+  format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+  logging.basicConfig(filename='{0}/monitor.{task_id}.{pid}.log'.format(logbase, task_id=task_id, pid=pid), level=logging.DEBUG, format=format_string)
+  logging.debug("start of monitor")
+
+  try:
 
     radio = UDPRadio(monitoring_hub_url,
                      source_id=task_id)
@@ -462,3 +464,6 @@ def monitor(pid, task_id, monitoring_hub_url, run_id, logbase, sleep_dur=10):
             logging.debug("sleeping")
             time.sleep(sleep_dur)
             first_msg = False
+  except:
+      logging.debug("caught an exception that will terminate this process", exc_info=True)
+      raise

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -250,12 +250,12 @@ class MonitoringHub(RepresentationMixin):
         self.close()
 
     @staticmethod
-    def monitor_wrapper(f, task_id, monitoring_hub_url, run_id, sleep_dur):
+    def monitor_wrapper(f, task_id, monitoring_hub_url, run_id, sleep_dur, remote_side_bash_executor_log_base):
         """ Internal
         Wrap the Parsl app with a function that will call the monitor function and point it at the correct pid when the task begins.
         """
         def wrapped(*args, **kwargs):
-            p = Process(target=monitor, args=(os.getpid(), task_id, monitoring_hub_url, run_id, sleep_dur))
+            p = Process(target=monitor, args=(os.getpid(), task_id, monitoring_hub_url, run_id, remote_side_bash_executor_log_base, sleep_dur))
             p.start()
             try:
                 return f(*args, **kwargs)
@@ -388,12 +388,19 @@ def hub_starter(comm_q, priority_msgs, resource_msgs, stop_q, *args, **kwargs):
     hub.start(priority_msgs, resource_msgs, stop_q)
 
 
-def monitor(pid, task_id, monitoring_hub_url, run_id, sleep_dur=10):
+def monitor(pid, task_id, monitoring_hub_url, run_id, logbase, sleep_dur=10):
     """Internal
     Monitors the Parsl task's resources by pointing psutil to the task's pid and watching it and its children.
     """
     import psutil
     import platform
+
+    import logging
+    import time
+
+    format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+    logging.basicConfig(filename='{0}/monitor.{1}.log'.format(logbase, time.time()), level=logging.DEBUG, format=format_string)
+    logging.debug("start of monitor")
 
     radio = UDPRadio(monitoring_hub_url,
                      source_id=task_id)

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -399,7 +399,7 @@ def monitor(pid, task_id, monitoring_hub_url, run_id, logbase, sleep_dur=10):
     import time
 
     format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
-    logging.basicConfig(filename='{0}/monitor.{1}.log'.format(logbase, time.time()), level=logging.DEBUG, format=format_string)
+    logging.basicConfig(filename='{0}/monitor.{task_id}.{pid}.log'.format(logbase, task_id=task_id, pid=pid), level=logging.DEBUG, format=format_string)
     logging.debug("start of monitor")
 
     radio = UDPRadio(monitoring_hub_url,

--- a/parsl/tests/configs/htex_local.py
+++ b/parsl/tests/configs/htex_local.py
@@ -6,6 +6,7 @@ from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 
 config = Config(
+    remote_side_bash_executor_log_base="/home/benc/tmp/parsl/",
     executors=[
         HighThroughputExecutor(
             label="htex_Local",

--- a/parsl/tests/configs/htex_local.py
+++ b/parsl/tests/configs/htex_local.py
@@ -6,7 +6,6 @@ from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 
 config = Config(
-    remote_side_bash_executor_log_base="/home/benc/tmp/parsl/",
     executors=[
         HighThroughputExecutor(
             label="htex_Local",


### PR DESCRIPTION
This is an assortment of changes to worker-side logging for bash apps and for monitoring.

I don't think they are ready to merge to master, but they might be useful for some debugging - I've used approximately these changes to debug that in monitoring on theta, calls to `pm.children()` are taking 10-20 seconds sometimes.
