### PR TITLE
Remove unused walltime parameter from launcher API

### DIFF
--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -7,7 +7,7 @@ class Launcher(RepresentationMixin, metaclass=ABCMeta):
     """ Launcher base class to enforce launcher interface
     """
     @abstractmethod
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block):
         """ Wraps the command with the Launcher calls.
         """
         pass
@@ -17,14 +17,12 @@ class SimpleLauncher(Launcher):
     """ Does no wrapping. Just returns the command as-is
     """
 
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block):
         """
         Args:
         - command (string): The command string to be launched
         - task_block (string) : bash evaluated string.
 
-        KWargs:
-        - walltime (int) : This is not used by this launcher.
         """
         return command
 
@@ -36,14 +34,12 @@ class SingleNodeLauncher(Launcher):
     task_blocks to an integer or to a bash expression the number of invocations
     of the command to be launched can be controlled.
     """
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block):
         """
         Args:
         - command (string): The command string to be launched
         - task_block (string) : bash evaluated string.
 
-        KWargs:
-        - walltime (int) : This is not used by this launcher.
         """
         task_blocks = tasks_per_node * nodes_per_block
 
@@ -78,14 +74,12 @@ class GnuParallelLauncher(Launcher):
       target nodes.
     - The provider makes available the $PBS_NODEFILE environment variable
     """
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block):
         """
         Args:
         - command (string): The command string to be launched
         - task_block (string) : bash evaluated string.
 
-        KWargs:
-        - walltime (int) : This is not used by this launcher.
         """
         task_blocks = tasks_per_node * nodes_per_block
 
@@ -136,14 +130,12 @@ class MpiExecLauncher(Launcher):
     - mpiexec is installed and can be located in $PATH
     - The provider makes available the $PBS_NODEFILE environment variable
     """
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block):
         """
         Args:
         - command (string): The command string to be launched
         - task_block (string) : bash evaluated string.
 
-        KWargs:
-        - walltime (int) : This is not used by this launcher.
         """
         task_blocks = tasks_per_node * nodes_per_block
 
@@ -185,14 +177,12 @@ class MpiRunLauncher(Launcher):
     def __init__(self, bash_location='/bin/bash'):
         self.bash_location = bash_location
 
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block):
         """
         Args:
         - command (string): The command string to be launched
         - task_block (string) : bash evaluated string.
 
-        KWargs:
-        - walltime (int) : This is not used by this launcher.
         """
         task_blocks = tasks_per_node * nodes_per_block
 
@@ -227,14 +217,12 @@ class SrunLauncher(Launcher):
         """
         self.overrides = overrides
 
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block):
         """
         Args:
         - command (string): The command string to be launched
         - task_block (string) : bash evaluated string.
 
-        KWargs:
-        - walltime (int) : This is not used by this launcher.
         """
         task_blocks = tasks_per_node * nodes_per_block
         x = '''export CORES=$SLURM_CPUS_ON_NODE
@@ -275,14 +263,12 @@ class SrunMPILauncher(Launcher):
         """
         self.overrides = overrides
 
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block):
         """
         Args:
         - command (string): The command string to be launched
         - task_block (string) : bash evaluated string.
 
-        KWargs:
-        - walltime (int) : This is not used by this launcher.
         """
         task_blocks = tasks_per_node * nodes_per_block
         x = '''export CORES=$SLURM_CPUS_ON_NODE
@@ -342,15 +328,13 @@ class AprunLauncher(Launcher):
         """
         self.overrides = overrides
 
-    def __call__(self, command, tasks_per_node, nodes_per_block, walltime=None):
+    def __call__(self, command, tasks_per_node, nodes_per_block):
         """
         Args:
         - command (string): The command string to be launched
         - tasks_per_node (int) : Workers to launch per node
         - nodes_per_block (int) : Number of nodes in a block
 
-        KWargs:
-        - walltime (int) : This is not used by this launcher.
         """
 
         tasks_per_block = tasks_per_node * nodes_per_block


### PR DESCRIPTION
This will affect parsl users who have implemented their own launcher.

Addresses part 2/2 of #1176