### PR TITLE
Catch errors during launch and set the task future exception appropriately

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -354,6 +354,18 @@ class DataFlowKernel(object):
         launch_if_ready is thread safe, so may be called from any thread
         or callback.
         """
+        try:
+            self._launch_if_ready(task_id)
+        except Exception as ex:
+            # catch errors properly, otherwise it's possible for code to
+            # throw an exception before the task is launched, which causes
+            # things to just hang.
+            #
+            # may want to wrap this exception into something that clearly
+            # indicates that this is an internal error
+            self.tasks[task_id]['app_fu'].set_exception(ex)
+
+    def _launch_if_ready(self, task_id):
         if self._count_deps(self.tasks[task_id]['depends']) == 0:
 
             # We can now launch *task*


### PR DESCRIPTION
This addresses one of the issues that causes #1274 and possibly #1267.

The gist of it is that, with monitoring enabled, launch_if_ready calls _create_task_log_info which accesses an nonexistent property on AppFutures. That causes an exception to be thrown. Now, launch_if_ready is called from submit(), in particular this snippet:

            def callback_adapter(dep_fut):
                self.launch_if_ready(task_id)

            try:
                d.add_done_callback(callback_adapter)
            except Exception as e:
                logger.error("add_done_callback got an exception {} which will be ignored".format(e))

The issue is that Future.add_done_callback, if the future is closed, directly invokes the callback. Long story short, such errors are explicitly ignored. Perhaps the right solution is to assume that other code paths handle this properly, but, to be safe, I wrapped launch_if_ready in a try/catch which sets an exception on the AppFuture that represents the task currently launched.