### PR TITLE
Add worker plot monitoring #1278

### DIFF
--- a/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
@@ -129,7 +129,7 @@ def worker_efficiency(task, node):
         return plot(fig, show_link=False, output_type="div", include_plotlyjs=False)
     except Exception as e:
         print(e)
-        return "The worker efficiency plot cannot be generated due to missing data.
+        return "The worker efficiency plot cannot be generated due to missing data."
 
 
 def resource_efficiency(resource, node, label='CPU'):

--- a/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
@@ -110,7 +110,7 @@ def worker_efficiency(task, node):
         total_workers = node['worker_count'].sum()
 
         for i, row in task.iterrows():
-            for j in range(int(row['epoch_time_running']), int(row['epoch_time_returned'])):
+            for j in range(int(row['epoch_time_running']), int(row['epoch_time_returned']) + 1):
                 worker_plot[j - start] += 1
         fig = go.Figure(
             data=[go.Scatter(x=list(range(0, end - start + 1)),

--- a/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
@@ -105,7 +105,6 @@ def worker_efficiency(task, node):
             task['task_time_returned']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
         start = min(task['epoch_time_start'].min(), node['epoch_time'].min())
         end = task['epoch_time_returned'].max()
-        node['relative_time'] = node['epoch_time'] - start
 
         worker_plot = [0] * (end - start + 1)
         total_workers = node['worker_count'].sum()

--- a/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
@@ -109,10 +109,10 @@ def worker_efficiency(task, node):
 
         worker_plot = [0] * (end - start + 1)
         total_workers = node['worker_count'].sum()
-        
+
         for i, row in task.iterrows():
             for j in range(int(row['epoch_time_running']), int(row['epoch_time_returned'])):
-                worker_plot[j-start] += 1
+                worker_plot[j - start] += 1
         fig = go.Figure(
             data=[go.Scatter(x=list(range(0, end - start + 1)),
                              y=worker_plot,
@@ -127,7 +127,7 @@ def worker_efficiency(task, node):
                                         title='Time (seconds)'),
                              yaxis=dict(title='Number of workers'),
                              title="Worker efficiency"))
-        return plot(fig, show_link=False, output_type="div", include_plotlyjs=False)        
+        return plot(fig, show_link=False, output_type="div", include_plotlyjs=False)
     except Exception as e:
         return "The resource efficiency plot cannot be generated because of exception {}.".format(e)
 

--- a/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
@@ -128,7 +128,7 @@ def worker_efficiency(task, node):
                              title="Worker efficiency"))
         return plot(fig, show_link=False, output_type="div", include_plotlyjs=False)
     except Exception as e:
-        return "The resource efficiency plot cannot be generated because of exception {}.".format(e)
+        return "The worker efficiency plot cannot be generated because of exception {}.".format(e)
 
 
 def resource_efficiency(resource, node, label='CPU'):

--- a/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
@@ -93,6 +93,45 @@ def resource_time_series(tasks, type='psutil_process_time_user', label='CPU user
     return plot(fig, show_link=False, output_type="div", include_plotlyjs=False)
 
 
+def worker_efficiency(task, node):
+    try:
+        node['epoch_time'] = (pd.to_datetime(
+            node['reg_time']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
+        task['epoch_time_start'] = (pd.to_datetime(
+            task['task_time_submitted']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
+        task['epoch_time_running'] = (pd.to_datetime(
+            task['task_time_running']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
+        task['epoch_time_returned'] = (pd.to_datetime(
+            task['task_time_returned']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
+        start = min(task['epoch_time_start'].min(), node['epoch_time'].min())
+        end = task['epoch_time_returned'].max()
+        node['relative_time'] = node['epoch_time'] - start
+
+        worker_plot = [0] * (end - start + 1)
+        total_workers = node['worker_count'].sum()
+        
+        for i, row in task.iterrows():
+            for j in range(int(row['epoch_time_running']), int(row['epoch_time_returned'])):
+                worker_plot[j-start] += 1
+        fig = go.Figure(
+            data=[go.Scatter(x=list(range(0, end - start + 1)),
+                             y=worker_plot,
+                             name='Busy workers',
+                             ),
+                  go.Scatter(x=list(range(0, end - start + 1)),
+                             y=[total_workers] * (end - start + 1),
+                             name='Total requested workers',
+                             )
+                 ],
+            layout=go.Layout(xaxis=dict(autorange=True,
+                                        title='Time (seconds)'),
+                             yaxis=dict(title='Number of workers'),
+                             title="Worker efficiency"))
+        return plot(fig, show_link=False, output_type="div", include_plotlyjs=False)        
+    except Exception as e:
+        return "The resource efficiency plot cannot be generated because of exception {}.".format(e)
+
+
 def resource_efficiency(resource, node, label='CPU'):
     try:
         resource['epoch_time'] = (pd.to_datetime(

--- a/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
@@ -115,11 +115,11 @@ def worker_efficiency(task, node):
         fig = go.Figure(
             data=[go.Scatter(x=list(range(0, end - start + 1)),
                              y=worker_plot,
-                             name='Busy workers',
+                             name='Total busy workers',
                              ),
                   go.Scatter(x=list(range(0, end - start + 1)),
                              y=[total_workers] * (end - start + 1),
-                             name='Total requested workers',
+                             name='Total online workers',
                              )
                  ],
             layout=go.Layout(xaxis=dict(autorange=True,

--- a/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
@@ -128,7 +128,8 @@ def worker_efficiency(task, node):
                              title="Worker efficiency"))
         return plot(fig, show_link=False, output_type="div", include_plotlyjs=False)
     except Exception as e:
-        return "The worker efficiency plot cannot be generated because of exception {}.".format(e)
+        print(e)
+        return "The worker efficiency plot cannot be generated due to missing data.
 
 
 def resource_efficiency(resource, node, label='CPU'):

--- a/parsl/monitoring/visualization/templates/resource_usage.html
+++ b/parsl/monitoring/visualization/templates/resource_usage.html
@@ -22,6 +22,12 @@
 <br><a href="dag_group_by_states">View workflow DAG -- colors grouped by task states</a>
 <br><a href="/workflow/{{ workflow_details['run_id'] }} ">View workflow task summary</a>
 
+
+<h5>Worker usage</h5>
+<div class="container" style="height: 500px;">
+{{ worker_efficiency|safe }}
+</div>
+
 <h5>CPU usage</h5>
 <div class="container" style="height: 500px;">
 {{ cpu_efficiency|safe }}

--- a/parsl/monitoring/visualization/views.py
+++ b/parsl/monitoring/visualization/views.py
@@ -5,7 +5,7 @@ from parsl.monitoring.visualization.models import Workflow, Task, Status, db
 
 from parsl.monitoring.visualization.plots.default.workflow_plots import task_gantt_plot, task_per_app_plot, workflow_dag_plot
 from parsl.monitoring.visualization.plots.default.task_plots import time_series_cpu_per_task_plot, time_series_memory_per_task_plot
-from parsl.monitoring.visualization.plots.default.workflow_resource_plots import resource_distribution_plot, resource_efficiency
+from parsl.monitoring.visualization.plots.default.workflow_resource_plots import resource_distribution_plot, resource_efficiency, worker_efficiency
 
 dummy = True
 
@@ -164,4 +164,5 @@ def workflow_resources(workflow_id):
                                df_resources, df_task, type='psutil_process_memory_resident', label='Memory Distribution', option='max'),
                            cpu_efficiency=resource_efficiency(df_resources, df_node, label='CPU'),
                            memory_efficiency=resource_efficiency(df_resources, df_node, label='mem'),
+                           worker_efficiency=worker_efficiency(df_task, df_node),
                            )


### PR DESCRIPTION
This PR adds a worker efficiency plot to the resource page of workflow.

The worker efficiency is computed by `total_running_tasks/total_workers`.

`total_running_tasks` is to count the total number of running tasks every one second (by checking if the `task_time_running` and `task_time_returned` include that timestamp).

`total_workers` is computed by adding up the `worker_count` in the `node` table (current assumption is that there is no scaling. If we want to have scaling, we need to add more info to the `node` table)