### PR TITLE
Flush stderr after printing executable diagnostic

### DIFF
--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -79,7 +79,7 @@ def remote_side_bash_executor(func, *args, **kwargs):
     timeout = kwargs.get('walltime')
 
     if std_err is not None:
-        print('--> executable follows <--\n{}\n--> end executable <--'.format(executable), file=std_err)
+        print('--> executable follows <--\n{}\n--> end executable <--'.format(executable), file=std_err, flush=True)
 
     returncode = None
     try:


### PR DESCRIPTION
In some cases, this message wasn't being sent to stderr
before the stderr of the spawned executable, meaning the
executable diagnostic information appeared at the end,
rather than start, of the logged stderr.

This added flush should provide the necessary sequencing
to ensure the message appears before the stderr of the
spawned process.

See issue #1008