### PR TITLE
Add a worker watchdog thread

### DIFF
--- a/parsl/executors/high_throughput/errors.py
+++ b/parsl/executors/high_throughput/errors.py
@@ -1,0 +1,12 @@
+class WorkerLost(Exception):
+    """Exception raised when a worker is lost
+    """
+    def __init__(self, worker_id, hostname):
+        self.worker_id = worker_id
+        self.hostname = hostname
+
+    def __repr__(self):
+        return "Task failure due to loss of worker {} on host {}".format(self.worker_id, self.hostname)
+
+    def __str__(self):
+        return self.__repr__()

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -29,6 +29,19 @@ TASK_REQUEST_TAG = 11
 
 HEARTBEAT_CODE = (2 ** 32) - 1
 
+class WorkerLost(Exception):
+    """Exception raised when a worker is lost
+    """
+    def __init__(self, worker_id, hostname):
+        self.worker_id = worker_id
+        self.tstamp = time.time()
+        self.hostname = hostname
+
+    def __repr__(self):
+        return "Task failure due to loss of worker {} on host {}".format(self.worker_id, self.hostname)
+
+    def __str__(self):
+        return self.__repr__()
 
 class Manager(object):
     """ Manager manages task execution by the workers
@@ -266,6 +279,7 @@ class Manager(object):
                     logger.critical("[TASK_PULL_THREAD] Exiting")
                     break
 
+
     def push_results(self, kill_event):
         """ Listens on the pending_result_queue and sends out results via 0mq
 
@@ -302,6 +316,49 @@ class Manager(object):
 
         logger.critical("[RESULT_PUSH_THREAD] Exiting")
 
+
+    def worker_watchdog(self, kill_event):
+        """ Listens on the pending_result_queue and sends out results via 0mq
+
+        Parameters:
+        -----------
+        kill_event : threading.Event
+              Event to let the thread know when it is time to die.
+        """
+
+        logger.debug("[WORKER_WATCHDOG_THREAD] Starting thread")
+
+        last_beat = time.time()
+        while not kill_event.is_set():
+            for worker_id, p in self.procs.items():
+                if not p.is_alive():
+                    logger.info("[WORKER_WATCHDOG_THREAD] Worker {} has died".format(worker_id))
+                    try:
+                        task = self._tasks_in_progress.pop(worker_id)
+                        logger.info("[WORKER_WATCHDOG_THREAD] Worker {} was busy when it died".format(worker_id))
+                        try:
+                            raise WorkerLost(worker_id, platform.node())
+                        except Exception:
+                            result_package = {'task_id': tid, 'exception': serialize_object(RemoteExceptionWrapper(*sys.exc_info()))}
+                            pkl_package = pickle.dumps(result_package)
+                            self.pending_result_queue.put(pkl_package)
+                    except KeyError:
+                        logger.info("[WORKER_WATCHDOG_THREAD] Worker {} was not busy when it died".format(worker_id))
+
+                    p = multiprocessing.Process(target=worker, args=(worker_id,
+                                                                     self.uid,
+                                                                     self.pending_task_queue,
+                                                                     self.pending_result_queue,
+                                                                     self.ready_worker_queue,
+                                                                     self._tasks_in_progress
+                                                                 ), name="HTEX-Worker-{}".format(worker_id))
+                    self.procs[worker_id] = p
+                    logger.info("[WORKER_WATCHDOG_THREAD] Worker {} has been restarted".format(worker_id))
+                time.sleep(self.poll_period)
+
+
+        logger.critical("[WORKER_WATCHDOG_THREAD] Exiting")
+
     def start(self):
         """ Start the worker processes.
 
@@ -309,6 +366,7 @@ class Manager(object):
         """
         start = time.time()
         self._kill_event = threading.Event()
+        self._tasks_in_progress = multiprocessing.Manager().dict()
 
         self.procs = {}
         for worker_id in range(self.worker_count):
@@ -317,6 +375,7 @@ class Manager(object):
                                                              self.pending_task_queue,
                                                              self.pending_result_queue,
                                                              self.ready_worker_queue,
+                                                             self._tasks_in_progress
                                                          ), name="HTEX-Worker-{}".format(worker_id))
             p.start()
             self.procs[worker_id] = p
@@ -329,8 +388,12 @@ class Manager(object):
         self._result_pusher_thread = threading.Thread(target=self.push_results,
                                                       args=(self._kill_event,),
                                                       name="Result-Pusher")
+        self._worker_watchdog_thread = threading.Thread(target=self.worker_watchdog,
+                                                      args=(self._kill_event,),
+                                                      name="worker-watchdog")
         self._task_puller_thread.start()
         self._result_pusher_thread.start()
+        self._worker_watchdog_thread.start()
 
         logger.info("Loop start")
 
@@ -341,6 +404,7 @@ class Manager(object):
 
         self._task_puller_thread.join()
         self._result_pusher_thread.join()
+        self._worker_watchdog_thread.join()
         for proc_id in self.procs:
             self.procs[proc_id].terminate()
             logger.critical("Terminating worker {}:{}".format(self.procs[proc_id],
@@ -394,7 +458,7 @@ def execute_task(bufs):
         return user_ns.get(resultname)
 
 
-def worker(worker_id, pool_id, task_queue, result_queue, worker_queue):
+def worker(worker_id, pool_id, task_queue, result_queue, worker_queue, tasks_in_progress):
     """
 
     Put request token into queue
@@ -417,6 +481,7 @@ def worker(worker_id, pool_id, task_queue, result_queue, worker_queue):
 
         # The worker will receive {'task_id':<tid>, 'buffer':<buf>}
         req = task_queue.get()
+        tasks_in_progress[worker_id] = req
         tid = req['task_id']
         logger.info("Received task {}".format(tid))
 
@@ -429,7 +494,8 @@ def worker(worker_id, pool_id, task_queue, result_queue, worker_queue):
         try:
             result = execute_task(req['buffer'])
             serialized_result = serialize_object(result)
-        except Exception:
+        except Exception as e:
+            logger.info('Caught an exception: {}'.format(e))
             result_package = {'task_id': tid, 'exception': serialize_object(RemoteExceptionWrapper(*sys.exc_info()))}
         else:
             result_package = {'task_id': tid, 'result': serialized_result}
@@ -439,6 +505,7 @@ def worker(worker_id, pool_id, task_queue, result_queue, worker_queue):
         pkl_package = pickle.dumps(result_package)
 
         result_queue.put(pkl_package)
+        tasks_in_progress.pop(worker_id)
 
 
 def start_file_logger(filename, rank, name='parsl', level=logging.DEBUG, format_string=None):

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -339,7 +339,8 @@ class Manager(object):
                         try:
                             raise WorkerLost(worker_id, platform.node())
                         except Exception:
-                            result_package = {'task_id': tid, 'exception': serialize_object(RemoteExceptionWrapper(*sys.exc_info()))}
+                            logger.info("[WORKER_WATCHDOG_THREAD] Putting exception for task {} in the pending result queue".format(task['task_id']))
+                            result_package = {'task_id': task['task_id'], 'exception': serialize_object(RemoteExceptionWrapper(*sys.exc_info()))}
                             pkl_package = pickle.dumps(result_package)
                             self.pending_result_queue.put(pkl_package)
                     except KeyError:

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -29,10 +29,12 @@ TASK_REQUEST_TAG = 11
 
 HEARTBEAT_CODE = (2 ** 32) - 1
 
+
 class WorkerLost(Exception):
     """Exception raised when a worker is lost
     """
     def __init__(self, worker_id, hostname):
+        import time
         self.worker_id = worker_id
         self.tstamp = time.time()
         self.hostname = hostname
@@ -42,6 +44,7 @@ class WorkerLost(Exception):
 
     def __str__(self):
         return self.__repr__()
+
 
 class Manager(object):
     """ Manager manages task execution by the workers
@@ -279,7 +282,6 @@ class Manager(object):
                     logger.critical("[TASK_PULL_THREAD] Exiting")
                     break
 
-
     def push_results(self, kill_event):
         """ Listens on the pending_result_queue and sends out results via 0mq
 
@@ -316,7 +318,6 @@ class Manager(object):
 
         logger.critical("[RESULT_PUSH_THREAD] Exiting")
 
-
     def worker_watchdog(self, kill_event):
         """ Listens on the pending_result_queue and sends out results via 0mq
 
@@ -328,7 +329,6 @@ class Manager(object):
 
         logger.debug("[WORKER_WATCHDOG_THREAD] Starting thread")
 
-        last_beat = time.time()
         while not kill_event.is_set():
             for worker_id, p in self.procs.items():
                 if not p.is_alive():
@@ -355,7 +355,6 @@ class Manager(object):
                     self.procs[worker_id] = p
                     logger.info("[WORKER_WATCHDOG_THREAD] Worker {} has been restarted".format(worker_id))
                 time.sleep(self.poll_period)
-
 
         logger.critical("[WORKER_WATCHDOG_THREAD] Exiting")
 

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -34,9 +34,7 @@ class WorkerLost(Exception):
     """Exception raised when a worker is lost
     """
     def __init__(self, worker_id, hostname):
-        import time
         self.worker_id = worker_id
-        self.tstamp = time.time()
         self.hostname = hostname
 
     def __repr__(self):

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -19,6 +19,7 @@ import psutil
 
 from parsl.version import VERSION as PARSL_VERSION
 from parsl.app.errors import RemoteExceptionWrapper
+from parsl.executors.high_throughput.errors import WorkerLost
 import multiprocessing
 
 from ipyparallel.serialize import unpack_apply_message  # pack_apply_message,
@@ -28,20 +29,6 @@ RESULT_TAG = 10
 TASK_REQUEST_TAG = 11
 
 HEARTBEAT_CODE = (2 ** 32) - 1
-
-
-class WorkerLost(Exception):
-    """Exception raised when a worker is lost
-    """
-    def __init__(self, worker_id, hostname):
-        self.worker_id = worker_id
-        self.hostname = hostname
-
-    def __repr__(self):
-        return "Task failure due to loss of worker {} on host {}".format(self.worker_id, self.hostname)
-
-    def __str__(self):
-        return self.__repr__()
 
 
 class Manager(object):

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -387,8 +387,8 @@ class Manager(object):
                                                       args=(self._kill_event,),
                                                       name="Result-Pusher")
         self._worker_watchdog_thread = threading.Thread(target=self.worker_watchdog,
-                                                      args=(self._kill_event,),
-                                                      name="worker-watchdog")
+                                                        args=(self._kill_event,),
+                                                        name="worker-watchdog")
         self._task_puller_thread.start()
         self._result_pusher_thread.start()
         self._worker_watchdog_thread.start()

--- a/parsl/tests/configs/htex_local.py
+++ b/parsl/tests/configs/htex_local.py
@@ -5,19 +5,22 @@ from parsl.launchers import SimpleLauncher
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 
-config = Config(
-    executors=[
-        HighThroughputExecutor(
-            label="htex_Local",
-            worker_debug=True,
-            cores_per_worker=1,
-            provider=LocalProvider(
-                channel=LocalChannel(),
-                init_blocks=1,
-                max_blocks=1,
-                launcher=SimpleLauncher(),
-            ),
-        )
-    ],
-    strategy=None,
-)
+def fresh_config():
+    return Config(
+        executors=[
+            HighThroughputExecutor(
+                label="htex_local",
+                worker_debug=True,
+                cores_per_worker=1,
+                provider=LocalProvider(
+                    channel=LocalChannel(),
+                    init_blocks=1,
+                    max_blocks=1,
+                    launcher=SimpleLauncher(),
+                ),
+            )
+        ],
+        strategy=None,
+    )
+
+config = fresh_config()

--- a/parsl/tests/configs/htex_local.py
+++ b/parsl/tests/configs/htex_local.py
@@ -5,6 +5,7 @@ from parsl.launchers import SimpleLauncher
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 
+
 def fresh_config():
     return Config(
         executors=[
@@ -22,5 +23,6 @@ def fresh_config():
         ],
         strategy=None,
     )
+
 
 config = fresh_config()

--- a/parsl/tests/test_error_handling/test_htex_worker_failure.py
+++ b/parsl/tests/test_error_handling/test_htex_worker_failure.py
@@ -4,6 +4,8 @@ import parsl
 from parsl.app.app import python_app
 from parsl.tests.configs.htex_local import fresh_config
 
+from parsl.executors.high_throughput.errors import WorkerLost
+
 
 def local_setup():
     config = fresh_config()
@@ -24,8 +26,6 @@ def kill_worker():
 
 @pytest.mark.local
 def test_htex_worker_failure():
-    # Putting `WorkerLost` here as the exception causes
-    # the test to fail-- I am not sure why
-    with pytest.raises(Exception):
+    with pytest.raises(WorkerLost):
         f = kill_worker()
         f.result()

--- a/parsl/tests/test_error_handling/test_htex_worker_failure.py
+++ b/parsl/tests/test_error_handling/test_htex_worker_failure.py
@@ -1,0 +1,33 @@
+import argparse
+import datetime
+import time
+
+import pytest
+
+import parsl
+from parsl.app.app import python_app
+from parsl.executors.high_throughput.process_worker_pool import WorkerLost
+
+def local_setup():
+    from parsl.tests.configs.htex_local import config
+    config.executors[0].worker_debug = True
+    config.executors[0].poll_period = 1
+    config.executors[0].max_workers = 1
+    parsl.load(config)
+
+
+def local_teardown():
+    # explicit clear without dfk.cleanup here, because the
+    # test does that already
+    parsl.clear()
+
+@python_app
+def kill_worker():
+    import sys
+    sys.exit(2)
+
+@pytest.mark.local
+def test_htex_worker_failure():
+    f = kill_worker()
+    with pytest.raises(WorkerLost):
+        f.result()

--- a/parsl/tests/test_error_handling/test_htex_worker_failure.py
+++ b/parsl/tests/test_error_handling/test_htex_worker_failure.py
@@ -1,25 +1,21 @@
 import argparse
-import datetime
-import time
 
 import pytest
 
 import parsl
 from parsl.app.app import python_app
 from parsl.executors.high_throughput.process_worker_pool import WorkerLost
+from parsl.tests.configs.htex_local import fresh_config
 
 def local_setup():
-    from parsl.tests.configs.htex_local import config
-    config.executors[0].worker_debug = True
+    config = fresh_config()
     config.executors[0].poll_period = 1
     config.executors[0].max_workers = 1
     parsl.load(config)
 
-
 def local_teardown():
-    # explicit clear without dfk.cleanup here, because the
-    # test does that already
     parsl.clear()
+
 
 @python_app
 def kill_worker():
@@ -28,6 +24,8 @@ def kill_worker():
 
 @pytest.mark.local
 def test_htex_worker_failure():
-    f = kill_worker()
-    with pytest.raises(WorkerLost):
+    # Putting `WorkerLost` here as the exception causes
+    # the test to fail-- I am not sure why
+    with pytest.raises(Exception):
+        f = kill_worker()
         f.result()

--- a/parsl/tests/test_error_handling/test_htex_worker_failure.py
+++ b/parsl/tests/test_error_handling/test_htex_worker_failure.py
@@ -1,10 +1,7 @@
-import argparse
-
 import pytest
 
 import parsl
 from parsl.app.app import python_app
-from parsl.executors.high_throughput.process_worker_pool import WorkerLost
 from parsl.tests.configs.htex_local import fresh_config
 
 

--- a/parsl/tests/test_error_handling/test_htex_worker_failure.py
+++ b/parsl/tests/test_error_handling/test_htex_worker_failure.py
@@ -7,11 +7,13 @@ from parsl.app.app import python_app
 from parsl.executors.high_throughput.process_worker_pool import WorkerLost
 from parsl.tests.configs.htex_local import fresh_config
 
+
 def local_setup():
     config = fresh_config()
     config.executors[0].poll_period = 1
     config.executors[0].max_workers = 1
     parsl.load(config)
+
 
 def local_teardown():
     parsl.clear()
@@ -21,6 +23,7 @@ def local_teardown():
 def kill_worker():
     import sys
     sys.exit(2)
+
 
 @pytest.mark.local
 def test_htex_worker_failure():


### PR DESCRIPTION
This commit makes two main changes:
1) A shared dictionary is added which the workers can access. They now
   put their in-progress tasks there.
2) A worker watchdog thread is added which monitors the worker
   processes. If it finds a dead worker, it checks for any in-progress
  tasks in the shared dictionary and sends it back to the DFK with a
  WorkerLost error, and restarts the worker.
Fixes #1245.