### PR TITLE
Catch exception for retries in monitoring

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -193,7 +193,7 @@ class DataFlowKernel(object):
         task_log_info['task_stderr'] = self.tasks[task_id]['kwargs'].get('stderr', None)
         task_log_info['task_fail_history'] = None
         if self.tasks[task_id]['fail_history'] is not None:
-            task_log_info['task_fail_history'] = "; ".join(self.tasks[task_id]['fail_history'])
+            task_log_info['task_fail_history'] = ",".join(self.tasks[task_id]['fail_history'])
         task_log_info['task_depends'] = None
         if self.tasks[task_id]['depends'] is not None:
             task_log_info['task_depends'] = ",".join([str(t._tid) for t in self.tasks[task_id]['depends']])

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -178,7 +178,7 @@ class DataFlowKernel(object):
         """
 
         info_to_monitor = ['func_name', 'fn_hash', 'memoize', 'checkpoint', 'fail_count',
-                           'fail_history', 'status', 'id', 'time_submitted', 'time_returned', 'executor']
+                           'status', 'id', 'time_submitted', 'time_returned', 'executor']
 
         task_log_info = {"task_" + k: self.tasks[task_id][k] for k in info_to_monitor}
         task_log_info['run_id'] = self.run_id
@@ -191,6 +191,9 @@ class DataFlowKernel(object):
         task_log_info['task_stdin'] = self.tasks[task_id]['kwargs'].get('stdin', None)
         task_log_info['task_stdout'] = self.tasks[task_id]['kwargs'].get('stdout', None)
         task_log_info['task_stderr'] = self.tasks[task_id]['kwargs'].get('stderr', None)
+        task_log_info['task_fail_history'] = None
+        if self.tasks[task_id]['fail_history'] is not None:
+            task_log_info['task_fail_history'] = "; ".join(self.tasks[task_id]['fail_history'])
         task_log_info['task_depends'] = None
         if self.tasks[task_id]['depends'] is not None:
             task_log_info['task_depends'] = ",".join([str(t._tid) for t in self.tasks[task_id]['depends']])
@@ -246,12 +249,12 @@ class DataFlowKernel(object):
             if isinstance(res, RemoteExceptionWrapper):
                 res.reraise()
 
-        except Exception:
+        except Exception as e:
             logger.exception("Task {} failed".format(task_id))
 
             # We keep the history separately, since the future itself could be
             # tossed.
-            self.tasks[task_id]['fail_history'].append(future._exception)
+            self.tasks[task_id]['fail_history'].append(str(e))
             self.tasks[task_id]['fail_count'] += 1
 
             if not self._config.lazy_errors:

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -136,6 +136,7 @@ class Database(object):
         task_stdout = Column('task_stdout', Text, nullable=True)
         task_stderr = Column('task_stderr', Text, nullable=True)
         task_fail_count = Column('task_fail_count', Integer, nullable=False)
+        task_fail_history = Column('task_fail_history', Text, nullable=True)
         __table_args__ = (
             PrimaryKeyConstraint('task_id', 'run_id'),
         )
@@ -296,7 +297,8 @@ class DatabaseManager(object):
                     self._update(table=TASK,
                                  columns=['task_time_returned',
                                           'task_elapsed_time', 'run_id', 'task_id',
-                                          'task_fail_count'],
+                                          'task_fail_count',
+                                          'task_fail_history'],
                                  messages=update_messages)
                 self._insert(table=STATUS, messages=all_messages)
 


### PR DESCRIPTION
As @TomGlanzman suggested, we should log the exception for each retry of a task to monitoring.
This PR adds the exceptions to `monitoring.db` as a column, in the format of `exception 1; exception 2; exception 3 ...`

Related to #1104 .
Fix #1105 .