### PR TITLE
Add a deprecation warning when DataFutures are constructed with strings

### DIFF
--- a/parsl/app/futures.py
+++ b/parsl/app/futures.py
@@ -53,6 +53,7 @@ class DataFuture(Future):
         super().__init__()
         self._tid = tid
         if isinstance(file_obj, str):
+            logger.warning("DataFuture constructed with a string, not a File. This is deprecated.")
             self.file_obj = File(file_obj)
         elif isinstance(file_obj, File):
             self.file_obj = file_obj


### PR DESCRIPTION
There might be better phrasing for the warning text, as likely a user will encounter this when using `outputs=[]` as they should not be constructing DataFutures themselves.

This manifests in the test suite when app outputs are specified with strings
rather than File objects; and for those strings, File objects are constructed.

However:
 * these Files are not staged out properly according to staging rules;
 * the behaviour of strings on inputs is to be passed through unmodified to
   apps, rather than being wrapped as files.

The longer term behaviour should be to remove this special casing, but it will
break user code that relies on specifying local unstaged files as strings.