### PR TITLE
Add Python app time limits.

### DIFF
--- a/docs/userguide/apps.rst
+++ b/docs/userguide/apps.rst
@@ -53,7 +53,7 @@ Any Parsl app (a Python function decorated with the ``@python_app`` or ``@bash_a
 2. outputs: (list) This keyword argument defines a list of output :ref:`label-futures` that
    will be produced by this app. Parsl will track these files and ensure they are correctly created.
    They can then be passed to other apps as input arguments.
-3. walltime: (int) If the app runs longer than ``walltime`` seconds, a ``TimeoutError`` will be raised.
+3. walltime: (int) If the app runs longer than ``walltime`` seconds, a ``parsl.app.errors.AppTimeout`` will be raised.
 
 Returns
 ^^^^^^^

--- a/docs/userguide/apps.rst
+++ b/docs/userguide/apps.rst
@@ -53,6 +53,7 @@ Any Parsl app (a Python function decorated with the ``@python_app`` or ``@bash_a
 2. outputs: (list) This keyword argument defines a list of output :ref:`label-futures` that
    will be produced by this app. Parsl will track these files and ensure they are correctly created.
    They can then be passed to other apps as input arguments.
+3. walltime: (int) If the app runs longer than ``walltime`` seconds, a ``TimeoutError`` will be raised.
 
 Returns
 ^^^^^^^

--- a/parsl/app/app.py
+++ b/parsl/app/app.py
@@ -67,6 +67,8 @@ class AppBase(metaclass=ABCMeta):
             self.kwargs['stdout'] = params['stdout'].default
         if 'stderr' in params:
             self.kwargs['stderr'] = params['stderr'].default
+        if 'walltime' in params:
+            self.kwargs['walltime'] = params['walltime'].default
         self.outputs = params['outputs'].default if 'outputs' in params else []
         self.inputs = params['inputs'].default if 'inputs' in params else []
 

--- a/parsl/app/python.py
+++ b/parsl/app/python.py
@@ -12,6 +12,28 @@ from parsl.dataflow.dflow import DataFlowKernelLoader
 logger = logging.getLogger(__name__)
 
 
+def timeout(f, seconds):
+    def wrapper(*args, **kwargs):
+        import threading
+
+        def stop(thread):
+            import ctypes
+            import parsl.app.errors
+
+            ctypes.pythonapi.PyThreadState_SetAsyncExc(
+                ctypes.c_long(thread),
+                ctypes.py_object(parsl.app.errors.AppTimeout)
+            )
+
+        thread = threading.current_thread().ident
+        timer = threading.Timer(seconds, stop, args=[thread])
+        timer.start()
+        result = f(*args, **kwargs)
+        timer.cancel()
+        return result
+    return wrapper
+
+
 class PythonApp(AppBase):
     """Extends AppBase to cover the Python App."""
 
@@ -47,26 +69,6 @@ class PythonApp(AppBase):
 
         walltime = self.kwargs.get('walltime')
         if walltime is not None:
-            def timeout(f, walltime):
-                def wrapper(*args, **kwargs):
-                    import threading
-
-                    def stop(thread):
-                        import ctypes
-                        import parsl.app.errors
-
-                        ctypes.pythonapi.PyThreadState_SetAsyncExc(
-                            ctypes.c_long(thread),
-                            ctypes.py_object(parsl.app.errors.AppTimeout)
-                        )
-
-                    thread = threading.current_thread().ident
-                    timer = threading.Timer(walltime, stop, args=[thread])
-                    timer.start()
-                    result = f(*args, **kwargs)
-                    timer.cancel()
-                    return result
-                return wrapper
             self.func = timeout(self.func, walltime)
         app_fut = dfk.submit(self.func, *args,
                              executors=self.executors,

--- a/parsl/app/python.py
+++ b/parsl/app/python.py
@@ -15,11 +15,10 @@ logger = logging.getLogger(__name__)
 def timeout(f, seconds):
     def wrapper(*args, **kwargs):
         import threading
+        import ctypes
+        import parsl.app.errors
 
         def stop(thread):
-            import ctypes
-            import parsl.app.errors
-
             ctypes.pythonapi.PyThreadState_SetAsyncExc(
                 ctypes.c_long(thread),
                 ctypes.py_object(parsl.app.errors.AppTimeout)

--- a/parsl/app/python.py
+++ b/parsl/app/python.py
@@ -18,14 +18,14 @@ def timeout(f, seconds):
         import ctypes
         import parsl.app.errors
 
-        def stop(thread):
+        def inject_exception(thread):
             ctypes.pythonapi.PyThreadState_SetAsyncExc(
                 ctypes.c_long(thread),
                 ctypes.py_object(parsl.app.errors.AppTimeout)
             )
 
         thread = threading.current_thread().ident
-        timer = threading.Timer(seconds, stop, args=[thread])
+        timer = threading.Timer(seconds, inject_exception, args=[thread])
         timer.start()
         result = f(*args, **kwargs)
         timer.cancel()

--- a/parsl/app/python.py
+++ b/parsl/app/python.py
@@ -50,6 +50,7 @@ class PythonApp(AppBase):
             def timeout(f, walltime):
                 def wrapper(*args, **kwargs):
                     import threading
+
                     def stop(thread):
                         import ctypes
                         import parsl.app.errors

--- a/parsl/tests/test_error_handling/test_python_walltime.py
+++ b/parsl/tests/test_error_handling/test_python_walltime.py
@@ -1,21 +1,23 @@
 import parsl
 from parsl.app.errors import AppTimeout
 
+
 @parsl.python_app
 def my_app(walltime=3):
-  import time
-  # the loop count must be substantially bigger than the walltime
-  # but not infinite - so that the test eventually terminates
-  # even if the walltime doesn't work.
-  for n in range(0, 6):
-    time.sleep(1)    
+    import time
+    # the loop count must be substantially bigger than the walltime
+    # but not infinite - so that the test eventually terminates
+    # even if the walltime doesn't work.
+    for n in range(0, 6):
+        time.sleep(1)
+
 
 def test_python_walltime():
-  f = my_app()
-  try:
-    f.result()
-    raise ValueError("Expected an exception, not a result")
-  except AppTimeout as e:
-    # AppTimeout is the correct result.
-    # Any other exception should propagate upwards
-    pass
+    f = my_app()
+    try:
+        f.result()
+        raise ValueError("Expected an exception, not a result")
+    except AppTimeout:
+        # AppTimeout is the correct result.
+        # Any other exception should propagate upwards
+        pass

--- a/parsl/tests/test_error_handling/test_python_walltime.py
+++ b/parsl/tests/test_error_handling/test_python_walltime.py
@@ -1,0 +1,21 @@
+import parsl
+from parsl.app.errors import AppTimeout
+
+@parsl.python_app
+def my_app(walltime=3):
+  import time
+  # the loop count must be substantially bigger than the walltime
+  # but not infinite - so that the test eventually terminates
+  # even in the walltime doesn't work.
+  for n in range(0, 6):
+    time.sleep(1)    
+
+def test_python_walltime():
+  f = my_app()
+  try:
+    f.result()
+    raise ValueError("Expected an exception, not a result")
+  except AppTimeout as e:
+    # AppTimeout is the correct result.
+    # Any other exception should propagate upwards
+    pass

--- a/parsl/tests/test_error_handling/test_python_walltime.py
+++ b/parsl/tests/test_error_handling/test_python_walltime.py
@@ -6,7 +6,7 @@ def my_app(walltime=3):
   import time
   # the loop count must be substantially bigger than the walltime
   # but not infinite - so that the test eventually terminates
-  # even in the walltime doesn't work.
+  # even if the walltime doesn't work.
   for n in range(0, 6):
     time.sleep(1)    
 

--- a/parsl/tests/test_error_handling/test_python_walltime.py
+++ b/parsl/tests/test_error_handling/test_python_walltime.py
@@ -1,3 +1,5 @@
+import pytest
+
 import parsl
 from parsl.app.errors import AppTimeout
 
@@ -14,10 +16,5 @@ def my_app(walltime=3):
 
 def test_python_walltime():
     f = my_app()
-    try:
+    with pytest.raises(AppTimeout):
         f.result()
-        raise ValueError("Expected an exception, not a result")
-    except AppTimeout:
-        # AppTimeout is the correct result.
-        # Any other exception should propagate upwards
-        pass


### PR DESCRIPTION
This PR adds python app time limits. As noted in #1118, there is currently a 'walltime' keyword arg to both the python and bash app decorators and classes-- all of which do nothing. I chose to match what is currently implemented for bash apps-- a reserved `walltime` keyword arg to the app. I'll remove the unused args in a separate PR. 