### PR TITLE
Remove calls to super() which probably should be self, in providers/

### DIFF
--- a/parsl/providers/cobalt/cobalt.py
+++ b/parsl/providers/cobalt/cobalt.py
@@ -98,7 +98,7 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
 
         jobs_missing = list(self.resources.keys())
 
-        retcode, stdout, stderr = super().execute_wait("qstat -u $USER")
+        retcode, stdout, stderr = self.execute_wait("qstat -u $USER")
 
         # Execute_wait failed. Do no update.
         if retcode != 0:
@@ -183,7 +183,7 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
             self.nodes_per_block, queue_opt, wtime_to_minutes(self.walltime), account_opt, channel_script_path)
         logger.debug("Executing {}".format(command))
 
-        retcode, stdout, stderr = super().execute_wait(command)
+        retcode, stdout, stderr = self.execute_wait(command)
 
         # TODO : FIX this block
         if retcode != 0:
@@ -216,7 +216,7 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
         """
 
         job_id_list = ' '.join(job_ids)
-        retcode, stdout, stderr = super().execute_wait("qdel {0}".format(job_id_list))
+        retcode, stdout, stderr = self.execute_wait("qdel {0}".format(job_id_list))
         rets = None
         if retcode == 0:
             for jid in job_ids:

--- a/parsl/providers/condor/condor.py
+++ b/parsl/providers/condor/condor.py
@@ -114,7 +114,7 @@ class CondorProvider(RepresentationMixin, ClusterProvider):
 
         job_id_list = ' '.join(self.resources.keys())
         cmd = "condor_q {0} -af:jr JobStatus".format(job_id_list)
-        retcode, stdout, stderr = super().execute_wait(cmd)
+        retcode, stdout, stderr = self.execute_wait(cmd)
         """
         Example output:
 
@@ -226,7 +226,7 @@ class CondorProvider(RepresentationMixin, ClusterProvider):
 
         cmd = "condor_submit {0}".format(channel_script_path)
         try:
-            retcode, stdout, stderr = super().execute_wait(cmd)
+            retcode, stdout, stderr = self.execute_wait(cmd)
         except Exception as e:
             raise ScaleOutFailed(self.label, str(e))
 
@@ -269,7 +269,7 @@ class CondorProvider(RepresentationMixin, ClusterProvider):
         job_id_list = ' '.join(job_ids)
         cmd = "condor_rm {0}; condor_rm -forcex {0}".format(job_id_list)
         logger.debug("Attempting removal of jobs : {0}".format(cmd))
-        retcode, stdout, stderr = super().execute_wait(cmd)
+        retcode, stdout, stderr = self.execute_wait(cmd)
         rets = None
         if retcode == 0:
             for jid in job_ids:

--- a/parsl/providers/grid_engine/grid_engine.py
+++ b/parsl/providers/grid_engine/grid_engine.py
@@ -141,7 +141,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
 
         channel_script_path = self.channel.push_file(script_path, self.channel.script_dir)
         cmd = "qsub -terse {0}".format(channel_script_path)
-        retcode, stdout, stderr = super().execute_wait(cmd, 10)
+        retcode, stdout, stderr = self.execute_wait(cmd, 10)
 
         if retcode == 0:
             for line in stdout.split('\n'):
@@ -169,7 +169,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
 
         cmd = "qstat"
 
-        retcode, stdout, stderr = super().execute_wait(cmd)
+        retcode, stdout, stderr = self.execute_wait(cmd)
 
         # Execute_wait failed. Do no update
         if retcode != 0:
@@ -207,7 +207,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
 
         job_id_list = ' '.join(job_ids)
         cmd = "qdel {}".format(job_id_list)
-        retcode, stdout, stderr = super().execute_wait(cmd, 3)
+        retcode, stdout, stderr = self.execute_wait(cmd, 3)
 
         rets = None
         if retcode == 0:

--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -125,7 +125,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         job_id_list = ','.join(self.resources.keys())
         cmd = "squeue --job {0}".format(job_id_list)
 
-        retcode, stdout, stderr = super().execute_wait(cmd)
+        retcode, stdout, stderr = self.execute_wait(cmd)
 
         # Execute_wait failed. Do no update
         if retcode != 0:
@@ -209,7 +209,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
             logger.debug("not moving files")
             channel_script_path = script_path
 
-        retcode, stdout, stderr = super().execute_wait("sbatch {0}".format(channel_script_path))
+        retcode, stdout, stderr = self.execute_wait("sbatch {0}".format(channel_script_path))
 
         job_id = None
         if retcode == 0:
@@ -233,7 +233,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         '''
 
         job_id_list = ' '.join(job_ids)
-        retcode, stdout, stderr = super().execute_wait("scancel {0}".format(job_id_list))
+        retcode, stdout, stderr = self.execute_wait("scancel {0}".format(job_id_list))
         rets = None
         if retcode == 0:
             for jid in job_ids:

--- a/parsl/providers/torque/torque.py
+++ b/parsl/providers/torque/torque.py
@@ -114,7 +114,7 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
 
         jobs_missing = list(self.resources.keys())
 
-        retcode, stdout, stderr = super().execute_wait("qstat {0}".format(job_id_list))
+        retcode, stdout, stderr = self.execute_wait("qstat {0}".format(job_id_list))
         for line in stdout.split('\n'):
             parts = line.split()
             if not parts or parts[0].upper().startswith('JOB') or parts[0].startswith('---'):
@@ -198,7 +198,7 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
             submit_options = '{0} -A {1}'.format(submit_options, self.account)
 
         launch_cmd = "qsub {0} {1}".format(submit_options, channel_script_path)
-        retcode, stdout, stderr = super().execute_wait(launch_cmd)
+        retcode, stdout, stderr = self.execute_wait(launch_cmd)
 
         job_id = None
         if retcode == 0:
@@ -225,7 +225,7 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
         '''
 
         job_id_list = ' '.join(job_ids)
-        retcode, stdout, stderr = super().execute_wait("qdel {0}".format(job_id_list))
+        retcode, stdout, stderr = self.execute_wait("qdel {0}".format(job_id_list))
         rets = None
         if retcode == 0:
             for jid in job_ids:


### PR DESCRIPTION
This shouldn't change parsl behaviour when using the providers directly, but
would affect any subclasses which attempt override the affected methods. (I am not
aware of any such subclasses)

Prior to this commit, subclasses could not override the affected methods.

Now they can.

This commit is more about tidying away unnecessarily complicated uses of
super() from the codebase, rather than fixing an immediate bug.

It looks like the many references to super() came from copy-paste of some
original code.