### PR TITLE
Extend mypy checking to more of the codebase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ script:
     - MYPYPATH=$(pwd)/mypy-stubs mypy parsl/tests/configs/
     - MYPYPATH=$(pwd)/mypy-stubs mypy parsl/tests/test*/
     - MYPYPATH=$(pwd)/mypy-stubs mypy parsl/tests/sites/
+    - MYPYPATH=$(pwd)/mypy-stubs mypy parsl/app/ parsl/channels/ parsl/dataflow/ parsl/data_provider/ parsl/launchers parsl/providers/
 
       # do this before any testing, but not in-between tests
     - rm -f .coverage


### PR DESCRIPTION
Previously, mypy only checked main parsl code which was imported
through any of the tests or test configs. This PR extends that to
any code in any of the enumerated main parsl code directories.

Not all of the parsl source tree passes mypy at the moment, which
is why there is an explicity whitelist of directories, rather than
a single `mypy parsl/`.

Notably, the following directories do not pass `mypy` checking at
the moment and are excluded from the list:

  parsl/executors/
  parsl/configs/

as well as the remaining parts of:

  parsl/test/

that are not already checked.

This PR does not attempt to fix up any of the mypy problems in
those directories.