### PR TITLE
Remove violations of flake8 W605 (invalid escape sequences)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,7 +9,7 @@
 # E129: Visual indent to not match indent as next line, counter eg here:
 # https://github.com/PyCQA/pycodestyle/issues/386
 # W504: Raised by flake8 even when it is followed
-ignore = D203, E124, E126, F405, E402, E129, W605, W504
+ignore = D203, E124, E126, F405, E402, E129, W504
 max-line-length = 160
 exclude = parsl/executors/serialize/, test_import_fail.py
 # E741 disallows ambiguous single letter names which look like numbers

--- a/parsl/providers/aws/template.py
+++ b/parsl/providers/aws/template.py
@@ -1,5 +1,4 @@
 template_string = """#!/bin/bash
-#sed -i 's/us-east-2\.ec2\.//g' /etc/apt/sources.list
 cd ~
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y

--- a/parsl/tests/test_error_handling/test_rand_fail.py
+++ b/parsl/tests/test_error_handling/test_rand_fail.py
@@ -110,27 +110,24 @@ def test_deps(numtasks=10):
         fu = sleep_fail(0.2, 0, .4)
         fus.extend([fu])
 
-    """
-    App1   App2  ... AppN
-    |       |        |
-    V       V        V
-    App1   App2  ... AppN
-    """
+    # App1   App2  ... AppN
+    # |       |        |
+    # V       V        V
+    # App1   App2  ... AppN
 
     fus_2 = []
     for fu in fus:
         fu = sleep_fail(0, 0, .8, inputs=[fu])
         fus_2.extend([fu])
 
-    """
-    App1   App2  ... AppN
-      |       |        |
-      V       V        V
-    App1   App2  ... AppN
-       \      |       /
-        \     |      /
-          App_Final
-    """
+    # App1   App2  ... AppN
+    #   |       |        |
+    #   V       V        V
+    # App1   App2  ... AppN
+    #    \      |       /
+    #     \     |      /
+    #       App_Final
+
     fu_final = sleep_fail(1, 0, 0, inputs=fus_2)
 
     try:

--- a/parsl/tests/test_python_apps/test_rand_fail.py
+++ b/parsl/tests/test_python_apps/test_rand_fail.py
@@ -88,27 +88,24 @@ def test_deps(numtasks=2):
         fu = sleep_fail(0.2, 0, .4)
         fus.extend([fu])
 
-    """
-    App1   App2  ... AppN
-    |       |        |
-    V       V        V
-    App1   App2  ... AppN
-    """
+    # App1   App2  ... AppN
+    # |       |        |
+    # V       V        V
+    # App1   App2  ... AppN
 
     fus_2 = []
     for fu in fus:
         fu = sleep_fail(0, 0, .8, inputs=[fu])
         fus_2.extend([fu])
 
-    """
-    App1   App2  ... AppN
-      |       |        |
-      V       V        V
-    App1   App2  ... AppN
-       \      |       /
-        \     |      /
-          App_Final
-    """
+    # App1   App2  ... AppN
+    #   |       |        |
+    #   V       V        V
+    # App1   App2  ... AppN
+    #    \      |       /
+    #     \     |      /
+    # App_Final
+
     fu_final = sleep_fail(1, 0, 0, inputs=fus_2)
 
     try:


### PR DESCRIPTION
The violations were all in commented out / docstring text.

This commit removes dead code to fix one violation, and
changes a literal string into #-comments, which may use
\ symbols without them forming an escape.