### PR TITLE
minor code enhancement in workflow_resource_plot

### DIFF
--- a/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
@@ -31,14 +31,14 @@ def resource_distribution_plot(df_resources, df_task, type='psutil_process_time_
                 task = df_resources[df_resources['task_id'] ==
                                     app][type].astype('float').mean()
             elif option == 'max':
-                task = max(
-                    df_resources[df_resources['task_id'] == app][type].astype('float'))
+                task = df_resources[df_resources['task_id'] == app][type].astype('float').max()
 
             for i in range(len(x_axis) - 1):
                 a = task >= x_axis[i]
                 b = task < x_axis[i + 1]
                 if a and b:
                     items[i] += 1
+                    break
             if task >= x_axis[-1]:
                 items[-1] += 1
         return items


### PR DESCRIPTION
A small PR breaking down from #1024.
1. Using `dataframe`'s built-in `max()` method
2. Break a loop earlier for speed