### PR TITLE
Replace super references with self references in AppFuture

### DIFF
--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -93,7 +93,7 @@ class AppFuture(Future):
         Returns:
             - None
 
-        Updates the super() with the result() or exception()
+        Updates the future with the result() or exception()
         """
         with self._update_lock:
 
@@ -113,7 +113,7 @@ class AppFuture(Future):
                 res = executor_fu.result()
                 if isinstance(res, RemoteExceptionWrapper):
                     res.reraise()
-                super().set_result(executor_fu.result())
+                self.set_result(executor_fu.result())
 
             except Exception as e:
                 if executor_fu.retries_left > 0:
@@ -122,7 +122,7 @@ class AppFuture(Future):
                     # will provide the answer
                     pass
                 else:
-                    super().set_exception(e)
+                    self.set_exception(e)
 
     @property
     def stdout(self):


### PR DESCRIPTION
The behaviour shouldn't change over this commit as the self methods should
be the same as the super methods at present, but super() calls
should be avoided unless something specific is being done with inheritence.