### PR TITLE
Restore PR1200 executor future callback order

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -246,8 +246,6 @@ class DataFlowKernel(object):
              makes this callback
         """
 
-        self.tasks[task_id]['app_fu'].parent_callback(future)
-
         try:
             res = future.result()
             if isinstance(res, RemoteExceptionWrapper):
@@ -300,6 +298,8 @@ class DataFlowKernel(object):
         # pending - in which case, we should consider ourself for relaunch
         if self.tasks[task_id]['status'] == States.pending:
             self.launch_if_ready(task_id)
+
+        self.tasks[task_id]['app_fu'].parent_callback(future)
 
         return
 


### PR DESCRIPTION
Callbacks on executor futures are executed in the order
they were added, so PR1200 should properly have made the
AppFuture callback at the end, rather than at the start,
of DFK executor callback processing.

This PR restores that order.

The new (and original) order means that the DFK will
record jobs as finished before setting the AppFuture,
which in turn means that the DFK will record jobs as
finished before the main workflow becomes aware of
the AppFuture completing, which further in turn means
that the DFK will have done that recording before
the main workflow falls of the end and exits.

The different there seems to be that in the 
post-PR1200 pre-this-PR case, workflows end with tasks
not recorded as finished:

2019-09-09 08:19:26.454 parsl.dataflow.dflow:747 [INFO]  Summary of tasks in DFK:
2019-09-09 08:19:26.454 parsl.dataflow.dflow:778 [INFO]  Tasks in state States.done: 0, 1, 3, 4
2019-09-09 08:19:26.454 parsl.dataflow.dflow:778 [INFO]  Tasks in state States.launched: 2


rather than like this:

2019-09-09 09:17:38 parsl.dataflow.dflow:747 [INFO]  Summary of tasks in DFK:
2019-09-09 09:17:38 parsl.dataflow.dflow:778 [INFO]  Tasks in state States.done: 0, 1, 2, 3, 4

as they are recorded as finished shortly after the above log happens.