### PR TITLE
Fix race condition in checkpoint test (issue #681)

### DIFF
--- a/parsl/tests/test_checkpointing/test_regression_233.py
+++ b/parsl/tests/test_checkpointing/test_regression_233.py
@@ -20,8 +20,11 @@ def run_checkpointed(checkpoints):
         x = cached_rand(i)
         items.append(x)
 
+    # wait for all of the results
+    results = [i.result() for i in items]
+
     dfk.cleanup()
-    return [i.result() for i in items], dfk.run_dir
+    return results, dfk.run_dir
 
 
 def run_race(sleep_dur):
@@ -58,7 +61,6 @@ def test_slower_apps():
 
 
 @pytest.mark.local
-@pytest.mark.skip('fails due to likely race in checkpointing; see issue #681')
 def test_checkpoint_availability():
     import os
 


### PR DESCRIPTION
The test previously made the incorrect assumption that
future.result() returning meant that the checkpoint for
the corresponding app had been written out.

The assumption made by the test after this commit is:

If future.result() has returned, and then *after that*
dfk.cleanup() has been invoked and returned, then
the checkpoint for the corresponding app has been
written out.

This test was previously skipped because of this race
condition, but is re-enabled in this PR.