### PR TITLE
Track psutil API changes for AccessDenied exception

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -449,7 +449,7 @@ def monitor(pid, task_id, monitoring_hub_url, run_id, sleep_dur=10):
             try:
                 d['psutil_process_disk_write'] = pm.io_counters().write_bytes
                 d['psutil_process_disk_read'] = pm.io_counters().read_bytes
-            except psutil._exceptions.AccessDenied:
+            except psutil.AccessDenied:
                 # occassionally pid temp files that hold this information are unvailable to be read so set to zero
                 d['psutil_process_disk_write'] = 0
                 d['psutil_process_disk_read'] = 0
@@ -463,7 +463,7 @@ def monitor(pid, task_id, monitoring_hub_url, run_id, sleep_dur=10):
                 try:
                     d['psutil_process_disk_write'] += child.io_counters().write_bytes
                     d['psutil_process_disk_read'] += child.io_counters().read_bytes
-                except psutil._exceptions.AccessDenied:
+                except psutil.AccessDenied:
                     # occassionally pid temp files that hold this information are unvailable to be read so add zero
                     d['psutil_process_disk_write'] += 0
                     d['psutil_process_disk_read'] += 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ tblib
 ipykernel
 requests
 paramiko
-psutil
+psutil>=5.5.1
 sqlalchemy==1.3.3
 sqlalchemy_utils
 pydot


### PR DESCRIPTION
The import location for AccessDenied has changed in psutil.

This commit uses the latest location, and requires psutil to
be at least the version that introduced that new location.

This was discovered as part of the investigations for
issue #1069