### PR TITLE
Allow monitoring db task_time_submitted to be NULL

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -123,7 +123,7 @@ class Database(object):
         task_executor = Column('task_executor', Text, nullable=False)
         task_func_name = Column('task_func_name', Text, nullable=False)
         task_time_submitted = Column(
-            'task_time_submitted', DateTime, nullable=False)
+            'task_time_submitted', DateTime, nullable=True)
         task_time_running = Column(
             'task_time_running', DateTime, nullable=True)
         task_time_returned = Column(


### PR DESCRIPTION
When a task is written to the DB which has not been submitted, then
prior to this commit, a database integrity error was raised, as the
database required a task to have a submit time.

This manifests in #1100 where unsubmitted tasks are written out to
the monitoring DB at the point that a workflow fails.

I haven't checked if this introduces a new failure mode for visualisation, where the visualisation code will now be sometimes presented with tasks that have no submit time.