### PR TITLE
Minor tidying to DataFuture result handling

### DIFF
--- a/parsl/app/futures.py
+++ b/parsl/app/futures.py
@@ -26,21 +26,21 @@ class DataFuture(Future):
     def parent_callback(self, parent_fu):
         """Callback from executor future to update the parent.
 
+        Updates the future with the result (the File object) or the parent future's
+        exception.
+
         Args:
             - parent_fu (Future): Future returned by the executor along with callback
 
         Returns:
             - None
-
-        Updates the super() with the result() or exception()
         """
-        if parent_fu.done() is True:
-            e = parent_fu._exception
-            if e:
-                super().set_exception(e)
-            else:
-                super().set_result(self.file_obj)
-        return
+
+        e = parent_fu._exception
+        if e:
+            self.set_exception(e)
+        else:
+            self.set_result(self.file_obj)
 
     def __init__(self, fut, file_obj, tid=None):
         """Construct the DataFuture object.
@@ -65,7 +65,7 @@ class DataFuture(Future):
         self.parent = fut
 
         if fut is None:
-            logger.debug("Setting result to filepath since no future was passed")
+            logger.debug("Setting result to filepath immediately since no parent future was passed")
             self.set_result(self.file_obj)
 
         else:


### PR DESCRIPTION
No need for super() - invoking set_result or set_exception
on self will pick the correct method.

No need to check if parent future is done in done callback.