### PR TITLE
Move output staging task submission to before task launch

### DIFF
--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -69,7 +69,7 @@ class DataManager(object):
         else:
             raise Exception('Staging in with unknown file scheme {} is not supported'.format(file.scheme))
 
-    def stage_out(self, file, executor):
+    def stage_out(self, file, executor, app_fu):
         """Transport the file from the local filesystem to the remote Globus endpoint.
 
         This function returns a DataFuture.
@@ -87,6 +87,6 @@ class DataManager(object):
         elif file.scheme == 'globus':
             globus_scheme = _get_globus_scheme(self.dfk, executor)
             stage_out_app = globus_scheme._globus_stage_out_app(executor=executor, dfk=self.dfk)
-            return stage_out_app(inputs=[file])
+            return stage_out_app(app_fu, inputs=[file])
         else:
             raise Exception('Staging out with unknown file scheme {} is not supported'.format(file.scheme))

--- a/parsl/data_provider/globus.py
+++ b/parsl/data_provider/globus.py
@@ -255,7 +255,14 @@ def _globus_stage_in(scheme, executor, outputs=[], staging_inhibit_output=True):
             file.path, dst_path)
 
 
-def _globus_stage_out(scheme, executor, inputs=[]):
+def _globus_stage_out(scheme, executor, app_fu, inputs=[]):
+    """
+    Although app_fu isn't directly used in the stage out code,
+    it is needed as an input dependency to ensure this code
+    doesn't run until the app_fu is complete. The actual change
+    that is represented by the app_fu completing is that the
+    executor filesystem will now contain the file to stage out.
+    """
     globus_ep = scheme._get_globus_endpoint(executor)
     file = inputs[0]
     src_path = os.path.join(globus_ep['endpoint_path'], file.filename)

--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -60,25 +60,20 @@ class AppFuture(Future):
 
     """
 
-    def __init__(self, tid=None, stdout=None, stderr=None):
+    def __init__(self, task_def):
         """Initialize the AppFuture.
 
         Args:
 
         KWargs:
-             - tid (Int) : Task id should be any unique identifier. Now Int.
-             - stdout (str) : Stdout file of the app.
-                   Default: None
-             - stderr (str) : Stderr file of the app.
-                   Default: None
+             - task_def : The DFK task definition dictionary for the task represented
+                   by this future.
         """
-        self._tid = tid
         super().__init__()
         self.parent = None
         self._update_lock = threading.Lock()
         self._outputs = []
-        self._stdout = stdout
-        self._stderr = stderr
+        self.task_def = task_def
 
     def parent_callback(self, executor_fu):
         """Callback from a parent future to update the AppFuture.
@@ -131,15 +126,15 @@ class AppFuture(Future):
 
     @property
     def stdout(self):
-        return self._stdout
+        return self.task_def['kwargs'].get('stdout')
 
     @property
     def stderr(self):
-        return self._stderr
+        return self.task_def['kwargs'].get('stderr')
 
     @property
     def tid(self):
-        return self._tid
+        return self.task_def['id']
 
     def update_parent(self, fut):
         """Add a callback to the parent to update the state.


### PR DESCRIPTION
This facilitates a few things which will appear in future PRs:

 * pluggable app replacement stage-out, where the submitted app
   task needs to know about stage outs at the time that it is submitted,
   rather than the DFK managing this separately after the task
   has completed.

 * a fix for issue #778, so that DataFutures completion can
   indicate successful stageout

 * a fix for issue #1173, where the stage-out code must be given a chance
   to set the localpath on a File before the main app task runs

Stage out tasks cannot run immediately upon submission now, as they are
submitted before their corresponding main task has completed. This PR
adds an extra parameter to stage out tasks to allow them to depend on the
main task.

That extra dependency means that stageout tasks depend on a task (the main
task) that does not fully exist at stageout submission time, although we
know the main task ID. `check_dep` is modified to take that into account,
by treating task IDs which have no DFK task structure as being
not-yet-complete.