### PR TITLE
Give processes/threads human readable names to aid debugging

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -161,10 +161,10 @@ class DataFlowKernel(object):
             try:
                 h, m, s = map(int, config.checkpoint_period.split(':'))
                 checkpoint_period = (h * 3600) + (m * 60) + s
-                self._checkpoint_timer = Timer(self.checkpoint, interval=checkpoint_period)
+                self._checkpoint_timer = Timer(self.checkpoint, interval=checkpoint_period, name="Checkpoint")
             except Exception:
                 logger.error("invalid checkpoint_period provided: {0} expected HH:MM:SS".format(config.checkpoint_period))
-                self._checkpoint_timer = Timer(self.checkpoint, interval=(30 * 60))
+                self._checkpoint_timer = Timer(self.checkpoint, interval=(30 * 60), name="Checkpoint")
 
         # if we use the functionality of dynamically adding executors
         # all executors should be managed.

--- a/parsl/dataflow/flow_control.py
+++ b/parsl/dataflow/flow_control.py
@@ -93,7 +93,7 @@ class FlowControl(object):
         self._event_buffer = []
         self._wake_up_time = time.time() + 1
         self._kill_event = threading.Event()
-        self._thread = threading.Thread(target=self._wake_up_timer, args=(self._kill_event,))
+        self._thread = threading.Thread(target=self._wake_up_timer, args=(self._kill_event,), name="FlowControl-Thread")
         self._thread.daemon = True
         self._thread.start()
 
@@ -165,7 +165,7 @@ class Timer(object):
 
     """
 
-    def __init__(self, callback, *args, interval=5):
+    def __init__(self, callback, *args, interval=5, name=None):
         """Initialize the flowcontrol object
         We start the timer thread here
 
@@ -175,6 +175,7 @@ class Timer(object):
         KWargs:
              - threshold (int) : Tasks after which the callback is triggered
              - interval (int) : seconds after which timer expires
+             - name (str) : a base name to use when naming the started thread
         """
 
         self.interval = interval
@@ -183,7 +184,11 @@ class Timer(object):
         self._wake_up_time = time.time() + 1
 
         self._kill_event = threading.Event()
-        self._thread = threading.Thread(target=self._wake_up_timer, args=(self._kill_event,))
+        if name is None:
+            name = "Timer-Thread-{}".format(id(self))
+        else:
+            name = "{}-Timer-Thread-{}".format(name, id(self))
+        self._thread = threading.Thread(target=self._wake_up_timer, args=(self._kill_event,), name=name)
         self._thread.daemon = True
         self._thread.start()
 

--- a/parsl/dataflow/usage_tracking/usage.py
+++ b/parsl/dataflow/usage_tracking/usage.py
@@ -20,7 +20,7 @@ def async_process(fn):
     """ Decorator function to launch a function as a separate process """
 
     def run(*args, **kwargs):
-        proc = mp.Process(target=fn, args=args, kwargs=kwargs)
+        proc = mp.Process(target=fn, args=args, kwargs=kwargs, name="Usage-Tracking")
         proc.start()
         return proc
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -427,6 +427,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                                           "poll_period": self.poll_period,
                                           "logging_level": logging.DEBUG if self.worker_debug else logging.INFO
                                   },
+                                  name="HTEX-Interchange"
         )
         self.queue_proc.start()
         try:
@@ -446,7 +447,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         """
         if self._queue_management_thread is None:
             logger.debug("Starting queue management thread")
-            self._queue_management_thread = threading.Thread(target=self._queue_management_worker)
+            self._queue_management_thread = threading.Thread(target=self._queue_management_worker, name="HTEX-Queue-Management-Thread")
             self._queue_management_thread.daemon = True
             self._queue_management_thread.start()
             logger.debug("Started queue management thread")

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -343,11 +343,13 @@ class Interchange(object):
 
         self._kill_event = threading.Event()
         self._task_puller_thread = threading.Thread(target=self.migrate_tasks_to_internal,
-                                                    args=(self._kill_event,))
+                                                    args=(self._kill_event,),
+                                                    name="Interchange-Task-Puller")
         self._task_puller_thread.start()
 
         self._command_thread = threading.Thread(target=self._command_server,
-                                                args=(self._kill_event,))
+                                                args=(self._kill_event,),
+                                                name="Interchange-Command")
         self._command_thread.start()
 
         poller = zmq.Poller()

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -317,16 +317,18 @@ class Manager(object):
                                                              self.pending_task_queue,
                                                              self.pending_result_queue,
                                                              self.ready_worker_queue,
-                                                         ))
+                                                         ), name="HTEX-Worker-{}".format(worker_id))
             p.start()
             self.procs[worker_id] = p
 
         logger.debug("Manager synced with workers")
 
         self._task_puller_thread = threading.Thread(target=self.pull_tasks,
-                                                    args=(self._kill_event,))
+                                                    args=(self._kill_event,),
+                                                    name="Task-Puller")
         self._result_pusher_thread = threading.Thread(target=self.push_results,
-                                                      args=(self._kill_event,))
+                                                      args=(self._kill_event,),
+                                                      name="Result-Pusher")
         self._task_puller_thread.start()
         self._result_pusher_thread.start()
 

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -223,19 +223,22 @@ class DatabaseManager(object):
         self._kill_event = threading.Event()
         self._priority_queue_pull_thread = threading.Thread(target=self._migrate_logs_to_internal,
                                                             args=(
-                                                                priority_queue, 'priority', self._kill_event,)
+                                                                priority_queue, 'priority', self._kill_event,),
+                                                            name="Monitoring-migrate-priority"
                                                             )
         self._priority_queue_pull_thread.start()
 
         self._node_queue_pull_thread = threading.Thread(target=self._migrate_logs_to_internal,
                                                         args=(
-                                                            node_queue, 'node', self._kill_event,)
+                                                            node_queue, 'node', self._kill_event,),
+                                                        name="Monitoring-migrate-node"
                                                         )
         self._node_queue_pull_thread.start()
 
         self._resource_queue_pull_thread = threading.Thread(target=self._migrate_logs_to_internal,
                                                             args=(
-                                                                resource_queue, 'resource', self._kill_event,)
+                                                                resource_queue, 'resource', self._kill_event,),
+                                                            name="Monitoring-migrate-resource"
                                                             )
         self._resource_queue_pull_thread.start()
 

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -235,6 +235,7 @@ class MonitoringHub(RepresentationMixin):
                                           "logging_level": self.logging_level,
                                           "run_id": run_id
                                   },
+                                  name="Monitoring-Queue-Process"
         )
         self.queue_proc.start()
 
@@ -244,6 +245,7 @@ class MonitoringHub(RepresentationMixin):
                                         "logging_level": self.logging_level,
                                         "db_url": self.logging_endpoint,
                                   },
+                                name="Monitoring-DBM-Process"
         )
         self.dbm_proc.start()
 
@@ -285,7 +287,7 @@ class MonitoringHub(RepresentationMixin):
         Wrap the Parsl app with a function that will call the monitor function and point it at the correct pid when the task begins.
         """
         def wrapped(*args, **kwargs):
-            p = Process(target=monitor, args=(os.getpid(), task_id, monitoring_hub_url, run_id, sleep_dur))
+            p = Process(target=monitor, args=(os.getpid(), task_id, monitoring_hub_url, run_id, sleep_dur), name="Monitor-Wrapper-{}".format(task_id))
             p.start()
             try:
                 return f(*args, **kwargs)

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -101,7 +101,7 @@ def timeout(seconds=None):
     def decorator(func, *args, **kwargs):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            t = threading.Thread(target=func, args=args, kwargs=kwargs)
+            t = threading.Thread(target=func, args=args, kwargs=kwargs, name="Timeout-Decorator")
             t.start()
             result = t.join(seconds)
             if t.is_alive():


### PR DESCRIPTION
Prior to this, the threads touched in this PR were named with
sequential numbers.

Thread exceptions will now look like this:

```
Exception in thread FlowControl-Thread:
Traceback (most recent call last):
```