### PR TITLE
Add a site test for ec2

### DIFF
--- a/parsl/tests/configs/ec2_single_node.py
+++ b/parsl/tests/configs/ec2_single_node.py
@@ -14,8 +14,7 @@ Block {Min:0, init:1, Max:1}
 from parsl.providers import AWSProvider
 
 from parsl.config import Config
-from parsl.executors.ipp import IPyParallelExecutor
-from parsl.executors.ipp_controller import Controller
+from parsl.executors import HighThroughputExecutor
 from parsl.tests.utils import get_rundir
 
 # If you are a developer running tests, make sure to update parsl/tests/configs/user_opts.py
@@ -27,9 +26,9 @@ from .user_opts import user_opts
 
 config = Config(
     executors=[
-        IPyParallelExecutor(
+        HighThroughputExecutor(
             label='ec2_single_node',
-            workers_per_node=2,
+            address=user_opts['public_ip'],
             provider=AWSProvider(
                 user_opts['ec2']['image_id'],
                 region=user_opts['ec2']['region'],
@@ -42,7 +41,6 @@ config = Config(
                 min_blocks=0,
                 walltime='01:00:00',
             ),
-            controller=Controller(public_ip=user_opts['public_ip']),
         )
     ],
     run_dir=get_rundir(),

--- a/parsl/tests/sites/test_ec2.py
+++ b/parsl/tests/sites/test_ec2.py
@@ -1,0 +1,81 @@
+import argparse
+
+import pytest
+
+import parsl
+
+if __name__ == "__main__":
+    parsl.set_stream_logger() # before import config, to get logging show from config declaration
+                              # as it looks like the AWS initializer is doing more than just
+                              # creating data structures
+
+from parsl.app.app import App
+from parsl.tests.conftest import load_dfk
+from parsl.tests.configs.ec2_single_node import config
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+@App("python", executors=['ec2_single_node'])
+def python_app_2():
+    import os
+    import threading
+    import time
+    time.sleep(1)
+    return "Hello from PID[{}] TID[{}]".format(os.getpid(), threading.current_thread())
+
+
+@App("python", executors=['ec2_single_node'])
+def python_app_1():
+    import os
+    import threading
+    import time
+    time.sleep(1)
+    return "Hello from PID[{}] TID[{}]".format(os.getpid(), threading.current_thread())
+
+
+@App("bash")
+def bash_app(stdout=None, stderr=None):
+    return 'echo "Hello from $(uname -a)" ; sleep 2'
+
+
+@pytest.mark.local
+def test_python(N=2):
+    """Testing basic python functionality."""
+
+    r1 = {}
+    r2 = {}
+    for i in range(0, N):
+        r1[i] = python_app_1()
+        r2[i] = python_app_2()
+    print("Waiting ....")
+
+    for x in r1:
+        print("python_app_1 : ", r1[x].result())
+    for x in r2:
+        print("python_app_2 : ", r2[x].result())
+
+    return
+
+
+def setup_module(module):
+    parsl.load(config)
+
+
+@pytest.mark.local
+def test_bash():
+    """Testing basic bash functionality."""
+
+    import os
+    fname = os.path.basename(__file__)
+
+    x = bash_app(stdout="{0}.out".format(fname))
+    print("Waiting ....")
+    print(x.result())
+
+
+if __name__ == "__main__":
+    parsl.load(config)
+    test_python()
+    test_bash()

--- a/parsl/tests/sites/test_ec2.py
+++ b/parsl/tests/sites/test_ec2.py
@@ -1,16 +1,14 @@
-import argparse
-
 import pytest
 
 import parsl
 
 if __name__ == "__main__":
-    parsl.set_stream_logger() # before import config, to get logging show from config declaration
-                              # as it looks like the AWS initializer is doing more than just
-                              # creating data structures
+    parsl.set_stream_logger()
+    # initialise logging before importing config, to get logging
+    # from config declaration # as it looks like the AWS initializer
+    # is doing more than just creating data structures
 
 from parsl.app.app import App
-from parsl.tests.conftest import load_dfk
 from parsl.tests.configs.ec2_single_node import config
 
 import logging


### PR DESCRIPTION
Awkwardnesses:

i) `template.py` needs to be adjusted to install the same version of parsl as is being submitted from, rather than whatever the most recent release is - as needs to happen with any non-trivial development version of parsl submitting to EC2.

ii) This will not run inside pytest - as with a bunch of other tests, some apps run inside pytest cause more modules to be loaded than run outside pytest, the reason for which I don't understand. In this case, that means the workers try to import the test script, which causes several problems - at least, that `PARSL_TESTING` is not installed, that the test-requirements dependency stack is not installed, that `user_opts` is not set correctly on the remote side.

Nevertheless, this is maybe worth merging to master as being better than not being in `master`.
