### PR TITLE
Add a test that passes in pytest but actually fails in two different ways

### DIFF
--- a/parsl/tests/sites/test_local_monitoring_with_failure.py
+++ b/parsl/tests/sites/test_local_monitoring_with_failure.py
@@ -1,0 +1,31 @@
+import pytest
+
+import parsl
+from parsl.dataflow.dflow import DataFlowKernel
+from parsl.app.app import python_app
+from parsl.tests.configs.local_threads_monitoring import config
+
+
+@python_app
+def python_app_2(f):
+    return "R2"
+
+@python_app
+def python_app_1():
+    # return "r1"
+    raise ValueError("deliberate failure")
+
+@pytest.mark.local
+def test_python(N=2):
+
+    parsl.set_stream_logger()
+    parsl.load(config)
+
+    f1 = python_app_1()
+    f2 = python_app_2(f1)
+
+    f2.exception()
+    # wait for a result or exception, but do not throw exception if
+    # that is what arrives
+
+    parsl.dfk().cleanup()


### PR DESCRIPTION
On my laptop, this test always passes according to pytest, but it behaves
wrongly in two different ways:

1. Sometimes it shows issue #1109 at the end of the test.

2. Sometimes it does not record task rows in the monitoring DB at all.
      - out of around 10 runs, I only get three task rows in my monitoring.db

I suspect for 2. that there is some race condition happening at shutdown
where the DFK is saying it is all closed before monitoring really is
finished.

Invoke like this:

```
pytest parsl/tests/sites/test_local_monitoring_with_failure.py --config local
```
