### PR TITLE
Move extreme scale executor mpi4py import requirement into start

### DIFF
--- a/parsl/executors/extreme_scale/executor.py
+++ b/parsl/executors/extreme_scale/executor.py
@@ -150,12 +150,6 @@ class ExtremeScaleExecutor(HighThroughputExecutor, RepresentationMixin):
                          heartbeat_period=heartbeat_period,
                          managed=managed)
 
-        if not _mpi_enabled:
-            raise OptionalModuleMissing("mpi4py", "Cannot initialize ExtremeScaleExecutor without mpi4py")
-        else:
-            # This is only to stop flake8 from complaining
-            logger.debug("MPI version :{}".format(mpi4py.__version__))
-
         self.ranks_per_node = ranks_per_node
 
         logger.debug("Initializing ExtremeScaleExecutor")
@@ -169,6 +163,15 @@ class ExtremeScaleExecutor(HighThroughputExecutor, RepresentationMixin):
                                "--hb_period={heartbeat_period} "
                                "--hb_threshold={heartbeat_threshold} ")
         self.worker_debug = worker_debug
+
+    def start(self):
+        if not _mpi_enabled:
+            raise OptionalModuleMissing("mpi4py", "Cannot initialize ExtremeScaleExecutor without mpi4py")
+        else:
+            # This is only to stop flake8 from complaining
+            logger.debug("MPI version :{}".format(mpi4py.__version__))
+
+        super().start()
 
     def initialize_scaling(self):
 


### PR DESCRIPTION
Prior to this commit, attempting to construct a Config involving
the extreme scale executor would fail if mpi4py was not installed
with an exception message informing the user about that requirement.

After this commit, that exception will be thrown later, at the point
that a user attempt to load a DFK with that config.

This allows unused extreme scale executor configs to be imported
safely - most immediately, for test rearrangements in PR #1210