### PR TITLE
Task gantt plot improvement

### DIFF
--- a/parsl/monitoring/visualization/views.py
+++ b/parsl/monitoring/visualization/views.py
@@ -56,9 +56,8 @@ def workflow(workflow_id):
                                 % (workflow_id), db.engine)
     task_summary = db.engine.execute(
         "SELECT task_func_name, count(*) as 'frequency' from task WHERE run_id='%s' group by task_func_name;" % workflow_id)
-    time_completed = None
-    if hasattr(workflow_details, 'time_completed'):
-        time_completed = workflow_details.time_completed
+
+    time_completed = workflow_details.time_completed
     return render_template('workflow.html',
                            workflow_details=workflow_details,
                            task_summary=task_summary,

--- a/parsl/monitoring/visualization/views.py
+++ b/parsl/monitoring/visualization/views.py
@@ -57,11 +57,10 @@ def workflow(workflow_id):
     task_summary = db.engine.execute(
         "SELECT task_func_name, count(*) as 'frequency' from task WHERE run_id='%s' group by task_func_name;" % workflow_id)
 
-    time_completed = workflow_details.time_completed
     return render_template('workflow.html',
                            workflow_details=workflow_details,
                            task_summary=task_summary,
-                           task_gantt=task_gantt_plot(df_task, time_completed=time_completed),
+                           task_gantt=task_gantt_plot(df_task, time_completed=workflow_details.time_completed),
                            task_per_app=task_per_app_plot(df_task, df_status))
 
 

--- a/parsl/monitoring/visualization/views.py
+++ b/parsl/monitoring/visualization/views.py
@@ -56,11 +56,13 @@ def workflow(workflow_id):
                                 % (workflow_id), db.engine)
     task_summary = db.engine.execute(
         "SELECT task_func_name, count(*) as 'frequency' from task WHERE run_id='%s' group by task_func_name;" % workflow_id)
-
+    time_completed = None
+    if hasattr(workflow_details, 'time_completed'):
+        time_completed = workflow_details.time_completed
     return render_template('workflow.html',
                            workflow_details=workflow_details,
                            task_summary=task_summary,
-                           task_gantt=task_gantt_plot(df_task),
+                           task_gantt=task_gantt_plot(df_task, time_completed=time_completed),
                            task_per_app=task_per_app_plot(df_task, df_status))
 
 


### PR DESCRIPTION
This PR is part of the big PR #1024, which mainly improves the layout of the first `task_gantt` plot.

1. Remove useless `print`
2. Change y axis -- not showing task IDs on y axis in case there are too many tasks and texts overlap, instead task ID is shown in hover text.
3. Minor correction of time.