### PR TITLE
Make AppFuture task-related properties be view of task_def struct

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -693,18 +693,12 @@ class DataFlowKernel(object):
         dep_cnt, depends = self._gather_all_deps(args, kwargs)
         self.tasks[task_id]['depends'] = depends
 
-        # Extract stdout and stderr to pass to AppFuture:
-        task_stdout = kwargs.get('stdout')
-        task_stderr = kwargs.get('stderr')
-
         logger.info("Task {} submitted for App {}, waiting on tasks {}".format(task_id,
                                                                                task_def['func_name'],
                                                                                [fu.tid for fu in depends]))
 
         self.tasks[task_id]['task_launch_lock'] = threading.Lock()
-        app_fu = AppFuture(tid=task_id,
-                           stdout=task_stdout,
-                           stderr=task_stderr)
+        app_fu = AppFuture(task_def)
 
         self.tasks[task_id]['app_fu'] = app_fu
         app_fu.add_done_callback(partial(self.handle_app_update, task_id))

--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -126,11 +126,11 @@ class AppFuture(Future):
 
     @property
     def stdout(self):
-        return self.task_def['kwargs']['stdout']
+        return self.task_def['kwargs'].get('stdout')
 
     @property
     def stderr(self):
-        return self.task_def['kwargs']['stderr']
+        return self.task_def['kwargs'].get('stderr')
 
     @property
     def tid(self):

--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -60,25 +60,20 @@ class AppFuture(Future):
 
     """
 
-    def __init__(self, tid=None, stdout=None, stderr=None):
+    def __init__(self, task_def):
         """Initialize the AppFuture.
 
         Args:
 
         KWargs:
-             - tid (Int) : Task id should be any unique identifier. Now Int.
-             - stdout (str) : Stdout file of the app.
-                   Default: None
-             - stderr (str) : Stderr file of the app.
-                   Default: None
+             - task_def : The DFK task definition dictionary for the task represented
+                   by this future.
         """
-        self._tid = tid
         super().__init__()
         self.parent = None
         self._update_lock = threading.Lock()
         self._outputs = []
-        self._stdout = stdout
-        self._stderr = stderr
+        self.task_def = task_def
 
     def parent_callback(self, executor_fu):
         """Callback from a parent future to update the AppFuture.
@@ -131,15 +126,15 @@ class AppFuture(Future):
 
     @property
     def stdout(self):
-        return self._stdout
+        return self.task_def['kwargs']['stdout']
 
     @property
     def stderr(self):
-        return self._stderr
+        return self.task_def['kwargs']['stderr']
 
     @property
     def tid(self):
-        return self._tid
+        return self.task_def['id']
 
     def update_parent(self, fut):
         """Add a callback to the parent to update the state.


### PR DESCRIPTION
Prior to this, AppFuture properties were copies provided at construction time,
which was fragile in the presence of these properties being modified - specifically,
the handling of parsl.AUTO_LOGNAME.

This PR makes the task_def structure the only place where these values
live, and makes the corresponding AppFuture properties a view into that
task_def structure.