### PR TITLE
Make it so we can specify a condor schedd

### DIFF
--- a/parsl/providers/condor/condor.py
+++ b/parsl/providers/condor/condor.py
@@ -234,7 +234,7 @@ class CondorProvider(RepresentationMixin, ClusterProvider):
 
         cmd = "condor_submit {0}".format(channel_script_path)
         if len(self.schedd_name) > 0:
-            cmd += " -name {0}".format(self.schedd_name)
+            cmd += " -remote {0}".format(self.schedd_name)
         retcode, stdout, stderr = super().execute_wait(cmd, 30)
         logger.debug("Retcode:%s STDOUT:%s STDERR:%s", retcode, stdout.strip(), stderr.strip())
 


### PR DESCRIPTION
This is important for correct function of the dfk at sites like Fermilab with multiple schedds.
It would be best to expand this to rather dynamically figure out which jobs are on which schedds, but I didn't want to write a text parser.