### PR TITLE
Test that exceptions from apps are delivered to caller

### DIFF
--- a/parsl/tests/test_error_handling/test_fail.py
+++ b/parsl/tests/test_error_handling/test_fail.py
@@ -1,11 +1,12 @@
-import parsl
 import pytest
 
 from parsl.app.app import python_app
 
+
 @python_app
 def always_fail():
     raise ValueError("This ValueError should propagate to the app caller in fut.result()")
+
 
 def test_simple():
     with pytest.raises(ValueError):

--- a/parsl/tests/test_error_handling/test_fail.py
+++ b/parsl/tests/test_error_handling/test_fail.py
@@ -1,0 +1,13 @@
+import parsl
+import pytest
+
+from parsl.app.app import python_app
+
+@python_app
+def always_fail():
+    raise ValueError("This ValueError should propagate to the app caller in fut.result()")
+
+def test_simple():
+    with pytest.raises(ValueError):
+        fut = always_fail()
+        fut.result()


### PR DESCRIPTION
I can't find where this is explicitly tested in the test suite at the moment, but maybe it is already?