### PR TITLE
Work Queue Executor Tidy Up Changes

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -28,6 +28,7 @@ from work_queue import cctools_debug_config_file
 
 logger = logging.getLogger(__name__)
 
+
 def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
                           queue_lock=threading.Lock(),
                           launch_cmd=None,
@@ -61,7 +62,7 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
         logger.error("Unable to create WorkQueue object: {}".format(e))
         raise e
 
-    # Specify WorkQueue queue attributes 
+    # Specify WorkQueue queue attributes
     if project_name:
         q.specify_name(project_name)
     if project_password:
@@ -105,7 +106,7 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
                 continue
             parsl_id = item["task_id"]
 
-            # Extract information about the task 
+            # Extract information about the task
             function_data_loc = item["data_loc"]
             function_data_loc_remote = function_data_loc.split("/")[-1]
             function_result_loc = item["result_loc"]
@@ -159,7 +160,7 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
             if env is not None:
                 for var in env:
                     t.specify_environment_variable(var, env[var])
-            
+
             # Specify script, and data/result files for task
             t.specify_file(full_script_name, script_name, WORK_QUEUE_INPUT, cache=True)
             t.specify_file(function_data_loc, function_data_loc_remote, WORK_QUEUE_INPUT, cache=False)
@@ -217,7 +218,7 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
                     task_result = t.result
                     msg = None
 
-                    # Task failure 
+                    # Task failure
                     if status != 0 or (task_result != WORK_QUEUE_RESULT_SUCCESS and task_result != WORK_QUEUE_RESULT_OUTPUT_MISSING):
                         logger.debug("Wrapper Script status: {}\nWorkQueue Status: {}".format(status, task_result))
                         # Wrapper script failure
@@ -243,21 +244,21 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
                                 reason += "unable to generate output file"
                             elif task_result == 4:
                                 reason += "stdout has been truncated"
-                            elif task_result == 1<<3:
+                            elif task_result == 1 << 3:
                                 reason += "task terminated with a signal"
-                            elif task_result == 2<<3:
+                            elif task_result == 2 << 3:
                                 reason += "task used more resources than requested"
-                            elif task_result == 3<<3:
+                            elif task_result == 3 << 3:
                                 reason += "task ran past the specified end time"
-                            elif task_result == 4<<3:
+                            elif task_result == 4 << 3:
                                 reason += "result could not be classified"
-                            elif task_result == 5<<3:
+                            elif task_result == 5 << 3:
                                 reason += "task failed, but not a task error"
-                            elif task_result == 6<<3:
+                            elif task_result == 6 << 3:
                                 reason += "unable to complete after specified number of retries"
-                            elif task_result == 7<<3:
+                            elif task_result == 7 << 3:
                                 reason += "task ran for more than the specified time"
-                            elif task_result == 8<<3:
+                            elif task_result == 8 << 3:
                                 reason += "task needed more space to complete task"
 
                         msg = {"tid": parsl_tid,
@@ -324,7 +325,6 @@ def WorkQueueCollectorThread(collector_queue=multiprocessing.Queue(),
             item = collector_queue.get(timeout=1)
         except queue.Empty:
             continue
-
 
         parsl_tid = item["tid"]
         received = item["result_received"]
@@ -420,11 +420,11 @@ class WorkQueueExecutor(ParslExecutor):
         self.shared_files = set()
         self.registered_files = set()
         self.worker_output = see_worker_output
-        self.full = False   
+        self.full = False
         self.source = source
         self.cancel_value = multiprocessing.Value('i', 1)
 
-        # Resolve ambiguity when password and password_file are both specified 
+        # Resolve ambiguity when password and password_file are both specified
         if self.project_password is not None and self.project_password_file is not None:
             logger.warning("Password File and Password text specified for WorkQueue Executor, only Password Text will be used")
             self.project_password_file = None
@@ -544,7 +544,7 @@ class WorkQueueExecutor(ParslExecutor):
                         inp = inp[0]
                     if not os.path.exists(os.path.join(".", os.path.split(inp)[0])):
                         continue
-                    # Create "std" files instead of input or output files 
+                    # Create "std" files instead of input or output files
                     if inp in self.registered_files:
                         input_files.append((inp, os.path.basename(inp) + "-1", False, "std"))
                         output_files.append((inp, os.path.basename(inp), False, "std"))
@@ -589,26 +589,25 @@ class WorkQueueExecutor(ParslExecutor):
             # Obtain function information and put into dictionary
             source_code = inspect.getsource(func)
             name = func.__name__
-            function_info = { "source code": source_code,
-                              "name": name,
-                              "args": args,
-                              "kwargs": kwargs }
+            function_info = {"source code": source_code,
+                             "name": name,
+                             "args": args,
+                             "kwargs": kwargs}
 
             # Pack the function data into file
             f = open(function_data_file, "wb")
             pickle.dump(function_info, f)
             f.close()
         else:
-            # Serialize function information 
-            function_info = pack_apply_message(func, args, kwargs, 
-                                        buffer_threshold=1024*1024,
-                                        item_threshold=1024)
+            # Serialize function information
+            function_info = pack_apply_message(func, args, kwargs,
+                                               buffer_threshold=1024 * 1024,
+                                               item_threshold=1024)
 
             # Pack the function data into file
             f = open(function_data_file, "wb")
             pickle.dump(function_info, f)
             f.close()
-
 
         # Create message to put into the message queue
         logger.debug("Placing task {} on message queue".format(task_id))

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -6,8 +6,8 @@ from concurrent.futures import Future
 import os
 import pickle
 import queue
-
-from ipyparallel.serialize import pack_apply_message, deserialize_object
+import inspect
+from ipyparallel import pack_apply_message
 
 from parsl.app.errors import AppFailure
 from parsl.app.errors import RemoteExceptionWrapper
@@ -26,8 +26,10 @@ from work_queue import WORK_QUEUE_RESULT_OUTPUT_MISSING
 from work_queue import cctools_debug_flags_set
 from work_queue import cctools_debug_config_file
 
-logger = logging.getLogger(__name__)
+WORK_QUEUE_RESULT_SUCCESS = 0
+WORK_QUEUE_RESULT_OUTPUT_MISSING = 2
 
+logger = logging.getLogger(__name__)
 
 def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
                           queue_lock=threading.Lock(),
@@ -46,69 +48,71 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
 
     logger.debug("Starting WorkQueue Submit/Wait Process")
 
-    orig_ppid = os.getppid()
-
-    wq_tasks = set()
-
-    continue_running = True
-
+    # Enable debugging flags and create logging file
     if wq_log_dir is not None:
-        wq_debug_log = os.path.join(wq_log_dir, "debug")
+        logger.debug("Setting debugging flags and creating logging file")
+        wq_debug_log = os.path.join(wq_log_dir, "debug_log")
         cctools_debug_flags_set("all")
         cctools_debug_config_file(wq_debug_log)
 
-    logger.debug("Creating Workqueue Object")
+    # Create WorkQueue queue object
+    logger.debug("Creating WorkQueue Object")
     try:
+        logger.debug("Listening on port {}".format(port))
         q = WorkQueue(port)
     except Exception as e:
-        logger.error("Unable to create Workqueue object: {}", format(e))
+        logger.error("Unable to create WorkQueue object: {}".format(e))
         raise e
 
+    # Specify WorkQueue queue attributes 
     if project_name:
         q.specify_name(project_name)
-
     if project_password:
         q.specify_password(project_password)
     elif project_password_file:
         q.specify_password_file(project_password_file)
 
-    # Only write Logs when the log_dir is specified, which is most likely always will be
+    # Only write logs when the wq_log_dir is specified, which it most likely will be
     if wq_log_dir is not None:
         wq_master_log = os.path.join(wq_log_dir, "master_log")
         wq_trans_log = os.path.join(wq_log_dir, "transaction_log")
         if full:
             wq_resource_log = os.path.join(wq_log_dir, "resource_logs")
             q.enable_monitoring_full(dirname=wq_resource_log)
-
         q.specify_log(wq_master_log)
         q.specify_transactions_log(wq_trans_log)
 
+    wq_tasks = set()
+    orig_ppid = os.getppid()
+    continue_running = True
     while(continue_running):
-        # Monitor the Task Queue
+        # Monitor the task queue
         ppid = os.getppid()
         if ppid != orig_ppid:
+            logger.debug("new Process")
             continue_running = False
             continue
 
-        # Submit Tasks
+        # Submit tasks
         while task_queue.qsize() > 0:
             if cancel_value.value == 0:
+                logger.debug("cancel value set to cancel")
                 continue_running = False
                 break
 
+            # Obtain task from task_queue
             try:
-                # item = task_queue.get_nowait()
                 item = task_queue.get(timeout=1)
                 logger.debug("Removing task from queue")
             except queue.Empty:
                 continue
             parsl_id = item["task_id"]
 
+            # Extract information about the task 
             function_data_loc = item["data_loc"]
+            function_data_loc_remote = function_data_loc.split("/")[-1]
             function_result_loc = item["result_loc"]
             function_result_loc_remote = function_result_loc.split("/")[-1]
-            function_data_loc_remote = function_data_loc.split("/")[-1]
-
             input_files = item["input_files"]
             output_files = item["output_files"]
             std_files = item["std_files"]
@@ -117,9 +121,10 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
             script_name = full_script_name.split("/")[-1]
 
             remapping_string = ""
-
             std_string = ""
-            logger.debug("looking at input")
+
+            # Parse input file information
+            logger.debug("Looking at input")
             for item in input_files:
                 if item[3] == "std":
                     std_string += "mv " + item[1] + " " + item[0] + "; "
@@ -127,7 +132,8 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
                     remapping_string += item[0] + ":" + item[1] + ","
             logger.debug(remapping_string)
 
-            logger.debug("looking at output")
+            # Parse output file information
+            logger.debug("Looking at output")
             for item in output_files:
                 remapping_string += item[0] + ":" + item[1] + ","
             logger.debug(remapping_string)
@@ -136,40 +142,48 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
                 remapping_string = "-r " + remapping_string
                 remapping_string = remapping_string[:-1]
 
+            # Create command string
             logger.debug(launch_cmd)
             command_str = launch_cmd.format(input_file=function_data_loc_remote,
                                             output_file=function_result_loc_remote,
                                             remapping_string=remapping_string)
-
-            logger.debug(command_str)
             command_str = std_string + command_str
             logger.debug(command_str)
 
+            # Create WorkQueue task for the command
             logger.debug("Sending task {} with command: {}".format(parsl_id, command_str))
             try:
                 t = Task(command_str)
             except Exception as e:
                 logger.error("Unable to create task: {}".format(e))
                 continue
+
+            # Specify environment variables for the task
             if env is not None:
                 for var in env:
                     t.specify_environment_variable(var, env[var])
-
+            
+            # Specify script, and data/result files for task
             t.specify_file(full_script_name, script_name, WORK_QUEUE_INPUT, cache=True)
-            t.specify_file(function_result_loc, function_result_loc_remote, WORK_QUEUE_OUTPUT, cache=False)
             t.specify_file(function_data_loc, function_data_loc_remote, WORK_QUEUE_INPUT, cache=False)
+            t.specify_file(function_result_loc, function_result_loc_remote, WORK_QUEUE_OUTPUT, cache=False)
             t.specify_tag(str(parsl_id))
+            logger.debug(t.id)
 
+            # Specify all input/output files for task
             for item in input_files:
                 t.specify_file(item[0], item[1], WORK_QUEUE_INPUT, cache=item[2])
-
             for item in output_files:
                 t.specify_file(item[0], item[1], WORK_QUEUE_OUTPUT, cache=item[2])
-
             for item in std_files:
                 t.specify_file(item[0], item[1], WORK_QUEUE_OUTPUT, cache=item[2])
 
-            logger.debug("Submitting task {} to workqueue".format(parsl_id))
+            t.specify_cores(1)
+            t.specify_memory(1000)
+            t.specify_disk(100)
+
+            # Submit the task to the WorkQueue object
+            logger.debug("Submitting task {} to WorkQueue".format(parsl_id))
             try:
                 wq_id = q.submit(t)
                 wq_tasks.add(wq_id)
@@ -184,51 +198,82 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
                 collector_queue.put_nowait(msg)
                 continue
 
-            logger.debug("Task {} submitted workqueue with id {}".format(parsl_id, wq_id))
+            logger.debug("Task {} submitted WorkQueue with id {}".format(parsl_id, wq_id))
 
         if cancel_value.value == 0:
             continue_running = False
 
-        # Wait for Tasks
+        # If the queue is not empty wait on the WorkQueue queue for a task
         task_found = True
-        # If the queue is not empty wait on the workqueue queue for a task
         if not q.empty() and continue_running:
             while task_found is True:
                 if cancel_value.value == 0:
                     continue_running = False
                     task_found = False
                     continue
+
+                # Obtain the task from the queue
                 t = q.wait(1)
                 if t is None:
                     task_found = False
                     continue
                 else:
                     parsl_tid = t.tag
-                    logger.debug("Completed workqueue task {}, parsl task {}".format(t.id, parsl_tid))
+                    logger.debug("Completed WorkQueue task {}, parsl task {}".format(t.id, parsl_tid))
                     status = t.return_status
                     task_result = t.result
                     msg = None
 
+                    # Task failure 
                     if status != 0 or (task_result != WORK_QUEUE_RESULT_SUCCESS and task_result != WORK_QUEUE_RESULT_OUTPUT_MISSING):
-                        if task_result == WORK_QUEUE_RESULT_SUCCESS:
-                            logger.debug("Workqueue task {} failed with status {}".format(t.id, status))
-
+                        logger.debug("Wrapper Script status: {}\nWorkQueue Status: {}".format(status, task_result))
+                        # Wrapper script failure
+                        if status != 0:
+                            logger.debug("WorkQueue task {} failed with status {}".format(t.id, status))
                             reason = "Wrapper Script Failure: "
                             if status == 1:
-                                reason += "command line parsing"
+                                reason += "problem parsing command line options"
                             if status == 2:
                                 reason += "problem loading function data"
                             if status == 3:
                                 reason += "problem remapping file names"
                             if status == 4:
                                 reason += "problem writing out function result"
-
+                            if status == 127: 
+                                logger.debug("*****************************************************************************************************************************************************************************************************************************unable to run command on host, blacklisting host {} and resubmitting task".format(t.hostname))
+                                q.blacklist(t.hostname)
+                                t2 = t.clone()
+                                wq_tasks.remove(t.id)
+                                new_id = q.submit(t2)
+                                wq_tasks.add(new_id)
+                                continue
                             reason += "\nTrace:\n" + t.output
-
-                            logger.debug("Workqueue runner script failed for task {} because {}\n".format(parsl_tid, reason))
-
+                            logger.debug("WorkQueue runner script failed for task {} because {}\n".format(parsl_tid, reason))
+                        # WorkQueue system failure
                         else:
-                            reason = "Workqueue system failure\n"
+                            reason = "WorkQueue System Failure: "
+                            if task_result == 1:
+                                reason += "missing input file"
+                            if task_result == 2:
+                                reason += "unable to generate output file"
+                            if task_result == 4:
+                                reason += "stdout has been truncated"
+                            if task_result == 1<<3:
+                                reason += "task terminated with a signal"
+                            if task_result == 2<<3:
+                                reason += "task used more resources than requested"
+                            if task_result == 3<<3:
+                                reason += "task ran past the specified end time"
+                            if task_result == 4<<3:
+                                reason += "result could not be classified"
+                            if task_result == 5<<3:
+                                reason += "task failed, but not a task error"
+                            if task_result == 6<<3:
+                                reason += "unable to complete after specified number of retries"
+                            if task_result == 7<<3:
+                                reason += "task ran for more than the specified time"
+                            if task_result == 8<<3:
+                                reason += "task needed more space to complete task"
 
                         msg = {"tid": parsl_tid,
                                "result_received": False,
@@ -237,11 +282,13 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
 
                         collector_queue.put_nowait(msg)
 
+                    # Task Success
                     else:
-
+                        # Print the output from the task
                         if see_worker_output:
                             print(t.output)
 
+                        # Load result into result file
                         result_loc = os.path.join(data_dir, "task_" + str(parsl_tid) + "_function_result")
                         logger.debug("Looking for result in {}".format(result_loc))
                         f = open(result_loc, "rb")
@@ -259,8 +306,9 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
             logger.debug("Exiting WorkQueue Master Thread event loop")
             break
 
+    # Remove all WorkQueue tasks that remain in the queue object
     for wq_task in wq_tasks:
-        logger.debug("Cancelling Workqueue Task {}".format(wq_task))
+        logger.debug("Cancelling WorkQueue Task {}".format(wq_task))
         q.cancel_by_taskid(wq_task)
 
     logger.debug("Exiting WorkQueue Monitoring Process")
@@ -282,33 +330,45 @@ def WorkQueueCollectorThread(collector_queue=multiprocessing.Queue(),
             continue_running = False
             continue
 
+        # The WorkQueue process that creates task has died
         if not submit_process.is_alive() and cancel_value.value != 0:
             raise ExecutorError(executor, "Workqueue Submit Process is not alive")
 
+        # Get the result message from the collector_queue
         try:
             item = collector_queue.get(timeout=1)
         except queue.Empty:
             continue
 
+
         parsl_tid = item["tid"]
         received = item["result_received"]
 
+        # Obtain the future from the tasks dictionary
         tasks_lock.acquire()
         future = tasks[parsl_tid]
         tasks_lock.release()
 
-        if received is False:
+        # Failed task
+        if recieved is False:
             reason = item["reason"]
             status = item["status"]
             future.set_exception(AppFailure(reason, status))
+        # Successful task
         else:
             result = item["result"]
-            future_update, _ = deserialize_object(result["result"])
+            future_update = result["result"]
             logger.debug("Updating Future for Parsl Task {}".format(parsl_tid))
             if result["failure"] is False:
                 future.set_result(future_update)
             else:
-                future.set_exception(RemoteExceptionWrapper(*future_update))
+                future_fail = pickle.loads(future_update)
+                exc = RemoteExceptionWrapper(*future_fail)
+                logger.debug("**************************** exc type: {}******************".format(type(exc)))
+                try:
+                    exc.reraise()
+                except Exception as e:
+                    future.set_exception(e)
 
     logger.debug("Exiting Collector Thread")
     return
@@ -344,7 +404,7 @@ class WorkQueueExecutor(ParslExecutor):
     """
 
     def __init__(self,
-                 label="wq",
+                 label="WorkQueueExecutor",
                  working_dir=".",
                  managed=True,
                  project_name=None,
@@ -353,6 +413,7 @@ class WorkQueueExecutor(ParslExecutor):
                  port=WORK_QUEUE_DEFAULT_PORT,
                  env=None,
                  shared_fs=False,
+                 source=False,
                  init_command="",
                  see_worker_output=False):
 
@@ -375,9 +436,11 @@ class WorkQueueExecutor(ParslExecutor):
         self.shared_files = set()
         self.registered_files = set()
         self.worker_output = see_worker_output
-        self.full = True
+        self.full = False     # Resource Monitor 
+        self.source = source
         self.cancel_value = multiprocessing.Value('i', 1)
 
+        # Resolve ambiguity when password and password_file are both specified 
         if self.project_password is not None and self.project_password_file is not None:
             logger.warning("Password File and Password text specified for WorkQueue Executor, only Password Text will be used")
             self.project_password_file = None
@@ -386,9 +449,12 @@ class WorkQueueExecutor(ParslExecutor):
                 logger.debug("Password File does not exist, no file used")
                 self.project_password_file = None
 
+        # Build foundations of the launch command
         self.launch_cmd = ("python3 workqueue_worker.py -i {input_file} -o {output_file} {remapping_string}")
         if self.shared_fs is True:
             self.launch_cmd += " --shared-fs"
+        if self.source is True:
+            self.launch_cmd += " --source"
         if self.init_command != "":
             self.launch_cmd = self.init_command + "; " + self.launch_cmd
 
@@ -396,14 +462,16 @@ class WorkQueueExecutor(ParslExecutor):
         self.queue_lock = threading.Lock()
         self.tasks_lock = threading.Lock()
 
+        # Create directories for data and results
         self.function_data_dir = os.path.join(self.run_dir, "function_data")
         self.wq_log_dir = os.path.join(self.run_dir, self.label)
-
+        logger.debug("function data directory: {}\nlog directory: {}".format(self.function_data_dir, self.wq_log_dir))
         os.mkdir(self.function_data_dir)
         os.mkdir(self.wq_log_dir)
 
         logger.debug("Starting WorkQueueExectutor")
 
+        # Create a Process to perform WorkQueue submissions
         submit_process_kwargs = {"task_queue": self.task_queue,
                                  "queue_lock": self.queue_lock,
                                  "launch_cmd": self.launch_cmd,
@@ -417,11 +485,11 @@ class WorkQueueExecutor(ParslExecutor):
                                  "project_password": self.project_password,
                                  "project_password_file": self.project_password_file,
                                  "project_name": self.project_name}
-
         self.submit_process = multiprocessing.Process(target=WorkQueueSubmitThread,
                                                       name="submit_thread",
                                                       kwargs=submit_process_kwargs)
 
+        # Create a process to analyze WorkQueue task completions
         collector_thread_kwargs = {"collector_queue": self.collector_queue,
                                    "tasks": self.tasks,
                                    "tasks_lock": self.tasks_lock,
@@ -433,10 +501,12 @@ class WorkQueueExecutor(ParslExecutor):
                                                  kwargs=collector_thread_kwargs)
         self.collector_thread.daemon = True
 
+        # Begin both processes
         self.submit_process.start()
         self.collector_thread.start()
 
     def create_name_tuple(self, parsl_file_obj, in_or_out):
+        # Determine new_name
         new_name = parsl_file_obj.filepath
         if parsl_file_obj.filepath not in self.used_names:
             if self.shared_fs is False:
@@ -444,6 +514,7 @@ class WorkQueueExecutor(ParslExecutor):
                 self.used_names[parsl_file_obj.filepath] = new_name
         else:
             new_name = self.used_names[parsl_file_obj.filepath]
+        # Determine file_is_shared
         file_is_shared = False
         if parsl_file_obj in self.registered_files:
             file_is_shared = True
@@ -475,32 +546,37 @@ class WorkQueueExecutor(ParslExecutor):
         output_files = []
         std_files = []
 
+        # Add input files from the "inputs" keyword argument
         func_inputs = kwargs.get("inputs", [])
         for inp in func_inputs:
             if isinstance(inp, File):
                 input_files.append(self.create_name_tuple(inp, "in"))
 
         for kwarg, inp in kwargs.items():
+            # Add appropriate input and output files from "stdout" and "stderr" keyword arguments
             if kwarg == "stdout" or kwarg == "stderr":
                 if (isinstance(inp, tuple) and len(inp) > 1 and isinstance(inp[0], str) and isinstance(inp[1], str)) or isinstance(inp, str):
                     if isinstance(inp, tuple):
                         inp = inp[0]
-                    print(os.path.split(inp))
                     if not os.path.exists(os.path.join(".", os.path.split(inp)[0])):
                         continue
+                    # Create "std" files instead of input or output files 
                     if inp in self.registered_files:
                         input_files.append((inp, os.path.basename(inp) + "-1", False, "std"))
                         output_files.append((inp, os.path.basename(inp), False, "std"))
                     else:
                         output_files.append((inp, os.path.basename(inp), False, "std"))
                         self.registered_files.add(inp)
+            # Add to input file if passed-in argument is a File object
             elif isinstance(inp, File):
                 input_files.append(self.create_name_tuple(inp, "in"))
 
+        # Add to input file if passed-in argument is a File object
         for inp in args:
             if isinstance(inp, File):
                 input_files.append(self.create_name_tuple(inp, "in"))
 
+        # Add output files from the "outputs" keyword argument
         func_outputs = kwargs.get("outputs", [])
         for output in func_outputs:
             if isinstance(output, File):
@@ -509,6 +585,7 @@ class WorkQueueExecutor(ParslExecutor):
         if not self.submit_process.is_alive():
             raise ExecutorError(self, "Workqueue Submit Process is not alive")
 
+        # Create a Future object and have it be mapped from the task ID in the tasks dictionary
         fu = Future()
         self.tasks_lock.acquire()
         self.tasks[str(task_id)] = fu
@@ -517,20 +594,39 @@ class WorkQueueExecutor(ParslExecutor):
         logger.debug("Creating task {} for function {} with args {}".format(task_id, func, args))
 
         # Pickle the result into object to pass into message buffer
-        # TODO Try/Except Block
         function_data_file = os.path.join(self.function_data_dir, "task_" + str(task_id) + "_function_data")
         function_result_file = os.path.join(self.function_data_dir, "task_" + str(task_id) + "_function_result")
 
         logger.debug("Creating Task {} with executable at: {}".format(task_id, function_data_file))
         logger.debug("Creating Task {} with result to be found at: {}".format(task_id, function_result_file))
 
-        f = open(function_data_file, "wb")
-        fn_buf = pack_apply_message(func, args, kwargs,
-                                    buffer_threshold=1024 * 1024,
-                                    item_threshold=1024)
-        pickle.dump(fn_buf, f)
-        f.close()
+        # Obtain function information and put into dictionary
+        if self.source:
+            # Obtain function information and put into dictionary
+            source_code = inspect.getsource(func)
+            name = func.__name__
+            function_info = { "source code": source_code,
+                              "name": name,
+                              "args": args,
+                              "kwargs": kwargs }
 
+            # Pack the function data into file
+            f = open(function_data_file, "wb")
+            pickle.dump(function_info, f)
+            f.close()
+        else:
+            # Serialize function information 
+            function_info = pack_apply_message(func, args, kwargs, 
+                                        buffer_threshold=1024*1024,
+                                        item_threshold=1024)
+
+            # Pack the function data into file
+            f = open(function_data_file, "wb")
+            pickle.dump(function_info, f)
+            f.close()
+
+
+        # Create message to put into the message queue
         logger.debug("Placing task {} on message queue".format(task_id))
         msg = {"task_id": task_id,
                "data_loc": function_data_file,
@@ -538,7 +634,6 @@ class WorkQueueExecutor(ParslExecutor):
                "input_files": input_files,
                "output_files": output_files,
                "std_files": std_files}
-
         self.task_queue.put_nowait(msg)
 
         return fu
@@ -568,6 +663,7 @@ class WorkQueueExecutor(ParslExecutor):
 
         This includes all attached resources such as workers and controllers.
         """
+        # Set shared variable to 0 to signal shutdown
         logger.debug("Setting value to cancel")
         self.cancel_value.value = 0
 

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -420,7 +420,7 @@ class WorkQueueExecutor(ParslExecutor):
         self.shared_files = set()
         self.registered_files = set()
         self.worker_output = see_worker_output
-        self.full = False     # Resource Monitor 
+        self.full = False   
         self.source = source
         self.cancel_value = multiprocessing.Value('i', 1)
 

--- a/parsl/executors/workqueue/workqueue_worker.py
+++ b/parsl/executors/workqueue/workqueue_worker.py
@@ -1,12 +1,13 @@
 import sys
 import pickle
 
+
 def check_file(parsl_file_obj, mapping, file_type_string):
     type_desc = str(type(parsl_file_obj))
     # Rename the file type string to the appropriate string
     if file_type_string is None:
         file_type_string = "<class 'parsl.data_provider.files.File'>"
-    # Obtain the local_path from the mapping 
+    # Obtain the local_path from the mapping
     if type_desc == file_type_string:
         if parsl_file_obj.filepath in mapping:
             parsl_file_obj.local_path = mapping[parsl_file_obj.filepath]
@@ -53,7 +54,7 @@ if __name__ == "__main__":
     user_ns = locals()
     user_ns.update({'__builtins__': __builtins__})
 
-    # Load function data 
+    # Load function data
     try:
         input_function = open(input_function_file, "rb")
         function_info = pickle.load(input_function)
@@ -131,7 +132,7 @@ if __name__ == "__main__":
         source = ""
         for line in source_list:
             source = source + line + "\n"
-        code = "{0} = {1}(*{2}, **{3})".format(resultname, name, 
+        code = "{0} = {1}(*{2}, **{3})".format(resultname, name,
                                                argname, kwargname)
         code = source + code
     # Otherwise, only import function call
@@ -145,7 +146,7 @@ if __name__ == "__main__":
     try:
         exec(code, user_ns, user_ns)
     # Failed function execution
-    except Exception as e:
+    except Exception:
         from tblib import pickling_support
         pickling_support.install()
         exec_info = sys.exc_info()
@@ -155,7 +156,7 @@ if __name__ == "__main__":
         result = user_ns.get(resultname)
         result_package = {"failure": False, "result": result}
 
-    # Write out function result to the result file 
+    # Write out function result to the result file
     try:
         f = open(output_result_file, "wb")
         pickle.dump(result_package, f)

--- a/parsl/executors/workqueue/workqueue_worker.py
+++ b/parsl/executors/workqueue/workqueue_worker.py
@@ -1,5 +1,6 @@
 import sys
 import pickle
+from ipyparallel.serialize import unpack_apply_meessage, serialize_object
 
 
 def check_file(parsl_file_obj, mapping, file_type_string):
@@ -16,7 +17,6 @@ def check_file(parsl_file_obj, mapping, file_type_string):
 if __name__ == "__main__":
     name = "parsl"
     shared_fs = False
-    source = False
     input_function_file = ""
     output_result_file = ""
     remapping_string = None
@@ -40,8 +40,6 @@ if __name__ == "__main__":
                 index += 1
             elif sys.argv[index] == "--shared-fs":
                 shared_fs = True
-            elif sys.argv[index] == "--source":
-                source = True
             else:
                 print("command line argument not supported")
                 exit(1)
@@ -50,28 +48,18 @@ if __name__ == "__main__":
         print(e)
         exit(1)
 
-    # Get all variables from the user namespace, and add __builtins__
-    user_ns = locals()
-    user_ns.update({'__builtins__': __builtins__})
-
     # Load function data
     try:
         input_function = open(input_function_file, "rb")
-        function_info = pickle.load(input_function)
-        # Extract information from transferred source code
-        if source:
-            source_code = function_info["source code"]
-            name = function_info["name"]
-            args = function_info["args"]
-            kwargs = function_info["kwargs"]
-        # Extract information from function pointer
-        else:
-            from ipyparallel.serialize import unpack_apply_message
-            func, args, kwargs = unpack_apply_message(function_info, user_ns, copy=False)
+        function_tuple = pickle.load(input_function)
         input_function.close()
     except Exception as e:
         print(e)
         exit(2)
+
+    user_ns = locals()
+    user_ns.update({'__builtins__':__builtins__})
+    f, args, kwargs = unpack_apply_message(function_tuple, user_ns, copy=False)
 
     # Remapping file names using remapping string
     mapping = {}
@@ -117,44 +105,32 @@ if __name__ == "__main__":
         exit(3)
 
     prefix = "parsl_"
+    fname = prefix + "f"
     argname = prefix + "args"
     kwargname = prefix + "kwargs"
     resultname = prefix + "result"
 
     # Add variables to the namespace to make function call
-    user_ns.update({argname: args,
+    user_ns.update({fname: f,
+                    argname: args,
                     kwargname: kwargs,
                     resultname: resultname})
 
-    # Import function source code and create function call
-    if source:
-        source_list = source_code.split('\n')[1:]
-        full_source = ""
-        for line in source_list:
-            full_source = full_source + line + "\n"
-        code = "{0} = {1}(*{2}, **{3})".format(resultname, name,
-                                               argname, kwargname)
-        code = full_source + code
-    # Otherwise, only import function call
-    else:
-        fname = prefix + "f"
-        user_ns.update({fname: func})
-        code = "{0} = {1}(*{2}, **{3})".format(resultname, fname,
-                                               argname, kwargname)
+    code = "{0} = {1}(*{2}, **{3})".format(resultname, fname,
+                                           argname, kwargname)
 
     # Perform the function call and handle errors
     try:
         exec(code, user_ns, user_ns)
     # Failed function execution
-    except Exception:
-        from tblib import pickling_support
-        pickling_support.install()
+    except Exception as e:
+        print(e)
         exec_info = sys.exc_info()
-        result_package = {"failure": True, "result": pickle.dumps(exec_info)}
+        result_package = {"failure": True, "result": serialize_object(exec_info)}
     # Successful function execution
     else:
         result = user_ns.get(resultname)
-        result_package = {"failure": False, "result": result}
+        result_package = {"failure": False, "result": serialize_object(result)}
 
     # Write out function result to the result file
     try:

--- a/parsl/executors/workqueue/workqueue_worker.py
+++ b/parsl/executors/workqueue/workqueue_worker.py
@@ -1,6 +1,6 @@
 import sys
 import pickle
-from ipyparallel.serialize import unpack_apply_meessage, serialize_object
+from ipyparallel.serialize import unpack_apply_message, serialize_object
 
 
 def check_file(parsl_file_obj, mapping, file_type_string):

--- a/parsl/executors/workqueue/workqueue_worker.py
+++ b/parsl/executors/workqueue/workqueue_worker.py
@@ -129,12 +129,12 @@ if __name__ == "__main__":
     # Import function source code and create function call
     if source:
         source_list = source_code.split('\n')[1:]
-        source = ""
+        full_source = ""
         for line in source_list:
-            source = source + line + "\n"
+            full_source = full_source + line + "\n"
         code = "{0} = {1}(*{2}, **{3})".format(resultname, name,
                                                argname, kwargname)
-        code = source + code
+        code = full_source + code
     # Otherwise, only import function call
     else:
         fname = prefix + "f"

--- a/parsl/executors/workqueue/workqueue_worker.py
+++ b/parsl/executors/workqueue/workqueue_worker.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
         exit(2)
 
     user_ns = locals()
-    user_ns.update({'__builtins__':__builtins__})
+    user_ns.update({'__builtins__': __builtins__})
     f, args, kwargs = unpack_apply_message(function_tuple, user_ns, copy=False)
 
     # Remapping file names using remapping string

--- a/parsl/executors/workqueue/workqueue_worker.py
+++ b/parsl/executors/workqueue/workqueue_worker.py
@@ -1,12 +1,12 @@
 import sys
 import pickle
-from ipyparallel.serialize import unpack_apply_message, serialize_object
-
 
 def check_file(parsl_file_obj, mapping, file_type_string):
     type_desc = str(type(parsl_file_obj))
+    # Rename the file type string to the appropriate string
     if file_type_string is None:
         file_type_string = "<class 'parsl.data_provider.files.File'>"
+    # Obtain the local_path from the mapping 
     if type_desc == file_type_string:
         if parsl_file_obj.filepath in mapping:
             parsl_file_obj.local_path = mapping[parsl_file_obj.filepath]
@@ -14,13 +14,14 @@ def check_file(parsl_file_obj, mapping, file_type_string):
 
 if __name__ == "__main__":
     name = "parsl"
-
     shared_fs = False
+    source = False
     input_function_file = ""
     output_result_file = ""
     remapping_string = None
     file_type_string = None
 
+    # Parse command line options
     try:
         index = 1
         while index < len(sys.argv):
@@ -38,6 +39,8 @@ if __name__ == "__main__":
                 index += 1
             elif sys.argv[index] == "--shared-fs":
                 shared_fs = True
+            elif sys.argv[index] == "--source":
+                source = True
             else:
                 print("command line argument not supported")
                 exit(1)
@@ -46,32 +49,46 @@ if __name__ == "__main__":
         print(e)
         exit(1)
 
+    # Get all variables from the user namespace, and add __builtins__
+    user_ns = locals()
+    user_ns.update({'__builtins__': __builtins__})
+
+    # Load function data 
     try:
         input_function = open(input_function_file, "rb")
-        function_tuple = pickle.load(input_function)
+        function_info = pickle.load(input_function)
+        # Extract information from transferred source code
+        if source:
+            source_code = function_info["source code"]
+            name = function_info["name"]
+            args = function_info["args"]
+            kwargs = function_info["kwargs"]
+        # Extract information from function pointer
+        else:
+            from ipyparallel.serialize import unpack_apply_message
+            func, args, kwargs = unpack_apply_message(function_info, user_ns, copy=False)
         input_function.close()
     except Exception as e:
         print(e)
         exit(2)
 
-    user_ns = locals()
-    user_ns.update({'__builtins__': __builtins__})
-    f, args, kwargs = unpack_apply_message(function_tuple, user_ns, copy=False)
-
+    # Remapping file names using remapping string
     mapping = {}
-
     try:
         if shared_fs is False and remapping_string is not None:
-
+            # Parse the remapping string into a dictionary
             for i in remapping_string.split(","):
                 split_mapping = i.split(":")
                 mapping[split_mapping[0]] = split_mapping[1]
 
+            # Check file attributes for inputs and make appropriate changes
             func_inputs = kwargs.get("inputs", [])
             for inp in func_inputs:
                 check_file(inp, mapping, file_type_string)
 
+            # Iterate through all arguments to the function
             for kwarg, potential_f in kwargs.items():
+                # Process the "stdout" and "stderr" arguments and add them to kwargs
                 if kwarg == "stdout" or kwarg == "stderr":
                     if (isinstance(potential_f, str) or isinstance(potential_f, tuple)):
                         if isinstance(potential_f, tuple) and len(potential_f) == 2:
@@ -86,9 +103,11 @@ if __name__ == "__main__":
                 else:
                     check_file(potential_f, mapping, file_type_string)
 
+            # Check all non-key-word arguments and make appropriate changes
             for inp in args:
                 check_file(inp, mapping, file_type_string)
 
+            # Check file attributes for outputs and make appropriate changes
             func_outputs = kwargs.get("outputs", [])
             for output in func_outputs:
                 check_file(output, mapping, file_type_string)
@@ -97,28 +116,46 @@ if __name__ == "__main__":
         exit(3)
 
     prefix = "parsl_"
-    fname = prefix + "f"
     argname = prefix + "args"
     kwargname = prefix + "kwargs"
     resultname = prefix + "result"
 
-    user_ns.update({fname: f,
-                    argname: args,
+    # Add variables to the namespace to make function call
+    user_ns.update({argname: args,
                     kwargname: kwargs,
                     resultname: resultname})
 
-    code = "{0} = {1}(*{2}, **{3})".format(resultname, fname,
-                                           argname, kwargname)
+    # Import function source code and create function call
+    if source:
+        source_list = source_code.split('\n')[1:]
+        source = ""
+        for line in source_list:
+            source = source + line + "\n"
+        code = "{0} = {1}(*{2}, **{3})".format(resultname, name, 
+                                               argname, kwargname)
+        code = source + code
+    # Otherwise, only import function call
+    else:
+        fname = prefix + "f"
+        user_ns.update({fname: func})
+        code = "{0} = {1}(*{2}, **{3})".format(resultname, fname,
+                                               argname, kwargname)
 
+    # Perform the function call and handle errors
     try:
         exec(code, user_ns, user_ns)
+    # Failed function execution
     except Exception as e:
-        print(e)
+        from tblib import pickling_support
+        pickling_support.install()
         exec_info = sys.exc_info()
-        result_package = {"failure": True, "result": serialize_object(exec_info)}
+        result_package = {"failure": True, "result": pickle.dumps(exec_info)}
+    # Successful function execution
     else:
         result = user_ns.get(resultname)
-        result_package = {"failure": False, "result": serialize_object(result)}
+        result_package = {"failure": False, "result": result}
+
+    # Write out function result to the result file 
     try:
         f = open(output_result_file, "wb")
         pickle.dump(result_package, f)

--- a/parsl/tests/workqueue_tests/test_scale.py
+++ b/parsl/tests/workqueue_tests/test_scale.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import time
 

--- a/parsl/tests/workqueue_tests/wqex_local.py
+++ b/parsl/tests/workqueue_tests/wqex_local.py
@@ -3,6 +3,9 @@ from parsl.executors import WorkQueueExecutor
 
 config = Config(
     executors=[WorkQueueExecutor(port=50055,
+                                 project_name="WQexample",
+                                 see_worker_output=True,
+                                 source=True,
                                  # init_command='source /home/yadu/src/wq_parsl/setup_parsl_env.sh;
                                  # echo "Ran at $date" > /home/yadu/src/wq_parsl/parsl/tests/workqueue_tests/ran.log',
         )]


### PR DESCRIPTION
This pull request makes many small changes to the `parsl/executors/workqueue/executor.py` and `parsl/executors/workqueue/workqueue_worker.py` script. These changes changes primarily deal with adding additional commenting and more verbose logging messages to help better describe the script. It additionally adds error messages to handle more Work Queue system failures, which were previously  not handled.

This PR contains all the tidyup changes that were originally submitted in PR #1152. If these changes are merged, then PR #1152 should only contain feature changes, i.e., changes that affect the serialization and deserialization of the Python functions and exceptions.