### PR TITLE
Re-enable disabled exception handling test

### DIFF
--- a/parsl/tests/test_python_apps/test_basic.py
+++ b/parsl/tests/test_python_apps/test_basic.py
@@ -91,7 +91,6 @@ def test_stdout():
     print("[TEST STATUS] test_stdout [SUCCESS]")
 
 
-@pytest.mark.skip("Broke somewhere between PR #525 and PR #652")
 def test_custom_exception():
     from globus_sdk import GlobusError
 


### PR DESCRIPTION
This was disabled in #652 because it was failing. It doesn't fail for me now on my laptop, and it gives a bit more coverage of exception handling.