### PR TITLE
Remove flake8 exemption for F403 undefined name detection

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,6 @@
 # D203: 1 blank line required before class docstring
 # E124: closing bracket does not match visual indentation
 # E126: continuation line over-indented for hanging indent
-# F403: ‘from module import *’ used; unable to detect undefined names
 # F405: name may be undefined, or defined from star imports: module
 # This one is bad. Sometimes ordering matters, conditional imports
 # setting env vars necessary etc.
@@ -10,10 +9,15 @@
 # E129: Visual indent to not match indent as next line, counter eg here:
 # https://github.com/PyCQA/pycodestyle/issues/386
 # W504: Raised by flake8 even when it is followed
-ignore = D203, E124, E126, F403, F405, E402, E129, W605, W504
+ignore = D203, E124, E126, F405, E402, E129, W605, W504
 max-line-length = 160
 exclude = parsl/executors/serialize/, test_import_fail.py
 # E741 disallows ambiguous single letter names which look like numbers
 # We disable it in visualization code because plotly uses 'l' as
 # a keyword arg
-per-file-ignores = parsl/monitoring/visualization/*:E741
+# F821: undefined name
+per-file-ignores = parsl/monitoring/visualization/*:E741,
+  # needed because this deliberately has undefined names in it
+  parsl/tests/test_swift.py:F821,
+  # test_ssh_errors.py really is broken
+  parsl/tests/integration/test_channels/test_ssh_errors.py:F821

--- a/parsl/app/futures.py
+++ b/parsl/app/futures.py
@@ -9,7 +9,7 @@ import logging
 from concurrent.futures import Future
 
 from parsl.dataflow.futures import AppFuture, _STATE_TO_DESCRIPTION_MAP, FINISHED
-from parsl.app.errors import *
+from parsl.app.errors import NotFutureError
 from parsl.data_provider.files import File
 
 logger = logging.getLogger(__name__)

--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 
 from parsl.channels.base import Channel
-from parsl.channels.errors import *
+from parsl.channels.errors import FileCopyException
 from parsl.utils import RepresentationMixin
 
 logger = logging.getLogger(__name__)

--- a/parsl/channels/ssh/ssh.py
+++ b/parsl/channels/ssh/ssh.py
@@ -4,7 +4,7 @@ import os
 
 import paramiko
 from parsl.channels.base import Channel
-from parsl.channels.errors import *
+from parsl.channels.errors import BadHostKeyException, AuthException, SSHException, BadScriptPath, BadPermsScriptPath, FileCopyException, FileExists
 from parsl.utils import RepresentationMixin
 
 logger = logging.getLogger(__name__)

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -24,7 +24,7 @@ from parsl.app.errors import RemoteExceptionWrapper
 from parsl.config import Config
 from parsl.data_provider.data_manager import DataManager
 from parsl.data_provider.files import File
-from parsl.dataflow.error import *
+from parsl.dataflow.error import BadCheckpoint, ConfigurationError, DependencyError, DuplicateTaskError
 from parsl.dataflow.flow_control import FlowControl, FlowNoControl, Timer
 from parsl.dataflow.futures import AppFuture
 from parsl.dataflow.memoization import Memoizer

--- a/parsl/executors/extreme_scale/executor.py
+++ b/parsl/executors/extreme_scale/executor.py
@@ -10,8 +10,7 @@ except ImportError:
 else:
     _mpi_enabled = True
 
-from parsl.errors import *
-from parsl.executors.errors import *
+from parsl.errors import OptionalModuleMissing
 from parsl.executors.high_throughput.executor import HighThroughputExecutor
 
 from parsl.utils import RepresentationMixin

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -16,7 +16,7 @@ from ipyparallel.serialize import deserialize_object  # ,serialize_object
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.executors.high_throughput import zmq_pipes
 from parsl.executors.high_throughput import interchange
-from parsl.executors.errors import *
+from parsl.executors.errors import BadMessage, ScalingFailed, DeserializationError
 from parsl.executors.base import ParslExecutor
 from parsl.dataflow.error import ConfigurationError
 from parsl.providers.provider_base import ExecutionProvider

--- a/parsl/executors/ipp.py
+++ b/parsl/executors/ipp.py
@@ -9,7 +9,7 @@ from parsl.utils import RepresentationMixin
 
 from parsl.dataflow.error import ConfigurationError
 from parsl.executors.base import ParslExecutor
-from parsl.executors.errors import *
+from parsl.executors.errors import ScalingFailed
 from parsl.executors.ipp_controller import Controller
 from parsl.utils import wait_for_file
 

--- a/parsl/executors/ipp_controller.py
+++ b/parsl/executors/ipp_controller.py
@@ -5,7 +5,7 @@ import signal
 import subprocess
 import time
 
-from parsl.executors.errors import *
+from parsl.executors.errors import ControllerError
 from parsl.utils import RepresentationMixin
 
 logger = logging.getLogger(__name__)

--- a/parsl/executors/low_latency/executor.py
+++ b/parsl/executors/low_latency/executor.py
@@ -13,7 +13,7 @@ from ipyparallel.serialize import deserialize_object  # ,serialize_object
 
 from parsl.executors.low_latency import zmq_pipes
 from parsl.executors.low_latency import interchange
-from parsl.executors.errors import *
+from parsl.executors.errors import ScalingFailed, DeserializationError, BadMessage
 from parsl.executors.base import ParslExecutor
 # from parsl.dataflow.error import ConfigurationError
 

--- a/parsl/monitoring/visualization/views.py
+++ b/parsl/monitoring/visualization/views.py
@@ -1,7 +1,7 @@
 from flask import render_template
 from flask import current_app as app
 import pandas as pd
-from parsl.monitoring.visualization.models import *
+from parsl.monitoring.visualization.models import Workflow, Task, Status, db
 
 from parsl.monitoring.visualization.plots.default.workflow_plots import task_gantt_plot, task_per_app_plot, workflow_dag_plot
 from parsl.monitoring.visualization.plots.default.task_plots import time_series_cpu_per_task_plot, time_series_memory_per_task_plot

--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -4,7 +4,7 @@ from parsl.providers.kubernetes.template import template_string
 
 logger = logging.getLogger(__name__)
 
-from parsl.providers.error import *
+from parsl.providers.error import OptionalModuleMissing
 from parsl.providers.provider_base import ExecutionProvider
 from parsl.utils import RepresentationMixin
 

--- a/parsl/tests/configs/local_threads_monitoring.py
+++ b/parsl/tests/configs/local_threads_monitoring.py
@@ -1,6 +1,6 @@
 import logging
 
-from parsl import *
+from parsl import ThreadPoolExecutor
 from parsl.config import Config
 from parsl.monitoring import MonitoringHub
 

--- a/parsl/tests/integration/test_apps/HEDM_processlayer/process_layer.py
+++ b/parsl/tests/integration/test_apps/HEDM_processlayer/process_layer.py
@@ -15,7 +15,8 @@ Foreach .. from .csv
 
 """
 
-from parsl import *
+import parsl
+from parsl import App, DataFlowKernel, ThreadPoolExecutor
 import os
 import shutil
 import random

--- a/parsl/tests/integration/test_apps/vasp/vasp_example.py
+++ b/parsl/tests/integration/test_apps/vasp/vasp_example.py
@@ -25,7 +25,7 @@ We will be working on Stampede 2. we haven't put our code in a repo (though we s
 
 """
 
-from parsl import *
+from parsl import App, DataFlowKernel, ThreadPoolExecutor
 import os
 import shutil
 import random

--- a/parsl/tests/integration/test_channels/test_ssh_errors.py
+++ b/parsl/tests/integration/test_channels/test_ssh_errors.py
@@ -1,4 +1,4 @@
-from parsl.channels.errors import *
+from parsl.channels.errors import SSHException, BadHostKeyException
 from parsl.channels.ssh.ssh import SSHChannel as SSH
 
 

--- a/parsl/tests/integration/test_early_attach_bug.py
+++ b/parsl/tests/integration/test_early_attach_bug.py
@@ -14,7 +14,7 @@ among the engine once it has been sent to the the engine's queue.
 
 
 """
-from parsl import *
+from parsl import App, DataFlowKernel
 import time
 
 from parsl.tests.configs.local_ipp import config

--- a/parsl/tests/integration/test_monitoring_config.py
+++ b/parsl/tests/integration/test_monitoring_config.py
@@ -1,5 +1,5 @@
 import parsl
-from parsl import *
+from parsl import App, DataFlowKernel
 from parsl.monitoring.db_logger import MonitoringConfig
 
 threads_config = parsl.config.Config(executors=[parsl.executors.threads.ThreadPoolExecutor(label='threads', max_threads=4)],

--- a/parsl/tests/integration/test_parsl_load_default_config.py
+++ b/parsl/tests/integration/test_parsl_load_default_config.py
@@ -1,5 +1,5 @@
 import parsl
-from parsl import *
+from parsl import App
 
 dfk = parsl.load()
 

--- a/parsl/tests/integration/test_stress/test_bash_apps.py
+++ b/parsl/tests/integration/test_stress/test_bash_apps.py
@@ -1,7 +1,7 @@
 """Testing bash apps
 """
 import parsl
-from parsl import *
+from parsl import App, DataFlowKernel, ThreadPoolExecutor
 
 print("Parsl version: ", parsl.__version__)
 

--- a/parsl/tests/integration/test_stress/test_python_ipp.py
+++ b/parsl/tests/integration/test_stress/test_python_ipp.py
@@ -1,6 +1,7 @@
 ''' Testing bash apps
 '''
-from parsl import *
+import parsl
+from parsl import App, DataFlowKernel
 
 import time
 import argparse

--- a/parsl/tests/integration/test_stress/test_python_simple.py
+++ b/parsl/tests/integration/test_stress/test_python_simple.py
@@ -1,7 +1,7 @@
 """Testing bash apps
 """
 import parsl
-from parsl import *
+from parsl import App, DataFlowKernel, ThreadPoolExecutor
 
 import time
 import argparse

--- a/parsl/tests/integration/test_stress/test_python_threads.py
+++ b/parsl/tests/integration/test_stress/test_python_threads.py
@@ -1,7 +1,7 @@
 ''' Testing bash apps
 '''
 import parsl
-from parsl import *
+from parsl import App, DataFlowKernel
 
 import time
 import argparse

--- a/parsl/tests/manual_tests/test_udp_simple.py
+++ b/parsl/tests/manual_tests/test_udp_simple.py
@@ -1,4 +1,4 @@
-from parsl import *
+from parsl import App, DataFlowKernel
 # from parsl.monitoring.db_logger import MonitoringConfig
 from parsl.monitoring.monitoring import MonitoringHub
 from parsl.config import Config

--- a/parsl/tests/test_swift.py
+++ b/parsl/tests/test_swift.py
@@ -1,11 +1,10 @@
 import pytest
 
 import parsl
-from parsl import *
 
 parsl.set_stream_logger()
 
-from parsl.executors.swift_t import *
+from parsl.executors.swift_t import TurbineExecutor
 
 
 def foo(x, y):


### PR DESCRIPTION
When a source file contains an `import *`, flake8 cannot
check that source file for use of symbols which are
not defined.

This commit also fixes some problems that were covered
over by the F403 exemption.

A couple of files have other problems which can have a
tighter per-file exemption applied.