### PR TITLE
Fixup checkpoint 'task_exit' test

### DIFF
--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -122,8 +122,8 @@ def wait_for_file(path, seconds=10):
 
 @contextmanager
 def time_limited_open(path, mode, seconds=1):
-    wait_for_file(path, seconds)
-
+    with wait_for_file(path, seconds):
+        logger.debug("wait_for_file yielded")
     f = open(path, mode)
     yield f
     f.close()


### PR DESCRIPTION
* Fix incorrect attribute name for DFK run directory
* Fix time_limited_open incorrectly using wait_for_file context manager
* Add some notes on race conditions
* Re-enable test