### PR TITLE
[WIP] data manager staging provider prototype

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -14,6 +14,7 @@ Reference guide
     parsl.dataflow.futures.AppFuture
     parsl.dataflow.dflow.DataFlowKernelLoader
     parsl.data_provider.data_manager.DataManager
+    parsl.data_provider.data_manager.Staging
     parsl.data_provider.files.File
     parsl.executors.base.ParslExecutor
     parsl.executors.ThreadPoolExecutor

--- a/docs/stubs/parsl.data_provider.staging.Staging.rst
+++ b/docs/stubs/parsl.data_provider.staging.Staging.rst
@@ -1,0 +1,8 @@
+parsl.data\_provider.staging.Staging
+==============================================
+
+.. currentmodule:: parsl.data_provider.staging
+
+.. autoclass:: Staging
+   :members:
+   :undoc-members:

--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -155,7 +155,7 @@ class BashApp(AppBase):
         else:
             dfk = self.data_flow_kernel
 
-        app_fut = dfk.submit(wrap_error(update_wrapper(remote_side_bash_executor, self.func)),
+        app_fut = dfk.submit(update_wrapper(remote_side_bash_executor, self.func),
                              self.func, *args,
                              executors=self.executors,
                              fn_hash=self.func_hash,

--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -1,9 +1,9 @@
 """Exceptions raised by Apps."""
 from functools import wraps
 
-import dill
+# import dill
 import logging
-from tblib import Traceback
+# from tblib import Traceback
 
 from six import reraise
 
@@ -143,24 +143,27 @@ class DependencyError(ParslError):
 class RemoteExceptionWrapper:
     def __init__(self, e_type, e_value, traceback):
 
-        self.e_type = dill.dumps(e_type)
-        self.e_value = dill.dumps(e_value)
-        self.e_traceback = Traceback(traceback)
+        self.e_type = e_type
+        self.e_value = e_value
+        self.e_traceback = traceback
+
+        # self.e_type = dill.dumps(e_type)
+        # self.e_value = dill.dumps(e_value)
+        # self.e_traceback = Traceback(traceback)
+
+        # t = dill.loads(self.e_type)
+        # v = dill.loads(self.e_value)
+        # tb = self.e_traceback.as_traceback()
 
     def reraise(self):
-
-        t = dill.loads(self.e_type)
 
         # the type is logged here before deserialising v and tb
         # because occasionally there are problems deserialising the
         # value (see #785, #548) and the fix is related to the
         # specific exception type.
-        logger.debug("Reraising exception of type {}".format(t))
+        logger.debug("Reraising exception of type {}".format(self.e_type))
 
-        v = dill.loads(self.e_value)
-        tb = self.e_traceback.as_traceback()
-
-        reraise(t, v, tb)
+        reraise(self.e_type, self.e_value, self.e_traceback)
 
 
 def wrap_error(func):

--- a/parsl/app/futures.py
+++ b/parsl/app/futures.py
@@ -53,6 +53,7 @@ class DataFuture(Future):
         super().__init__()
         self._tid = tid
         if isinstance(file_obj, str):
+            logger.warning("DataFuture constructed with a string, not a File. This is deprecated.")
             self.file_obj = File(file_obj)
         elif isinstance(file_obj, File):
             self.file_obj = file_obj

--- a/parsl/app/futures.py
+++ b/parsl/app/futures.py
@@ -71,8 +71,7 @@ class DataFuture(Future):
             else:
                 raise NotFutureError("DataFuture can be created only with a FunctionFuture on None")
 
-        logger.debug("Creating DataFuture with parent: %s", self.parent)
-        logger.debug("Filepath: %s", self.filepath)
+        logger.debug("Creating DataFuture with parent: %s and file: %s", self.parent, repr(self.file_obj))
 
     @property
     def tid(self):
@@ -120,11 +119,11 @@ class DataFuture(Future):
                             _STATE_TO_DESCRIPTION_MAP[parent._state],
                             parent._exception.__class__.__name__)
                     else:
-                        return '<%s at %#x state=%s returned %s>' % (
+                        return '<%s at %#x state=%s with file %s>' % (
                             self.__class__.__name__,
                             id(self),
                             _STATE_TO_DESCRIPTION_MAP[parent._state],
-                            self.filepath)
+                            repr(self.file_obj))
                 return '<%s at %#x state=%s>' % (
                     self.__class__.__name__,
                     id(self),

--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -55,15 +55,21 @@ class DataManager(object):
         # if we reach here, we haven't found a suitable staging mechanism
         raise ValueError("Executor {} cannot stage file {}".format(executor, repr(file)))
 
-    def replace_task(self, input: Any, func: Callable, executor: str) -> Callable:
-        """This will give staging providers the chance to wrap (or replace entirely!) the task function."""
-
+    def stage_in_rename_this(self, input, func, executor):
         if isinstance(input, DataFuture):
             file = input.file_obj
         elif isinstance(input, File):
             file = input
         else:
-            return func
+            return (input, func)
+
+        task = self.stage_in(file, input, executor)
+        func = self.replace_task(file, func, executor)
+        return (task, func)
+
+
+    def replace_task(self, file: File, func: Callable, executor: str) -> Callable:
+        """This will give staging providers the chance to wrap (or replace entirely!) the task function."""
 
         executor_obj = self.dfk.executors[executor]
         if hasattr(executor_obj, "storage_access") and executor_obj.storage_access is not None:
@@ -84,7 +90,7 @@ class DataManager(object):
         # if we reach here, we haven't found a suitable staging mechanism
         raise ValueError("Executor {} cannot stage file {}".format(executor, repr(file)))
 
-    def stage_in(self, input: Any, executor: str) -> Any:
+    def stage_in(self, file: File, input: Any, executor: str) -> Any:
         """Transport the input from the input source to the executor, if it is file-like,
         returning a DataFuture that wraps the stage-in operation.
 
@@ -100,13 +106,11 @@ class DataManager(object):
         """
 
         if isinstance(input, DataFuture):
-            file = input.file_obj
             parent_fut = input  # type: Optional[Future]
         elif isinstance(input, File):
-            file = input
             parent_fut = None
         else:
-            return input
+            raise ValueError("Internal consistency error - should have checked DataFuture/File earlier")
 
         executor_obj = self.dfk.executors[executor]
         if hasattr(executor_obj, "storage_access") and executor_obj.storage_access is not None:

--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -1,12 +1,22 @@
 import logging
+from concurrent.futures import Future
+from typing import Any, Callable, List, Optional, TYPE_CHECKING
 
 from parsl.app.futures import DataFuture
 from parsl.data_provider.files import File
-from parsl.data_provider.ftp import _ftp_stage_in_app
-from parsl.data_provider.globus import _get_globus_scheme
-from parsl.data_provider.http import _http_stage_in_app
+from parsl.data_provider.file_noop import NoOpFileStaging
+from parsl.data_provider.ftp import FTPSeparateTaskStaging
+from parsl.data_provider.http import HTTPSeparateTaskStaging
+from parsl.data_provider.staging import Staging
+
+if TYPE_CHECKING:
+    from parsl.dataflow.dflow import DataFlowKernel
 
 logger = logging.getLogger(__name__)
+
+# these will be shared between all executors that do not explicitly
+# override, so should not contain executor-specific state
+defaultStaging = [NoOpFileStaging(), FTPSeparateTaskStaging(), HTTPSeparateTaskStaging()]  # type: List[Staging]
 
 
 class DataManager(object):
@@ -14,7 +24,7 @@ class DataManager(object):
 
     """
 
-    def __init__(self, dfk):
+    def __init__(self, dfk: "DataFlowKernel") -> None:
         """Initialize the DataManager.
 
         Args:
@@ -24,7 +34,57 @@ class DataManager(object):
 
         self.dfk = dfk
 
-    def stage_in(self, input, executor):
+    def replace_task_stage_out(self, file: File, func: Callable, executor: str) -> Callable:
+        """This will give staging providers the chance to wrap (or replace entirely!) the task function."""
+        executor_obj = self.dfk.executors[executor]
+        if hasattr(executor_obj, "storage_access") and executor_obj.storage_access is not None:
+            storage_access = executor_obj.storage_access  # type: List[Staging]
+        else:
+            storage_access = defaultStaging
+
+        for scheme in storage_access:
+            logger.debug("stage_out checking Staging provider {}".format(scheme))
+            if scheme.can_stage_out(file):
+                newfunc = scheme.replace_task_stage_out(self, executor, file, func)
+                if newfunc:
+                    return newfunc
+                else:
+                    return func
+
+        logger.debug("reached end of staging scheme list")
+        # if we reach here, we haven't found a suitable staging mechanism
+        raise ValueError("Executor {} cannot stage file {}".format(executor, repr(file)))
+
+    def replace_task(self, input: Any, func: Callable, executor: str) -> Callable:
+        """This will give staging providers the chance to wrap (or replace entirely!) the task function."""
+
+        if isinstance(input, DataFuture):
+            file = input.file_obj
+        elif isinstance(input, File):
+            file = input
+        else:
+            return func
+
+        executor_obj = self.dfk.executors[executor]
+        if hasattr(executor_obj, "storage_access") and executor_obj.storage_access is not None:
+            storage_access = executor_obj.storage_access
+        else:
+            storage_access = defaultStaging
+
+        for scheme in storage_access:
+            logger.debug("stage_in checking Staging provider {}".format(scheme))
+            if scheme.can_stage_in(file):
+                newfunc = scheme.replace_task(self, executor, file, func)
+                if newfunc:
+                    return newfunc
+                else:
+                    return func
+
+        logger.debug("reached end of staging scheme list")
+        # if we reach here, we haven't found a suitable staging mechanism
+        raise ValueError("Executor {} cannot stage file {}".format(executor, repr(file)))
+
+    def stage_in(self, input: Any, executor: str) -> Any:
         """Transport the input from the input source to the executor, if it is file-like,
         returning a DataFuture that wraps the stage-in operation.
 
@@ -39,68 +99,59 @@ class DataManager(object):
             - executor (str) : an executor the file is going to be staged in to.
         """
 
-        if isinstance(input, DataFuture) and input.file_obj.is_remote():
+        if isinstance(input, DataFuture):
             file = input.file_obj
-            parent_fut = input
-        elif isinstance(input, File) and input.is_remote():
+            parent_fut = input  # type: Optional[Future]
+        elif isinstance(input, File):
             file = input
             parent_fut = None
         else:
             return input
 
-        if file.scheme == 'ftp':
-            working_dir = self.dfk.executors[executor].working_dir
-            stage_in_app = _ftp_stage_in_app(self, executor=executor)
-            app_fut = stage_in_app(working_dir, parent_fut=parent_fut, outputs=[file], staging_inhibit_output=True)
-            return app_fut._outputs[0]
-        elif file.scheme == 'http' or file.scheme == 'https':
-            working_dir = self.dfk.executors[executor].working_dir
-            stage_in_app = _http_stage_in_app(self, executor=executor)
-            app_fut = stage_in_app(working_dir, parent_fut=parent_fut, outputs=[file], staging_inhibit_output=True)
-            return app_fut._outputs[0]
-        elif file.scheme == 'globus':
-            # what should happen here is...
-            # we should acquire the GlobusScheme object that goes with
-            # this executor (rather than _get_globus_endpoint)
-            # and then ask the scheme to provide the stage_in_app without
-            # invocations to that app needing any further globus specific
-            # parameters.
-            # The longer term path is then that http/ftp also become a
-            # Scheme, and we allow each one a chance to inspect the
-            # file to see if it can handle it (rather than the data manager
-            # having to know about staging)
-            # At that point, we wouldn't be looking up the GlobusScheme
-            # object explicitly - instead we'd be in possession of it just
-            # like the other schemes... and each scheme would know all the
-            # parameterisation it needs to.
-            # so the three real cases of this if/elif block should
-            # look pretty much identical
-            globus_scheme = _get_globus_scheme(self.dfk, executor)
-            stage_in_app = globus_scheme._globus_stage_in_app(executor=executor, dfk=self.dfk)
-            app_fut = stage_in_app(parent_fut=parent_fut, outputs=[file], staging_inhibit_output=True)
-            return app_fut._outputs[0]
+        executor_obj = self.dfk.executors[executor]
+        if hasattr(executor_obj, "storage_access") and executor_obj.storage_access is not None:
+            storage_access = executor_obj.storage_access
         else:
-            raise Exception('Staging in with unknown file scheme {} is not supported'.format(file.scheme))
+            storage_access = defaultStaging
 
-    def stage_out(self, file, executor, app_fu):
+        for scheme in storage_access:
+            logger.debug("stage_in checking Staging provider {}".format(scheme))
+            if scheme.can_stage_in(file):
+                staging_fut = scheme.stage_in(self, executor, file, parent_fut=parent_fut)
+                if staging_fut:
+                    return staging_fut
+                else:
+                    return input
+
+        logger.debug("reached end of staging scheme list")
+        # if we reach here, we haven't found a suitable staging mechanism
+        raise ValueError("Executor {} cannot stage file {}".format(executor, repr(file)))
+
+    def stage_out(self, file: File, executor: str, app_fu: Future) -> Optional[Future]:
         """Transport the file from the local filesystem to the remote Globus endpoint.
 
-        This function returns a DataFuture.
+        This function returns either a Future which should complete when the stageout
+        is complete, or None, if no staging needs to be waited for.
 
         Args:
             - self
             - file (File) - file to stage out
             - executor (str) - Which executor the file is going to be staged out from.
+            - app_fu (Future) - a future representing the main body of the task that should
+                                complete before stageout begins.
         """
-
-        if file.scheme == 'http' or file.scheme == 'https':
-            raise Exception('HTTP/HTTPS file staging out is not supported')
-        elif file.scheme == 'ftp':
-            raise Exception('FTP file staging out is not supported')
-        elif file.scheme == 'globus':
-            globus_scheme = _get_globus_scheme(self.dfk, executor)
-            globus_scheme._update_stage_out_local_path(file, executor, self.dfk)
-            stage_out_app = globus_scheme._globus_stage_out_app(executor=executor, dfk=self.dfk)
-            return stage_out_app(app_fu, inputs=[file])
+        executor_obj = self.dfk.executors[executor]
+        if hasattr(executor_obj, "storage_access") and executor_obj.storage_access is not None:
+            storage_access = executor_obj.storage_access
         else:
-            raise Exception('Staging out with unknown file scheme {} is not supported'.format(file.scheme))
+            storage_access = defaultStaging
+
+        for scheme in storage_access:
+            logger.debug("stage_out checking Staging provider {}".format(scheme))
+            if scheme.can_stage_out(file):
+                # globus_scheme._update_stage_out_local_path(file, executor, self.dfk)
+                return scheme.stage_out(self, executor, file, app_fu)
+
+        logger.debug("reached end of staging scheme list")
+        # if we reach here, we haven't found a suitable staging mechanism
+        raise ValueError("Executor {} cannot stage out file {}".format(executor, repr(file)))

--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -57,9 +57,9 @@ class DataManager(object):
 
     def stage_in_rename_this(self, input, func, executor):
         if isinstance(input, DataFuture):
-            file = input.file_obj
+            file = input.file_obj.cleancopy()
         elif isinstance(input, File):
-            file = input
+            file = input.cleancopy()
         else:
             return (input, func)
 

--- a/parsl/data_provider/file_args.py
+++ b/parsl/data_provider/file_args.py
@@ -1,0 +1,145 @@
+import logging
+import os
+from typing import Callable
+
+from parsl.app.app import python_app
+from parsl.utils import RepresentationMixin
+from parsl.data_provider.staging import Staging
+
+logger = logging.getLogger(__name__)
+
+
+class FileArgsStaging(Staging, RepresentationMixin):
+    """A staging provider than can stage in/out local files
+    by sending the file alongside the app function call. This
+    provider probably only works for small files. It does not
+    need a shared file system on the executor side.
+
+    Staging-in happens in two pieces:
+
+    * The task is wrapped with a wrapper that will write out the file
+      contents from a shared data structure. That data structure will
+      often be serialised across the wire (and so become non-shared),
+      but only after an app task is submitted for execution. Up until
+      that time, the shared data structure can be updated on the submit
+      side by other code.
+
+    * A stage_in method which runs when the input file is ready - after
+      any tasks which might produce that output have complete - and
+      updates the shared data structure with the contents of that
+      input file.
+
+    Staging out needs some similar behaviour, but more awkwardly needs
+    the ability to remove the modified return result on the submit side
+    afterwards. This is not symmetric with the stage_in way of doing things
+    - why? Because we need to run code *after* the app has returned, which
+    there isn't a hook for at the moment - the hook for running code
+    *before* an app is launched exists as replace_task_stage_in which
+    as well as making a hook can run arbitrary code at that point.
+
+    The stage_out hook can do things to do with files but it *can't* do
+    things to do with post-processing results: by that time, the result
+    has already been handed over to user code via the AppFuture.
+
+    Probably then there should be another hook point here for stageout
+    which allows that post-processing to happen.
+
+    """
+
+    def can_stage_in(self, file) -> bool:
+        logger.debug("FileArgsStaging checking file {}".format(file.__repr__()))
+        logger.debug("file has scheme {}".format(file.scheme))
+        return file.scheme == 'file'
+
+    def can_stage_out(self, file) -> bool:
+        logger.debug("FileArgsStaging checking file {} for stageout".format(file.__repr__()))
+        logger.debug("file has scheme {}".format(file.scheme))
+        return file.scheme == 'file'
+
+    # I think there is a race condition here. We read in the file content at the time
+    # of setting up the staging - but that might be before a prior task has completed
+    # which is going to produce the content we want to stage.
+    # There should be a test case which tests this (which can work for any file staging,
+    # I think?)
+    # Maybe what should happen is that there is a stage_in function which runs at the
+    # appropriate point: after any dependent input content has been created, but before
+    # the task has been submitted for execution. At that point, we could update some
+    # shared object before it is serialised. However, it's a bit awkward in the API at the
+    # moment how that memory should be shared? There's nothing in the API that specifically
+    # ties a replace_stage and a stage_in together except the File object. So perhaps
+    # FileArgsStaging should keep some persistent state which is keyed by that File object?
+    # (a bit like workqueue does? it brings up a question about mutable files and how to
+    # free that memory when it's no longer needed)
+    def replace_task(self, dm, executor, file, func) -> Callable:
+        working_dir = dm.dfk.executors[executor].working_dir
+        return in_task_transfer_in_wrapper(func, file, working_dir)
+
+
+    def stage_in(self, dm, executor, file, parent_fut):
+    #   # globus_scheme = _get_globus_scheme(dm.dfk, executor)
+    #   # stage_in_app = globus_scheme._globus_stage_in_app(executor=executor, dfk=dm.dfk)
+    #
+        logger.debug("launching stage_in_app")
+        # stage_in_app needs to do the read and update
+        app_fut = stage_in_app(outputs=[file], staging_inhibit_output=True, parent_fut=parent_fut)
+        return app_fut._outputs[0]
+
+
+    def replace_task_stage_out(self, dm, executor, file, func, unwrap_func) -> Callable:
+        working_dir = dm.dfk.executors[executor].working_dir
+        return in_task_transfer_out_wrapper(func, unwrap_func, file, working_dir)
+
+# TODO: force to me on data_manager executor
+@python_app
+def stage_in_app(outputs=[], parent_fut=None, staging_inhibit_output=True):
+    file = outputs[0]
+    with open(file.path, 'rb') as fh:
+        file.content = fh.read()
+
+
+def in_task_transfer_in_wrapper(func, file, working_dir):
+    """Write out the named file before invoking the wrapped function."""
+    logger.debug("Wrapping for args-based stagein")
+
+    def wrapper(*args, **kwargs):
+        if working_dir:
+            os.makedirs(working_dir, exist_ok=True)
+            file.local_path = os.path.join(working_dir, file.filename)
+        else:
+            file.local_path = file.filename
+        with open(file.local_path, 'wb') as fh:
+            fh.write(file.content)
+
+        result = func(*args, **kwargs)
+        return result
+    return wrapper
+
+
+def in_task_transfer_out_wrapper(func, unwrap_func, file, working_dir):
+    logger.debug("Wrapping for args-based stageout")
+    """Read in the named file before invoking the wrapped function, and
+       return its contents to be written out on the submit side.
+    """
+    def wrapper(*args, **kwargs):
+        logger.debug("BENC: in wrapper - setting local_path")
+        if working_dir:
+            os.makedirs(working_dir, exist_ok=True)
+            file.local_path = os.path.join(working_dir, file.filename)
+        else:
+            file.local_path = file.filename
+        logger.debug("BENC: pre-exec local_path is {}".format(file.local_path))
+        result = func(*args, **kwargs)
+        logger.debug("BENC: post-exec local_path is {}".format(file.local_path))
+
+        with open(file.local_path, 'rb') as fh:
+            content = fh.read()
+
+        return (result, content)
+
+    def unwrapper(r):
+        (result, content) = r
+        with open(file.path, 'wb') as fh:
+            fh.write(content)
+        return unwrap_func(result) 
+
+    return (wrapper, unwrapper)

--- a/parsl/data_provider/file_noop.py
+++ b/parsl/data_provider/file_noop.py
@@ -1,0 +1,20 @@
+import logging
+
+from parsl.utils import RepresentationMixin
+from parsl.data_provider.staging import Staging
+
+
+logger = logging.getLogger(__name__)
+
+
+class NoOpFileStaging(Staging, RepresentationMixin):
+
+    def can_stage_in(self, file):
+        logger.debug("NoOpFileStaging checking file {}".format(file.__repr__()))
+        logger.debug("file has scheme {}".format(file.scheme))
+        return file.scheme == 'file'
+
+    def can_stage_out(self, file):
+        logger.debug("NoOpFileStaging checking file {}".format(file.__repr__()))
+        logger.debug("file has scheme {}".format(file.scheme))
+        return file.scheme == 'file'

--- a/parsl/data_provider/files.py
+++ b/parsl/data_provider/files.py
@@ -63,7 +63,10 @@ class File(object):
         """Return the resolved filepath on the side where it is called from.
 
         The appropriate filepath will be returned when called from within
-        an app running remotely as well as regular python on the client side.
+        an app running remotely as well as regular python on the submit side.
+
+        Only file: scheme URLs make sense to have a submit-side path, as other
+        URLs are not accessible through POSIX file access.
 
         Args:
             - self
@@ -73,12 +76,10 @@ class File(object):
         if hasattr(self, 'local_path'):
             return self.local_path
 
-        if self.scheme in ['ftp', 'http', 'https', 'globus']:
-            return self.filename
-        elif self.scheme in ['file']:
+        if self.scheme in ['file']:
             return self.path
         else:
-            raise Exception('Cannot return filepath for unknown scheme {}'.format(self.scheme))
+            raise ValueError("No local_path set for {}".format(repr(self)))
 
 
 if __name__ == '__main__':

--- a/parsl/data_provider/files.py
+++ b/parsl/data_provider/files.py
@@ -45,6 +45,14 @@ class File(object):
         self.filename = os.path.basename(self.path)
         self._local_path = None
 
+    def cleancopy(self) -> "File":
+        """Returns a copy of the file containing only the global immutable state,
+           without any mutable site-local local_path information. The returned File
+           object will be as the original object was when it was constructed.
+        """
+        logger.debug("Making clean copy of File object {}".format(repr(self)))
+        return File(self.url)
+
     def __str__(self):
         return self.filepath
 

--- a/parsl/data_provider/files.py
+++ b/parsl/data_provider/files.py
@@ -58,14 +58,6 @@ class File(object):
     def __fspath__(self):
         return self.filepath
 
-    def is_remote(self):
-        if self.scheme in ['ftp', 'http', 'https', 'globus']:
-            return True
-        elif self.scheme in ['file']:  # TODO: is this enough?
-            return False
-        else:
-            raise Exception('Cannot determine if unknown file scheme {} is remote'.format(self.scheme))
-
     @property
     def filepath(self):
         """Return the resolved filepath on the side where it is called from.

--- a/parsl/data_provider/files.py
+++ b/parsl/data_provider/files.py
@@ -43,6 +43,7 @@ class File(object):
         self.netloc = parsed_url.netloc
         self.path = parsed_url.path
         self.filename = os.path.basename(self.path)
+        self._local_path = None
 
     def __str__(self):
         return self.filepath
@@ -50,13 +51,23 @@ class File(object):
     def __repr__(self):
         content = "{0} at 0x{1:x} url={2} scheme={3} netloc={4} path={5} filename={6}".format(
             self.__class__, id(self), self.url, self.scheme, self.netloc, self.path, self.filename)
-        if hasattr(self, 'local_path'):
-            content += " local_path={0}".format(self.local_path)
+        content += " _local_path={0}".format(self._local_path)
 
         return "<{}>".format(content)
 
     def __fspath__(self):
         return self.filepath
+
+    @property
+    def local_path(self):
+        return self._local_path
+
+    @local_path.setter
+    def local_path(self, p):
+        if self._local_path is None:
+            self._local_path = p
+        else:
+            raise ValueError("Local path is already set for file {}".format(repr(self)))
 
     @property
     def filepath(self):
@@ -73,13 +84,14 @@ class File(object):
         Returns:
              - filepath (string)
         """
-        if hasattr(self, 'local_path'):
+        if self._local_path is not None:
+            logger.debug("File {} has filepath from local_path {}".format(repr(self), self._local_path))
             return self.local_path
-
-        if self.scheme in ['file']:
+        elif self.scheme in ['file']:
+            logger.debug("File {} filepath from URL path {}".format(repr(self), self.path))
             return self.path
         else:
-            raise ValueError("No local_path set for {}".format(repr(self)))
+            raise ValueError("No filepath available for {}".format(repr(self)))
 
 
 if __name__ == '__main__':

--- a/parsl/data_provider/ftp.py
+++ b/parsl/data_provider/ftp.py
@@ -1,7 +1,29 @@
 import ftplib
+import logging
 import os
 
 from parsl import python_app
+
+from parsl.utils import RepresentationMixin
+from parsl.data_provider.staging import Staging
+
+
+logger = logging.getLogger(__name__)
+
+
+class FTPSeparateTaskStaging(Staging, RepresentationMixin):
+    """Performs FTP staging as a separate parsl level task."""
+
+    def can_stage_in(self, file):
+        logger.debug("FTPSeparateTaskStaging checking file {}".format(file.__repr__()))
+        logger.debug("file has scheme {}".format(file.scheme))
+        return file.scheme == 'ftp'
+
+    def stage_in(self, dm, executor, file, parent_fut):
+        working_dir = dm.dfk.executors[executor].working_dir
+        stage_in_app = _ftp_stage_in_app(dm, executor=executor)
+        app_fut = stage_in_app(working_dir, outputs=[file], staging_inhibit_output=True, parent_fut=parent_fut)
+        return app_fut._outputs[0]
 
 
 def _ftp_stage_in(working_dir, parent_fut=None, outputs=[], staging_inhibit_output=True):

--- a/parsl/data_provider/ftp.py
+++ b/parsl/data_provider/ftp.py
@@ -26,6 +26,40 @@ class FTPSeparateTaskStaging(Staging, RepresentationMixin):
         return app_fut._outputs[0]
 
 
+class FTPInTaskStaging(Staging, RepresentationMixin):
+    """Performs FTP staging as a wrapper around the application task."""
+
+    def can_stage_in(self, file):
+        logger.debug("FTPInTaskStaging checking file {}".format(file.__repr__()))
+        logger.debug("file has scheme {}".format(file.scheme))
+        return file.scheme == 'ftp'
+
+    def replace_task(self, dm, executor, file, f):
+        working_dir = dm.dfk.executors[executor].working_dir
+        return in_task_transfer_wrapper(f, file, working_dir)
+
+
+def in_task_transfer_wrapper(func, file, working_dir):
+    def wrapper(*args, **kwargs):
+        import ftplib
+        if working_dir:
+            os.makedirs(working_dir, exist_ok=True)
+            file.local_path = os.path.join(working_dir, file.filename)
+        else:
+            file.local_path = file.filename
+
+        with open(file.local_path, 'wb') as f:
+            ftp = ftplib.FTP(file.netloc)
+            ftp.login()
+            ftp.cwd(os.path.dirname(file.path))
+            ftp.retrbinary('RETR {}'.format(file.filename), f.write)
+            ftp.quit()
+
+        result = func(*args, **kwargs)
+        return result
+    return wrapper
+
+
 def _ftp_stage_in(working_dir, parent_fut=None, outputs=[], staging_inhibit_output=True):
     file = outputs[0]
     if working_dir:

--- a/parsl/data_provider/http.py
+++ b/parsl/data_provider/http.py
@@ -1,7 +1,30 @@
+import logging
 import os
 import requests
 
 from parsl import python_app
+
+from parsl.utils import RepresentationMixin
+from parsl.data_provider.staging import Staging
+
+logger = logging.getLogger(__name__)
+
+
+class HTTPSeparateTaskStaging(Staging, RepresentationMixin):
+    """A staging provider that Performs HTTP and HTTPS staging
+    as a separate parsl-level task. This requires a shared file
+    system on the executor."""
+
+    def can_stage_in(self, file):
+        logger.debug("HTTPSeparateTaskStaging checking file {}".format(file.__repr__()))
+        logger.debug("file has scheme {}".format(file.scheme))
+        return file.scheme == 'http' or file.scheme == 'https'
+
+    def stage_in(self, dm, executor, file, parent_fut):
+        working_dir = dm.dfk.executors[executor].working_dir
+        stage_in_app = _http_stage_in_app(dm, executor=executor)
+        app_fut = stage_in_app(working_dir, outputs=[file], staging_inhibit_output=True, parent_fut=parent_fut)
+        return app_fut._outputs[0]
 
 
 def _http_stage_in(working_dir, parent_fut=None, outputs=[], staging_inhibit_output=True):

--- a/parsl/data_provider/staging.py
+++ b/parsl/data_provider/staging.py
@@ -1,0 +1,68 @@
+from concurrent.futures import Future
+from typing import Optional, Callable
+from parsl.app.futures import DataFuture
+from parsl.data_provider.files import File
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from parsl.data_provider.data_manager import DataManager
+
+
+class Staging:
+    """
+    This class defines the interface for file staging providers.
+
+    For each file to be staged in, the data manager will present the file
+    to each configured Staging provider in turn: first, it will ask if the
+    provider can stage this file by calling `can_stage_in`, and if so, it
+    will call both `stage_in` and `replace_task` to give the provider the
+    opportunity to perform staging.
+
+    For each file to be staged out, the data manager will follow the same
+    pattern using the corresponding stage out methods of this class.
+
+    The default implementation of this class rejects all files, and
+    performs no staging actions.
+
+    To implement a concrete provider, one or both of the `can_stage_*`
+    methods should be overridden to match the appropriate files, and then
+    the corresponding `stage_*` and/or `replace_task*` methods should be
+    implemented.
+    """
+
+    def can_stage_in(self, file: File) -> bool:
+        """
+        Given a File object, decide if this staging provider can
+        stage the file. Usually this is be based on the URL
+        scheme, but does not have to be. If this returns True,
+        then other methods of this Staging object will be called
+        to perform the staging.
+        """
+        return False
+
+    def can_stage_out(self, file: File) -> bool:
+        """
+        Like can_stage_in, but for staging out.
+        """
+        return False
+
+    def stage_in(self, dm: "DataManager", executor: str, file: File, parent_fut: Optional[Future]) -> Optional[DataFuture]:
+        """
+        For a given file, either return a DataFuture to substitute
+        for this file, or return None to perform no substitution
+        """
+        return None
+
+    def stage_out(self, dm: "DataManager", executor: str, file: File, app_fu) -> Optional[DataFuture]:
+        return None
+
+    def replace_task(self, dm: "DataManager", executor: str, file: File, func: Callable) -> Optional[Callable]:
+        """
+        For a file to be staged in, either return a replacement app
+        function, which usually should be the original app function wrapped
+        in staging code.
+        """
+        return None
+
+    def replace_task_stage_out(self, dm: "DataManager", executor: str, file: File, func: Callable) -> Optional[Callable]:
+        return None

--- a/parsl/data_provider/staging.py
+++ b/parsl/data_provider/staging.py
@@ -1,5 +1,5 @@
 from concurrent.futures import Future
-from typing import Optional, Callable
+from typing import Optional, Tuple, Callable
 from parsl.app.futures import DataFuture
 from parsl.data_provider.files import File
 
@@ -64,5 +64,15 @@ class Staging:
         """
         return None
 
-    def replace_task_stage_out(self, dm: "DataManager", executor: str, file: File, func: Callable) -> Optional[Callable]:
+    def replace_task_stage_out(self, dm: "DataManager", executor: str, file: File, func: Callable, unwrap_func: Callable) -> Optional[Tuple[Callable, Callable]]:
+        """
+        For a file to be staged out, optionally return a pair of a replacement app
+        function (which usually should be the original app function wrapped
+        in staging code) and an unwrapper function which be called on the submit side
+        after the task returns.
+
+        This is not symmetric with the stage_in replace_task, because code to be called
+        before wrapper functions on the submit side can be called inside the replace_task
+        call itself.
+        """
         return None

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -478,17 +478,14 @@ class DataFlowKernel(object):
 
         inputs = kwargs.get('inputs', [])
         for idx, f in enumerate(inputs):
-            inputs[idx] = self.data_manager.stage_in(f, executor)
-            func = self.data_manager.replace_task(f, func, executor)
+            (inputs[idx], func) = self.data_manager.stage_in_rename_this(f, func, executor)
 
         for kwarg, f in kwargs.items():
-            kwargs[kwarg] = self.data_manager.stage_in(f, executor)
-            func = self.data_manager.replace_task(f, func, executor)
+            (kwargs[kwarg], func) = self.data_manager.stage_in_rename_this(f, func, executor)
 
         newargs = list(args)
         for idx, f in enumerate(newargs):
-            newargs[idx] = self.data_manager.stage_in(f, executor)
-            func = self.data_manager.replace_task(f, func, executor)
+            (newargs[idx], func) = self.data_manager.stage_in_rename_this(f, func, executor)
 
         return tuple(newargs), kwargs, func
 

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -498,8 +498,12 @@ class DataFlowKernel(object):
                 # replace a File with a DataFuture - either completing when the stageout
                 # future completes, or if no stage out future is returned, then when the
                 # app itself completes.
+
+                # The staging code will get a clean copy which it is allowed to mutate,
+                # while the DataFuture-contained original will not be modified by any staging.
+                f_copy = f.cleancopy()
                 logger.debug("Submitting stage out for output file {}".format(f))
-                stageout_fut = self.data_manager.stage_out(f, executor, app_fut)
+                stageout_fut = self.data_manager.stage_out(f_copy, executor, app_fut)
                 if stageout_fut:
                     logger.debug("Adding a dependency on stageout future for {}".format(f))
                     app_fut._outputs.append(DataFuture(stageout_fut, f, tid=app_fut.tid))

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -517,7 +517,7 @@ class DataFlowKernel(object):
                 if newfunc:
                     func = newfunc
             else:
-                logger.debug("Not performing staging for: {}".format(f))
+                logger.debug("Not performing staging for: {}".format(repr(f)))
                 app_fut._outputs.append(DataFuture(app_fut, f, tid=app_fut.tid))
         return func
 

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -461,10 +461,10 @@ class DataFlowKernel(object):
         logger.info("Task {} launched on executor {}".format(task_id, executor.label))
         return exec_fu
 
-    def _add_input_deps(self, executor, args, kwargs):
-        """Look for inputs of the app that are remote files. Submit stage_in
-        apps for such files and replace the file objects in the inputs list with
-        corresponding DataFuture objects.
+    def _add_input_deps(self, executor, args, kwargs, func):
+        """Look for inputs of the app that are files. Give the data manager
+        the opportunity to replace a file with a data future for that file,
+        for example wrapping the result of a staging action.
 
         Args:
             - executor (str) : executor where the app is going to be launched
@@ -474,41 +474,52 @@ class DataFlowKernel(object):
 
         # Return if the task is _*_stage_in
         if executor == 'data_manager':
-            return args, kwargs
+            return args, kwargs, func
 
         inputs = kwargs.get('inputs', [])
         for idx, f in enumerate(inputs):
             inputs[idx] = self.data_manager.stage_in(f, executor)
+            func = self.data_manager.replace_task(f, func, executor)
 
         for kwarg, f in kwargs.items():
             kwargs[kwarg] = self.data_manager.stage_in(f, executor)
+            func = self.data_manager.replace_task(f, func, executor)
 
         newargs = list(args)
         for idx, f in enumerate(newargs):
             newargs[idx] = self.data_manager.stage_in(f, executor)
+            func = self.data_manager.replace_task(f, func, executor)
 
-        return tuple(newargs), kwargs
+        return tuple(newargs), kwargs, func
 
-    def _add_output_deps(self, executor, args, kwargs, app_fut):
+    def _add_output_deps(self, executor, args, kwargs, app_fut, func):
         logger.debug("Adding output dependencies")
-        inhibit = self.check_staging_inhibited(kwargs)
         outputs = kwargs.get('outputs', [])
         app_fut._outputs = []
         for f in outputs:
-            if isinstance(f, File) and f.is_remote() and not inhibit:
-                # with remote stageout, the DataFuture will be complete when
-                # the staging task is complete
-                logger.debug("Submitting stage out job for output file {}".format(f))
+            if isinstance(f, File) and not self.check_staging_inhibited(kwargs):
+                # replace a File with a DataFuture - either completing when the stageout
+                # future completes, or if no stage out future is returned, then when the
+                # app itself completes.
+                logger.debug("Submitting stage out for output file {}".format(f))
                 stageout_fut = self.data_manager.stage_out(f, executor, app_fut)
-                app_fut._outputs.append(DataFuture(stageout_fut, f, tid=app_fut.tid))
+                if stageout_fut:
+                    logger.debug("Adding a dependency on stageout future for {}".format(f))
+                    app_fut._outputs.append(DataFuture(stageout_fut, f, tid=app_fut.tid))
+                else:
+                    logger.debug("No stageout dependency for {}".format(f))
+                    app_fut._outputs.append(DataFuture(app_fut, f, tid=app_fut.tid))
+
+                # this is a hook for post-task stageout
+                # note that nothing depends on the output - which is maybe a bug
+                # in the not-very-tested stageout system?
+                newfunc = self.data_manager.replace_task_stage_out(f, func, executor)
+                if newfunc:
+                    func = newfunc
             else:
-                # with local stageout, the DataFuture will be complete when
-                # the core task future is complete
-                # with remote URLs, if staging is inhibited, the app future completing
-                # will signal that stage-out is complete - because that app *is* the
-                # stageout task
-                logger.debug("Skipping stageout for output {}".format(f))
+                logger.debug("Not performing staging for: {}".format(f))
                 app_fut._outputs.append(DataFuture(app_fut, f, tid=app_fut.tid))
+        return func
 
     def _gather_all_deps(self, args, kwargs):
         """Count the number of unresolved futures on which a task depends.
@@ -646,6 +657,8 @@ class DataFlowKernel(object):
             raise ValueError("Task {} supplied invalid type for executors: {}".format(task_id, type(executors)))
         executor = random.choice(choices)
 
+        # The below uses func.__name__ before it has been wrapped by any staging code.
+
         label = kwargs.get('label')
         for kw in ['stdout', 'stderr']:
             if kw in kwargs:
@@ -663,7 +676,6 @@ class DataFlowKernel(object):
 
         task_def = {'depends': None,
                     'executor': executor,
-                    'func': func,
                     'func_name': func.__name__,
                     'fn_hash': fn_hash,
                     'memoize': cache,
@@ -681,12 +693,13 @@ class DataFlowKernel(object):
         app_fu = AppFuture(task_def)
 
         # Transform remote input files to data futures
-        args, kwargs = self._add_input_deps(executor, args, kwargs)
+        args, kwargs, func = self._add_input_deps(executor, args, kwargs, func)
 
-        self._add_output_deps(executor, args, kwargs, app_fu)
+        self._add_output_deps(executor, args, kwargs, app_fu, func)
 
         task_def.update({
                     'args': args,
+                    'func': func,
                     'kwargs': kwargs,
                     'app_fu': app_fu})
 

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1024,7 +1024,7 @@ class DataFlowKernel(object):
                 logger.error(reason)
                 raise BadCheckpoint(reason)
 
-            logger.info("Completed loading checkpoint:{0} with {1} tasks".format(checkpoint_file,
+            logger.info("Completed loading checkpoint: {0} with {1} tasks".format(checkpoint_file,
                                                                                  len(memo_lookup_table.keys())))
         return memo_lookup_table
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -8,7 +8,7 @@ import threading
 import queue
 import pickle
 from multiprocessing import Process, Queue
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from ipyparallel.serialize import pack_apply_message  # ,unpack_apply_message
 from ipyparallel.serialize import deserialize_object  # ,serialize_object
@@ -18,8 +18,8 @@ from parsl.executors.high_throughput import zmq_pipes
 from parsl.executors.high_throughput import interchange
 from parsl.executors.errors import BadMessage, ScalingFailed, DeserializationError
 from parsl.executors.base import ParslExecutor
-from parsl.dataflow.error import ConfigurationError
 from parsl.providers.provider_base import ExecutionProvider
+from parsl.data_provider.staging import Staging
 
 from parsl.utils import RepresentationMixin
 from parsl.providers import LocalProvider
@@ -154,7 +154,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                  worker_ports: Optional[Tuple[int, int]] = None,
                  worker_port_range: Optional[Tuple[int, int]] = (54000, 55000),
                  interchange_port_range: Optional[Tuple[int, int]] = (55000, 56000),
-                 storage_access: Optional[List[Any]] = None,
+                 storage_access: Optional[List[Staging]] = None,
                  working_dir: Optional[str] = None,
                  worker_debug: bool = False,
                  cores_per_worker: float = 1.0,
@@ -174,9 +174,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         self.launch_cmd = launch_cmd
         self.provider = provider
         self.worker_debug = worker_debug
-        self.storage_access = storage_access if storage_access is not None else []
-        if len(self.storage_access) > 1:
-            raise ConfigurationError('Multiple storage access schemes are not supported')
+        self.storage_access = storage_access
         self.working_dir = working_dir
         self.managed = managed
         self.blocks = {}  # type: Dict[str, str]

--- a/parsl/executors/ipp.py
+++ b/parsl/executors/ipp.py
@@ -7,7 +7,6 @@ from ipyparallel import Client
 from parsl.providers import LocalProvider
 from parsl.utils import RepresentationMixin
 
-from parsl.dataflow.error import ConfigurationError
 from parsl.executors.base import ParslExecutor
 from parsl.executors.errors import ScalingFailed
 from parsl.executors.ipp_controller import Controller
@@ -84,9 +83,7 @@ class IPyParallelExecutor(ParslExecutor, RepresentationMixin):
         self.container_image = container_image
         self.engine_dir = engine_dir
         self.workers_per_node = workers_per_node
-        self.storage_access = storage_access if storage_access is not None else []
-        if len(self.storage_access) > 1:
-            raise ConfigurationError('Multiple storage access schemes are not yet supported')
+        self.storage_access = storage_access
         self.managed = managed
 
         self.debug_option = ""

--- a/parsl/executors/swift_t.py
+++ b/parsl/executors/swift_t.py
@@ -15,7 +15,6 @@ from ipyparallel.serialize import pack_apply_message, unpack_apply_message
 from ipyparallel.serialize import serialize_object, deserialize_object
 
 from parsl.executors.base import ParslExecutor
-from parsl.dataflow.error import ConfigurationError
 
 logger = logging.getLogger(__name__)
 
@@ -180,9 +179,7 @@ class TurbineExecutor(ParslExecutor):
         """
         logger.debug("Initializing TurbineExecutor")
         self.label = label
-        self.storage_access = storage_access if storage_access is not None else []
-        if len(self.storage_access) > 1:
-            raise ConfigurationError('Multiple storage access schemes are not yet supported')
+        self.storage_access = storage_access
         self.working_dir = working_dir
         self.managed = managed
 

--- a/parsl/tests/configs/local_threads_file_args.py
+++ b/parsl/tests/configs/local_threads_file_args.py
@@ -1,0 +1,18 @@
+import os
+
+from parsl.config import Config
+from parsl.data_provider.file_args import FileArgsStaging
+from parsl.data_provider.http import HTTPInTaskStaging
+from parsl.executors.threads import ThreadPoolExecutor
+from parsl.tests.utils import get_rundir
+
+config = Config(
+    executors=[
+        ThreadPoolExecutor(
+            label='local_threads_file_args',
+            storage_access=[FileArgsStaging(), HTTPInTaskStaging()],
+            working_dir=os.getcwd() + "/test_file_args_workdir"
+        )
+    ],
+    run_dir=get_rundir()
+)

--- a/parsl/tests/configs/local_threads_ftp_in_task.py
+++ b/parsl/tests/configs/local_threads_ftp_in_task.py
@@ -1,0 +1,15 @@
+from parsl.config import Config
+from parsl.data_provider.file_noop import NoOpFileStaging
+from parsl.data_provider.ftp import FTPInTaskStaging
+from parsl.executors.threads import ThreadPoolExecutor
+from parsl.tests.utils import get_rundir
+
+config = Config(
+    executors=[
+        ThreadPoolExecutor(
+            label='local_threads_http_in_task',
+            storage_access=[FTPInTaskStaging(), NoOpFileStaging()]
+        )
+    ],
+    run_dir=get_rundir()
+)

--- a/parsl/tests/configs/local_threads_globus.py
+++ b/parsl/tests/configs/local_threads_globus.py
@@ -1,4 +1,5 @@
 from parsl.config import Config
+from parsl.data_provider.data_manager import defaultStaging
 from parsl.data_provider.globus import GlobusScheme
 from parsl.executors.threads import ThreadPoolExecutor
 from parsl.tests.utils import get_rundir
@@ -10,15 +11,17 @@ from parsl.tests.utils import get_rundir
 #          (i.e., user_opts['swan']['username'] -> 'your_username')
 from .user_opts import user_opts
 
+storage_access = defaultStaging + [GlobusScheme(
+                endpoint_uuid=user_opts['globus']['endpoint'],
+                endpoint_path=user_opts['globus']['path']
+            )]
+
 config = Config(
     executors=[
         ThreadPoolExecutor(
             label='local_threads_globus',
-            storage_access=[GlobusScheme(
-                endpoint_uuid=user_opts['globus']['endpoint'],
-                endpoint_path=user_opts['globus']['path']
-            )],
-            working_dir=user_opts['globus']['path']
+            working_dir=user_opts['globus']['path'],
+            storage_access=storage_access
         )
     ],
     run_dir=get_rundir()

--- a/parsl/tests/configs/local_threads_http_in_task.py
+++ b/parsl/tests/configs/local_threads_http_in_task.py
@@ -1,0 +1,15 @@
+from parsl.config import Config
+from parsl.data_provider.file_noop import NoOpFileStaging
+from parsl.data_provider.http import HTTPInTaskStaging
+from parsl.executors.threads import ThreadPoolExecutor
+from parsl.tests.utils import get_rundir
+
+config = Config(
+    executors=[
+        ThreadPoolExecutor(
+            label='local_threads_http_in_task',
+            storage_access=[HTTPInTaskStaging(), NoOpFileStaging()]
+        )
+    ],
+    run_dir=get_rundir()
+)

--- a/parsl/tests/test_bash_apps/test_pipeline.py
+++ b/parsl/tests/test_bash_apps/test_pipeline.py
@@ -65,6 +65,7 @@ def test_increment(depth=5):
             filename = file.filepath
 
             assert file.local_path is None, "File on local side has overridden local_path, file: {}".format(repr(file))
+            assert file.filepath == "test{0}.txt".format(key), "Submit side filepath has not been preserved over execution"
 
             data = open(filename, 'r').read().strip()
             assert data == str(

--- a/parsl/tests/test_bash_apps/test_pipeline.py
+++ b/parsl/tests/test_bash_apps/test_pipeline.py
@@ -5,7 +5,7 @@ import parsl
 from parsl.app.app import App
 from parsl.data_provider.files import File
 
-from parsl.tests.configs.local_threads import config
+from parsl.tests.configs.local_threads_file_args import config
 
 
 @App('bash')
@@ -126,5 +126,5 @@ if __name__ == '__main__':
         parsl.set_stream_logger()
 
     # test_increment(depth=int(args.width))
-    # test_increment(depth=int(args.width))
+    test_increment(depth=int(args.width))
     test_increment_slow(depth=int(args.width))

--- a/parsl/tests/test_bash_apps/test_pipeline.py
+++ b/parsl/tests/test_bash_apps/test_pipeline.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 
 import parsl
 from parsl.app.app import App
@@ -26,9 +27,19 @@ def slow_increment(dur, inputs=[], outputs=[], stdout=None, stderr=None):
     return cmd_line
 
 
+def cleanup_work(depth):
+    for i in range(0,depth):
+        fn = "test{0}.txt".format(i)
+        if os.path.exists(fn):
+            os.remove(fn)
+
+
 def test_increment(depth=5):
     """Test simple pipeline A->B...->N
     """
+
+    cleanup_work(depth)
+
     # Create the first file
     open("test0.txt", 'w').write('0\n')
 
@@ -61,10 +72,15 @@ def test_increment(depth=5):
             assert data == str(
                 key), "[TEST] incr failed for key: {0} got data: {1} from filename {2}".format(key, data, filename)
 
+    cleanup_work(depth)
+
 
 def test_increment_slow(depth=5, dur=0.5):
     """Test simple pipeline slow (sleep.5) A->B...->N
     """
+
+    cleanup_work(depth)
+
     # Create the first file
     open("test0.txt", 'w').write('0\n')
 
@@ -92,6 +108,8 @@ def test_increment_slow(depth=5, dur=0.5):
             data = open(fu.result().filepath, 'r').read().strip()
             assert data == str(
                 key), "[TEST] incr failed for key: {0} got: {1}".format(key, data)
+
+    cleanup_work(depth)
 
 
 if __name__ == '__main__':

--- a/parsl/tests/test_bash_apps/test_pipeline.py
+++ b/parsl/tests/test_bash_apps/test_pipeline.py
@@ -50,9 +50,16 @@ def test_increment(depth=5):
     for key in futs:
         if key > 0:
             fu = futs[key]
-            data = open(fu.result().filepath, 'r').read().strip()
+            file = fu.result()
+            filename = file.filepath
+
+            # this test is a bit close to a test of the specific implementation
+            # of File
+            assert not hasattr(file, 'local_path'), "File on local side has overridden local_path, file: {}".format(repr(file))
+
+            data = open(filename, 'r').read().strip()
             assert data == str(
-                key), "[TEST] incr failed for key: {0} got: {1}".format(key, data)
+                key), "[TEST] incr failed for key: {0} got data: {1} from filename {2}".format(key, data, filename)
 
 
 def test_increment_slow(depth=5, dur=0.5):

--- a/parsl/tests/test_bash_apps/test_pipeline.py
+++ b/parsl/tests/test_bash_apps/test_pipeline.py
@@ -64,9 +64,7 @@ def test_increment(depth=5):
             file = fu.result()
             filename = file.filepath
 
-            # this test is a bit close to a test of the specific implementation
-            # of File
-            assert not hasattr(file, 'local_path'), "File on local side has overridden local_path, file: {}".format(repr(file))
+            assert file.local_path is None, "File on local side has overridden local_path, file: {}".format(repr(file))
 
             data = open(filename, 'r').read().strip()
             assert data == str(

--- a/parsl/tests/test_data/test_file_ipp.py
+++ b/parsl/tests/test_data/test_file_ipp.py
@@ -3,7 +3,7 @@ import os
 import parsl
 from parsl.app.app import App
 from parsl.data_provider.files import File
-from parsl.tests.configs.local_threads import config
+from parsl.tests.configs.local_threads_file_args import config
 
 
 @App('bash')
@@ -89,6 +89,6 @@ def test_increment(depth=5):
 if __name__ == '__main__':
     parsl.clear()
     parsl.load(config)
+    parsl.set_stream_logger()
 
-    test_files()
-    test_increment()
+    test_regression_200()

--- a/parsl/tests/test_python_apps/test_arg_input_types.py
+++ b/parsl/tests/test_python_apps/test_arg_input_types.py
@@ -1,0 +1,34 @@
+"""
+These tests check that inputs[] can be passed from any type,
+and that they can be used as regular objects unless they are
+Files.
+"""
+from parsl import python_app
+
+
+@python_app
+def take_a_value(inputs=[]):
+    return str(inputs[0])
+
+
+@python_app
+def add_two_values(inputs=[]):
+    return inputs[0] + inputs[1]
+
+
+def test_input_str():
+    f = take_a_value(inputs=["hi"])
+    assert f.result() == "hi"
+
+
+def test_input_num():
+    f = take_a_value(inputs=[3.14])
+    assert f.result() == "3.14"
+
+    f = add_two_values(inputs=[5, 7, 3])
+    assert f.result() == 12
+
+
+def test_input_list():
+    f = take_a_value(inputs=[["foo", 7]])
+    assert f.result() == "['foo', 7]"

--- a/parsl/tests/test_staging/test_implicit_staging_ftp_in_task.py
+++ b/parsl/tests/test_staging/test_implicit_staging_ftp_in_task.py
@@ -1,0 +1,52 @@
+import pytest
+
+import parsl
+from parsl.app.app import App
+from parsl.data_provider.files import File
+from parsl.tests.configs.local_threads_ftp_in_task import config
+
+parsl.load(config)
+
+
+@App('python')
+def sort_strings(inputs=[], outputs=[]):
+    with open(inputs[0].filepath, 'r') as u:
+        strs = u.readlines()
+        strs.sort()
+        with open(outputs[0].filepath, 'w') as s:
+            for e in strs:
+                s.write(e)
+
+
+@pytest.mark.local
+@pytest.mark.cleannet
+def test_implicit_staging_ftp():
+    """Test implicit staging for an ftp file
+
+    Create a remote input file (ftp) that points to file_test_cpt.txt.
+    """
+
+    unsorted_file = File('ftp://www.iana.org/pub/mirror/rirstats/arin/ARIN-STATS-FORMAT-CHANGE.txt')
+
+    # Create a local file for output data
+    sorted_file = File('sorted.txt')
+
+    f = sort_strings(inputs=[unsorted_file], outputs=[sorted_file])
+    f.result()
+
+
+if __name__ == "__main__":
+
+    import argparse
+
+    parsl.load()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--debug", action='store_true',
+                        help="Count of apps to launch")
+    args = parser.parse_args()
+
+    if args.debug:
+        parsl.set_stream_logger()
+
+    test_implicit_staging_ftp()

--- a/parsl/tests/test_staging/test_implicit_staging_https_in_task.py
+++ b/parsl/tests/test_staging/test_implicit_staging_https_in_task.py
@@ -1,0 +1,37 @@
+import pytest
+
+import parsl
+from parsl.app.app import App
+from parsl.data_provider.files import File
+
+from parsl.tests.configs.local_threads_http_in_task import config
+
+parsl.load(config)
+
+
+@App('python')
+def sort_strings(inputs=[], outputs=[]):
+    with open(inputs[0].filepath, 'r') as u:
+        strs = u.readlines()
+        strs.sort()
+        with open(outputs[0].filepath, 'w') as s:
+            for e in strs:
+                s.write(e)
+
+
+@pytest.mark.local
+def test_implicit_staging_https():
+    """Test implicit staging for an ftp file
+
+    Create a remote input file (https) that points to unsorted.txt.
+    """
+
+    # unsorted_file = File('https://testbed.petrel.host/test/public/unsorted.txt')
+    unsorted_file = File('https://gist.githubusercontent.com/yadudoc/7f21dd15e64a421990a46766bfa5359c/'
+                         'raw/7fe04978ea44f807088c349f6ecb0f6ee350ec49/unsorted.txt')
+
+    # Create a local file for output data
+    sorted_file = File('sorted.txt')
+
+    f = sort_strings(inputs=[unsorted_file], outputs=[sorted_file])
+    f.result()

--- a/parsl/tests/test_staging/test_local_file_args.py
+++ b/parsl/tests/test_staging/test_local_file_args.py
@@ -1,0 +1,49 @@
+import pytest
+
+import parsl
+from parsl.data_provider.files import File
+
+if __name__ == "__main__":
+    parsl.set_stream_logger()
+    # initialise logging before importing config, to get logging
+    # from config declaration # as it looks like the AWS initializer
+    # is doing more than just creating data structures
+
+from parsl import bash_app
+from parsl.tests.configs.local_threads_file_args import config
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+@bash_app
+def bash_cat(inputs=[], outputs=[]):
+    return 'cat {inp} > {out}'.format(inp=inputs[0].filepath, out=outputs[0].filepath)
+
+
+def setup_module(module):
+    parsl.load(config)
+
+
+@pytest.mark.local
+def test_bash():
+    """Testing basic bash functionality."""
+
+    # TODO: delete these files before use to stop
+    # test overlap.
+
+    in_file = File("test_bash.in")
+    out_file = File("test_bash.out")
+
+    x = bash_cat(inputs=[in_file], outputs=[out_file])
+
+    # wait for the output future
+
+    f = x.outputs[0].result()
+
+    assert x.result() == 0, "Bash result code was not success"
+
+
+if __name__ == "__main__":
+    parsl.load(config)
+    test_bash()


### PR DESCRIPTION
This PR contains all of my work in progress related to data manager.

The main interesting thing is the replacement of hard-coded staging mechanisms with a `Staging` interface - something I've had in my head for a while but wanted to actually code up to see what it looked like in real life.

Executors now have a list of `Staging` providers (a more elaborate form of the earlier globus staging configuration - so still supplied in a `storage_access` attribute on the executor).

For each file to be staged in, each staging provider is offered the file in turn to see if it knows how to perform the staging.
There are 4 staging providers which replicate the existing behavior: FileNoOpStaging - which handles `file://` URLs by doing nothing; `HTTPSeparateTaskStaging` and `FTPSeparateTaskStaging` which perform HTTP, HTTPS and FTP staging as separate parsl tasks; and `GlobusScheme`  which performs transfers using globus.

There are 2 further staging providers which attempt some more interesting functionality:
- `FileArgsStaging` provides an alternative method for staging-in (small) `file://` URLs by reading the content and storing it in a wrapper that goes around the app function
- `HTTPInTaskStaging` which stages-in files in a wrapper around the app, so that the stage-in is guaranteed to happen on the same node as the app execution. This is a prototype for running on executors with no shared file system.

The main staging provider interface is in parsl/data_provider/staging.py and provides three hooks: one for replacing stage-in Files with DataFutures (as happens with the existing staging mechanism) and one for wrapping the called app with a wrapper function. This API deliberately does not try to constrain how a staging provider implements those two hooks. A further hook allows a staging provider to indicate if it can or cannot stage a particular URL.

The implementations of the above staging providers are found in the various files in parsl/data-provider/*.py

There is a bunch of other stuff in this PR as fairly clean separate commits that I would like to get into master at some point.

I would like to understand how this interacts with the workqueue (PR #771) method of staging files, which looks like it can only deal with files already on the submit-side filesystem.