### PR TITLE
Rearrange AWS initializer params to reflect that key_name is mandatory

### DIFF
--- a/parsl/providers/aws/aws.py
+++ b/parsl/providers/aws/aws.py
@@ -93,6 +93,7 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
 
     def __init__(self,
                  image_id,
+                 key_name,
                  init_blocks=1,
                  min_blocks=0,
                  max_blocks=10,
@@ -104,7 +105,6 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
                  region='us-east-2',
                  spot_max_bid=0,
 
-                 key_name=None,
                  key_file=None,
                  profile=None,
                  iam_instance_profile_arn='',


### PR DESCRIPTION
Before this patch, the provider would initialize and then later fail when
attempting to allocate a resource, with:

2019-07-10 23:02:00 parsl.providers.aws.aws:495 [ERROR]  Request for EC2 resources failed : Parameter validation failed:
Invalid type for parameter KeyName, value: None, type: <class 'NoneType'>, valid types: <class 'str'>

After this patch, the initializer will fail when intializing the
AWSProvider, before the DFK is even loaded, and with an error message
that better reflects the missing mandatory parameter.