### PR TITLE
Add a test that checks that inputs=[] can take a variety of types

### DIFF
--- a/parsl/tests/test_python_apps/test_arg_input_types.py
+++ b/parsl/tests/test_python_apps/test_arg_input_types.py
@@ -10,9 +10,11 @@ from parsl import python_app
 def take_a_value(inputs=[]):
     return str(inputs[0])
 
+
 @python_app
 def add_two_values(inputs=[]):
     return inputs[0] + inputs[1]
+
 
 def test_input_str():
     f = take_a_value(inputs=["hi"])

--- a/parsl/tests/test_python_apps/test_arg_input_types.py
+++ b/parsl/tests/test_python_apps/test_arg_input_types.py
@@ -1,0 +1,32 @@
+"""
+These tests check that inputs[] can be passed from any type,
+and that they can be used as regular objects unless they are
+Files.
+"""
+from parsl import python_app
+
+
+@python_app
+def take_a_value(inputs=[]):
+    return str(inputs[0])
+
+@python_app
+def add_two_values(inputs=[]):
+    return inputs[0] + inputs[1]
+
+def test_input_str():
+    f = take_a_value(inputs=["hi"])
+    assert f.result() == "hi"
+
+
+def test_input_num():
+    f = take_a_value(inputs=[3.14])
+    assert f.result() == "3.14"
+
+    f = add_two_values(inputs=[5, 7, 3])
+    assert f.result() == 12
+
+
+def test_input_list():
+    f = take_a_value(inputs=[["foo", 7]])
+    assert f.result() == "['foo', 7]"


### PR DESCRIPTION
This behaviour has been much debated, but the consensus on
expected existing behaviour is that any object can be passed into
inputs=[], and that if it is not a File, it should be passed
through unmodified to the app code.