### PR TITLE
Give Globus stageout code the chance to set File.localpath

### DIFF
--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -86,6 +86,7 @@ class DataManager(object):
             raise Exception('FTP file staging out is not supported')
         elif file.scheme == 'globus':
             globus_scheme = _get_globus_scheme(self.dfk, executor)
+            globus_scheme._update_stage_out_local_path(file, executor, self.dfk)
             stage_out_app = globus_scheme._globus_stage_out_app(executor=executor, dfk=self.dfk)
             return stage_out_app(app_fu, inputs=[file])
         else:

--- a/parsl/data_provider/globus.py
+++ b/parsl/data_provider/globus.py
@@ -236,6 +236,11 @@ class GlobusScheme(RepresentationMixin):
                 'endpoint_path': endpoint_path,
                 'working_dir': working_dir}
 
+    def _update_stage_out_local_path(self, file, executor, dfk):
+        executor_obj = dfk.executors[executor]
+        globus_ep = self._get_globus_endpoint(executor_obj)
+        file.local_path = os.path.join(globus_ep['working_dir'], file.filename)
+
 
 # this cannot be a class method, but must be a function, because I want
 # to be able to use partial() on it - and partial() does not work on


### PR DESCRIPTION
This makes Globus stageout localpath behaviour the same as stagein behaviour:
if staging will be happening to some non-default working directory, then
localpath will be set to point to that actual location of staging.

Because stageout completion is not tested at the moment, the behavioural change is:

Before this PR, if user_opts['globus']['path'] is not equal to the current working directory:
globus stageout test would complete with a successful exit code before
stageout happens (see issue #778); but a transfer job would be left in globus
stalled with a file-not-found error (forever, or at least for a day)

After this PR: globus stageout test will complete with a successful exit code before
stageout happens; a globus transfer job will be made and this will successfully
stage out the file.

Fixes issue #1173