### PR TITLE
Elevate a warning message about appcaching to warning level

### DIFF
--- a/parsl/app/app.py
+++ b/parsl/app/app.py
@@ -53,7 +53,7 @@ class AppBase(metaclass=ABCMeta):
             try:
                 self.fn_source = getsource(func)
             except OSError:
-                logger.debug("Unable to get source code for AppCaching. Recommend creating module")
+                logger.warning("Unable to get source code for AppCaching. Recommend creating module")
                 self.fn_source = func.__name__
 
             self.func_hash = md5(self.fn_source.encode('utf-8')).hexdigest()


### PR DESCRIPTION
If this message fires, the user should be aware that it is happening
in more than debug level logging