### PR TITLE
Add a lot of debugging around File.local_path

### DIFF
--- a/parsl/data_provider/files.py
+++ b/parsl/data_provider/files.py
@@ -43,6 +43,7 @@ class File(object):
         self.netloc = parsed_url.netloc
         self.path = parsed_url.path
         self.filename = os.path.basename(self.path)
+        self._local_path = None
 
     def __str__(self):
         return self.filepath
@@ -50,13 +51,23 @@ class File(object):
     def __repr__(self):
         content = "{0} at 0x{1:x} url={2} scheme={3} netloc={4} path={5} filename={6}".format(
             self.__class__, id(self), self.url, self.scheme, self.netloc, self.path, self.filename)
-        if hasattr(self, 'local_path'):
-            content += " local_path={0}".format(self.local_path)
+        content += " _local_path={0}".format(self._local_path)
 
         return "<{}>".format(content)
 
     def __fspath__(self):
         return self.filepath
+
+    @property
+    def local_path(self):
+        return self._local_path
+
+    @local_path.setter
+    def local_path(self, p):
+        if self._local_path is None:
+            self._local_path = p
+        else:
+            raise ValueError("Local path is already set for file {}".format(repr(self)))
 
     @property
     def filepath(self):
@@ -70,7 +81,8 @@ class File(object):
         Returns:
              - filepath (string)
         """
-        if hasattr(self, 'local_path'):
+        if self._local_path is not None:
+            logger.debug("File {} has filepath from local_path {}".format(repr(self), self._local_path))
             return self.local_path
 
         if self.scheme in ['ftp', 'http', 'https', 'globus']:

--- a/parsl/tests/test_bash_apps/test_pipeline.py
+++ b/parsl/tests/test_bash_apps/test_pipeline.py
@@ -53,9 +53,7 @@ def test_increment(depth=5):
             file = fu.result()
             filename = file.filepath
 
-            # this test is a bit close to a test of the specific implementation
-            # of File
-            assert not hasattr(file, 'local_path'), "File on local side has overridden local_path, file: {}".format(repr(file))
+            assert file.local_path is None, "File on local side has overridden local_path, file: {}".format(repr(file))
 
             data = open(filename, 'r').read().strip()
             assert data == str(


### PR DESCRIPTION
This PR converts local_path into a `@property`.

It then adds log messages around related to use of local_path.

It also makes repeated assignment to local_path an invalid operation which
will now raise an exception. This is to help detect/debug improper sharing
of File objects, as might be encountered in situations related to issues #1197 and #308 
although this PR does not attempt to fix any of those issues.