### PR TITLE
Improve wrapper script error handling for workqueue

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -241,7 +241,7 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
                                 reason += "problem writing out function result"
                             else:
                                 reason += "unable to process wrapper script failure"
-                            reason += "\nTrace:\n" + t.output
+                            reason += "\nTrace:\n" + str(t.output)
                             logger.debug("WorkQueue runner script failed for task {} because {}\n".format(parsl_tid, reason))
                         # WorkQueue system failure
                         else:

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -240,7 +240,7 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
                             elif status == 4:
                                 reason += "problem writing out function result"
                             else:
-                                reason += "unable to process wrapper script failure"
+                                reason += "unable to process wrapper script failure with status = {}".format(status)
                             reason += "\nTrace:\n" + str(t.output)
                             logger.debug("WorkQueue runner script failed for task {} because {}\n".format(parsl_tid, reason))
                         # WorkQueue system failure


### PR DESCRIPTION
In some situations that I've encountered (working on PR#1181),
t.output is None and so error reporting breaks with:

```
...
  File "/home/benc/parsl/src/parsl/parsl/executors/workqueue/executor.py", line 244, in WorkQueueSubmitThread
    reason += "\nTrace:\n" + t.output
TypeError: Can't convert 'NoneType' object to str implicitly
```

This PR also logs the numerical value of WQ task return status when it does not have a corresponding text description.

When the above error happens, apps hang rather than return an error. With this PR applied, those apps fail rather than hang.