### PR TITLE
Remove get_data_manager and the concept of a global data manager

### DIFF
--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -47,15 +47,6 @@ class DataManager(ParslExecutor):
     to it, and DataFutures are returned.
     """
 
-    @classmethod
-    def get_data_manager(cls):
-        """Return the DataManager of the currently loaded DataFlowKernel.
-        """
-        from parsl.dataflow.dflow import DataFlowKernelLoader
-        dfk = DataFlowKernelLoader.dfk()
-
-        return dfk.executors['data_manager']
-
     def __init__(self, dfk, max_threads=10):
         """Initialize the DataManager.
 


### PR DESCRIPTION
A data manager always belongs to a DFK, and there can be multiple
DFKs in existence - so the notion of getting a data manager globally
outside the context of a specific DFK does not make sense.

The last call to this was removed in PR #885 (b7c14695)