### PR TITLE
Remove ability for providers to be not-scalable

### DIFF
--- a/parsl/executors/extreme_scale/executor.py
+++ b/parsl/executors/extreme_scale/executor.py
@@ -189,7 +189,7 @@ class ExtremeScaleExecutor(HighThroughputExecutor, RepresentationMixin):
         self.launch_cmd = l_cmd
         logger.debug("Launch command: {}".format(self.launch_cmd))
 
-        self._scaling_enabled = self.provider.scaling_enabled
+        self._scaling_enabled = True
         logger.debug("Starting ExtremeScaleExecutor with provider:\n%s", self.provider)
         if hasattr(self.provider, 'init_blocks'):
             try:

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -255,7 +255,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
         self.launch_cmd = l_cmd
         logger.debug("Launch command: {}".format(self.launch_cmd))
 
-        self._scaling_enabled = self.provider.scaling_enabled
+        self._scaling_enabled = True
         logger.debug("Starting HighThroughputExecutor with provider:\n%s", self.provider)
         if hasattr(self.provider, 'init_blocks'):
             try:

--- a/parsl/executors/ipp.py
+++ b/parsl/executors/ipp.py
@@ -116,7 +116,7 @@ class IPyParallelExecutor(ParslExecutor, RepresentationMixin):
         self.launch_cmd = command_composer(self.engine_file, self.engine_dir, self.container_image)
         self.engines = []
 
-        self._scaling_enabled = self.provider.scaling_enabled
+        self._scaling_enabled = True
         logger.debug("Starting IPyParallelExecutor with provider:\n%s", self.provider)
         if hasattr(self.provider, 'init_blocks'):
             try:

--- a/parsl/executors/low_latency/executor.py
+++ b/parsl/executors/low_latency/executor.py
@@ -92,7 +92,7 @@ class LowLatencyExecutor(ParslExecutor, RepresentationMixin):
             self.launch_cmd = l_cmd
             logger.debug("Launch command: {}".format(self.launch_cmd))
 
-            self._scaling_enabled = self.provider.scaling_enabled
+            self._scaling_enabled = True
             logger.debug(
                 "Starting LowLatencyExecutor with provider:\n%s", self.provider)
             if hasattr(self.provider, 'init_blocks'):

--- a/parsl/providers/aws/aws.py
+++ b/parsl/providers/aws/aws.py
@@ -687,10 +687,6 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
         os.remove(self.config['state_file_path'])
 
     @property
-    def scaling_enabled(self):
-        return True
-
-    @property
     def label(self):
         return self._label
 

--- a/parsl/providers/azure/azure.py
+++ b/parsl/providers/azure/azure.py
@@ -354,10 +354,6 @@ class AzureProvider(ExecutionProvider, RepresentationMixin):
         return return_vals
 
     @property
-    def scaling_enabled(self):
-        return True
-
-    @property
     def label(self):
         return self._label
 

--- a/parsl/providers/cluster_provider.py
+++ b/parsl/providers/cluster_provider.py
@@ -41,8 +41,6 @@ class ClusterProvider(ExecutionProvider):
           [ ids ]       ------->|  cancel
           [cancel]     <--------|----+
                                 |
-          [True/False] <--------|  scaling_enabled
-                                |
                                 +-------------------
     """
 
@@ -58,7 +56,6 @@ class ClusterProvider(ExecutionProvider):
                  launcher,
                  cmd_timeout=10):
 
-        self._scaling_enabled = True
         self._label = label
         self.channel = channel
         self.nodes_per_block = nodes_per_block
@@ -147,16 +144,6 @@ class ClusterProvider(ExecutionProvider):
         if job_ids:
             self._status()
         return [self.resources[jid]['status'] for jid in job_ids]
-
-    @property
-    def scaling_enabled(self):
-        """ The callers of ParslExecutors need to differentiate between Executors
-        and Executors wrapped in a resource provider
-
-        Returns:
-              - Status (Bool)
-        """
-        return self._scaling_enabled
 
     @property
     def current_capacity(self):

--- a/parsl/providers/condor/condor.py
+++ b/parsl/providers/condor/condor.py
@@ -310,10 +310,6 @@ class CondorProvider(RepresentationMixin, ClusterProvider):
         return rets
 
     @property
-    def scaling_enabled(self):
-        return True
-
-    @property
     def current_capacity(self):
         return self
 

--- a/parsl/providers/googlecloud/googlecloud.py
+++ b/parsl/providers/googlecloud/googlecloud.py
@@ -71,8 +71,6 @@ class GoogleCloudProvider():
           [ ids ]       ------->|  cancel
           [cancel]     <--------|----+
                                 |
-          [True/False] <--------|  scaling_enabled
-                                |
                                 +-------------------
      """
 
@@ -178,15 +176,6 @@ class GoogleCloudProvider():
             except Exception:
                 statuses.append(False)
         return statuses
-
-    @property
-    def scaling_enabled(self):
-        ''' Scaling is enabled
-
-        Returns:
-              - Status (Bool)
-        '''
-        return True
 
     @property
     def current_capacity(self):

--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -285,9 +285,5 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         logger.debug("Pod deleted. status='{0}'".format(str(api_response.status)))
 
     @property
-    def scaling_enabled(self):
-        return True
-
-    @property
     def label(self):
         return "kubernetes"

--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -248,10 +248,6 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
         return rets
 
     @property
-    def scaling_enabled(self):
-        return True
-
-    @property
     def current_capacity(self):
         return len(self.resources)
 

--- a/parsl/providers/provider_base.py
+++ b/parsl/providers/provider_base.py
@@ -18,8 +18,6 @@ class ExecutionProvider(metaclass=ABCMeta):
           [ ids ]       ------->|  cancel
           [cancel]     <--------|----+
                                 |
-          [True/False] <--------|  scaling_enabled
-                                |
                                 +-------------------
      """
     _cores_per_node = None  # type: Optional[int]
@@ -80,17 +78,6 @@ class ExecutionProvider(metaclass=ABCMeta):
 
         Raises:
              - ExecutionProviderException or its subclasses
-        '''
-
-        pass
-
-    @abstractproperty
-    def scaling_enabled(self) -> bool:
-        ''' The callers of ParslExecutors need to differentiate between Executors
-        and Executors wrapped in a resource provider
-
-        Returns:
-              - Status (Bool)
         '''
 
         pass


### PR DESCRIPTION
This code path is not used, and providers have a more nuanced
ability to control their own scaling, because they are allowed
to not launch a block when asked.

This does not remove the ability for executors (rather
than providers) to be marked as scalable or not. Executors which
previously sometimes inherited their scalability from their
provider now also report themselves as scalable when given a
provider.

Fixes #1304