### PR TITLE
Remove use of 'noci' pytest marker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,8 @@ script:
       # do this before any testing, but not in-between tests
     - rm -f .coverage
 
-    - pytest parsl -k "not cleannet and not noci" --config parsl/tests/configs/htex_local.py --cov=parsl --cov-append --cov-report= --random-order
-    - pytest parsl -k "not cleannet and not noci" --config parsl/tests/configs/local_threads.py --cov=parsl --cov-append --cov-report= --random-order
+    - pytest parsl -k "not cleannet" --config parsl/tests/configs/htex_local.py --cov=parsl --cov-append --cov-report= --random-order
+    - pytest parsl -k "not cleannet" --config parsl/tests/configs/local_threads.py --cov=parsl --cov-append --cov-report= --random-order
 
     # some of the site/ tests require more dependencies. These are installed here as needed,
     # so that the above tests happen with only the basic requirements installed.
@@ -64,12 +64,12 @@ script:
 
     - work_queue_worker localhost 9000 &> /dev/null &
 
-    - pytest parsl -k "not cleannet and not noci" --config parsl/tests/configs/workqueue_ex.py --cov=parsl --cov-append --cov-report= --random-order --bodge-dfk-per-test
+    - pytest parsl -k "not cleannet" --config parsl/tests/configs/workqueue_ex.py --cov=parsl --cov-append --cov-report= --random-order --bodge-dfk-per-test
     - kill -3 $(ps aux | grep -E -e "[0-9]+:[0-9]+ work_queue_worker" | tr -s ' ' | cut -f 2 -d " ")
 
     # these tests run with specific configs loaded within the tests themselves.
     # This mode is enabled with: --config local
-    - pytest parsl -k "not cleannet and not noci" --config local --cov=parsl --cov-append --cov-report= --random-order
+    - pytest parsl -k "not cleannet" --config local --cov=parsl --cov-append --cov-report= --random-order
 
     # run simple worker test. this is unlikely to scale due to
     # a stdout/stderr buffering bug in present master.

--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -290,3 +290,13 @@ def pytest_make_collect_report(collector):
     rep = runner.CollectReport(collector.nodeid, outcome, longrepr, getattr(call, 'result', None))
     rep.call = call  # see collect_one_node
     return rep
+
+def pytest_ignore_collect(path):
+    if 'integration' in path.strpath:
+        return True
+    elif 'manual_tests' in path.strpath:
+        return True
+    elif 'workqueue_tests/test_scale' in path.strpath:
+        return True
+    else:
+        return False

--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -291,6 +291,7 @@ def pytest_make_collect_report(collector):
     rep.call = call  # see collect_one_node
     return rep
 
+
 def pytest_ignore_collect(path):
     if 'integration' in path.strpath:
         return True

--- a/parsl/tests/integration/test_apps/HEDM_processlayer/process_layer.py
+++ b/parsl/tests/integration/test_apps/HEDM_processlayer/process_layer.py
@@ -14,7 +14,6 @@ Foreach .. from .csv
 <Bash> wait on all for loop
 
 """
-import pytest
 
 import parsl
 from parsl import App, DataFlowKernel, ThreadPoolExecutor

--- a/parsl/tests/integration/test_apps/HEDM_processlayer/process_layer.py
+++ b/parsl/tests/integration/test_apps/HEDM_processlayer/process_layer.py
@@ -123,7 +123,6 @@ def main(count):
     return c3
 
 
-@pytest.mark.noci
 def test_HEDM(count=10):
     x = main(count)
     x.result()

--- a/parsl/tests/integration/test_channels/test_channels.py
+++ b/parsl/tests/integration/test_channels/test_channels.py
@@ -1,5 +1,4 @@
 from parsl.channels.local.local import LocalChannel
-import pytest
 
 
 def test_local():

--- a/parsl/tests/integration/test_channels/test_channels.py
+++ b/parsl/tests/integration/test_channels/test_channels.py
@@ -2,7 +2,6 @@ from parsl.channels.local.local import LocalChannel
 import pytest
 
 
-@pytest.mark.noci
 def test_local():
 
     channel = LocalChannel(None, None)

--- a/parsl/tests/integration/test_channels/test_scp_1.py
+++ b/parsl/tests/integration/test_channels/test_scp_1.py
@@ -21,7 +21,6 @@ echo "Done----------"
 '''
 
 
-@pytest.mark.noci
 def test_connect_1():
     with open('remote_run.sh', 'w') as f:
         f.write(script)

--- a/parsl/tests/integration/test_channels/test_scp_1.py
+++ b/parsl/tests/integration/test_channels/test_scp_1.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 
 from parsl.channels.ssh.ssh import SSHChannel as SSH
 

--- a/parsl/tests/integration/test_channels/test_ssh_1.py
+++ b/parsl/tests/integration/test_channels/test_ssh_1.py
@@ -9,7 +9,6 @@ def connect_and_list(hostname, username):
     return out
 
 
-@pytest.mark.noci
 def test_midway():
     ''' Test ssh channels to midway
     '''
@@ -19,7 +18,6 @@ def test_midway():
     print("Sitename :{0}  hostname:{1}".format(url, out))
 
 
-@pytest.mark.noci
 def test_beagle():
     ''' Test ssh channels to beagle
     '''
@@ -29,7 +27,6 @@ def test_beagle():
     print("Sitename :{0}  hostname:{1}".format(url, out))
 
 
-@pytest.mark.noci
 def test_osg():
     ''' Test ssh connectivity to osg
     '''
@@ -39,7 +36,6 @@ def test_osg():
     print("Sitename :{0}  hostname:{1}".format(url, out))
 
 
-@pytest.mark.noci
 def test_cori():
     ''' Test ssh connectivity to cori
     '''

--- a/parsl/tests/integration/test_channels/test_ssh_1.py
+++ b/parsl/tests/integration/test_channels/test_ssh_1.py
@@ -1,5 +1,4 @@
 from parsl.channels.ssh.ssh import SSHChannel as SSH
-import pytest
 
 
 def connect_and_list(hostname, username):

--- a/parsl/tests/integration/test_channels/test_ssh_errors.py
+++ b/parsl/tests/integration/test_channels/test_ssh_errors.py
@@ -1,8 +1,6 @@
 from parsl.channels.errors import SSHException, BadHostKeyException
 from parsl.channels.ssh.ssh import SSHChannel as SSH
 
-import pytest
-
 
 def connect_and_list(hostname, username):
     conn = SSH(hostname, username=username)

--- a/parsl/tests/integration/test_channels/test_ssh_errors.py
+++ b/parsl/tests/integration/test_channels/test_ssh_errors.py
@@ -11,7 +11,6 @@ def connect_and_list(hostname, username):
     return out
 
 
-@pytest.mark.noci
 def test_error_1():
     try:
         connect_and_list("bad.url.gov", "ubuntu")
@@ -19,7 +18,6 @@ def test_error_1():
         assert type(e) == SSHException, "Expected SSException, got: {0}".format(e)
 
 
-@pytest.mark.noci
 def test_error_2():
     try:
         connect_and_list("swift.rcc.uchicago.edu", "mango")
@@ -29,7 +27,6 @@ def test_error_2():
         raise Exception("Expected SSException, got: {0}".format(e))
 
 
-@pytest.mark.noci
 def test_error_3():
     ''' This should work
     '''

--- a/parsl/tests/integration/test_channels/test_ssh_file_transport.py
+++ b/parsl/tests/integration/test_channels/test_ssh_file_transport.py
@@ -10,7 +10,6 @@ def connect_and_list(hostname, username):
     return out
 
 
-@pytest.mark.noci
 def test_push(conn, fname="test001.txt"):
 
     with open(fname, 'w') as f:
@@ -21,7 +20,6 @@ def test_push(conn, fname="test001.txt"):
     print(ec, out, err)
 
 
-@pytest.mark.noci
 def test_pull(conn, fname="test001.txt"):
 
     local = "foo"

--- a/parsl/tests/integration/test_channels/test_ssh_file_transport.py
+++ b/parsl/tests/integration/test_channels/test_ssh_file_transport.py
@@ -1,6 +1,5 @@
 import parsl
 from parsl.channels.ssh.ssh import SSHChannel as SSH
-import pytest
 
 
 def connect_and_list(hostname, username):

--- a/parsl/tests/integration/test_channels/test_ssh_interactive.py
+++ b/parsl/tests/integration/test_channels/test_ssh_interactive.py
@@ -1,6 +1,5 @@
 import parsl
 from parsl.channels.ssh_il.ssh_il import SSHInteractiveLoginChannel as SSH
-import pytest
 
 
 def connect_and_list(hostname, username):

--- a/parsl/tests/integration/test_channels/test_ssh_interactive.py
+++ b/parsl/tests/integration/test_channels/test_ssh_interactive.py
@@ -10,7 +10,6 @@ def connect_and_list(hostname, username):
     return out
 
 
-@pytest.mark.noci
 def test_cooley():
     ''' Test ssh channels to midway
     '''

--- a/parsl/tests/integration/test_early_attach_bug.py
+++ b/parsl/tests/integration/test_early_attach_bug.py
@@ -16,7 +16,6 @@ among the engine once it has been sent to the the engine's queue.
 """
 from parsl import DataFlowKernel, python_app
 import time
-import pytest
 
 from parsl.tests.configs.local_ipp import config
 

--- a/parsl/tests/integration/test_early_attach_bug.py
+++ b/parsl/tests/integration/test_early_attach_bug.py
@@ -28,7 +28,6 @@ def sleep_double(x):
     return x * 2
 
 
-@pytest.mark.noci
 def test_z_cleanup():
     dfk = DataFlowKernel(config=config)
     dfk.cleanup()

--- a/parsl/tests/integration/test_parsl_load_default_config.py
+++ b/parsl/tests/integration/test_parsl_load_default_config.py
@@ -11,7 +11,6 @@ def cpu_stress(inputs=[], outputs=[]):
     return s
 
 
-@pytest.mark.noci
 def test_parsl_load_default_config():
     dfk = parsl.load()
     a1, b1 = [cpu_stress(),

--- a/parsl/tests/integration/test_parsl_load_default_config.py
+++ b/parsl/tests/integration/test_parsl_load_default_config.py
@@ -1,6 +1,5 @@
 import parsl
 from parsl import python_app
-import pytest
 
 
 @python_app

--- a/parsl/tests/integration/test_retries.py
+++ b/parsl/tests/integration/test_retries.py
@@ -46,7 +46,6 @@ def sleep(sleep_dur=0.1):
     return 0
 
 
-@pytest.mark.noci
 def test_fail_nowait(numtasks=10):
     """Test retries on tasks with no dependencies.
     """
@@ -64,7 +63,6 @@ def test_fail_nowait(numtasks=10):
     print("Done")
 
 
-@pytest.mark.noci
 def test_fail_delayed(numtasks=10):
     """Test retries on tasks with dependencies.
 
@@ -87,7 +85,6 @@ def test_fail_delayed(numtasks=10):
     print("Done")
 
 
-@pytest.mark.noci
 def test_retry():
     """Test retries via app that succeeds on the Nth retry.
     """

--- a/parsl/tests/integration/test_retries.py
+++ b/parsl/tests/integration/test_retries.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import pytest
 
 import parsl
 from parsl.app.app import App

--- a/parsl/tests/integration/test_stress/test_python_ipp.py
+++ b/parsl/tests/integration/test_stress/test_python_ipp.py
@@ -2,7 +2,6 @@
 '''
 import parsl
 from parsl import DataFlowKernel, python_app
-import pytest
 
 import time
 import argparse

--- a/parsl/tests/integration/test_stress/test_python_ipp.py
+++ b/parsl/tests/integration/test_stress/test_python_ipp.py
@@ -15,7 +15,6 @@ def increment(x):
     return x + 1
 
 
-@pytest.mark.noci
 def test_stress(count=1000):
     """IPP app launch stress test"""
     start = time.time()

--- a/parsl/tests/integration/test_stress/test_python_simple.py
+++ b/parsl/tests/integration/test_stress/test_python_simple.py
@@ -14,7 +14,6 @@ def increment(x):
     return x + 1
 
 
-@pytest.mark.noci
 def test_stress(count=1000):
     """Threaded app RTT stress test"""
 

--- a/parsl/tests/integration/test_stress/test_python_simple.py
+++ b/parsl/tests/integration/test_stress/test_python_simple.py
@@ -6,8 +6,6 @@ from parsl.configs.htex_local import config
 import time
 import argparse
 
-import pytest
-
 
 @python_app
 def increment(x):

--- a/parsl/tests/integration/test_stress/test_python_threads.py
+++ b/parsl/tests/integration/test_stress/test_python_threads.py
@@ -18,7 +18,6 @@ def increment(x):
     return x + 1
 
 
-@pytest.mark.noci
 def test_stress(count=1000):
     """Threaded app launch stress test"""
     start = time.time()

--- a/parsl/tests/integration/test_stress/test_python_threads.py
+++ b/parsl/tests/integration/test_stress/test_python_threads.py
@@ -3,7 +3,6 @@
 import parsl
 from parsl import python_app
 
-import pytest
 import time
 import argparse
 

--- a/parsl/tests/manual_tests/test_basic.py
+++ b/parsl/tests/manual_tests/test_basic.py
@@ -1,6 +1,5 @@
 import argparse
 import time
-import pytest
 
 import parsl
 # Tested. Confirmed. Local X Local X SingleNodeLauncher

--- a/parsl/tests/manual_tests/test_basic.py
+++ b/parsl/tests/manual_tests/test_basic.py
@@ -77,7 +77,6 @@ def platform(sleep=10, stdout=None):
     return platform.uname()
 
 
-@pytest.mark.noci
 def test_simple(n=2):
     start = time.time()
     x = double(n)
@@ -90,7 +89,6 @@ def test_simple(n=2):
     return True
 
 
-@pytest.mark.noci
 def test_imports(n=2):
     start = time.time()
     x = import_echo(n, "hello world")
@@ -103,7 +101,6 @@ def test_imports(n=2):
     return True
 
 
-@pytest.mark.noci
 def test_platform(n=2):
     # sync
     x = platform(sleep=0)
@@ -119,7 +116,6 @@ def test_platform(n=2):
     return True
 
 
-@pytest.mark.noci
 def test_parallel_for(n=2):
     d = {}
     start = time.time()

--- a/parsl/tests/manual_tests/test_memory_limits.py
+++ b/parsl/tests/manual_tests/test_memory_limits.py
@@ -18,7 +18,6 @@ def double(x):
     return x * 2
 
 
-@pytest.mark.noci
 def test_simple(mem_per_worker):
 
     config = Config(

--- a/parsl/tests/manual_tests/test_memory_limits.py
+++ b/parsl/tests/manual_tests/test_memory_limits.py
@@ -2,7 +2,6 @@ import argparse
 import parsl
 import psutil
 import multiprocessing
-import pytest
 
 from parsl.providers import LocalProvider
 from parsl.channels import LocalChannel

--- a/parsl/tests/manual_tests/test_oauth_ssh.py
+++ b/parsl/tests/manual_tests/test_oauth_ssh.py
@@ -1,5 +1,4 @@
 from parsl.channels import OAuthSSHChannel
-import pytest
 
 
 def test_channel():

--- a/parsl/tests/manual_tests/test_oauth_ssh.py
+++ b/parsl/tests/manual_tests/test_oauth_ssh.py
@@ -2,7 +2,6 @@ from parsl.channels import OAuthSSHChannel
 import pytest
 
 
-@pytest.mark.noci
 def test_channel():
     channel = OAuthSSHChannel(hostname='ssh.demo.globus.org', username='yadunand')
     x, stdout, stderr = channel.execute_wait('ls')

--- a/parsl/tests/manual_tests/test_worker_count.py
+++ b/parsl/tests/manual_tests/test_worker_count.py
@@ -32,7 +32,6 @@ def slow_pid(sleep=1):
     return os.getppid(), os.getpid()
 
 
-@pytest.mark.noci
 def test_worker(n=2, sleep=0):
     d = {}
     start = time.time()

--- a/parsl/tests/manual_tests/test_worker_count.py
+++ b/parsl/tests/manual_tests/test_worker_count.py
@@ -2,7 +2,6 @@ import argparse
 import time
 import math
 import multiprocessing
-import pytest
 
 import parsl
 

--- a/parsl/tests/pytest.ini
+++ b/parsl/tests/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 env =
     PARSL_TESTING=False
-addopts = -x -rs --ignore parsl/tests/integration
+addopts = -x -rs

--- a/parsl/tests/pytest.ini
+++ b/parsl/tests/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 env =
-    PARSL_TESTING=True
-addopts = -x -rs --ignore parsl/tests/integration --ignore tests/integration --ignore integration
+    PARSL_TESTING=False
+addopts = -x -rs --ignore parsl/tests/integration

--- a/parsl/tests/sites/test_ec2.py
+++ b/parsl/tests/sites/test_ec2.py
@@ -1,5 +1,3 @@
-import pytest
-
 import parsl
 
 if __name__ == "__main__":

--- a/parsl/tests/sites/test_ec2.py
+++ b/parsl/tests/sites/test_ec2.py
@@ -39,7 +39,6 @@ def bash_app(stdout=None, stderr=None):
 
 
 # @pytest.mark.local
-@pytest.mark.noci
 def test_python(N=2):
     """Testing basic python functionality."""
 
@@ -62,7 +61,6 @@ local_config = config
 
 
 # @pytest.mark.local
-@pytest.mark.noci
 def test_bash():
     """Testing basic bash functionality."""
 

--- a/parsl/tests/workqueue_tests/test_scale.py
+++ b/parsl/tests/workqueue_tests/test_scale.py
@@ -46,7 +46,6 @@ def platform(sleep=10, stdout=None):
     return platform.uname()
 
 
-@pytest.mark.noci
 def test_simple(n=2):
     start = time.time()
     x = double(n)
@@ -59,7 +58,6 @@ def test_simple(n=2):
     return True
 
 
-@pytest.mark.noci
 def test_imports(n=2):
     start = time.time()
     x = import_echo(n, "hello world")
@@ -72,7 +70,6 @@ def test_imports(n=2):
     return True
 
 
-@pytest.mark.noci
 def test_platform(n=2, sleep=1):
 
     dfk = parsl.dfk()
@@ -102,7 +99,6 @@ def test_platform(n=2, sleep=1):
     return True
 
 
-@pytest.mark.noci
 def test_parallel_for(n=2, sleep=1):
     d = {}
 

--- a/parsl/tests/workqueue_tests/test_scale.py
+++ b/parsl/tests/workqueue_tests/test_scale.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import pytest
 import argparse
 import time
 


### PR DESCRIPTION
This leaves the marker implementation in case it is needed in the
future, but removes its use in favor of implementing a
`pytest_ignore_collect` function in `conftest.py`. The advantage of this
is it removes the need to append each pytest invocation with `-k not
noci`, which is needed by definition. The disadvantage is that, since we
mix pytest and non-pytest tests in the testing directory, this
obfuscates which tests will be ignored by pytest.