### PR TITLE
Add control of logging level to the Config, stream_ and file_logger

### DIFF
--- a/parsl/__init__.py
+++ b/parsl/__init__.py
@@ -79,12 +79,14 @@ wait_for_current_tasks = DataFlowKernelLoader.wait_for_current_tasks
 
 
 @typeguard.typechecked
-def set_stream_logger(name: str = 'parsl', level: int = logging.DEBUG, format_string: Optional[str] = None):
+def set_stream_logger(name: str = 'parsl', level: int = logging.DEBUG, stream_level: Optional[int] = None,
+                      format_string: Optional[str] = None):
     """Add a stream log handler.
 
     Args:
          - name (string) : Set the logger name.
          - level (logging.LEVEL) : Set to logging.DEBUG by default.
+         - stream_level (logging.LEVEL) : Set to same value as level by default
          - format_string (string) : Set to None by default.
 
     Returns:
@@ -94,10 +96,11 @@ def set_stream_logger(name: str = 'parsl', level: int = logging.DEBUG, format_st
         # format_string = "%(asctime)s %(name)s [%(levelname)s] Thread:%(thread)d %(message)s"
         format_string = "%(asctime)s %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
 
+    stream_level = level if stream_level is None else stream_level
     logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(level)
     handler = logging.StreamHandler()
-    handler.setLevel(level)
+    handler.setLevel(stream_level)
     formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
     handler.setFormatter(formatter)
     logger.addHandler(handler)
@@ -107,16 +110,19 @@ def set_stream_logger(name: str = 'parsl', level: int = logging.DEBUG, format_st
     # and then discarded. (see #240)
     futures_logger = logging.getLogger("concurrent.futures")
     futures_logger.addHandler(handler)
+    futures_logger.setLevel(level)
 
 
 @typeguard.typechecked
-def set_file_logger(filename: str, name: str = 'parsl', level: int = logging.DEBUG, format_string: Optional[str] = None):
+def set_file_logger(filename: str, name: str = 'parsl', level: int = logging.DEBUG,
+                    file_level: Optional[int] = None, format_string: Optional[str] = None):
     """Add a stream log handler.
 
     Args:
         - filename (string): Name of the file to write logs to
         - name (string): Logger name
         - level (logging.LEVEL): Set the logging level.
+        - file_level (logging.LEVEL) : Set to same value as level by default
         - format_string (string): Set the format string
 
     Returns:
@@ -125,10 +131,11 @@ def set_file_logger(filename: str, name: str = 'parsl', level: int = logging.DEB
     if format_string is None:
         format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
 
+    file_level = level if file_level is None else file_level
     logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(level)
     handler = logging.FileHandler(filename)
-    handler.setLevel(level)
+    handler.setLevel(file_level)
     formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
     handler.setFormatter(formatter)
     logger.addHandler(handler)
@@ -137,6 +144,7 @@ def set_file_logger(filename: str, name: str = 'parsl', level: int = logging.DEB
     # concurrent.futures
     futures_logger = logging.getLogger("concurrent.futures")
     futures_logger.addHandler(handler)
+    futures_logger.setLevel(level)
 
 
 class NullHandler(logging.Handler):

--- a/parsl/config.py
+++ b/parsl/config.py
@@ -50,6 +50,13 @@ class Config(RepresentationMixin):
     usage_tracking : bool, optional
         Set this field to True to opt-in to Parsl's usage tracking system. Parsl only collects minimal, non personally-identifiable,
         information used for reporting to our funding agencies. Default is False.
+    logging_level : int, optional
+        Level of logging to report for to the main Python logger outputs (often STDOUT). Accepts values of the int
+        representation of the Python logging module levels (e.g. logger.DEBUG = 10). Default is logging.DEBUG
+    stream_file_logging_level : int, optional
+        Level of logging to report for to the streams and files separate from the main loggers. Accepts values of the
+        int representation of the Python logging module levels (e.g. logger.DEBUG = 10). Default is same value as
+        logging_level
     """
 
     @typeguard.typechecked
@@ -65,7 +72,9 @@ class Config(RepresentationMixin):
                  run_dir: str = 'runinfo',
                  strategy: Optional[str] = 'simple',
                  monitoring: Optional[MonitoringHub] = None,
-                 usage_tracking: bool = False):
+                 usage_tracking: bool = False,
+                 logging_level: int = logging.DEBUG,
+                 stream_file_logging_level: Optional[int] = None):
         if executors is None:
             executors = [ThreadPoolExecutor()]
         self.executors = executors
@@ -91,6 +100,9 @@ class Config(RepresentationMixin):
         self.strategy = strategy
         self.usage_tracking = usage_tracking
         self.monitoring = monitoring
+        self.logging_level = logging_level
+        self.stream_file_logging_level = (logging_level if stream_file_logging_level is None
+                                          else stream_file_logging_level)
 
     @property
     def executors(self):

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -76,7 +76,8 @@ class DataFlowKernel(object):
                     'see http://parsl.readthedocs.io/en/stable/stubs/parsl.config.Config.html')
         self._config = config
         self.run_dir = make_rundir(config.run_dir)
-        parsl.set_file_logger("{}/parsl.log".format(self.run_dir), level=logging.DEBUG)
+        parsl.set_file_logger("{}/parsl.log".format(self.run_dir), level=config.logging_level,
+                              file_level=config.stream_file_logging_level)
         logger.debug("Starting DataFlowKernel with config\n{}".format(config))
         logger.info("Parsl version: {}".format(get_version()))
 


### PR DESCRIPTION
This adds new settings in the `Config` class which enables setting
the logging levels to the stream_logger and the file_logger.

The main use case here is for those directly invoking the
`DataFlowKernel` with a `Config` who don't want the output loggers to
be automatically set to `DEBUG` level.

Default behavior should be identical to the current behavior and this
*should* be an extension of the existing API without breaking backwards
compatibility.

It is a rather simplistic change, so I'm not sure I made the changes
everywhere that is needed nor have I figured out how to properly test
this, so any comments or suggestions would be helpful.

Change is related to a conversation @yadudoc and myself had previously. There is no issue directly tied to this, but I can open one if requested and if this feature needs more discussion before a PR.