### PR TITLE
Remove outdated bits from data manager initialization

### DIFF
--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -17,12 +17,9 @@ class DataManager(object):
         Args:
            - dfk (DataFlowKernel): The DataFlowKernel that this DataManager is managing data for.
 
-        Kwargs:
-           - executors (list of Executors): Executors for which data transfer will be managed.
         """
 
         self.dfk = dfk
-        self.globus = None
 
     def stage_in(self, file, executor):
         """Transport the file from the input source to the executor.


### PR DESCRIPTION
Remove doctring for executor parameter which was removed in PR #805, commit
66b423066b199296bd9ba0d19ece22bd73192470

Remove data manager globus reference, which was moved into GlobusScheme in PR #1165, commit
73c1909d95f2a0ab2062002745421bdc0fc8e0d873c1909d95f2a0ab2062002745421bdc0fc8e0d8