### PR TITLE
Catch and log errors in flow control callback

### DIFF
--- a/parsl/dataflow/flow_control.py
+++ b/parsl/dataflow/flow_control.py
@@ -136,7 +136,10 @@ class FlowControl(object):
                  triggered the callback
         """
         self._wake_up_time = time.time() + self.interval
-        self.callback(tasks=self._event_buffer, kind=kind)
+        try:
+            self.callback(tasks=self._event_buffer, kind=kind)
+        except Exception:
+            logger.error("Flow control callback threw an exception - logging and proceeding anyway", exc_info=True)
         self._event_buffer = []
 
     def close(self):


### PR DESCRIPTION
Prior to this, exceptions raised by the flow control
callback caused the flow control thread to die.

After this, exceptions raised by the flow control
callback are logged with a stack trace, but flow
control continues.