### PR TITLE
Add non-version-controlled user opts override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ web/*
 api/*
 .idea/*
 
+# local user configuration which should never be
+# version controlled
+./parsl/tests/configs/local_user_opts.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,9 @@ plugins = sqlmypy
 [mypy-non_existent.*]
 ignore_missing_imports = True
 
+[mypy-parsl.tests.configs.local_user_opts]
+ignore_missing_imports = True
+
 [mypy-sqlalchemy_utils.*]
 ignore_missing_imports = True
 

--- a/parsl/tests/configs/user_opts.py
+++ b/parsl/tests/configs/user_opts.py
@@ -3,8 +3,12 @@ Specification of user-specific configuration options.
 
 The fields must be configured separately for each user. To disable any associated configurations, comment
 out the entry.
-"""
 
+User specific overrides that should not go in version control can be set by creating a
+file called local_user_opts.py, which declares a dictionary local_user_opts. Top level
+keys in that dictionary will replace entries in the below user opts file, so it should
+be safe to cut-and-paste entries from this file into that file.
+"""
 from typing import Any, Dict
 
 # PUBLIC_IP = "52.86.208.63" # "128.135.250.229"
@@ -92,3 +96,18 @@ user_opts = {
     #     'path': 'fixme'
     # }
 }  # type: Dict[str, Any]
+
+# This block attempts to import local_user_opts.py, which
+# can provide local overrides to the version-controlled
+# user_opts.
+# Users can add their own overrides into local_user_opts
+# in local_user_opts.py, which should not exist in a
+# pristine parsl source tree, and which should help avoid
+# accidentally committing secrets and other per-user
+# config into version control.
+try:
+    from .local_user_opts import local_user_opts
+    user_opts.update(local_user_opts)
+
+except ModuleNotFoundError:
+    pass

--- a/parsl/tests/configs/user_opts.py
+++ b/parsl/tests/configs/user_opts.py
@@ -109,5 +109,5 @@ try:
     from .local_user_opts import local_user_opts
     user_opts.update(local_user_opts)
 
-except ModuleNotFoundError:
+except ImportError:
     pass


### PR DESCRIPTION
This is intended to facilitate putting secrets into a
user configuration file while reducing the chances of
those secrets being published as part of version
control history