### PR TITLE
Remove unused channel-related code from kubernetes provider

### DIFF
--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -23,11 +23,6 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         Kubernetes namespace to create deployments.
     image : str
         Docker image to use in the deployment.
-    channel : Channel
-        Channel for accessing this provider. Possible channels include
-        :class:`~parsl.channels.LocalChannel` (the default),
-        :class:`~parsl.channels.SSHChannel`, or
-        :class:`~parsl.channels.SSHInteractiveLoginChannel`.
     nodes_per_block : int
         Nodes to provision per block.
     init_blocks : int
@@ -61,7 +56,6 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
     def __init__(self,
                  image,
                  namespace='default',
-                 channel=None,
                  nodes_per_block=1,
                  init_blocks=4,
                  min_blocks=0,
@@ -81,7 +75,6 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
 
         self.namespace = namespace
         self.image = image
-        self.channel = channel
         self.nodes_per_block = nodes_per_block
         self.init_blocks = init_blocks
         self.min_blocks = min_blocks
@@ -263,10 +256,6 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
     @property
     def scaling_enabled(self):
         return True
-
-    @property
-    def channels_required(self):
-        return False
 
     @property
     def label(self):


### PR DESCRIPTION
Channels are not required, but where a `channel` attribute is provided, it should actually be a `Channel`. This was not the case.
