### PR TITLE
Removes barely used/implemented blocksize parameter from provider.submit API

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -547,7 +547,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
             if self.provider:
                 external_block_id = str(len(self.blocks))
                 launch_cmd = self.launch_cmd.format(block_id=external_block_id)
-                internal_block = self.provider.submit(launch_cmd, 1, 1)
+                internal_block = self.provider.submit(launch_cmd, 1)
                 logger.debug("Launched block {}->{}".format(external_block_id, internal_block))
                 if not internal_block:
                     raise(ScalingFailed(self.provider.label,

--- a/parsl/executors/ipp.py
+++ b/parsl/executors/ipp.py
@@ -238,7 +238,7 @@ sleep infinity
         r = []
         for i in range(blocks):
             if self.provider:
-                block = self.provider.submit(self.launch_cmd, 1, self.workers_per_node)
+                block = self.provider.submit(self.launch_cmd, self.workers_per_node)
                 logger.debug("Launched block {}:{}".format(i, block))
                 if not block:
                     raise(ScalingFailed(self.provider.label,

--- a/parsl/executors/low_latency/executor.py
+++ b/parsl/executors/low_latency/executor.py
@@ -101,7 +101,7 @@ class LowLatencyExecutor(ParslExecutor, RepresentationMixin):
                 try:
                     for i in range(self.provider.init_blocks):
                         block = self.provider.submit(
-                            self.launch_cmd, 1, self.workers_per_node)
+                            self.launch_cmd, self.workers_per_node)
                         logger.debug("Launched block {}:{}".format(i, block))
                         if not block:
                             raise(ScalingFailed(self.provider.label,
@@ -231,7 +231,7 @@ class LowLatencyExecutor(ParslExecutor, RepresentationMixin):
         for i in range(blocks):
             if self.provider:
                 block = self.provider.submit(
-                    self.launch_cmd, 1, self.workers_per_node)
+                    self.launch_cmd, self.workers_per_node)
                 logger.debug("Launched block {}:{}".format(i, block))
                 if not block:
                     raise(ScalingFailed(self.provider.label,

--- a/parsl/providers/aws/aws.py
+++ b/parsl/providers/aws/aws.py
@@ -563,7 +563,7 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
 
         return all_states
 
-    def submit(self, command='sleep 1', blocksize=1, tasks_per_node=1, job_name="parsl.auto"):
+    def submit(self, command='sleep 1', tasks_per_node=1, job_name="parsl.auto"):
         """Submit the command onto a freshly instantiated AWS EC2 instance.
 
         Submit returns an ID that corresponds to the task that was just submitted.
@@ -572,8 +572,6 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
         ----------
         command : str
             Command to be invoked on the remote side.
-        blocksize : int
-            Number of blocks requested.
         tasks_per_node : int (default=1)
             Number of command invocations to be launched per node
         job_name : str

--- a/parsl/providers/azure/azure.py
+++ b/parsl/providers/azure/azure.py
@@ -206,7 +206,6 @@ class AzureProvider(ExecutionProvider, RepresentationMixin):
 
     def submit(self,
                command='sleep 1',
-               blocksize=1,
                tasks_per_node=1,
                job_name="parsl.auto"):
         """
@@ -216,8 +215,6 @@ class AzureProvider(ExecutionProvider, RepresentationMixin):
         ----------
         command : str
             Command to be invoked on the remote side.
-        blocksize : int
-            Number of blocks requested.
         tasks_per_node : int (default=1)
             Number of command invocations to be launched per node
         job_name : str

--- a/parsl/providers/cluster_provider.py
+++ b/parsl/providers/cluster_provider.py
@@ -124,14 +124,13 @@ class ClusterProvider(ExecutionProvider):
 
         return True
 
-    def submit(self, cmd_string, blocksize, tasks_per_node, job_name="parsl.auto"):
+    def submit(self, cmd_string, tasks_per_node, job_name="parsl.auto"):
         ''' The submit method takes the command string to be executed upon
         instantiation of a resource most often to start a pilot (such as IPP engine
         or even Swift-T engines).
 
         Args :
              - cmd_string (str) : The bash command string to be executed
-             - blocksize (int) : Blocksize to be requested
              - tasks_per_node (int) : command invocations to be launched per node
 
         KWargs:

--- a/parsl/providers/cobalt/cobalt.py
+++ b/parsl/providers/cobalt/cobalt.py
@@ -126,8 +126,8 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
             if self.resources[missing_job]['status'] in ['RUNNING', 'KILLING', 'EXITING']:
                 self.resources[missing_job]['status'] = translate_table['EXITING']
 
-    def submit(self, command, blocksize, tasks_per_node, job_name="parsl.auto"):
-        """ Submits the command onto an Local Resource Manager job of blocksize parallel elements.
+    def submit(self, command, tasks_per_node, job_name="parsl.auto"):
+        """ Submits the command onto an Local Resource Manager job of parallel elements.
         Submit returns an ID that corresponds to the task that was just submitted.
 
         If tasks_per_node <  1 : ! This is illegal. tasks_per_node should be integer
@@ -136,11 +136,10 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
              A single node is provisioned
 
         If tasks_per_node >  1 :
-             tasks_per_node * blocksize number of nodes are provisioned.
+             tasks_per_node number of nodes are provisioned.
 
         Args:
              - command  :(String) Commandline invocation to be made on the remote side.
-             - blocksize   :(float)
              - tasks_per_node (int) : command invocations to be launched per node
 
         Kwargs:
@@ -156,11 +155,6 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
             logger.warn("[%s] at capacity, cannot add more blocks now", self.label)
             return None
 
-        # Note: Fix this later to avoid confusing behavior.
-        # We should always allocate blocks in integer counts of node_granularity
-        if blocksize < self.nodes_per_block:
-            blocksize = self.nodes_per_block
-
         account_opt = '-A {}'.format(self.account) if self.account is not None else ''
 
         job_name = "parsl.{0}.{1}".format(job_name, time.time())
@@ -172,8 +166,8 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
         job_config["scheduler_options"] = self.scheduler_options
         job_config["worker_init"] = self.worker_init
 
-        logger.debug("Requesting blocksize:%s nodes_per_block:%s tasks_per_node:%s",
-                     blocksize, self.nodes_per_block, tasks_per_node)
+        logger.debug("Requesting nodes_per_block:%s tasks_per_node:%s",
+                     self.nodes_per_block, tasks_per_node)
 
         # Wrap the command
         job_config["user_script"] = self.launcher(command, tasks_per_node, self.nodes_per_block)
@@ -203,7 +197,7 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
         if retcode == 0:
             # We should be getting only one line back
             job_id = stdout.strip()
-            self.resources[job_id] = {'job_id': job_id, 'status': 'PENDING', 'blocksize': blocksize}
+            self.resources[job_id] = {'job_id': job_id, 'status': 'PENDING'}
         else:
             logger.error("Submission of command to scale_out failed: {0}".format(stderr))
             raise (ScaleOutFailed(self.__class__, "Request to submit job to local scheduler failed"))

--- a/parsl/providers/condor/condor.py
+++ b/parsl/providers/condor/condor.py
@@ -146,8 +146,8 @@ class CondorProvider(RepresentationMixin, ClusterProvider):
         self._status()
         return [self.resources[jid]['status'] for jid in job_ids]
 
-    def submit(self, command, blocksize, tasks_per_node, job_name="parsl.auto"):
-        """Submits the command onto an Local Resource Manager job of blocksize parallel elements.
+    def submit(self, command, tasks_per_node, job_name="parsl.auto"):
+        """Submits the command onto an Local Resource Manager job.
 
         example file with the complex case of multiple submits per job:
             Universe =vanilla
@@ -169,8 +169,6 @@ class CondorProvider(RepresentationMixin, ClusterProvider):
         ----------
         command : str
             Command to execute
-        blocksize : int
-            Number of blocks to request.
         job_name : str
             Job name prefix.
         tasks_per_node : int
@@ -181,15 +179,11 @@ class CondorProvider(RepresentationMixin, ClusterProvider):
             None if at capacity and cannot provision more; otherwise the identifier for the job.
         """
 
-        logger.debug("Attempting to launch with blocksize: {}".format(blocksize))
+        logger.debug("Attempting to launch")
         if self.provisioned_blocks >= self.max_blocks:
             template = "Provider {} is currently using {} blocks while max_blocks is {}; no blocks will be added"
             logger.warn(template.format(self.label, self.provisioned_blocks, self.max_blocks))
             return None
-
-        # Note: Fix this later to avoid confusing behavior.
-        # We should always allocate blocks in integer counts of node_granularity
-        blocksize = max(self.nodes_per_block, blocksize)
 
         job_name = "parsl.{0}.{1}".format(job_name, time.time())
 

--- a/parsl/providers/googlecloud/googlecloud.py
+++ b/parsl/providers/googlecloud/googlecloud.py
@@ -109,13 +109,12 @@ class GoogleCloudProvider():
         self.provisioned_blocks = 0
         atexit.register(self.bye)
 
-    def submit(self, command, blocksize, tasks_per_node, job_name="parsl.auto"):
+    def submit(self, command, tasks_per_node, job_name="parsl.auto"):
         ''' The submit method takes the command string to be executed upon
         instantiation of a resource most often to start a pilot.
 
         Args :
              - command (str) : The bash command string to be executed.
-             - blocksize (int) : Blocksize to be requested
              - tasks_per_node (int) : command invocations to be launched per node
 
         KWargs:

--- a/parsl/providers/grid_engine/grid_engine.py
+++ b/parsl/providers/grid_engine/grid_engine.py
@@ -108,14 +108,13 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
                                                   self.nodes_per_block)
         return job_config
 
-    def submit(self, command, blocksize, tasks_per_node, job_name="parsl.auto"):
+    def submit(self, command, tasks_per_node, job_name="parsl.auto"):
         ''' The submit method takes the command string to be executed upon
         instantiation of a resource most often to start a pilot (such as IPP engine
         or even Swift-T engines).
 
         Args :
              - command (str) : The bash command string to be executed.
-             - blocksize (int) : Blocksize to be requested
              - tasks_per_node (int) : command invocations to be launched per node
 
         KWargs:
@@ -127,11 +126,6 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
         Raises:
              - ExecutionProviderException or its subclasses
         '''
-
-        # Note: Fix this later to avoid confusing behavior.
-        # We should always allocate blocks in integer counts of node_granularity
-        if blocksize < self.nodes_per_block:
-            blocksize = self.nodes_per_block
 
         # Set job name
         job_name = "{0}.{1}".format(job_name, time.time())
@@ -154,7 +148,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
                 job_id = line.strip()
                 if not job_id:
                     continue
-                self.resources[job_id] = {'job_id': job_id, 'status': 'PENDING', 'blocksize': blocksize}
+                self.resources[job_id] = {'job_id': job_id, 'status': 'PENDING'}
                 return job_id
         else:
             print("[WARNING!!] Submission of command to scale_out failed")

--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -96,11 +96,10 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         # Dictionary that keeps track of jobs, keyed on job_id
         self.resources = {}  # type: Dict[str, Dict[str, Any]]
 
-    def submit(self, cmd_string, blocksize, tasks_per_node, job_name="parsl"):
+    def submit(self, cmd_string, tasks_per_node, job_name="parsl"):
         """ Submit a job
         Args:
              - cmd_string  :(String) - Name of the container to initiate
-             - blocksize   :(float) - Number of replicas
              - tasks_per_node (int) : command invocations to be launched per node
 
         Kwargs:
@@ -128,8 +127,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
                          job_name=job_name,
                          cmd_string=formatted_cmd,
                          volumes=self.persistent_volumes)
-        self.resources[pod_name] = {'status': 'RUNNING',
-                                    'pods': blocksize}
+        self.resources[pod_name] = {'status': 'RUNNING'}
 
         return pod_name
 

--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -152,8 +152,8 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
 
         return True
 
-    def submit(self, command, blocksize, tasks_per_node, job_name="parsl.auto"):
-        ''' Submits the command onto an Local Resource Manager job of blocksize parallel elements.
+    def submit(self, command, tasks_per_node, job_name="parsl.auto"):
+        ''' Submits the command onto an Local Resource Manager job.
         Submit returns an ID that corresponds to the task that was just submitted.
 
         If tasks_per_node <  1:
@@ -163,11 +163,10 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
              A single node is provisioned
 
         If tasks_per_node >  1 :
-             tasks_per_node * blocksize number of nodes are provisioned.
+             tasks_per_node nodes are provisioned.
 
         Args:
              - command  :(String) Commandline invocation to be made on the remote side.
-             - blocksize   :(float) - Not really used for local
              - tasks_per_node (int) : command invocations to be launched per node
 
         Kwargs:
@@ -216,7 +215,6 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
                 raise
 
         self.resources[job_id] = {'job_id': job_id, 'status': 'RUNNING',
-                                  'blocksize': blocksize,
                                   'remote_pid': remote_pid,
                                   'proc': proc}
 

--- a/parsl/providers/pbspro/pbspro.py
+++ b/parsl/providers/pbspro/pbspro.py
@@ -96,15 +96,13 @@ class PBSProProvider(TorqueProvider):
         self._label = 'pbspro'
         self.cpus_per_node = cpus_per_node
 
-    def submit(self, command, blocksize, tasks_per_node, job_name="parsl"):
-        """Submits the command job of blocksize parallel elements.
+    def submit(self, command, tasks_per_node, job_name="parsl"):
+        """Submits the command job.
 
         Parameters
         ----------
         command : str
             Command to be executed on the remote side.
-        blocksize : int
-            Not implemented.
         tasks_per_node : int
             Command invocations to be launched per node.
         job_name : str

--- a/parsl/providers/provider_base.py
+++ b/parsl/providers/provider_base.py
@@ -23,14 +23,13 @@ class ExecutionProvider(metaclass=ABCMeta):
      """
 
     @abstractmethod
-    def submit(self, command, blocksize, tasks_per_node, job_name="parsl.auto"):
+    def submit(self, command, tasks_per_node, job_name="parsl.auto"):
         ''' The submit method takes the command string to be executed upon
         instantiation of a resource most often to start a pilot (such as IPP engine
         or even Swift-T engines).
 
         Args :
              - command (str) : The bash command string to be executed
-             - blocksize (int) : Blocksize to be requested
              - tasks_per_node (int) : command invocations to be launched per node
 
         KWargs:

--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -136,15 +136,13 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
             if self.resources[missing_job]['status'] in ['PENDING', 'RUNNING']:
                 self.resources[missing_job]['status'] = 'COMPLETED'
 
-    def submit(self, command, blocksize, tasks_per_node, job_name="parsl.auto"):
-        """Submit the command as a slurm job of blocksize parallel elements.
+    def submit(self, command, tasks_per_node, job_name="parsl.auto"):
+        """Submit the command as a slurm job.
 
         Parameters
         ----------
         command : str
             Command to be made on the remote side.
-        blocksize : int
-            Not implemented.
         tasks_per_node : int
             Command invocations to be launched per node
         job_name : str
@@ -198,7 +196,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
             for line in stdout.split('\n'):
                 if line.startswith("Submitted batch job"):
                     job_id = line.split("Submitted batch job")[1].strip()
-                    self.resources[job_id] = {'job_id': job_id, 'status': 'PENDING', 'blocksize': blocksize}
+                    self.resources[job_id] = {'job_id': job_id, 'status': 'PENDING'}
         else:
             print("Submission of command to scale_out failed")
             logger.error("Retcode:%s STDOUT:%s STDERR:%s", retcode, stdout.strip(), stderr.strip())


### PR DESCRIPTION
This API change will affect parsl users who have implemented their own providers.

Addresses part 1/2 of #1176

Method:

I've been through all of the providers grepping for 'blocksize', and removed
the code that uses those. Generally it didn't do much.

The docstrings of those providers are a bit weird and I haven't attempted to
rewrite them - instead I have just removed blocksize references, replacing/folding
in a constant '1' in where necessary.

I've also gone through the whole codebase using

  `git grep -C 3 provider.submit`

to find hopefully all of the places where a provider submit call is made,
and removed the blocksize parameter from those.

Two tests make provider.submit calls, but look like they are very dated
as they use dictionary based parsl configs, not class based configs:

```
  parsl/tests/integration/test_integration/test_ssh/test_ssh_beagle.py
  parsl/tests/integration/test_integration/test_ssh/test_ssh_condor_earth.py
```

I have not touched those two tests in this PR.