### PR TITLE
Fix muted condor #1059

### DIFF
--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -73,12 +73,8 @@ class LocalChannel(Channel, RepresentationMixin):
             retcode = proc.returncode
 
         except Exception as e:
-            print("Caught exception: {0}".format(e))
-            logger.warn("Execution of command [%s] failed due to \n %s ", cmd, e)
-            # Set retcode to non-zero so that this can be handled in the provider.
-            if retcode == 0:
-                retcode = -1
-            return (retcode, None, None)
+            logger.warn("Execution of command '{}' failed due to \n{}".format(cmd, e))
+            raise
 
         return (retcode, stdout.decode("utf-8"), stderr.decode("utf-8"))
 
@@ -113,7 +109,7 @@ class LocalChannel(Channel, RepresentationMixin):
             pid = proc.pid
 
         except Exception as e:
-            logger.warn("Execution of command [%s] failed due to \n %s ", (cmd, e))
+            logger.warn("Execution of command '{}' failed due to \n{}".format(cmd, e))
             raise
 
         return pid, proc

--- a/parsl/providers/error.py
+++ b/parsl/providers/error.py
@@ -42,10 +42,8 @@ class ScaleOutFailed(ExecutionProviderException):
         self.provider = provider
         self.reason = reason
 
-    def __repr__(self):
-        return "Unable to Initialize provider.Provider:{0}, Reason:{1}".format(
-            self.provider, self.reason
-        )
+    def __str__(self):
+        return "Unable to scale out {} provider: {}".format(self.provider, self.reason)
 
 
 class SchedulerMissingArgs(ExecutionProviderException):


### PR DESCRIPTION
**timeout error**

Before:
```
~/parsl/providers/condor/condor.py in submit(self, command, blocksize, tasks_per_node, job_name)
    229         cmd = "condor_submit {0}".format(channel_script_path)
    230         retcode, stdout, stderr = super().execute_wait(cmd, 30)
--> 231         logger.debug("Retcode:%s STDOUT:%s STDERR:%s", retcode, stdout.strip(), stderr.strip())
    232 
    233         job_id = []

AttributeError: 'NoneType' object has no attribute 'strip'
```

After:
```
~/parsl/providers/condor/condor.py in submit(self, command, blocksize, tasks_per_node, job_name)
    235             retcode, stdout, stderr = super().execute_wait(cmd)
    236         except Exception as e:
--> 237             raise ScaleOutFailed(self.label, str(e))


ScaleOutFailed: Unable to scale out condor provider: Command 'condor_submit /nfs_scratch/awoodard/coffea/coffeandbacon/analysis/runinfo/020/submit_scripts/parsl.parsl.auto.1560968401.8491464.submit' timed out after 2 seconds
```

**artificial error in the scheduler**
Before:
```
~/parsl/providers/condor/condor.py in submit(self, command, blocksize, tasks_per_node, job_name)
    229         cmd = "condor_submit {0}".format(channel_script_path)
    230         retcode, stdout, stderr = super().execute_wait(cmd, 30)
--> 231         logger.debug("Retcode:%s STDOUT:%s STDERR:%s", retcode, stdout.strip(), stderr.strip())
    232 
    233         job_id = []

AttributeError: 'NoneType' object has no attribute 'strip'
```

After:
```
~/parsl/providers/condor/condor.py in submit(self, command, blocksize, tasks_per_node, job_name)
    257             message += " and standard output '{}'".format(stdout.strip()) if stdout is not None else ''
    258             message += " and standard error '{}'".format(stderr.strip()) if stderr is not None else ''
--> 259             raise ScaleOutFailed(self.label, message)
    260 
    261     def cancel(self, job_ids):
ScaleOutFailed: Unable to scale out condor provider: Command 'condor_submit /nfs_scratch/awoodard/coffea/coffeandbacon/analysis/runinfo/022/submit_scripts/parsl.parsl.auto.1560971966.6890364.submit' failed with return code 1 and standard output 'Submitting job(s)' and standard error 'ERROR: on Line 2 of submit file: 

ERROR: Failed to parse command file (line 2).'
```