### PR TITLE
Implement file staging provider API

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -14,6 +14,7 @@ Reference guide
     parsl.dataflow.futures.AppFuture
     parsl.dataflow.dflow.DataFlowKernelLoader
     parsl.data_provider.data_manager.DataManager
+    parsl.data_provider.data_manager.Staging
     parsl.data_provider.files.File
     parsl.executors.base.ParslExecutor
     parsl.executors.ThreadPoolExecutor

--- a/docs/stubs/parsl.data_provider.staging.Staging.rst
+++ b/docs/stubs/parsl.data_provider.staging.Staging.rst
@@ -1,0 +1,8 @@
+parsl.data\_provider.staging.Staging
+==============================================
+
+.. currentmodule:: parsl.data_provider.staging
+
+.. autoclass:: Staging
+   :members:
+   :undoc-members:

--- a/docs/userguide/data.rst
+++ b/docs/userguide/data.rst
@@ -10,7 +10,7 @@ Parsl aims to abstract not only parallel execution but also execution location, 
 Files
 -----
 
-The :py:class:`~parsl.data_provider.files.File` class abstracts the file access layer. Irrespective of where the script or its apps are executed, Parsl uses this abstraction to access that file. When referencing a Parsl file in an app, Parsl maps the object to the appropriate access path according to the selected access *scheme*: Local, FTP, HTTP, HTTPS and Globus.
+The :py:class:`~parsl.data_provider.files.File` class abstracts the file access layer. Irrespective of where the script or its apps are executed, Parsl uses this abstraction to access that file. When referencing a Parsl file in an app, Parsl maps the object to the appropriate access path according to the selected URL *scheme*: Local, FTP, HTTP, HTTPS and Globus.
 
 
 Local
@@ -132,7 +132,7 @@ In some cases, for example when using a Globus `shared endpoint <https://www.glo
 
         from parsl.config import Config
         from parsl.executors.ipp import IPyParallelExecutor
-        from parsl.data_provider.scheme import GlobusStaging
+        from parsl.data_provider.globus import GlobusStaging
 
         config = Config(
             executors=[

--- a/docs/userguide/data.rst
+++ b/docs/userguide/data.rst
@@ -132,13 +132,13 @@ In some cases, for example when using a Globus `shared endpoint <https://www.glo
 
         from parsl.config import Config
         from parsl.executors.ipp import IPyParallelExecutor
-        from parsl.data_provider.scheme import GlobusScheme
+        from parsl.data_provider.scheme import GlobusStaging
 
         config = Config(
             executors=[
                 IPyParallelExecutor(
                     working_dir="/home/user/parsl_script",
-                    storage_access=[GlobusScheme(
+                    storage_access=[GlobusStaging(
                         endpoint_uuid="7d2dc622-2edb-11e8-b8be-0ac6873fc732",
                         endpoint_path="/",
                         local_path="/home/user"

--- a/docs/userguide/data.rst
+++ b/docs/userguide/data.rst
@@ -133,12 +133,13 @@ In some cases, for example when using a Globus `shared endpoint <https://www.glo
         from parsl.config import Config
         from parsl.executors.ipp import IPyParallelExecutor
         from parsl.data_provider.globus import GlobusStaging
+        from parsl.data_provider.data_manager import default_staging
 
         config = Config(
             executors=[
                 IPyParallelExecutor(
                     working_dir="/home/user/parsl_script",
-                    storage_access=[GlobusStaging(
+                    storage_access=default_staging + [GlobusStaging(
                         endpoint_uuid="7d2dc622-2edb-11e8-b8be-0ac6873fc732",
                         endpoint_path="/",
                         local_path="/home/user"

--- a/parsl/configs/local_threads_globus.py
+++ b/parsl/configs/local_threads_globus.py
@@ -1,5 +1,5 @@
 from parsl.config import Config
-from parsl.data_provider.globus import GlobusScheme
+from parsl.data_provider.globus import GlobusStaging
 from parsl.executors.threads import ThreadPoolExecutor
 
 # This is an example config, make sure to
@@ -10,7 +10,7 @@ config = Config(
     executors=[
         ThreadPoolExecutor(
             label='local_threads_globus',
-            storage_access=[GlobusScheme(
+            storage_access=[GlobusStaging(
                 endpoint_uuid='UUID',    # Please replace UUID with your uuid
                 endpoint_path='PATH'    # Please replace PATH with your path
             )],

--- a/parsl/configs/stampede2_htex_multinode.py
+++ b/parsl/configs/stampede2_htex_multinode.py
@@ -2,7 +2,7 @@ from parsl.config import Config
 from parsl.providers import SlurmProvider
 from parsl.executors import HighThroughputExecutor
 from parsl.addresses import address_by_hostname
-from parsl.data_provider.globus import GlobusScheme
+from parsl.data_provider.globus import GlobusStaging
 
 
 config = Config(
@@ -23,7 +23,7 @@ config = Config(
                 worker_init='',
                 walltime='00:30:00'
             ),
-            storage_access=[GlobusScheme(
+            storage_access=[GlobusStaging(
                 endpoint_uuid='ceea5ca0-89a9-11e7-a97f-22000a92523b',
                 endpoint_path='/',
                 local_path='/'

--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 # these will be shared between all executors that do not explicitly
 # override, so should not contain executor-specific state
-defaultStaging = [NoOpFileStaging(), FTPSeparateTaskStaging(), HTTPSeparateTaskStaging()]  # type: List[Staging]
+default_staging = [NoOpFileStaging(), FTPSeparateTaskStaging(), HTTPSeparateTaskStaging()]  # type: List[Staging]
 
 
 class DataManager(object):
@@ -43,7 +43,7 @@ class DataManager(object):
         if hasattr(executor_obj, "storage_access") and executor_obj.storage_access is not None:
             storage_access = executor_obj.storage_access  # type: List[Staging]
         else:
-            storage_access = defaultStaging
+            storage_access = default_staging
 
         for scheme in storage_access:
             logger.debug("stage_out checking Staging provider {}".format(scheme))
@@ -72,7 +72,7 @@ class DataManager(object):
         if hasattr(executor_obj, "storage_access") and executor_obj.storage_access is not None:
             storage_access = executor_obj.storage_access
         else:
-            storage_access = defaultStaging
+            storage_access = default_staging
 
         for scheme in storage_access:
             logger.debug("stage_in checking Staging provider {}".format(scheme))
@@ -115,7 +115,7 @@ class DataManager(object):
         if hasattr(executor_obj, "storage_access") and executor_obj.storage_access is not None:
             storage_access = executor_obj.storage_access
         else:
-            storage_access = defaultStaging
+            storage_access = default_staging
 
         for scheme in storage_access:
             logger.debug("stage_in checking Staging provider {}".format(scheme))
@@ -147,7 +147,7 @@ class DataManager(object):
         if hasattr(executor_obj, "storage_access") and executor_obj.storage_access is not None:
             storage_access = executor_obj.storage_access
         else:
-            storage_access = defaultStaging
+            storage_access = default_staging
 
         for scheme in storage_access:
             logger.debug("stage_out checking Staging provider {}".format(scheme))

--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -45,16 +45,16 @@ class DataManager(object):
         else:
             storage_access = default_staging
 
-        for scheme in storage_access:
-            logger.debug("stage_out checking Staging provider {}".format(scheme))
-            if scheme.can_stage_out(file):
-                newfunc = scheme.replace_task_stage_out(self, executor, file, func)
+        for provider in storage_access:
+            logger.debug("stage_out checking Staging provider {}".format(provider))
+            if provider.can_stage_out(file):
+                newfunc = provider.replace_task_stage_out(self, executor, file, func)
                 if newfunc:
                     return newfunc
                 else:
                     return func
 
-        logger.debug("reached end of staging scheme list")
+        logger.debug("reached end of staging provider list")
         # if we reach here, we haven't found a suitable staging mechanism
         raise ValueError("Executor {} cannot stage file {}".format(executor, repr(file)))
 
@@ -74,16 +74,16 @@ class DataManager(object):
         else:
             storage_access = default_staging
 
-        for scheme in storage_access:
-            logger.debug("stage_in checking Staging provider {}".format(scheme))
-            if scheme.can_stage_in(file):
-                newfunc = scheme.replace_task(self, executor, file, func)
+        for provider in storage_access:
+            logger.debug("stage_in checking Staging provider {}".format(provider))
+            if provider.can_stage_in(file):
+                newfunc = provider.replace_task(self, executor, file, func)
                 if newfunc:
                     return newfunc
                 else:
                     return func
 
-        logger.debug("reached end of staging scheme list")
+        logger.debug("reached end of staging provider list")
         # if we reach here, we haven't found a suitable staging mechanism
         raise ValueError("Executor {} cannot stage file {}".format(executor, repr(file)))
 
@@ -117,16 +117,16 @@ class DataManager(object):
         else:
             storage_access = default_staging
 
-        for scheme in storage_access:
-            logger.debug("stage_in checking Staging provider {}".format(scheme))
-            if scheme.can_stage_in(file):
-                staging_fut = scheme.stage_in(self, executor, file, parent_fut=parent_fut)
+        for provider in storage_access:
+            logger.debug("stage_in checking Staging provider {}".format(provider))
+            if provider.can_stage_in(file):
+                staging_fut = provider.stage_in(self, executor, file, parent_fut=parent_fut)
                 if staging_fut:
                     return staging_fut
                 else:
                     return input
 
-        logger.debug("reached end of staging scheme list")
+        logger.debug("reached end of staging provider list")
         # if we reach here, we haven't found a suitable staging mechanism
         raise ValueError("Executor {} cannot stage file {}".format(executor, repr(file)))
 
@@ -149,12 +149,11 @@ class DataManager(object):
         else:
             storage_access = default_staging
 
-        for scheme in storage_access:
-            logger.debug("stage_out checking Staging provider {}".format(scheme))
-            if scheme.can_stage_out(file):
-                # globus_scheme._update_stage_out_local_path(file, executor, self.dfk)
-                return scheme.stage_out(self, executor, file, app_fu)
+        for provider in storage_access:
+            logger.debug("stage_out checking Staging provider {}".format(provider))
+            if provider.can_stage_out(file):
+                return provider.stage_out(self, executor, file, app_fu)
 
-        logger.debug("reached end of staging scheme list")
+        logger.debug("reached end of staging provider list")
         # if we reach here, we haven't found a suitable staging mechanism
         raise ValueError("Executor {} cannot stage out file {}".format(executor, repr(file)))

--- a/parsl/data_provider/file_noop.py
+++ b/parsl/data_provider/file_noop.py
@@ -1,0 +1,20 @@
+import logging
+
+from parsl.utils import RepresentationMixin
+from parsl.data_provider.staging import Staging
+
+
+logger = logging.getLogger(__name__)
+
+
+class NoOpFileStaging(Staging, RepresentationMixin):
+
+    def can_stage_in(self, file):
+        logger.debug("NoOpFileStaging checking file {}".format(file.__repr__()))
+        logger.debug("file has scheme {}".format(file.scheme))
+        return file.scheme == 'file'
+
+    def can_stage_out(self, file):
+        logger.debug("NoOpFileStaging checking file {}".format(file.__repr__()))
+        logger.debug("file has scheme {}".format(file.scheme))
+        return file.scheme == 'file'

--- a/parsl/data_provider/files.py
+++ b/parsl/data_provider/files.py
@@ -56,14 +56,6 @@ class File(object):
     def __fspath__(self):
         return self.filepath
 
-    def is_remote(self):
-        if self.scheme in ['ftp', 'http', 'https', 'globus']:
-            return True
-        elif self.scheme in ['file']:  # TODO: is this enough?
-            return False
-        else:
-            raise Exception('Cannot determine if unknown file scheme {} is remote'.format(self.scheme))
-
     @property
     def filepath(self):
         """Return the resolved filepath on the side where it is called from.

--- a/parsl/data_provider/ftp.py
+++ b/parsl/data_provider/ftp.py
@@ -1,7 +1,29 @@
 import ftplib
+import logging
 import os
 
 from parsl import python_app
+
+from parsl.utils import RepresentationMixin
+from parsl.data_provider.staging import Staging
+
+
+logger = logging.getLogger(__name__)
+
+
+class FTPSeparateTaskStaging(Staging, RepresentationMixin):
+    """Performs FTP staging as a separate parsl level task."""
+
+    def can_stage_in(self, file):
+        logger.debug("FTPSeparateTaskStaging checking file {}".format(file.__repr__()))
+        logger.debug("file has scheme {}".format(file.scheme))
+        return file.scheme == 'ftp'
+
+    def stage_in(self, dm, executor, file, parent_fut):
+        working_dir = dm.dfk.executors[executor].working_dir
+        stage_in_app = _ftp_stage_in_app(dm, executor=executor)
+        app_fut = stage_in_app(working_dir, outputs=[file], staging_inhibit_output=True, parent_fut=parent_fut)
+        return app_fut._outputs[0]
 
 
 def _ftp_stage_in(working_dir, parent_fut=None, outputs=[], staging_inhibit_output=True):

--- a/parsl/data_provider/globus.py
+++ b/parsl/data_provider/globus.py
@@ -37,7 +37,7 @@ def _get_globus_scheme(dfk, executor_label):
     if not hasattr(executor, "storage_access"):
         raise ValueError("specified executor does not have storage_access attribute")
     for scheme in executor.storage_access:
-        if isinstance(scheme, GlobusScheme):
+        if isinstance(scheme, GlobusStaging):
             return scheme
 
     raise Exception('No suitable Globus endpoint defined for executor {}'.format(executor_label))
@@ -182,7 +182,7 @@ class Globus(object):
             on_refresh=cls._update_tokens_file_on_refresh)
 
 
-class GlobusScheme(Staging, RepresentationMixin):
+class GlobusStaging(Staging, RepresentationMixin):
     """Specification for accessing data on a remote executor via Globus.
 
     Parameters
@@ -244,7 +244,7 @@ class GlobusScheme(Staging, RepresentationMixin):
         if executor.working_dir:
             working_dir = os.path.normpath(executor.working_dir)
         else:
-            raise ValueError("executor working_dir must be specified for GlobusScheme")
+            raise ValueError("executor working_dir must be specified for GlobusStaging")
         if self.endpoint_path and self.local_path:
             endpoint_path = os.path.normpath(self.endpoint_path)
             local_path = os.path.normpath(self.local_path)

--- a/parsl/data_provider/http.py
+++ b/parsl/data_provider/http.py
@@ -1,7 +1,30 @@
+import logging
 import os
 import requests
 
 from parsl import python_app
+
+from parsl.utils import RepresentationMixin
+from parsl.data_provider.staging import Staging
+
+logger = logging.getLogger(__name__)
+
+
+class HTTPSeparateTaskStaging(Staging, RepresentationMixin):
+    """A staging provider that Performs HTTP and HTTPS staging
+    as a separate parsl-level task. This requires a shared file
+    system on the executor."""
+
+    def can_stage_in(self, file):
+        logger.debug("HTTPSeparateTaskStaging checking file {}".format(file.__repr__()))
+        logger.debug("file has scheme {}".format(file.scheme))
+        return file.scheme == 'http' or file.scheme == 'https'
+
+    def stage_in(self, dm, executor, file, parent_fut):
+        working_dir = dm.dfk.executors[executor].working_dir
+        stage_in_app = _http_stage_in_app(dm, executor=executor)
+        app_fut = stage_in_app(working_dir, outputs=[file], staging_inhibit_output=True, parent_fut=parent_fut)
+        return app_fut._outputs[0]
 
 
 def _http_stage_in(working_dir, parent_fut=None, outputs=[], staging_inhibit_output=True):

--- a/parsl/data_provider/staging.py
+++ b/parsl/data_provider/staging.py
@@ -1,0 +1,68 @@
+from concurrent.futures import Future
+from typing import Optional, Callable
+from parsl.app.futures import DataFuture
+from parsl.data_provider.files import File
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from parsl.data_provider.data_manager import DataManager
+
+
+class Staging:
+    """
+    This class defines the interface for file staging providers.
+
+    For each file to be staged in, the data manager will present the file
+    to each configured Staging provider in turn: first, it will ask if the
+    provider can stage this file by calling `can_stage_in`, and if so, it
+    will call both `stage_in` and `replace_task` to give the provider the
+    opportunity to perform staging.
+
+    For each file to be staged out, the data manager will follow the same
+    pattern using the corresponding stage out methods of this class.
+
+    The default implementation of this class rejects all files, and
+    performs no staging actions.
+
+    To implement a concrete provider, one or both of the `can_stage_*`
+    methods should be overridden to match the appropriate files, and then
+    the corresponding `stage_*` and/or `replace_task*` methods should be
+    implemented.
+    """
+
+    def can_stage_in(self, file: File) -> bool:
+        """
+        Given a File object, decide if this staging provider can
+        stage the file. Usually this is be based on the URL
+        scheme, but does not have to be. If this returns True,
+        then other methods of this Staging object will be called
+        to perform the staging.
+        """
+        return False
+
+    def can_stage_out(self, file: File) -> bool:
+        """
+        Like can_stage_in, but for staging out.
+        """
+        return False
+
+    def stage_in(self, dm: "DataManager", executor: str, file: File, parent_fut: Optional[Future]) -> Optional[DataFuture]:
+        """
+        For a given file, either return a DataFuture to substitute
+        for this file, or return None to perform no substitution
+        """
+        return None
+
+    def stage_out(self, dm: "DataManager", executor: str, file: File, app_fu) -> Optional[DataFuture]:
+        return None
+
+    def replace_task(self, dm: "DataManager", executor: str, file: File, func: Callable) -> Optional[Callable]:
+        """
+        For a file to be staged in, either return a replacement app
+        function, which usually should be the original app function wrapped
+        in staging code.
+        """
+        return None
+
+    def replace_task_stage_out(self, dm: "DataManager", executor: str, file: File, func: Callable) -> Optional[Callable]:
+        return None

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -461,10 +461,10 @@ class DataFlowKernel(object):
         logger.info("Task {} launched on executor {}".format(task_id, executor.label))
         return exec_fu
 
-    def _add_input_deps(self, executor, args, kwargs):
-        """Look for inputs of the app that are remote files. Submit stage_in
-        apps for such files and replace the file objects in the inputs list with
-        corresponding DataFuture objects.
+    def _add_input_deps(self, executor, args, kwargs, func):
+        """Look for inputs of the app that are files. Give the data manager
+        the opportunity to replace a file with a data future for that file,
+        for example wrapping the result of a staging action.
 
         Args:
             - executor (str) : executor where the app is going to be launched
@@ -474,41 +474,52 @@ class DataFlowKernel(object):
 
         # Return if the task is _*_stage_in
         if executor == 'data_manager':
-            return args, kwargs
+            return args, kwargs, func
 
         inputs = kwargs.get('inputs', [])
         for idx, f in enumerate(inputs):
             inputs[idx] = self.data_manager.stage_in(f, executor)
+            func = self.data_manager.replace_task(f, func, executor)
 
         for kwarg, f in kwargs.items():
             kwargs[kwarg] = self.data_manager.stage_in(f, executor)
+            func = self.data_manager.replace_task(f, func, executor)
 
         newargs = list(args)
         for idx, f in enumerate(newargs):
             newargs[idx] = self.data_manager.stage_in(f, executor)
+            func = self.data_manager.replace_task(f, func, executor)
 
-        return tuple(newargs), kwargs
+        return tuple(newargs), kwargs, func
 
-    def _add_output_deps(self, executor, args, kwargs, app_fut):
+    def _add_output_deps(self, executor, args, kwargs, app_fut, func):
         logger.debug("Adding output dependencies")
-        inhibit = self.check_staging_inhibited(kwargs)
         outputs = kwargs.get('outputs', [])
         app_fut._outputs = []
         for f in outputs:
-            if isinstance(f, File) and f.is_remote() and not inhibit:
-                # with remote stageout, the DataFuture will be complete when
-                # the staging task is complete
-                logger.debug("Submitting stage out job for output file {}".format(f))
+            if isinstance(f, File) and not self.check_staging_inhibited(kwargs):
+                # replace a File with a DataFuture - either completing when the stageout
+                # future completes, or if no stage out future is returned, then when the
+                # app itself completes.
+                logger.debug("Submitting stage out for output file {}".format(f))
                 stageout_fut = self.data_manager.stage_out(f, executor, app_fut)
-                app_fut._outputs.append(DataFuture(stageout_fut, f, tid=app_fut.tid))
+                if stageout_fut:
+                    logger.debug("Adding a dependency on stageout future for {}".format(f))
+                    app_fut._outputs.append(DataFuture(stageout_fut, f, tid=app_fut.tid))
+                else:
+                    logger.debug("No stageout dependency for {}".format(f))
+                    app_fut._outputs.append(DataFuture(app_fut, f, tid=app_fut.tid))
+
+                # this is a hook for post-task stageout
+                # note that nothing depends on the output - which is maybe a bug
+                # in the not-very-tested stageout system?
+                newfunc = self.data_manager.replace_task_stage_out(f, func, executor)
+                if newfunc:
+                    func = newfunc
             else:
-                # with local stageout, the DataFuture will be complete when
-                # the core task future is complete
-                # with remote URLs, if staging is inhibited, the app future completing
-                # will signal that stage-out is complete - because that app *is* the
-                # stageout task
-                logger.debug("Skipping stageout for output {}".format(f))
+                logger.debug("Not performing staging for: {}".format(f))
                 app_fut._outputs.append(DataFuture(app_fut, f, tid=app_fut.tid))
+        return func
 
     def _gather_all_deps(self, args, kwargs):
         """Count the number of unresolved futures on which a task depends.
@@ -646,6 +657,8 @@ class DataFlowKernel(object):
             raise ValueError("Task {} supplied invalid type for executors: {}".format(task_id, type(executors)))
         executor = random.choice(choices)
 
+        # The below uses func.__name__ before it has been wrapped by any staging code.
+
         label = kwargs.get('label')
         for kw in ['stdout', 'stderr']:
             if kw in kwargs:
@@ -663,7 +676,6 @@ class DataFlowKernel(object):
 
         task_def = {'depends': None,
                     'executor': executor,
-                    'func': func,
                     'func_name': func.__name__,
                     'fn_hash': fn_hash,
                     'memoize': cache,
@@ -681,12 +693,13 @@ class DataFlowKernel(object):
         app_fu = AppFuture(task_def)
 
         # Transform remote input files to data futures
-        args, kwargs = self._add_input_deps(executor, args, kwargs)
+        args, kwargs, func = self._add_input_deps(executor, args, kwargs, func)
 
-        self._add_output_deps(executor, args, kwargs, app_fu)
+        self._add_output_deps(executor, args, kwargs, app_fu, func)
 
         task_def.update({
                     'args': args,
+                    'func': func,
                     'kwargs': kwargs,
                     'app_fu': app_fu})
 

--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -13,6 +13,19 @@ class ParslExecutor(metaclass=ABCMeta):
        label: str - a human readable label for the executor, unique
               with respect to other executors.
 
+    An executor may optionally expose:
+
+       storage_access: List[parsl.data_provider.staging.Staging] - a list of staging
+              providers that will be used for file staging. In the absence of this
+              attribute, or if this attribute is `None`, then a default value of
+              `parsl.data_provider.staging.default_staging` will be used by the
+              staging code.
+
+              Typechecker note: Ideally storage_access would be declared on executor
+              __init__ methods as List[Staging] - however, lists are by default
+              invariant, not co-variant, and it looks like @typeguard cannot be
+              persuaded otherwise. So if you're implementing an executor and want to
+              @typeguard the constructor, you'll have to use List[Any] here.
     """
 
     @abstractmethod

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -8,7 +8,7 @@ import threading
 import queue
 import pickle
 from multiprocessing import Process, Queue
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from ipyparallel.serialize import pack_apply_message  # ,unpack_apply_message
 from ipyparallel.serialize import deserialize_object  # ,serialize_object
@@ -18,8 +18,8 @@ from parsl.executors.high_throughput import zmq_pipes
 from parsl.executors.high_throughput import interchange
 from parsl.executors.errors import BadMessage, ScalingFailed, DeserializationError
 from parsl.executors.base import ParslExecutor
-from parsl.dataflow.error import ConfigurationError
 from parsl.providers.provider_base import ExecutionProvider
+from parsl.data_provider.staging import Staging
 
 from parsl.utils import RepresentationMixin
 from parsl.providers import LocalProvider
@@ -154,7 +154,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                  worker_ports: Optional[Tuple[int, int]] = None,
                  worker_port_range: Optional[Tuple[int, int]] = (54000, 55000),
                  interchange_port_range: Optional[Tuple[int, int]] = (55000, 56000),
-                 storage_access: Optional[List[Any]] = None,
+                 storage_access: Optional[List[Staging]] = None,
                  working_dir: Optional[str] = None,
                  worker_debug: bool = False,
                  cores_per_worker: float = 1.0,
@@ -174,9 +174,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         self.launch_cmd = launch_cmd
         self.provider = provider
         self.worker_debug = worker_debug
-        self.storage_access = storage_access if storage_access is not None else []
-        if len(self.storage_access) > 1:
-            raise ConfigurationError('Multiple storage access schemes are not supported')
+        self.storage_access = storage_access
         self.working_dir = working_dir
         self.managed = managed
         self.blocks = {}  # type: Dict[str, str]

--- a/parsl/executors/ipp.py
+++ b/parsl/executors/ipp.py
@@ -7,7 +7,6 @@ from ipyparallel import Client
 from parsl.providers import LocalProvider
 from parsl.utils import RepresentationMixin
 
-from parsl.dataflow.error import ConfigurationError
 from parsl.executors.base import ParslExecutor
 from parsl.executors.errors import ScalingFailed
 from parsl.executors.ipp_controller import Controller
@@ -84,9 +83,7 @@ class IPyParallelExecutor(ParslExecutor, RepresentationMixin):
         self.container_image = container_image
         self.engine_dir = engine_dir
         self.workers_per_node = workers_per_node
-        self.storage_access = storage_access if storage_access is not None else []
-        if len(self.storage_access) > 1:
-            raise ConfigurationError('Multiple storage access schemes are not yet supported')
+        self.storage_access = storage_access
         self.managed = managed
 
         self.debug_option = ""

--- a/parsl/executors/ipp.py
+++ b/parsl/executors/ipp.py
@@ -47,7 +47,7 @@ class IPyParallelExecutor(ParslExecutor, RepresentationMixin):
         Directory where engine logs and configuration files will be stored.
     working_dir : str
         Directory where input data should be staged to.
-    storage_access : list of :class:`~parsl.data_provider.scheme.Scheme`
+    storage_access : list of :class:`~parsl.data_provider.staging.Staging`
         Specifications for accessing data this executor remotely.
     managed : bool
         If True, parsl will control dynamic scaling of this executor, and be responsible. Otherwise,

--- a/parsl/executors/ipp.py
+++ b/parsl/executors/ipp.py
@@ -48,7 +48,7 @@ class IPyParallelExecutor(ParslExecutor, RepresentationMixin):
     working_dir : str
         Directory where input data should be staged to.
     storage_access : list of :class:`~parsl.data_provider.scheme.Scheme`
-        Specifications for accessing data this executor remotely. Multiple `Scheme`s are not yet supported.
+        Specifications for accessing data this executor remotely.
     managed : bool
         If True, parsl will control dynamic scaling of this executor, and be responsible. Otherwise,
         this is managed by the user.

--- a/parsl/executors/swift_t.py
+++ b/parsl/executors/swift_t.py
@@ -15,7 +15,6 @@ from ipyparallel.serialize import pack_apply_message, unpack_apply_message
 from ipyparallel.serialize import serialize_object, deserialize_object
 
 from parsl.executors.base import ParslExecutor
-from parsl.dataflow.error import ConfigurationError
 
 logger = logging.getLogger(__name__)
 
@@ -180,9 +179,7 @@ class TurbineExecutor(ParslExecutor):
         """
         logger.debug("Initializing TurbineExecutor")
         self.label = label
-        self.storage_access = storage_access if storage_access is not None else []
-        if len(self.storage_access) > 1:
-            raise ConfigurationError('Multiple storage access schemes are not yet supported')
+        self.storage_access = storage_access
         self.working_dir = working_dir
         self.managed = managed
 

--- a/parsl/executors/threads.py
+++ b/parsl/executors/threads.py
@@ -21,7 +21,7 @@ class ThreadPoolExecutor(ParslExecutor, RepresentationMixin):
     thread_name_prefix : string
         Thread name prefix (only supported in python v3.6+).
     storage_access : list of :class:`~parsl.data_provider.staging.Staging`
-        Specifications for accessing data this executor remotely. Multiple `Scheme`s are not yet supported.
+        Specifications for accessing data this executor remotely.
     managed : bool
         If True, parsl will control dynamic scaling of this executor, and be responsible. Otherwise,
         this is managed by the user.

--- a/parsl/executors/threads.py
+++ b/parsl/executors/threads.py
@@ -30,10 +30,6 @@ class ThreadPoolExecutor(ParslExecutor, RepresentationMixin):
     @typeguard.typechecked
     def __init__(self, label: str = 'threads', max_threads: int = 2,
                  thread_name_prefix: str = '', storage_access: List[Any] = None,
-                 # storage_access should be a list of Staging, but Lists are by default
-                 # invariant, not co-variant, and it looks like 'typeguard' author actually
-                 # prefers to fix stuff in 'pytypes' not 'typeguard' - so it's a list of Any for now.
-                 # maybe should port to pytypes, our third live typechecker?
                  working_dir: Optional[str] = None, managed: bool = True):
         self.label = label
         self._scaling_enabled = False

--- a/parsl/tests/configs/local_threads_globus.py
+++ b/parsl/tests/configs/local_threads_globus.py
@@ -1,4 +1,5 @@
 from parsl.config import Config
+from parsl.data_provider.data_manager import defaultStaging
 from parsl.data_provider.globus import GlobusScheme
 from parsl.executors.threads import ThreadPoolExecutor
 from parsl.tests.utils import get_rundir
@@ -10,15 +11,17 @@ from parsl.tests.utils import get_rundir
 #          (i.e., user_opts['swan']['username'] -> 'your_username')
 from .user_opts import user_opts
 
+storage_access = defaultStaging + [GlobusScheme(
+                endpoint_uuid=user_opts['globus']['endpoint'],
+                endpoint_path=user_opts['globus']['path']
+            )]
+
 config = Config(
     executors=[
         ThreadPoolExecutor(
             label='local_threads_globus',
-            storage_access=[GlobusScheme(
-                endpoint_uuid=user_opts['globus']['endpoint'],
-                endpoint_path=user_opts['globus']['path']
-            )],
-            working_dir=user_opts['globus']['path']
+            working_dir=user_opts['globus']['path'],
+            storage_access=storage_access
         )
     ],
     run_dir=get_rundir()

--- a/parsl/tests/configs/local_threads_globus.py
+++ b/parsl/tests/configs/local_threads_globus.py
@@ -1,6 +1,6 @@
 from parsl.config import Config
 from parsl.data_provider.data_manager import default_staging
-from parsl.data_provider.globus import GlobusScheme
+from parsl.data_provider.globus import GlobusStaging
 from parsl.executors.threads import ThreadPoolExecutor
 from parsl.tests.utils import get_rundir
 
@@ -11,7 +11,7 @@ from parsl.tests.utils import get_rundir
 #          (i.e., user_opts['swan']['username'] -> 'your_username')
 from .user_opts import user_opts
 
-storage_access = default_staging + [GlobusScheme(
+storage_access = default_staging + [GlobusStaging(
                 endpoint_uuid=user_opts['globus']['endpoint'],
                 endpoint_path=user_opts['globus']['path']
             )]

--- a/parsl/tests/configs/local_threads_globus.py
+++ b/parsl/tests/configs/local_threads_globus.py
@@ -1,5 +1,5 @@
 from parsl.config import Config
-from parsl.data_provider.data_manager import defaultStaging
+from parsl.data_provider.data_manager import default_staging
 from parsl.data_provider.globus import GlobusScheme
 from parsl.executors.threads import ThreadPoolExecutor
 from parsl.tests.utils import get_rundir
@@ -11,7 +11,7 @@ from parsl.tests.utils import get_rundir
 #          (i.e., user_opts['swan']['username'] -> 'your_username')
 from .user_opts import user_opts
 
-storage_access = defaultStaging + [GlobusScheme(
+storage_access = default_staging + [GlobusScheme(
                 endpoint_uuid=user_opts['globus']['endpoint'],
                 endpoint_path=user_opts['globus']['path']
             )]


### PR DESCRIPTION
Instead of dispatching inside the DFK explicitly based on a
hard-coded map between URI schemes and staging implementations,
go through each staging scheme in sequence, giving that scheme the chance
to handle staging

The concept of 'is_remote' being a property of files defined
by the URL scheme is also superceded by this, and so
is_remote is removed. For behaviour of "file:" URLs to mean
'no staging', then a no-op staging scheme is implemented
in this PR. Other  staging providers can implement different
semantics for `file:` URLs.

There's a user-facing API change here: if a configuration specifies
`storage_access=[]` rather than omitting it or specifying `storage_access=None`,
then the default staging mechanisms will be removed and
even no-op file access won't work; and the way to configure Globus has changed.

Start reading at parsl/data_provider/staging.py, which defines the new API.
Existing staging code is modified to implement that API, and existing code that calls into staging does so via that API - defaulting to a set of staging providers giving equivalent behaviour to that  immediately before this PR.
