### PR TITLE
Remove PARSL_TESTING requirement from test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ os:
 
 # command to run tests
 script:
-    - export PARSL_TESTING="true"
     - pip install -r test-requirements.txt
     - flake8 parsl/
     - parsl/tests/lint-inits.sh

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -36,10 +36,7 @@ Testing
 =======
 
 Parsl uses ``pytest`` to run most tests. All tests should be placed in
-the ``parsl/tests`` directory. Before running tests usage tracking
-should be disabled using the PARSL_TESTING environment variable::
-
-  $ export PARSL_TESTING="true"
+the ``parsl/tests`` directory.
 
 There are two broad groups of tests: those which must run with a
 specific configuration, and those which should work with any

--- a/parsl/tests/__init__.py
+++ b/parsl/tests/__init__.py
@@ -1,4 +1,0 @@
-import os
-
-if str(os.environ.get('PARSL_TESTING', False)).lower() != 'true':
-    raise RuntimeError("must first run 'export PARSL_TESTING=True'")

--- a/parsl/tests/integration/test_apps/__init__.py
+++ b/parsl/tests/integration/test_apps/__init__.py
@@ -1,4 +1,0 @@
-import os
-
-if str(os.environ.get('PARSL_TESTING', False)).lower() != 'true':
-    raise RuntimeError("must first run 'export PARSL_TESTING=True'")

--- a/parsl/tests/integration/test_stress/__init__.py
+++ b/parsl/tests/integration/test_stress/__init__.py
@@ -1,4 +1,0 @@
-import os
-
-if str(os.environ.get('PARSL_TESTING', False)).lower() != 'true':
-    raise RuntimeError("must first run 'export PARSL_TESTING=True'")

--- a/parsl/tests/pytest.ini
+++ b/parsl/tests/pytest.ini
@@ -1,4 +1,2 @@
 [pytest]
-env =
-    PARSL_TESTING=False
 addopts = -x -rs

--- a/parsl/tests/sites/__init__.py
+++ b/parsl/tests/sites/__init__.py
@@ -1,4 +1,0 @@
-import os
-
-if str(os.environ.get('PARSL_TESTING', False)).lower() != 'true':
-    raise RuntimeError("must first run 'export PARSL_TESTING=True'")

--- a/parsl/tests/test_checkpointing/__init__.py
+++ b/parsl/tests/test_checkpointing/__init__.py
@@ -1,4 +1,0 @@
-import os
-
-if str(os.environ.get('PARSL_TESTING', False)).lower() != 'true':
-    raise RuntimeError("must first run 'export PARSL_TESTING=True'")

--- a/parsl/tests/test_data/__init__.py
+++ b/parsl/tests/test_data/__init__.py
@@ -1,4 +1,0 @@
-import os
-
-if str(os.environ.get('PARSL_TESTING', False)).lower() != 'true':
-    raise RuntimeError("must first run 'export PARSL_TESTING=True'")

--- a/parsl/tests/test_error_handling/__init__.py
+++ b/parsl/tests/test_error_handling/__init__.py
@@ -1,4 +1,0 @@
-import os
-
-if str(os.environ.get('PARSL_TESTING', False)).lower() != 'true':
-    raise RuntimeError("must first run 'export PARSL_TESTING=True'")

--- a/parsl/tests/test_flowcontrol/__init__.py
+++ b/parsl/tests/test_flowcontrol/__init__.py
@@ -1,4 +1,0 @@
-import os
-
-if str(os.environ.get('PARSL_TESTING', False)).lower() != 'true':
-    raise RuntimeError("must first run 'export PARSL_TESTING=True'")


### PR DESCRIPTION
This commit removes most of PARSL_TESTING environment handling from the
test suite in order to make pytests easier to run. Since usage tracking
became opt-in, there has been less need for this environment variable.

The reporting of PARSL_TESTING in usage tracking code is left in place.