### PR TITLE
Add missing setup_data annotation to test that uses data/

### DIFF
--- a/parsl/tests/test_data/test_file_ipp.py
+++ b/parsl/tests/test_data/test_file_ipp.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 import parsl
 from parsl.app.app import App
@@ -14,6 +15,7 @@ def cat(inputs=[], outputs=[], stdout=None, stderr=None):
     """.format(i=infiles, o=outputs[0])
 
 
+@pytest.mark.usefixtures('setup_data')
 def test_files():
 
     if os.path.exists('cat_out.txt'):


### PR DESCRIPTION
Previously this test could not be run on a pristine checkout on its
own; it relied on a previous execution of a test with the setup_data
annotation (in CI, parsl/tests/test_data/test_file_apps.py) to pass.