### PR TITLE
Make DataFutures complete after stageout (issue #778)

### DIFF
--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -2,7 +2,6 @@ from functools import update_wrapper
 from inspect import signature, Parameter
 
 from parsl.app.errors import wrap_error
-from parsl.app.futures import DataFuture
 from parsl.app.app import AppBase
 from parsl.dataflow.dflow import DataFlowKernelLoader
 
@@ -162,9 +161,5 @@ class BashApp(AppBase):
                              fn_hash=self.func_hash,
                              cache=self.cache,
                              **self.kwargs)
-
-        out_futs = [DataFuture(app_fut, o, tid=app_fut.tid)
-                    for o in kwargs.get('outputs', [])]
-        app_fut._outputs = out_futs
 
         return app_fut

--- a/parsl/app/python.py
+++ b/parsl/app/python.py
@@ -3,7 +3,6 @@ import logging
 import tblib.pickling_support
 tblib.pickling_support.install()
 
-from parsl.app.futures import DataFuture
 from parsl.app.app import AppBase
 from parsl.app.errors import wrap_error
 from parsl.dataflow.dflow import DataFlowKernelLoader
@@ -71,11 +70,5 @@ class PythonApp(AppBase):
                              fn_hash=self.func_hash,
                              cache=self.cache,
                              **kwargs)
-
-        # logger.debug("App[{}] assigned Task[{}]".format(self.func.__name__,
-        #                                                 app_fut.tid))
-        out_futs = [DataFuture(app_fut, o, tid=app_fut.tid)
-                    for o in kwargs.get('outputs', [])]
-        app_fut._outputs = out_futs
 
         return app_fut


### PR DESCRIPTION
Prior to this, DataFutures were marked as complete when the main app
task completed, prior to any staging happening.

This meant that DataFutures completing were not an indication that
Globus stage-out had completed (or even been started).

This commit causes DataFutures to complete when the relevant
staging task has completed.

Prior to this commit, DataFutures were created by bash/python
app decorators. This commit creates the DataFutures as part
of stageout setup.

When stageout is inhibited, we still need to create the
DataFutures; in such case, a DataFuture will be marked as complete
as soon as its app future is complete (the existing behaviour).

The key difference here is that the call to 

> self.data_manager.stage_out(f, executor, app_fu)

can now return a future, rather than not getting any opportunity to
influence the task DAG.

Fixes #778