### PR TITLE
Make aws template use non-interactive apt-get

### DIFF
--- a/parsl/providers/aws/template.py
+++ b/parsl/providers/aws/template.py
@@ -3,7 +3,8 @@ template_string = """#!/bin/bash
 cd ~
 apt-get update -y
 apt-get install -y python3 python3-pip libffi-dev g++ libssl-dev
-pip3 install numpy scipy parsl
+pip3 install numpy scipy
+pip3 install git+https://github.com/macintoshpie/parsl.git@debug/aws
 $worker_init
 
 $user_script

--- a/parsl/providers/aws/template.py
+++ b/parsl/providers/aws/template.py
@@ -1,6 +1,7 @@
 template_string = """#!/bin/bash
 #sed -i 's/us-east-2\.ec2\.//g' /etc/apt/sources.list
 cd ~
+export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
 apt-get install -y python3 python3-pip libffi-dev g++ libssl-dev
 pip3 install numpy scipy

--- a/parsl/providers/aws/template.py
+++ b/parsl/providers/aws/template.py
@@ -4,8 +4,7 @@ cd ~
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
 apt-get install -y python3 python3-pip libffi-dev g++ libssl-dev
-pip3 install numpy scipy
-pip3 install git+https://github.com/macintoshpie/parsl.git@debug/aws
+pip3 install numpy scipy parsl
 $worker_init
 
 $user_script


### PR DESCRIPTION
Addresses #1094 

## Changes
- set DEBIAN_FRONTEND to noninteractive in aws template.py to prevent apt-get from starting interactive prompts