### PR TITLE
Flag interchange process as daemon to reduce shutdown hangs

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -427,6 +427,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
                                           "poll_period": self.poll_period,
                                           "logging_level": logging.DEBUG if self.worker_debug else logging.INFO
                                   },
+                                  daemon=True
         )
         self.queue_proc.start()
         try:


### PR DESCRIPTION
Setting the daemon flag causes a process which has encountered some
error condition such as a provider timeout to exit rather than hang.

I think what was going on before was that the interchange would not
shut down, so no atexit behaviour would fire that would cause the
interchange to shut down.

It is, I think, more proper that the interchange be killed at
process shutdown.

In a test on cori using a cmd_timeout deliberately set low to 2
seconds, using LocalChannel and HighThroughputExecutor, runs go
from hanging 4 out of 5 tests, to hanging 0 out of 5 tests.