### PR TITLE
Fix flake8 F811 violations and remove F811 exemption

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,7 +12,7 @@
 # E129: Visual indent to not match indent as next line, counter eg here:
 # https://github.com/PyCQA/pycodestyle/issues/386
 # W504: Raised by flake8 even when it is followed
-ignore = D203, E124, E126, F403, F405, F811, E402, E129, W605, W504
+ignore = D203, E124, E126, F403, F405, E402, E129, W605, W504
 max-line-length = 160
 exclude = parsl/executors/serialize/, test_import_fail.py
 # E741 disallows ambiguous single letter names which look like numbers

--- a/.flake8
+++ b/.flake8
@@ -4,8 +4,6 @@
 # E126: continuation line over-indented for hanging indent
 # F403: ‘from module import *’ used; unable to detect undefined names
 # F405: name may be undefined, or defined from star imports: module
-# Ignoring the next one for valid tests
-# F811: redefinition of unused name from line N
 # This one is bad. Sometimes ordering matters, conditional imports
 # setting env vars necessary etc.
 # E402: module level import not at top of file

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -4,7 +4,6 @@ import argparse
 import logging
 import os
 import sys
-import sys
 import platform
 # import random
 import threading

--- a/parsl/launchers/__init__.py
+++ b/parsl/launchers/__init__.py
@@ -1,5 +1,5 @@
 from parsl.launchers.launchers import SimpleLauncher, SingleNodeLauncher, \
-    SrunLauncher, AprunLauncher, SrunMPILauncher, AprunLauncher, \
+    SrunLauncher, AprunLauncher, SrunMPILauncher, \
     GnuParallelLauncher, MpiExecLauncher, MpiRunLauncher
 
 __all__ = ['SimpleLauncher',

--- a/parsl/tests/integration/latency.py
+++ b/parsl/tests/integration/latency.py
@@ -83,18 +83,6 @@ def test_python_remote_slow(count=2):
         print(fu.result())
 
 
-def test_python_remote(count=1):
-    """ Run with no delay.
-    """
-    fus = []
-    for i in range(0, count):
-        fu = python_app_slow(0)
-        fus.extend([fu])
-
-    for fu in fus:
-        print(fu.result())
-
-
 def average(l):
     return sum(l) / len(l)
 

--- a/parsl/tests/integration/test_channels/test_ssh_errors.py
+++ b/parsl/tests/integration/test_channels/test_ssh_errors.py
@@ -29,17 +29,6 @@ def test_error_3():
     ''' This should work
     '''
     try:
-        connect_and_list("login.mcs.anl.gov", "yadunand")
-    except AuthException as e:
-        print("Caught exception : ", e)
-    else:
-        assert type(e) == BadHostKeyException, "Expected SSException, got :{0}".format(e)
-
-
-def test_error_3():
-    ''' This should work
-    '''
-    try:
         connect_and_list("edison.nersc.gov", "yadunand")
     except BadHostKeyException as e:
         print("Caught exception BadHostKeyException: ", e)


### PR DESCRIPTION
Where two functions with the same name are defined differently, the second
one is used as that seems to reflect how python actually does things.