### PR TITLE
Treat DataFuture inputs as dependencies

### DIFF
--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -54,12 +54,12 @@ class DataManager(object):
         if file.scheme == 'ftp':
             working_dir = self.dfk.executors[executor].working_dir
             stage_in_app = _ftp_stage_in_app(self, executor=executor)
-            app_fut = stage_in_app(working_dir, outputs=[file], staging_inhibit_output=True)
+            app_fut = stage_in_app(working_dir, parent_fut=parent_fut, outputs=[file], staging_inhibit_output=True)
             return app_fut._outputs[0]
         elif file.scheme == 'http' or file.scheme == 'https':
             working_dir = self.dfk.executors[executor].working_dir
             stage_in_app = _http_stage_in_app(self, executor=executor)
-            app_fut = stage_in_app(working_dir, outputs=[file], staging_inhibit_output=True)
+            app_fut = stage_in_app(working_dir, parent_fut=parent_fut, outputs=[file], staging_inhibit_output=True)
             return app_fut._outputs[0]
         elif file.scheme == 'globus':
             # what should happen here is...
@@ -80,7 +80,7 @@ class DataManager(object):
             # look pretty much identical
             globus_scheme = _get_globus_scheme(self.dfk, executor)
             stage_in_app = globus_scheme._globus_stage_in_app(executor=executor, dfk=self.dfk)
-            app_fut = stage_in_app(outputs=[file], staging_inhibit_output=True)
+            app_fut = stage_in_app(parent_fut=parent_fut, outputs=[file], staging_inhibit_output=True)
             return app_fut._outputs[0]
         else:
             raise Exception('Staging in with unknown file scheme {} is not supported'.format(file.scheme))

--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -51,8 +51,6 @@ class DataManager(object):
         else:
             return input
 
-        file = input
-
         if file.scheme == 'ftp':
             working_dir = self.dfk.executors[executor].working_dir
             stage_in_app = _ftp_stage_in_app(self, executor=executor)

--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -24,7 +24,7 @@ class DataManager(object):
         self.dfk = dfk
         self.globus = None
 
-    def stage_in(self, file, executor):
+    def stage_in(self, file, executor, parent_fut):
         """Transport the file from the input source to the executor.
 
         This function returns a DataFuture.
@@ -33,6 +33,9 @@ class DataManager(object):
             - self
             - file (File) : file to stage in
             - executor (str) : an executor the file is going to be staged in to.
+            - parent_fut: (optional DataFuture) : If specified, stage in tasks will depend on this
+                future completing before executing, and the File contained in that future will be
+                used as input.
         """
 
         if file.scheme == 'ftp':

--- a/parsl/data_provider/ftp.py
+++ b/parsl/data_provider/ftp.py
@@ -4,7 +4,7 @@ import os
 from parsl import python_app
 
 
-def _ftp_stage_in(working_dir, outputs=[], staging_inhibit_output=True):
+def _ftp_stage_in(working_dir, parent_fut=None, outputs=[], staging_inhibit_output=True):
     file = outputs[0]
     if working_dir:
         os.makedirs(working_dir, exist_ok=True)

--- a/parsl/data_provider/globus.py
+++ b/parsl/data_provider/globus.py
@@ -245,7 +245,7 @@ class GlobusScheme(RepresentationMixin):
 # this cannot be a class method, but must be a function, because I want
 # to be able to use partial() on it - and partial() does not work on
 # class methods
-def _globus_stage_in(scheme, executor, outputs=[], staging_inhibit_output=True):
+def _globus_stage_in(scheme, executor, parent_fut=None, outputs=[], staging_inhibit_output=True):
     globus_ep = scheme._get_globus_endpoint(executor)
     file = outputs[0]
     file.local_path = os.path.join(

--- a/parsl/data_provider/http.py
+++ b/parsl/data_provider/http.py
@@ -4,7 +4,7 @@ import requests
 from parsl import python_app
 
 
-def _http_stage_in(working_dir, outputs=[], staging_inhibit_output=True):
+def _http_stage_in(working_dir, parent_fut=None, outputs=[], staging_inhibit_output=True):
     file = outputs[0]
     if working_dir:
         os.makedirs(working_dir, exist_ok=True)

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -20,7 +20,6 @@ from concurrent.futures import Future
 from functools import partial
 
 import parsl
-from parsl.app.futures import DataFuture
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.config import Config
 from parsl.data_provider.data_manager import DataManager
@@ -497,25 +496,14 @@ class DataFlowKernel(object):
 
         inputs = kwargs.get('inputs', [])
         for idx, f in enumerate(inputs):
-            if isinstance(f, DataFuture) and f.file_obj.is_remote():
-                inputs[idx] = self.data_manager.stage_in(f.file_obj, executor, f)
-            if isinstance(f, File) and f.is_remote():
-                inputs[idx] = self.data_manager.stage_in(f, executor, None)
-            # if neither of the above, then local File, or local DataFuture, or non-File-related
-            # so do no stage-in
+            inputs[idx] = self.data_manager.stage_in(f, executor)
 
         for kwarg, f in kwargs.items():
-            if isinstance(f, DataFuture) and f.file_obj.is_remote():
-                kwargs[kwarg] = self.data_manager.stage_in(f.file_obj, executor, f)
-            elif isinstance(f, File) and f.is_remote():
-                kwargs[kwarg] = self.data_manager.stage_in(f, executor, None)
+            kwargs[kwarg] = self.data_manager.stage_in(f, executor)
 
         newargs = list(args)
         for idx, f in enumerate(newargs):
-            if isinstance(f, DataFuture) and f.file_obj.is_remote():
-                newargs[idx] = self.data_manager.stage_in(f.file_obj, executor, f)
-            if isinstance(f, File) and f.is_remote():
-                newargs[idx] = self.data_manager.stage_in(f, executor, None)
+            newargs[idx] = self.data_manager.stage_in(f, executor)
 
         return tuple(newargs), kwargs
 


### PR DESCRIPTION
Prior to this PR, DataFutures were treated, dependency-wise, like
any other input value, and did not cause any deferral of execution.

This meant that output DataFutures from one app passed as inputs
to a second app would not cause the second app to wait for the
first app to complete.

Fixes issue #1125