### PR TITLE
Set optional port as proper Channel attribute.

### DIFF
--- a/parsl/channels/oauth_ssh/oauth_ssh.py
+++ b/parsl/channels/oauth_ssh/oauth_ssh.py
@@ -44,7 +44,7 @@ class OAuthSSHChannel(SSHChannel):
         self.hostname = hostname
         self.username = username
         self.script_dir = script_dir
-
+        self.port = port
         self.envs = {}
         if envs is not None:
             self.envs = envs


### PR DESCRIPTION
This avoids this error when custom port is set:

AttributeError: class OAuthSSHChannel uses port in the constructor, but does not define it as an attribute
