### PR TITLE
Make check_memo return its documented type

### DIFF
--- a/parsl/dataflow/memoization.py
+++ b/parsl/dataflow/memoization.py
@@ -97,7 +97,7 @@ class Memoizer(object):
         """
         if not self.memoize or not task['memoize']:
             task['hashsum'] = None
-            return None, None
+            return False, None
 
         hashsum = self.make_hash(task)
         present = False


### PR DESCRIPTION
The returned value is now a bool as documented,
rather than a different value which can be used
in a bool context.

This shouldn't change behaviour of the code as
used now, but reduces this programmer's confusion
and makes mypy happy.