### PR TITLE
Better error handling when app 'executors' parameter is wrong

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -445,6 +445,7 @@ class DataFlowKernel(object):
             executor = self.executors[executor_label]
         except Exception:
             logger.exception("Task {} requested invalid executor {}: config is\n{}".format(task_id, executor_label, self._config))
+            raise ValueError("Task {} requested invalid executor {}".format(task_id, executor_label))
 
         if self.monitoring is not None and self.monitoring.resource_monitoring_enabled:
             executable = self.monitoring.monitor_wrapper(executable, task_id,
@@ -628,6 +629,8 @@ class DataFlowKernel(object):
             choices = list(e for e in self.executors if e != 'data_manager')
         elif isinstance(executors, list):
             choices = executors
+        else:
+            raise ValueError("Task {} supplied invalid type for executors: {}".format(task_id, type(executors)))
         executor = random.choice(choices)
 
         # Transform remote input files to data futures


### PR DESCRIPTION
With these changes, exceptions still happen in the same circumstances
as before (when a user supplies an incorrect executors value to an
app definition) but with better explanations: they are reported as the
type being wrong, rather than some later piece of code breaking.