### PR TITLE
Add whole-run DFK pytest fixture. Remove many-config capability.

### DIFF
--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -24,8 +24,10 @@ def pytest_addoption(parser):
         '--config',
         action='store',
         metavar='CONFIG',
+        type='string',
         nargs=1,
-        help="only run parsl CONFIG; use 'local' to run locally-defined config"
+        required=True,
+        help="run with parsl CONFIG; use 'local' to run locally-defined config"
     )
 
 
@@ -103,7 +105,7 @@ def load_dfk_session(request, pytestconfig):
     load_dfk_local_module for module-level configuration management.
     """
 
-    config = pytestconfig.getoption('config')
+    config = pytestconfig.getoption('config')[0]
 
     if config != 'local':
         spec = importlib.util.spec_from_file_location('', config)
@@ -143,7 +145,7 @@ def load_dfk_local_module(request, pytestconfig):
     with local_config.
     """
 
-    config = pytestconfig.getoption('config')
+    config = pytestconfig.getoption('config')[0]
 
     if config == 'local':
         local_setup = getattr(request.module, "local_setup", None)
@@ -179,7 +181,7 @@ def apply_masks(request, pytestconfig):
     not in the whitelist are skipped. Similarly, configs in a blacklist are skipped,
     and configs which are not `local` are skipped if the `local` decorator is applied.
     """
-    config = pytestconfig.getoption('config')
+    config = pytestconfig.getoption('config')[0]
     m = request.node.get_marker('whitelist')
     if m is not None:
         if os.path.abspath(config) not in chain.from_iterable([glob(x) for x in m.args]):


### PR DESCRIPTION
This change will (in non-local mode) load a single DFK for a specified
config, which will be used for all tests in the run.

For local mode, new ways of initialising tests are added: local_config,
local_setup and local_teardown, that can be used to write 'local'-mode
tests which do not interfere with other tests - the parsl test suite
local mode tests, at present, do lots of global stuff, and these new
parameters and methods allow that globus stuff to be more constrained
to individual test runtime.

This conflicts with the implementation of multiple test configurations
in one run - that feature causes the DFK to be loaded/unloaded for each
test module as pytest sweeps over the list of configs, even if the list
only has one entry.

Multiple test configuration handling is removed, and --configs is renamed
to --config.

The behaviour can be demonstrated by running:

pytest parsl/tests/test_bash_apps/test_apptimeout.py \
  parsl/tests/test_bash_apps/test_basic.py \
  --config parsl/tests/configs/local_threads.py --setup-show

before and after, where --setup-show will show when each fixture is executed