### PR TITLE
Make explicit copies of File objects per execution

### DIFF
--- a/parsl/app/futures.py
+++ b/parsl/app/futures.py
@@ -71,8 +71,7 @@ class DataFuture(Future):
             else:
                 raise NotFutureError("DataFuture can be created only with a FunctionFuture on None")
 
-        logger.debug("Creating DataFuture with parent: %s", self.parent)
-        logger.debug("Filepath: %s", self.filepath)
+        logger.debug("Creating DataFuture with parent: %s and file: %s", self.parent, repr(self.file_obj))
 
     @property
     def tid(self):
@@ -115,11 +114,11 @@ class DataFuture(Future):
                             _STATE_TO_DESCRIPTION_MAP[parent._state],
                             parent._exception.__class__.__name__)
                     else:
-                        return '<%s at %#x state=%s returned %s>' % (
+                        return '<%s at %#x state=%s with file %s>' % (
                             self.__class__.__name__,
                             id(self),
                             _STATE_TO_DESCRIPTION_MAP[parent._state],
-                            self.filepath)
+                            repr(self.file_obj))
                 return '<%s at %#x state=%s>' % (
                     self.__class__.__name__,
                     id(self),

--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -57,9 +57,9 @@ class DataManager(object):
 
     def optionally_stage_in(self, input, func, executor):
         if isinstance(input, DataFuture):
-            file = input.file_obj
+            file = input.file_obj.cleancopy()
         elif isinstance(input, File):
-            file = input
+            file = input.cleancopy()
         else:
             return (input, func)
 

--- a/parsl/data_provider/files.py
+++ b/parsl/data_provider/files.py
@@ -44,6 +44,14 @@ class File(object):
         self.path = parsed_url.path
         self.filename = os.path.basename(self.path)
 
+    def cleancopy(self) -> "File":
+        """Returns a copy of the file containing only the global immutable state,
+           without any mutable site-local local_path information. The returned File
+           object will be as the original object was when it was constructed.
+        """
+        logger.debug("Making clean copy of File object {}".format(repr(self)))
+        return File(self.url)
+
     def __str__(self):
         return self.filepath
 
@@ -63,7 +71,10 @@ class File(object):
         """Return the resolved filepath on the side where it is called from.
 
         The appropriate filepath will be returned when called from within
-        an app running remotely as well as regular python on the client side.
+        an app running remotely as well as regular python on the submit side.
+
+        Only file: scheme URLs make sense to have a submit-side path, as other
+        URLs are not accessible through POSIX file access.
 
         Args:
             - self
@@ -73,12 +84,10 @@ class File(object):
         if hasattr(self, 'local_path'):
             return self.local_path
 
-        if self.scheme in ['ftp', 'http', 'https', 'globus']:
-            return self.filename
-        elif self.scheme in ['file']:
+        if self.scheme in ['file']:
             return self.path
         else:
-            raise Exception('Cannot return filepath for unknown scheme {}'.format(self.scheme))
+            raise ValueError("No local_path set for {}".format(repr(self)))
 
 
 if __name__ == '__main__':

--- a/parsl/data_provider/ftp.py
+++ b/parsl/data_provider/ftp.py
@@ -21,7 +21,6 @@ class FTPSeparateTaskStaging(Staging, RepresentationMixin):
     def stage_in(self, dm, executor, file, parent_fut):
         working_dir = dm.dfk.executors[executor].working_dir
         if working_dir:
-            os.makedirs(working_dir, exist_ok=True)
             file.local_path = os.path.join(working_dir, file.filename)
         else:
             file.local_path = file.filename

--- a/parsl/data_provider/globus.py
+++ b/parsl/data_provider/globus.py
@@ -206,13 +206,14 @@ class GlobusStaging(Staging, RepresentationMixin):
 
     def stage_in(self, dm, executor, file, parent_fut):
         globus_provider = _get_globus_provider(dm.dfk, executor)
+        globus_provider._update_local_path(file, executor, dm.dfk)
         stage_in_app = globus_provider._globus_stage_in_app(executor=executor, dfk=dm.dfk)
         app_fut = stage_in_app(outputs=[file], staging_inhibit_output=True, parent_fut=parent_fut)
         return app_fut._outputs[0]
 
     def stage_out(self, dm, executor, file, app_fu):
         globus_provider = _get_globus_provider(dm.dfk, executor)
-        globus_provider._update_stage_out_local_path(file, executor, dm.dfk)
+        globus_provider._update_local_path(file, executor, dm.dfk)
         stage_out_app = globus_provider._globus_stage_out_app(executor=executor, dfk=dm.dfk)
         return stage_out_app(app_fu, inputs=[file])
 
@@ -257,7 +258,7 @@ class GlobusStaging(Staging, RepresentationMixin):
                 'endpoint_path': endpoint_path,
                 'working_dir': working_dir}
 
-    def _update_stage_out_local_path(self, file, executor, dfk):
+    def _update_local_path(self, file, executor, dfk):
         executor_obj = dfk.executors[executor]
         globus_ep = self._get_globus_endpoint(executor_obj)
         file.local_path = os.path.join(globus_ep['working_dir'], file.filename)
@@ -269,8 +270,6 @@ class GlobusStaging(Staging, RepresentationMixin):
 def _globus_stage_in(provider, executor, parent_fut=None, outputs=[], staging_inhibit_output=True):
     globus_ep = provider._get_globus_endpoint(executor)
     file = outputs[0]
-    file.local_path = os.path.join(
-            globus_ep['working_dir'], file.filename)
     dst_path = os.path.join(
             globus_ep['endpoint_path'], file.filename)
 

--- a/parsl/data_provider/http.py
+++ b/parsl/data_provider/http.py
@@ -2,8 +2,6 @@ import logging
 import os
 import requests
 
-from parsl.app.futures import DataFuture
-
 from parsl import python_app
 
 from parsl.utils import RepresentationMixin
@@ -58,7 +56,6 @@ class HTTPInTaskStaging(Staging, RepresentationMixin):
 # rest of the app calls - what can be returned here is, I think,
 # either a DataFuture (in the case of staging apps) or plain
 # File (if no dependency needs to happen)
-
 
     def replace_task(self, dm, executor, file, f):
         working_dir = dm.dfk.executors[executor].working_dir

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -485,8 +485,12 @@ class DataFlowKernel(object):
                 # replace a File with a DataFuture - either completing when the stageout
                 # future completes, or if no stage out future is returned, then when the
                 # app itself completes.
+
+                # The staging code will get a clean copy which it is allowed to mutate,
+                # while the DataFuture-contained original will not be modified by any staging.
+                f_copy = f.cleancopy()
                 logger.debug("Submitting stage out for output file {}".format(f))
-                stageout_fut = self.data_manager.stage_out(f, executor, app_fut)
+                stageout_fut = self.data_manager.stage_out(f_copy, executor, app_fut)
                 if stageout_fut:
                     logger.debug("Adding a dependency on stageout future for {}".format(f))
                     app_fut._outputs.append(DataFuture(stageout_fut, f, tid=app_fut.tid))
@@ -501,7 +505,7 @@ class DataFlowKernel(object):
                 if newfunc:
                     func = newfunc
             else:
-                logger.debug("Not performing staging for: {}".format(f))
+                logger.debug("Not performing staging for: {}".format(repr(f)))
                 app_fut._outputs.append(DataFuture(app_fut, f, tid=app_fut.tid))
         return func
 

--- a/parsl/tests/test_bash_apps/test_pipeline.py
+++ b/parsl/tests/test_bash_apps/test_pipeline.py
@@ -67,6 +67,7 @@ def test_increment(depth=5):
             # this test is a bit close to a test of the specific implementation
             # of File
             assert not hasattr(file, 'local_path'), "File on local side has overridden local_path, file: {}".format(repr(file))
+            assert file.filepath == "test{0}.txt".format(key), "Submit side filepath has not been preserved over execution"
 
             data = open(filename, 'r').read().strip()
             assert data == str(

--- a/parsl/tests/test_staging/test_implicit_staging_globus.py
+++ b/parsl/tests/test_staging/test_implicit_staging_globus.py
@@ -59,7 +59,16 @@ def test_stage_in_out_globus():
     # sometimes pass even though stageout is not working.
 
     f.result()
-    f.outputs[0].result()
+
+    result_file = f.outputs[0].result()
+
+    assert not hasattr(unsorted_file, 'local_path'), "Input file on local side has overridden local_path, file: {}".format(repr(unsorted_file))
+
+    # use 'is' rather than '==' because specifically want to check
+    # object identity rather than value equality
+    assert sorted_file is result_file, "Result file is not the specified input-output file"
+
+    assert not hasattr(result_file, 'local_path'), "Result file on local side has overridden local_path, file: {}".format(repr(result_file))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This addresses issue #1197

Prior to this PR, File objects were shared or not-shared between
different pieces of parsl code based on the nature of the
executor.

For example, modifying a File object inside a stage-in task
running in the local thread executor would modify the original
File object passed into the app (because the thread executor passes
around the original object), but modifying a File object inside
a stage-in task running in the htex executor would not modify
the original File object, as File objects are copied (implicitly
by serialization of app arguments).

Also, the local_path attribute which was sometimes set to provide
an execution-side filesystem path did not always propagate properly.
This was generally disguised by the presence of a vestigial
enumeration of http/ftp/globus file schemes which should have been
removed as part of the earlier staging API work.

Also, sometimes when the local_path attribute was set, that
sometimes propagated too much: if staging ended up modifying the
original source File object (as described above) then this would
modify the File object even when passed to a different app
invocation - most badly, an app invocation on another site where the
execution-side filesystem path may be different to the one
already set.

This PR more explicitly copies File objects at the point that they
are used for an app invocation; staging code can modify only that
invocation-specific copy, leaving the original pristine.

This PR removes the above-mentioned vestigial scheme enumeration;
it is now an error to ask for the local filesystem path of a File
which does not have local_path set, except in the case of a file:
schemed file. It is now a requirement that all staging providers
set File.local_path.

This PR changes the way in which the existing staging providers
set File.local_path so that it is always set properly.