### PR TITLE
Add node resource monitoring

### DIFF
--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -81,3 +81,23 @@ class ParslExecutor(metaclass=ABCMeta):
     @run_dir.setter
     def run_dir(self, value):
         self._run_dir = value
+
+    @property
+    def hub_address(self):
+        """Address to the Hub for monitoring.
+        """
+        return self._hub_address
+
+    @hub_address.setter
+    def hub_address(self, value):
+        self._hub_address = value
+
+    @property
+    def hub_port(self):
+        """Port to the Hub for monitoring.
+        """
+        return self._hub_port
+
+    @hub_port.setter
+    def hub_port(self, value):
+        self._hub_port = value

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -151,6 +151,8 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                  provider: ExecutionProvider = LocalProvider(),
                  launch_cmd: Optional[str] = None,
                  address: str = "127.0.0.1",
+                 hub_address: Optional[str] = None,
+                 hub_port: Optional[str] = None,
                  worker_ports: Optional[Tuple[int, int]] = None,
                  worker_port_range: Optional[Tuple[int, int]] = (54000, 55000),
                  interchange_port_range: Optional[Tuple[int, int]] = (55000, 56000),
@@ -188,6 +190,8 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
 
         self._task_counter = 0
         self.address = address
+        self.hub_address = hub_address
+        self.hub_port = hub_port
         self.worker_ports = worker_ports
         self.worker_port_range = worker_port_range
         self.interchange_port_range = interchange_port_range
@@ -403,6 +407,8 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                                                            self.command_client.port),
                                           "worker_ports": self.worker_ports,
                                           "worker_port_range": self.worker_port_range,
+                                          "hub_address": self.hub_address,
+                                          "hub_port": self.hub_port,
                                           "logdir": "{}/{}".format(self.run_dir, self.label),
                                           "suppress_failure": self.suppress_failure,
                                           "heartbeat_threshold": self.heartbeat_threshold,

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -188,8 +188,8 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
 
         self._task_counter = 0
         self.address = address
-        self.hub_address = None # set to the correct hub address in dfk
-        self.hub_port = None    # set to the correct hub port in dfk
+        self.hub_address = None  # set to the correct hub address in dfk
+        self.hub_port = None  # set to the correct hub port in dfk
         self.worker_ports = worker_ports
         self.worker_port_range = worker_port_range
         self.interchange_port_range = interchange_port_range

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -151,8 +151,6 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                  provider: ExecutionProvider = LocalProvider(),
                  launch_cmd: Optional[str] = None,
                  address: str = "127.0.0.1",
-                 hub_address: Optional[str] = None,
-                 hub_port: Optional[str] = None,
                  worker_ports: Optional[Tuple[int, int]] = None,
                  worker_port_range: Optional[Tuple[int, int]] = (54000, 55000),
                  interchange_port_range: Optional[Tuple[int, int]] = (55000, 56000),
@@ -190,8 +188,8 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
 
         self._task_counter = 0
         self.address = address
-        self.hub_address = hub_address
-        self.hub_port = hub_port
+        self.hub_address = None # set to the correct hub address in dfk
+        self.hub_port = None    # set to the correct hub port in dfk
         self.worker_ports = worker_ports
         self.worker_port_range = worker_port_range
         self.interchange_port_range = interchange_port_range

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -17,6 +17,8 @@ from parsl.version import VERSION as PARSL_VERSION
 from ipyparallel.serialize import serialize_object
 
 from parsl.app.errors import RemoteExceptionWrapper
+from parsl.monitoring.message_type import MessageType
+
 
 LOOP_SLOWDOWN = 0.0  # in seconds
 HEARTBEAT_CODE = (2 ** 32) - 1
@@ -84,9 +86,11 @@ class Interchange(object):
     def __init__(self,
                  client_address="127.0.0.1",
                  interchange_address="127.0.0.1",
+                 hub_address=None,
                  client_ports=(50055, 50056, 50057),
                  worker_ports=None,
                  worker_port_range=(54000, 55000),
+                 hub_port=None,
                  heartbeat_threshold=60,
                  logdir=".",
                  logging_level=logging.INFO,
@@ -157,6 +161,14 @@ class Interchange(object):
         self.command_channel.RCVTIMEO = 1000  # in milliseconds
         self.command_channel.connect("tcp://{}:{}".format(client_address, client_ports[2]))
         logger.info("Connected to client")
+
+        self.monitoring_enabled = False
+        if hub_address and hub_port:
+            self.hub_channel = self.context.socket(zmq.DEALER)
+            self.hub_channel.set_hwm(0)
+            self.hub_channel.connect("tcp://{}:{}".format(hub_address, hub_port))
+            self.monitoring_enabled = True
+            logger.info("Monitoring enabled and connected to hub")
 
         self.pending_task_queue = queue.Queue(maxsize=10 ** 6)
 
@@ -378,6 +390,9 @@ class Interchange(object):
                         logger.info("[MAIN] Adding manager: {} to ready queue".format(manager))
                         self._ready_manager_queue[manager].update(msg)
                         logger.info("[MAIN] Registration info for manager {}: {}".format(manager, msg))
+                        if self.monitoring_enabled:
+                            logger.info("Sending message {} to hub".format(self._ready_manager_queue[manager]))
+                            self.hub_channel.send_pyobj((MessageType.NODE_INFO, self._ready_manager_queue[manager]))
 
                         if (msg['python_v'].rsplit(".", 1)[0] != self.current_platform['python_v'].rsplit(".", 1)[0] or
                             msg['parsl_v'] != self.current_platform['parsl_v']):

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -106,6 +106,10 @@ class Interchange(object):
         interchange_address : str
              The ip address at which the workers will be able to reach the Interchange. Default: "127.0.0.1"
 
+        hub_address : str
+             The ip address at which the interchange can send info about managers to when monitoring is enabled.
+             This is passed via dfk and executor automatically. Default: None (meaning monitoring disabled)
+
         client_ports : triple(int, int, int)
              The ports at which the client can be reached
 
@@ -115,6 +119,10 @@ class Interchange(object):
         worker_port_range : tuple(int, int)
              The interchange picks ports at random from the range which will be used by workers.
              This is overridden when the worker_ports option is set. Defauls: (54000, 55000)
+
+        hub_port : str
+             The port at which the interchange can send info about managers to when monitoring is enabled.
+             This is passed via dfk and executor automatically. Default: None (meaning monitoring disabled)
 
         heartbeat_threshold : int
              Number of seconds since the last heartbeat after which worker is considered lost.

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -6,6 +6,7 @@ import time
 
 from parsl.dataflow.states import States
 from parsl.providers.error import OptionalModuleMissing
+from parsl.monitoring.message_type import MessageType
 
 try:
     import sqlalchemy as sa
@@ -29,8 +30,6 @@ TASK = 'task'            # Task table includes task metadata
 STATUS = 'status'        # Status table includes task status
 RESOURCE = 'resource'    # Resource table includes task resource utilization
 NODE = 'node'            # Node table include node info
-
-from parsl.monitoring.message_type import MessageType
 
 
 class Database(object):
@@ -229,9 +228,9 @@ class DatabaseManager(object):
         self._priority_queue_pull_thread.start()
 
         self._node_queue_pull_thread = threading.Thread(target=self._migrate_logs_to_internal,
-                                                            args=(
-                                                                node_queue, 'node', self._kill_event,)
-                                                            )
+                                                        args=(
+                                                            node_queue, 'node', self._kill_event,)
+                                                        )
         self._node_queue_pull_thread.start()
 
         self._resource_queue_pull_thread = threading.Thread(target=self._migrate_logs_to_internal,
@@ -330,7 +329,6 @@ class DatabaseManager(object):
                 self.logger.debug(
                     "Got {} messages from node queue".format(len(messages)))
                 self._insert(table=NODE, messages=messages)
-
 
             """
             RESOURCE_INFO messages

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -9,7 +9,7 @@ from parsl.providers.error import OptionalModuleMissing
 
 try:
     import sqlalchemy as sa
-    from sqlalchemy import Column, Text, Float, Integer, DateTime, PrimaryKeyConstraint
+    from sqlalchemy import Column, Text, Float, Boolean, Integer, DateTime, PrimaryKeyConstraint
     from sqlalchemy.orm import sessionmaker
     from sqlalchemy.ext.declarative import declarative_base
 except ImportError:
@@ -28,6 +28,7 @@ WORKFLOW = 'workflow'    # Workflow table includes workflow metadata
 TASK = 'task'            # Task table includes task metadata
 STATUS = 'status'        # Status table includes task status
 RESOURCE = 'resource'    # Resource table includes task resource utilization
+NODE = 'node'            # Node table include node info
 
 from parsl.monitoring.message_type import MessageType
 
@@ -138,6 +139,19 @@ class Database(object):
             PrimaryKeyConstraint('task_id', 'run_id'),
         )
 
+    class Node(Base):
+        __tablename__ = NODE
+        run_id = Column('run_id', Text, nullable=False)
+        hostname = Column('hostname', Text, nullable=True)
+        cpu_count = Column('cpu_count', Integer, nullable=False)
+        total_memory = Column('total_memory', Integer, nullable=False)
+        active = Column('active', Boolean, nullable=False)
+        worker_count = Column('worker_count', Integer, nullable=False)
+        python_v = Column('python_v', Text, nullable=False)
+        __table_args__ = (
+            PrimaryKeyConstraint('hostname', 'run_id'),
+        )
+
     class Resource(Base):
         __tablename__ = RESOURCE
         task_id = Column('task_id', Integer, sa.ForeignKey(
@@ -201,9 +215,10 @@ class DatabaseManager(object):
         self.batching_threshold = batching_threshold
 
         self.pending_priority_queue = queue.Queue()
+        self.pending_node_queue = queue.Queue()
         self.pending_resource_queue = queue.Queue()
 
-    def start(self, priority_queue, resource_queue):
+    def start(self, priority_queue, node_queue, resource_queue):
 
         self._kill_event = threading.Event()
         self._priority_queue_pull_thread = threading.Thread(target=self._migrate_logs_to_internal,
@@ -211,6 +226,12 @@ class DatabaseManager(object):
                                                                 priority_queue, 'priority', self._kill_event,)
                                                             )
         self._priority_queue_pull_thread.start()
+
+        self._node_queue_pull_thread = threading.Thread(target=self._migrate_logs_to_internal,
+                                                            args=(
+                                                                node_queue, 'node', self._kill_event,)
+                                                            )
+        self._node_queue_pull_thread.start()
 
         self._resource_queue_pull_thread = threading.Thread(target=self._migrate_logs_to_internal,
                                                             args=(
@@ -298,6 +319,19 @@ class DatabaseManager(object):
                 self._insert(table=STATUS, messages=all_messages)
 
             """
+            NODE_INFO messages
+
+            """
+            messages = self._get_messages_in_batch(self.pending_node_queue,
+                                                   interval=self.batching_interval,
+                                                   threshold=self.batching_threshold)
+            if messages:
+                self.logger.debug(
+                    "Got {} messages from node queue".format(len(messages)))
+                self._insert(table=NODE, messages=messages)
+
+
+            """
             RESOURCE_INFO messages
 
             """
@@ -343,6 +377,8 @@ class DatabaseManager(object):
                         self.pending_priority_queue.put(x)
                 elif queue_tag == 'resource':
                     self.pending_resource_queue.put(x[-1])
+                elif queue_tag == 'node':
+                    self.pending_node_queue.put(x[-1])
 
     def _update(self, table, columns, messages):
         self.db.update(table=table, columns=columns, messages=messages)
@@ -405,11 +441,11 @@ def start_file_logger(filename, name='database_manager', level=logging.DEBUG, fo
     return logger
 
 
-def dbm_starter(priority_msgs, resource_msgs, *args, **kwargs):
+def dbm_starter(priority_msgs, node_msgs, resource_msgs, *args, **kwargs):
     """Start the database manager process
 
     The DFK should start this function. The args, kwargs match that of the monitoring config
 
     """
     dbm = DatabaseManager(*args, **kwargs)
-    dbm.start(priority_msgs, resource_msgs)
+    dbm.start(priority_msgs, node_msgs, resource_msgs)

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -152,7 +152,7 @@ class Database(object):
         python_v = Column('python_v', Text, nullable=False)
         reg_time = Column('reg_time', DateTime, nullable=False)
         __table_args__ = (
-            PrimaryKeyConstraint('hostname', 'run_id'),
+            PrimaryKeyConstraint('hostname', 'run_id', 'reg_time'),
         )
 
     class Resource(Base):

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -142,12 +142,13 @@ class Database(object):
     class Node(Base):
         __tablename__ = NODE
         run_id = Column('run_id', Text, nullable=False)
-        hostname = Column('hostname', Text, nullable=True)
+        hostname = Column('hostname', Text, nullable=False)
         cpu_count = Column('cpu_count', Integer, nullable=False)
         total_memory = Column('total_memory', Integer, nullable=False)
         active = Column('active', Boolean, nullable=False)
         worker_count = Column('worker_count', Integer, nullable=False)
         python_v = Column('python_v', Text, nullable=False)
+        reg_time = Column('reg_time', DateTime, nullable=False)
         __table_args__ = (
             PrimaryKeyConstraint('hostname', 'run_id'),
         )

--- a/parsl/monitoring/message_type.py
+++ b/parsl/monitoring/message_type.py
@@ -11,3 +11,6 @@ class MessageType(Enum):
 
     # Top level workflow information
     WORKFLOW_INFO = 2
+
+    # Reports of the resource capacity for each node
+    NODE_INFO = 3

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -510,32 +510,3 @@ def monitor(pid, task_id, monitoring_hub_url, run_id, sleep_dur=10):
             logging.debug("sleeping")
             time.sleep(sleep_dur)
             first_msg = False
-
-
-def send_node_info(hub_url, hub_port, run_id, logger):
-    '''
-    Send the resource capacity of a node to MonitoringHub. Currently works for HTEX model only.
-    '''
-
-    import psutil
-    import zmq
-    import hostname
-
-    context = zmq.Context()
-    socket = self._context.socket(zmq.DEALER)
-    socket.set_hwm(0)
-    ports = socket.bind_to_random_port("tcp://{}".format(monitoring_hub_url),
-                                       min_port=client_port_range[0],
-                                       max_port=client_port_range[1])
-    
-    message = {
-               'cpu_core_count': psutil.cpu_count(logical=False),
-               'total_memory': psutil.virtual_memory().total,
-               'run_id': run_id,
-               'hostname': platform.node()
-    }
-
-    logger.debug("Sending node info message {} to Monitoring Hub".format(message))
-    socket.send_pyobj((MessageType.NODE_INFO, message))
-    scoket.close()
-    logger.info("Terminating ZMQ sockets for sending resource capacity messages") 

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -194,7 +194,7 @@ class MonitoringHub(RepresentationMixin):
         self.resource_monitoring_enabled = resource_monitoring_enabled
         self.resource_monitoring_interval = resource_monitoring_interval
 
-    def start(self):
+    def start(self, run_id):
 
         if self.logdir is None:
             self.logdir = "."
@@ -223,9 +223,10 @@ class MonitoringHub(RepresentationMixin):
         self.stop_q = Queue(maxsize=10)
         self.priority_msgs = Queue()
         self.resource_msgs = Queue()
+        self.node_msgs = Queue()
 
         self.queue_proc = Process(target=hub_starter,
-                                  args=(comm_q, self.priority_msgs, self.resource_msgs, self.stop_q),
+                                  args=(comm_q, self.priority_msgs, self.node_msgs, self.resource_msgs, self.stop_q),
                                   kwargs={"hub_address": self.hub_address,
                                           "hub_port": self.hub_port,
                                           "hub_port_range": self.hub_port_range,
@@ -233,12 +234,13 @@ class MonitoringHub(RepresentationMixin):
                                           "client_port": self.dfk_port,
                                           "logdir": self.logdir,
                                           "logging_level": self.logging_level,
+                                          "run_id": run_id
                                   },
         )
         self.queue_proc.start()
 
         self.dbm_proc = Process(target=dbm_starter,
-                                args=(self.priority_msgs, self.resource_msgs,),
+                                args=(self.priority_msgs, self.node_msgs, self.resource_msgs,),
                                 kwargs={"logdir": self.logdir,
                                         "logging_level": self.logging_level,
                                         "db_url": self.logging_endpoint,
@@ -247,13 +249,13 @@ class MonitoringHub(RepresentationMixin):
         self.dbm_proc.start()
 
         try:
-            udp_dish_port = comm_q.get(block=True, timeout=120)
+            udp_dish_port, ic_port = comm_q.get(block=True, timeout=120)
         except queue.Empty:
             self.logger.error("Hub has not completed initialization in 120s. Aborting")
             raise Exception("Hub failed to start")
 
         self.monitoring_hub_url = "udp://{}:{}".format(self.hub_address, udp_dish_port)
-        return self.monitoring_hub_url
+        return ic_port
 
     def send(self, mtype, message):
         self.logger.debug("Sending message {}, {}".format(mtype, message))
@@ -307,6 +309,7 @@ class Hub(object):
 
                  monitoring_hub_address="127.0.0.1",
                  logdir=".",
+                 run_id=None,
                  logging_level=logging.DEBUG,
                  atexit_timeout=3    # in seconds
                 ):
@@ -348,6 +351,7 @@ class Hub(object):
         self.hub_port = hub_port
         self.hub_address = hub_address
         self.atexit_timeout = atexit_timeout
+        self.run_id = run_id
 
         self.loop_freq = 10.0  # milliseconds
 
@@ -371,7 +375,15 @@ class Hub(object):
         self.dfk_channel.RCVTIMEO = int(self.loop_freq)  # in milliseconds
         self.dfk_channel.connect("tcp://{}:{}".format(client_address, client_port))
 
-    def start(self, priority_msgs, resource_msgs, stop_q):
+        self.ic_channel = self._context.socket(zmq.DEALER)
+        self.ic_channel.set_hwm(0)
+        self.ic_channel.RCVTIMEO = int(self.loop_freq)  # in milliseconds
+        self.logger.debug("hub_address: {}. hub_port_range {}".format(hub_address, hub_port_range))
+        self.ic_port = self.ic_channel.bind_to_random_port("tcp://*",
+                                                           min_port=hub_port_range[0],
+                                                           max_port=hub_port_range[1])
+
+    def start(self, priority_msgs, node_msgs, resource_msgs, stop_q):
 
         while True:
             try:
@@ -384,10 +396,19 @@ class Hub(object):
 
             try:
                 msg = self.dfk_channel.recv_pyobj()
-                self.logger.debug("Got ZMQ Message: {}".format(msg))
+                self.logger.debug("Got ZMQ Message from DFK: {}".format(msg))
                 priority_msgs.put((msg, 0))
                 if msg[0].value == MessageType.WORKFLOW_INFO.value and 'python_version' not in msg[1]:
                     break
+            except zmq.Again:
+                pass
+
+            try:
+                msg = self.ic_channel.recv_pyobj()
+                msg[1]['run_id'] = self.run_id
+                msg = (msg[0], msg[1])
+                self.logger.debug("Got ZMQ Message from interchange: {}".format(msg))
+                node_msgs.put((msg, 0))
             except zmq.Again:
                 pass
 
@@ -404,10 +425,10 @@ class Hub(object):
         stop_q.put("STOP")
 
 
-def hub_starter(comm_q, priority_msgs, resource_msgs, stop_q, *args, **kwargs):
+def hub_starter(comm_q, priority_msgs, node_msgs, resource_msgs, stop_q, *args, **kwargs):
     hub = Hub(*args, **kwargs)
-    comm_q.put(hub.hub_port)
-    hub.start(priority_msgs, resource_msgs, stop_q)
+    comm_q.put((hub.hub_port, hub.ic_port))
+    hub.start(priority_msgs, node_msgs, resource_msgs, stop_q)
 
 
 def monitor(pid, task_id, monitoring_hub_url, run_id, sleep_dur=10):
@@ -489,3 +510,32 @@ def monitor(pid, task_id, monitoring_hub_url, run_id, sleep_dur=10):
             logging.debug("sleeping")
             time.sleep(sleep_dur)
             first_msg = False
+
+
+def send_node_info(hub_url, hub_port, run_id, logger):
+    '''
+    Send the resource capacity of a node to MonitoringHub. Currently works for HTEX model only.
+    '''
+
+    import psutil
+    import zmq
+    import hostname
+
+    context = zmq.Context()
+    socket = self._context.socket(zmq.DEALER)
+    socket.set_hwm(0)
+    ports = socket.bind_to_random_port("tcp://{}".format(monitoring_hub_url),
+                                       min_port=client_port_range[0],
+                                       max_port=client_port_range[1])
+    
+    message = {
+               'cpu_core_count': psutil.cpu_count(logical=False),
+               'total_memory': psutil.virtual_memory().total,
+               'run_id': run_id,
+               'hostname': platform.node()
+    }
+
+    logger.debug("Sending node info message {} to Monitoring Hub".format(message))
+    socket.send_pyobj((MessageType.NODE_INFO, message))
+    scoket.close()
+    logger.info("Terminating ZMQ sockets for sending resource capacity messages") 

--- a/parsl/tests/manual_tests/test_fan_in_out_htex_remote.py
+++ b/parsl/tests/manual_tests/test_fan_in_out_htex_remote.py
@@ -2,35 +2,34 @@ import parsl
 # from parsl.monitoring.db_logger import MonitoringConfig
 from parsl.monitoring.monitoring import MonitoringHub
 from parsl.config import Config
-from parsl.executors import ThreadPoolExecutor
 from parsl.executors import HighThroughputExecutor
-from parsl.launchers import SrunLauncher
-from parsl.providers.slurm.slurm import SlurmProvider
+from parsl.launchers import AprunLauncher
+from parsl.providers import CobaltProvider
 from parsl.addresses import address_by_hostname
 
 import logging
 from parsl.app.app import python_app
 
-#parsl.set_stream_logger()
 
 threads_config = Config(
     executors=[
         HighThroughputExecutor(
-            label="midway_htex",
-            #worker_debug=True,
-            cores_per_worker=1,
+            label="theta_htex",
+            # worker_debug=True,
+            cores_per_worker=4,
             address=address_by_hostname(),
-            provider=SlurmProvider(
-                'broadwl',
-                launcher=SrunLauncher(),
-                scheduler_options='#SBATCH --exclusive\n#SBATCH --ntasks-per-node=29',
+            provider=CobaltProvider(
+                queue='debug-flat-quad',
+                account='CSC249ADCD01',
+                launcher=AprunLauncher(overrides="-d 64"),
                 worker_init='source activate parsl-issues',
                 init_blocks=1,
                 max_blocks=1,
                 min_blocks=1,
-                nodes_per_block=2,
+                nodes_per_block=4,
+                cmd_timeout=60,
                 walltime='00:10:00',
-           ),
+            ),
         )
     ],
     monitoring=MonitoringHub(
@@ -44,6 +43,7 @@ threads_config = Config(
 
 dfk = parsl.load(threads_config)
 
+
 @python_app
 def inc(x):
     import time
@@ -55,6 +55,7 @@ def inc(x):
         if end - start >= sleep_duration:
             break
     return x
+
 
 @python_app
 def add_inc(inputs=[]):
@@ -72,17 +73,17 @@ def add_inc(inputs=[]):
 
 if __name__ == "__main__":
 
-    total = 100 
+    total = 200
     half = int(total / 2)
     one_third = int(total / 3)
     two_third = int(total / 3 * 2)
     futures_1 = [inc(i) for i in range(total)]
     futures_2 = [add_inc(inputs=futures_1[0:half]),
-                 add_inc(inputs=futures_1[half:total])]  
+                 add_inc(inputs=futures_1[half:total])]
     futures_3 = [inc(futures_2[0]) for _ in range(half)] + [inc(futures_2[1]) for _ in range(half)]
     futures_4 = [add_inc(inputs=futures_3[0:one_third]),
                  add_inc(inputs=futures_3[one_third:two_third]),
                  add_inc(inputs=futures_3[two_third:total])]
-    
+
     print([f.result() for f in futures_4])
     print("Done")

--- a/parsl/tests/manual_tests/test_fan_in_out_htex_remote.py
+++ b/parsl/tests/manual_tests/test_fan_in_out_htex_remote.py
@@ -1,0 +1,88 @@
+import parsl
+# from parsl.monitoring.db_logger import MonitoringConfig
+from parsl.monitoring.monitoring import MonitoringHub
+from parsl.config import Config
+from parsl.executors import ThreadPoolExecutor
+from parsl.executors import HighThroughputExecutor
+from parsl.launchers import SrunLauncher
+from parsl.providers.slurm.slurm import SlurmProvider
+from parsl.addresses import address_by_hostname
+
+import logging
+from parsl.app.app import python_app
+
+#parsl.set_stream_logger()
+
+threads_config = Config(
+    executors=[
+        HighThroughputExecutor(
+            label="midway_htex",
+            #worker_debug=True,
+            cores_per_worker=1,
+            address=address_by_hostname(),
+            provider=SlurmProvider(
+                'broadwl',
+                launcher=SrunLauncher(),
+                scheduler_options='#SBATCH --exclusive\n#SBATCH --ntasks-per-node=29',
+                worker_init='source activate parsl-issues',
+                init_blocks=1,
+                max_blocks=1,
+                min_blocks=1,
+                nodes_per_block=2,
+                walltime='00:10:00',
+           ),
+        )
+    ],
+    monitoring=MonitoringHub(
+        hub_address=address_by_hostname(),
+        hub_port=55055,
+        logging_level=logging.DEBUG,
+        resource_monitoring_interval=10,
+    ),
+    strategy=None
+)
+
+dfk = parsl.load(threads_config)
+
+@python_app
+def inc(x):
+    import time
+    start = time.time()
+    sleep_duration = 30.0
+    while True:
+        x += 1
+        end = time.time()
+        if end - start >= sleep_duration:
+            break
+    return x
+
+@python_app
+def add_inc(inputs=[]):
+    import time
+    start = time.time()
+    sleep_duration = 30.0
+    res = sum(inputs)
+    while True:
+        res += 1
+        end = time.time()
+        if end - start >= sleep_duration:
+            break
+    return res
+
+
+if __name__ == "__main__":
+
+    total = 100 
+    half = int(total / 2)
+    one_third = int(total / 3)
+    two_third = int(total / 3 * 2)
+    futures_1 = [inc(i) for i in range(total)]
+    futures_2 = [add_inc(inputs=futures_1[0:half]),
+                 add_inc(inputs=futures_1[half:total])]  
+    futures_3 = [inc(futures_2[0]) for _ in range(half)] + [inc(futures_2[1]) for _ in range(half)]
+    futures_4 = [add_inc(inputs=futures_3[0:one_third]),
+                 add_inc(inputs=futures_3[one_third:two_third]),
+                 add_inc(inputs=futures_3[two_third:total])]
+    
+    print([f.result() for f in futures_4])
+    print("Done")


### PR DESCRIPTION
This PR is a major breaking down of PR #1024 . It tries to add a node table to monitoring.db, which logs the node information including resource capacity, reg_time, python version, etc.

1. The node info is first collected by the interchange.
2. The interchange send data to the Hub (then send to db_manager). The db_manager logs all the data then.

To allow interchange to connect to the Hub, we need dfk to pass the hub address and hub port to executor and interchange.