### PR TITLE
Remove use of __del__ in monitoring

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -190,9 +190,6 @@ class Database(object):
             PrimaryKeyConstraint('task_id', 'run_id', 'timestamp'),
         )
 
-    def __del__(self):
-        self.session.close()
-
 
 class DatabaseManager(object):
     def __init__(self,

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -121,9 +121,6 @@ class UDPRadio(object):
             return False
         return x
 
-    def __del__(self):
-        self.sock.close()
-
 
 class MonitoringHub(RepresentationMixin):
     def __init__(self,
@@ -277,9 +274,6 @@ class MonitoringHub(RepresentationMixin):
             self.logger.info("Terminating Hub")
             self.queue_proc.terminate()
             self.priority_msgs.put(("STOP", 0))
-
-    def __del__(self):
-        self.close()
 
     @staticmethod
     def monitor_wrapper(f, task_id, monitoring_hub_url, run_id, sleep_dur):


### PR DESCRIPTION
This was a bad use (IMO) of __del__ and frequently threw
exceptions at python shutdown.

Fixes #1044 