### PR TITLE
add reg_time, cpu and memory, rename hostname in manager registration msg

### DIFF
--- a/parsl/executors/extreme_scale/mpi_worker_pool.py
+++ b/parsl/executors/extreme_scale/mpi_worker_pool.py
@@ -9,6 +9,7 @@ import platform
 import threading
 import pickle
 import time
+import datetime
 import queue
 import uuid
 import zmq
@@ -98,11 +99,12 @@ class Manager(object):
                                              sys.version_info.minor,
                                              sys.version_info.micro),
                'os': platform.system(),
-               'hname': platform.node(),
+               'hostname': platform.node(),
                'dir': os.getcwd(),
                'prefetch_capacity': 0,
                'worker_count': (self.comm.size - 1),
                'max_capacity': (self.comm.size - 1) + 0,  # (+prefetch)
+               'reg_time': datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         }
         b_msg = json.dumps(msg).encode('utf-8')
         return b_msg

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -358,8 +358,7 @@ class Interchange(object):
 
                     try:
                         msg = json.loads(message[1].decode('utf-8'))
-                        if 'reg_time' in msg:
-                            msg['reg_time'] = datetime.datetime.strptime(msg['reg_time'], "%Y-%m-%d %H:%M:%S")
+                        msg['reg_time'] = datetime.datetime.strptime(msg['reg_time'], "%Y-%m-%d %H:%M:%S")
                         reg_flag = True
                     except Exception:
                         logger.warning("[MAIN] Got a non-json registration message from manager:{}".format(

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -6,6 +6,7 @@ import sys
 import platform
 import random
 import time
+import datetime
 import pickle
 import logging
 import queue
@@ -194,7 +195,7 @@ class Interchange(object):
                                                                sys.version_info.minor,
                                                                sys.version_info.micro),
                                  'os': platform.system(),
-                                 'hname': platform.node(),
+                                 'hostname': platform.node(),
                                  'dir': os.getcwd()}
 
         logger.info("Platform info: {}".format(self.current_platform))
@@ -357,6 +358,8 @@ class Interchange(object):
 
                     try:
                         msg = json.loads(message[1].decode('utf-8'))
+                        if 'reg_time' in msg:
+                            msg['reg_time'] = datetime.datetime.strptime(msg['reg_time'], "%Y-%m-%d %H:%M:%S")
                         reg_flag = True
                     except Exception:
                         logger.warning("[MAIN] Got a non-json registration message from manager:{}".format(
@@ -384,7 +387,7 @@ class Interchange(object):
                             if self.suppress_failure is False:
                                 logger.debug("Setting kill event")
                                 self._kill_event.set()
-                                e = ManagerLost(manager, self._ready_manager_queue[manager]['hname'])
+                                e = ManagerLost(manager, self._ready_manager_queue[manager]['hostname'])
                                 result_package = {'task_id': -1, 'exception': serialize_object(e)}
                                 pkl_package = pickle.dumps(result_package)
                                 self.results_outgoing.send(pkl_package)
@@ -480,7 +483,7 @@ class Interchange(object):
 
                 for tid in self._ready_manager_queue[manager]['tasks']:
                     try:
-                        raise ManagerLost(manager, self._ready_manager_queue[manager]['hname'])
+                        raise ManagerLost(manager, self._ready_manager_queue[manager]['hostname'])
                     except Exception:
                         result_package = {'task_id': tid, 'exception': serialize_object(RemoteExceptionWrapper(*sys.exc_info()))}
                         pkl_package = pickle.dumps(result_package)

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -10,6 +10,7 @@ import platform
 import threading
 import pickle
 import time
+import datetime
 import queue
 import uuid
 import zmq
@@ -163,8 +164,11 @@ class Manager(object):
                'prefetch_capacity': self.prefetch_capacity,
                'max_capacity': self.worker_count + self.prefetch_capacity,
                'os': platform.system(),
-               'hname': platform.node(),
+               'hostname': platform.node(),
                'dir': os.getcwd(),
+               'cpu_count': psutil.cpu_count(logical=False),
+               'total_memory': psutil.virtual_memory().total,
+               'reg_time': datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         }
         b_msg = json.dumps(msg).encode('utf-8')
         return b_msg


### PR DESCRIPTION
This PR is a small part of PR #1024 . This includes:

1. rename `hname` to `hostname`

2. Add `reg_time` to manager registration message -- this specifically refers to the time on the manager node, but not the interchange node. I have seen the times on manager node and on interchange node have huge difference (e.g., on Theta). We need the manager-side time to infer the resource efficiency plot, as all the info like resource usage is collected on managers.

3. Add `cpu_count` and `total_memory` to registration message in HTEX.