### PR TITLE
Fix userguide and test for @bash_app exit codes

### DIFF
--- a/docs/userguide/apps.rst
+++ b/docs/userguide/apps.rst
@@ -122,8 +122,10 @@ to the decorated function. The string that is returned is formatted by the Pytho
 Returns
 ^^^^^^^
 
-A Bash app returns an AppFuture just like a Python app, however the values returned by the
-future are different. The result made available upon
-completion is the **return/exit code** of the Bash script. This future may also hold various
-exceptions that capture errors during execution such as incorrect privileges, missing output
-files, etc.
+A Bash app returns an AppFuture just like a Python app; however the value returned inside the
+AppFuture has no real meaning.
+
+If a bash app exits with unix exit code 0, then the AppFuture will complete. If a bash app
+exits with any other code, this will be treated as a failure, and the AppFuture will instead
+contain an AppFailure exception. The unix edit code can be accessed through the
+`exitcode` attribute of that AppFailure.

--- a/parsl/tests/test_bash_apps/test_error_codes.py
+++ b/parsl/tests/test_bash_apps/test_error_codes.py
@@ -20,7 +20,7 @@ def command_not_found(stderr='std.err', stdout='std.out'):
 
 @bash_app
 def bash_misuse(stderr='std.err', stdout='std.out'):
-    cmd_line = 'exit(15)'
+    cmd_line = 'exit 15'
     return cmd_line
 
 
@@ -101,7 +101,6 @@ def test_div_0(test_fn=div_0):
     return True
 
 
-@pytest.mark.skip('broken')
 def test_bash_misuse(test_fn=bash_misuse):
     err_code = test_matrix[test_fn]['exit_code']
     f = test_fn()

--- a/parsl/tests/test_bash_apps/test_error_codes.py
+++ b/parsl/tests/test_bash_apps/test_error_codes.py
@@ -5,6 +5,8 @@ import pytest
 
 import parsl
 from parsl.app.app import bash_app
+import parsl.app.errors as pe
+
 
 from parsl.tests.configs.local_threads import config
 
@@ -106,14 +108,13 @@ def test_bash_misuse(test_fn=bash_misuse):
     f = test_fn()
     try:
         f.result()
-    except Exception as e:
-        print("Caught exception", e)
+    except pe.AppFailure as e:
+        print("Caught expected AppFailure", e)
         assert e.exitcode == err_code, "{0} expected err_code:{1} but got {2}".format(test_fn.__name__,
                                                                                       err_code,
                                                                                       e.exitcode)
     os.remove('std.err')
     os.remove('std.out')
-    return True
 
 
 # @pytest.mark.whitelist(whitelist, reason='broken in IPP')

--- a/parsl/tests/test_bash_apps/test_error_codes.py
+++ b/parsl/tests/test_bash_apps/test_error_codes.py
@@ -117,14 +117,12 @@ def test_bash_misuse(test_fn=bash_misuse):
     os.remove('std.out')
 
 
-# @pytest.mark.whitelist(whitelist, reason='broken in IPP')
-@pytest.mark.skip("Broke somewhere between PR #525 and PR #652")
 def test_command_not_found(test_fn=command_not_found):
     err_code = test_matrix[test_fn]['exit_code']
     f = test_fn()
     try:
         f.result()
-    except Exception as e:
+    except pe.AppFailure as e:
         print("Caught exception", e)
         assert e.exitcode == err_code, "{0} expected err_code:{1} but got {2}".format(test_fn.__name__,
                                                                                       err_code,

--- a/parsl/tests/test_bash_apps/test_error_codes.py
+++ b/parsl/tests/test_bash_apps/test_error_codes.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 import parsl
-from parsl.app.app import App
+from parsl.app.app import bash_app
 
 from parsl.tests.configs.local_threads import config
 
@@ -12,37 +12,37 @@ from parsl.tests.configs.local_threads import config
 local_config = config
 
 
-@App('bash')
+@bash_app
 def command_not_found(stderr='std.err', stdout='std.out'):
     cmd_line = 'catdogcat'
     return cmd_line
 
 
-@App('bash')
+@bash_app
 def bash_misuse(stderr='std.err', stdout='std.out'):
     cmd_line = 'exit(15)'
     return cmd_line
 
 
-@App('bash')
+@bash_app
 def div_0(stderr='std.err', stdout='std.out'):
     cmd_line = '$((5/0))'
     return cmd_line
 
 
-@App('bash')
+@bash_app
 def invalid_exit(stderr='std.err', stdout='std.out'):
     cmd_line = 'exit 3.141'
     return cmd_line
 
 
-@App('bash')
+@bash_app
 def not_executable(stderr='std.err', stdout='std.out'):
     cmd_line = '/dev/null'
     return cmd_line
 
 
-@App('bash')
+@bash_app
 def bad_format(stderr='std.err', stdout='std.out'):
     cmd_line = 'echo {0}'
     return cmd_line


### PR DESCRIPTION
This PR changes the user guide to describe the actual behaviour of the code wrt bash_app unix exit codes.

Two previously broken tests are fixed to test that behaviour.

Fixes issue #802 