### PR TITLE
Fixup and re-enable bash memoization test

### DIFF
--- a/parsl/tests/test_bash_apps/test_memoize.py
+++ b/parsl/tests/test_bash_apps/test_memoize.py
@@ -14,7 +14,6 @@ def fail_on_presence(outputs=[]):
     return 'if [ -f {0} ] ; then exit 1 ; else touch {0}; fi'.format(outputs[0])
 
 
-@pytest.mark.xfail(reason="This test demonstrates issue #1269: broken @bash_app checkpointing", strict=True)
 def test_bash_memoization(n=2):
     """Testing bash memoization
     """
@@ -32,7 +31,7 @@ def test_bash_memoization(n=2):
         d[i] = fail_on_presence(outputs=[temp_filename])
 
     for i in d:
-        assert isinstance(d[i].exception(), AppFailure)
+        assert d[i].exception() == None
 
 
 if __name__ == '__main__':

--- a/parsl/tests/test_bash_apps/test_memoize.py
+++ b/parsl/tests/test_bash_apps/test_memoize.py
@@ -14,7 +14,7 @@ def fail_on_presence(outputs=[]):
     return 'if [ -f {0} ] ; then exit 1 ; else touch {0}; fi'.format(outputs[0])
 
 
-@pytest.mark.xfail(reason="This failing test demonstrates broken @bash_app checkpointing", strict=True)
+@pytest.mark.xfail(reason="This test demonstrates issue #1269: broken @bash_app checkpointing", strict=True)
 def test_bash_memoization(n=2):
     """Testing bash memoization
     """

--- a/parsl/tests/test_bash_apps/test_memoize.py
+++ b/parsl/tests/test_bash_apps/test_memoize.py
@@ -1,0 +1,53 @@
+import argparse
+import os
+
+import pytest
+
+import parsl
+from parsl.app.app import App
+from parsl.tests.configs.local_threads import config
+from parsl.app.errors import AppFailure
+
+
+@App('bash', cache=True)
+def fail_on_presence(outputs=[]):
+    return 'if [ -f {0} ] ; then exit 1 ; else touch {0}; fi'.format(outputs[0])
+
+
+@pytest.mark.xfail(reason="This failing test demonstrates broken @bash_app checkpointing", strict=True)
+def test_bash_memoization(n=2):
+    """Testing bash memoization
+    """
+    temp_filename = "test.memoization.tmp"
+
+    if os.path.exists(temp_filename):
+        os.remove(temp_filename)
+
+    print("Launching: ", n)
+    x = fail_on_presence(outputs=[temp_filename])
+    x.result()
+
+    d = {}
+    for i in range(0, n):
+        d[i] = fail_on_presence(outputs=[temp_filename])
+
+    print("Waiting for results from round1")
+    for i in d:
+        assert isinstance(d[i].exception(), AppFailure)
+
+
+if __name__ == '__main__':
+    parsl.clear()
+    parsl.load(config)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-c", "--count", default="10",
+                        help="Count of apps to launch")
+    parser.add_argument("-d", "--debug", action='store_true',
+                        help="Count of apps to launch")
+    args = parser.parse_args()
+
+    if args.debug:
+        parsl.set_stream_logger()
+
+    x = test_bash_memoization(n=4)

--- a/parsl/tests/test_bash_apps/test_memoize.py
+++ b/parsl/tests/test_bash_apps/test_memoize.py
@@ -31,7 +31,6 @@ def test_bash_memoization(n=2):
     for i in range(0, n):
         d[i] = fail_on_presence(outputs=[temp_filename])
 
-    print("Waiting for results from round1")
     for i in d:
         assert isinstance(d[i].exception(), AppFailure)
 

--- a/parsl/tests/test_bash_apps/test_memoize.py
+++ b/parsl/tests/test_bash_apps/test_memoize.py
@@ -1,12 +1,9 @@
 import argparse
 import os
 
-import pytest
-
 import parsl
 from parsl.app.app import App
 from parsl.tests.configs.local_threads import config
-from parsl.app.errors import AppFailure
 
 
 @App('bash', cache=True)
@@ -31,7 +28,7 @@ def test_bash_memoization(n=2):
         d[i] = fail_on_presence(outputs=[temp_filename])
 
     for i in d:
-        assert d[i].exception() == None
+        assert d[i].exception() is None
 
 
 if __name__ == '__main__':

--- a/parsl/tests/test_python_apps/test_memoize_1.py
+++ b/parsl/tests/test_python_apps/test_memoize_1.py
@@ -1,7 +1,4 @@
 import argparse
-import time
-
-import pytest
 
 import parsl
 from parsl.app.app import App
@@ -26,32 +23,6 @@ def test_python_memoization(n=2):
         assert foo.result() == x.result(), "Memoized results were not used"
 
 
-@App('bash', cache=True)
-def slow_echo_to_file(msg, outputs=[], stderr='std.err', stdout='std.out'):
-    return 'sleep 1; echo {0} > {outputs[0]}'
-
-
-@pytest.mark.skip('fails intermittently depending on machine load')
-def test_bash_memoization(n=2):
-    """Testing bash memoization
-    """
-
-    print("Launching : ", n)
-    x = slow_echo_to_file("hello world", outputs=['h1.out'])
-    x.result()
-
-    start = time.time()
-    d = {}
-    for i in range(0, n):
-        d[i] = slow_echo_to_file("hello world", outputs=['h1.out'])
-
-    print("Waiting for results from round1")
-    [d[i].result() for i in d]
-    end = time.time()
-    delta = end - start
-    assert delta < 0.1, "Memoized results were not used"
-
-
 if __name__ == '__main__':
     parsl.clear()
     parsl.load(config)
@@ -67,4 +38,3 @@ if __name__ == '__main__':
         parsl.set_stream_logger()
 
     x = test_python_memoization(n=4)
-    x = test_bash_memoization(n=4)


### PR DESCRIPTION
* Remove use of sleep:
   * Remove a likely race condition coming from using sleep
   * Removing use of sleep makes this test fail faster
   * Assertions are based on the expected errors, not based on
     timing

* Move into own file in bash directory - this is not a test of
  python_apps, as the previous location implied.
