### PR TITLE
Remove vestigial scheme enumeration

### DIFF
--- a/parsl/app/futures.py
+++ b/parsl/app/futures.py
@@ -71,8 +71,7 @@ class DataFuture(Future):
             else:
                 raise NotFutureError("DataFuture can be created only with a FunctionFuture on None")
 
-        logger.debug("Creating DataFuture with parent: %s", self.parent)
-        logger.debug("Filepath: %s", self.filepath)
+        logger.debug("Creating DataFuture with parent: %s and file: %s", self.parent, repr(self.file_obj))
 
     @property
     def tid(self):
@@ -120,11 +119,11 @@ class DataFuture(Future):
                             _STATE_TO_DESCRIPTION_MAP[parent._state],
                             parent._exception.__class__.__name__)
                     else:
-                        return '<%s at %#x state=%s returned %s>' % (
+                        return '<%s at %#x state=%s with file %s>' % (
                             self.__class__.__name__,
                             id(self),
                             _STATE_TO_DESCRIPTION_MAP[parent._state],
-                            self.filepath)
+                            repr(self.file_obj))
                 return '<%s at %#x state=%s>' % (
                     self.__class__.__name__,
                     id(self),

--- a/parsl/data_provider/files.py
+++ b/parsl/data_provider/files.py
@@ -63,7 +63,10 @@ class File(object):
         """Return the resolved filepath on the side where it is called from.
 
         The appropriate filepath will be returned when called from within
-        an app running remotely as well as regular python on the client side.
+        an app running remotely as well as regular python on the submit side.
+
+        Only file: scheme URLs make sense to have a submit-side path, as other
+        URLs are not accessible through POSIX file access.
 
         Args:
             - self
@@ -73,12 +76,10 @@ class File(object):
         if hasattr(self, 'local_path'):
             return self.local_path
 
-        if self.scheme in ['ftp', 'http', 'https', 'globus']:
-            return self.filename
-        elif self.scheme in ['file']:
+        if self.scheme in ['file']:
             return self.path
         else:
-            raise Exception('Cannot return filepath for unknown scheme {}'.format(self.scheme))
+            raise ValueError("No local_path set for {}".format(repr(self)))
 
 
 if __name__ == '__main__':

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -517,7 +517,7 @@ class DataFlowKernel(object):
                 if newfunc:
                     func = newfunc
             else:
-                logger.debug("Not performing staging for: {}".format(f))
+                logger.debug("Not performing staging for: {}".format(repr(f)))
                 app_fut._outputs.append(DataFuture(app_fut, f, tid=app_fut.tid))
         return func
 


### PR DESCRIPTION
It should be up to staging providers to specify the appropriate
local_path for all schemes, except for file: which has an
implicit meaning on the submit side POSIX filesystem.

File.filepath will now throw an exception in many cases where
this does not make sense. As a consequence, some log messages
throughout the codebase are adjusted to not call filepath,
and instead use the full File repr.

Consequent changes are needed for the existing staging provider
to make them work.

Staging providers that attempted to implement a differently
named scheme would fail.#

This is related to the localpath problems in #1197 