### PR TITLE
Re-order extreme scale and workqueue for better dependency validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ script:
     - export PATH=$PATH:/tmp/cctools/bin
     - export PYTHONPATH=/tmp/cctools/lib/python3.5/site-packages
 
-    - pip install .[extreme_scale,monitoring,workqueue]
+    - pip install .[extreme_scale,monitoring]
 
     - work_queue_worker localhost 9000 &> /dev/null &
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,15 @@ script:
     # some of the site/ tests require more dependencies. These are installed here as needed,
     # so that the above tests happen with only the basic requirements installed.
 
+    # workqueue
     - bash parsl/executors/workqueue/install-workqueue.sh
     - export PATH=$PATH:/tmp/cctools/bin
     - export PYTHONPATH=/tmp/cctools/lib/python3.5/site-packages
+
+    # mpi
+    - bash parsl/executors/extreme_scale/install-mpi.sh $MPI
+    - if [[ "$MPI" == "mpich"   ]]; then mpichversion; fi
+    - if [[ "$MPI" == "openmpi" ]]; then ompi_info;    fi
 
     - pip install .[extreme_scale,monitoring]
 
@@ -60,10 +66,6 @@ script:
 
     - (for test in parsl/tests/test*/test*; do pytest $test -k "not cleannet" --config parsl/tests/configs/workqueue_ex.py --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
     - kill -3 $(ps aux | grep -E -e "[0-9]+:[0-9]+ work_queue_worker" | tr -s ' ' | cut -f 2 -d " ")
-
-    - bash parsl/executors/extreme_scale/install-mpi.sh $MPI
-    - if [[ "$MPI" == "mpich"   ]]; then mpichversion; fi
-    - if [[ "$MPI" == "openmpi" ]]; then ompi_info;    fi
 
     # these tests run with specific configs loaded within the tests themselves.
     # This mode is enabled with: --config local

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,20 +14,14 @@ before_install:
     - sudo apt-get update -q
     - python$PY -m pip install Cython
     - python$PY -m pip install numpy
-    - bash parsl/executors/extreme_scale/install-mpi.sh $MPI
-    - bash parsl/executors/workqueue/install-workqueue.sh
-    - export PATH=$PATH:/tmp/cctools/bin
-    - export PYTHONPATH=/tmp/cctools/lib/python3.5/site-packages
     - python$PY --version
     - python$PY -m cython --version
     - python$PY -c "import numpy;print(numpy.__version__)"
-    - if [[ "$MPI" == "mpich"   ]]; then mpichversion; fi
-    - if [[ "$MPI" == "openmpi" ]]; then ompi_info;    fi
+
 
 # command to install dependencies
 install:
     - pip install -r requirements.txt
-    - pip install .[extreme_scale]
 
 # Os tests
 os:
@@ -50,11 +44,25 @@ script:
 
     - (for test in parsl/tests/test*/test*; do pytest $test -k "not cleannet" --config parsl/tests/configs/htex_local.py --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
     - (for test in parsl/tests/test*/test*; do pytest $test -k "not cleannet" --config parsl/tests/configs/local_threads.py --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
-    - work_queue_worker localhost 9000 &> /dev/null &
-    - (for test in parsl/tests/test*/test*; do pytest $test -k "not cleannet" --config parsl/tests/configs/workqueue_ex.py --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
-    - kill -3 $(ps aux | grep -E -e "[0-9]+:[0-9]+ work_queue_worker" | tr -s ' ' | cut -f 2 -d " ")
     # allow exit code 5; this means pytest did not run a test in the
     # specified file
+
+    # some of the site/ tests require more dependencies. These are installed here as needed,
+    # so that the above tests happen with only the basic requirements installed.
+
+    - bash parsl/executors/workqueue/install-workqueue.sh
+    - export PATH=$PATH:/tmp/cctools/bin
+    - export PYTHONPATH=/tmp/cctools/lib/python3.5/site-packages
+    - work_queue_worker localhost 9000 &> /dev/null &
+
+    - (for test in parsl/tests/test*/test*; do pytest $test -k "not cleannet" --config parsl/tests/configs/workqueue_ex.py --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
+    - kill -3 $(ps aux | grep -E -e "[0-9]+:[0-9]+ work_queue_worker" | tr -s ' ' | cut -f 2 -d " ")
+
+    - bash parsl/executors/extreme_scale/install-mpi.sh $MPI
+    - pip install .[extreme_scale]
+    - if [[ "$MPI" == "mpich"   ]]; then mpichversion; fi
+    - if [[ "$MPI" == "openmpi" ]]; then ompi_info;    fi
+
 
     # these tests run with specific configs loaded within the tests themselves.
     # This mode is enabled with: --config local

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,17 +53,17 @@ script:
     - bash parsl/executors/workqueue/install-workqueue.sh
     - export PATH=$PATH:/tmp/cctools/bin
     - export PYTHONPATH=/tmp/cctools/lib/python3.5/site-packages
+
+    - pip install .[extreme_scale,monitoring,workqueue]
+
     - work_queue_worker localhost 9000 &> /dev/null &
 
     - (for test in parsl/tests/test*/test*; do pytest $test -k "not cleannet" --config parsl/tests/configs/workqueue_ex.py --cov=parsl --cov-append --cov-report= ; export PytestReturnCode=$? ; echo pytest return code is $PytestReturnCode ; if [[ "$PytestReturnCode" != 0 ]] && [[ "$PytestReturnCode" != 5 ]]; then exit 1; fi; done ) ;
     - kill -3 $(ps aux | grep -E -e "[0-9]+:[0-9]+ work_queue_worker" | tr -s ' ' | cut -f 2 -d " ")
 
-    - pip install .[extreme_scale,monitoring,workqueue]
-
     - bash parsl/executors/extreme_scale/install-mpi.sh $MPI
     - if [[ "$MPI" == "mpich"   ]]; then mpichversion; fi
     - if [[ "$MPI" == "openmpi" ]]; then ompi_info;    fi
-
 
     # these tests run with specific configs loaded within the tests themselves.
     # This mode is enabled with: --config local

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ before_install:
     - python$PY -c "import numpy;print(numpy.__version__)"
 
 
-# command to install dependencies
+# install parsl with no optional extras
 install:
-    - pip install -r requirements.txt
+    - pip install .
 
 # Os tests
 os:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 flake8
+pandas
 pytest>=3.6.0,<4.1.0
 pytest-cov
 pytest-xdist==1.26.1


### PR DESCRIPTION
This attempts to reduce the optional dependencies installed before the majority of tests, and installs those dependencies later on only for mechanism-specific testing.

This addresses a problem encountered a few times in CI, where missing dependencies  in the core `requirements.txt` were not discovered because of the more exciting dependency options installed in CI.