### PR TITLE
Tighten pipeline tests to assert more.

### DIFF
--- a/parsl/tests/test_bash_apps/test_pipeline.py
+++ b/parsl/tests/test_bash_apps/test_pipeline.py
@@ -4,6 +4,7 @@ import os
 import parsl
 from parsl.app.app import App
 from parsl.data_provider.files import File
+from parsl.app.futures import DataFuture
 
 from parsl.tests.configs.local_threads import config
 
@@ -11,6 +12,7 @@ from parsl.tests.configs.local_threads import config
 @App('bash')
 def increment(inputs=[], outputs=[], stdout=None, stderr=None):
     cmd_line = """
+    if ! [ -f {inputs[0]} ] ; then exit 43 ; fi
     x=$(cat {inputs[0]})
     echo $(($x+1)) > {outputs[0]}
     """.format(inputs=inputs, outputs=outputs)
@@ -48,6 +50,7 @@ def test_increment(depth=5):
     futs = {}
     for i in range(1, depth):
         print("Launching {0} with {1}".format(i, prev))
+        assert(isinstance(prev, DataFuture) or isinstance(prev, File))
         output = File("test{0}.txt".format(i))
         fu = increment(inputs=[prev],  # Depend on the future from previous call
                        # Name the file to be created here
@@ -57,6 +60,7 @@ def test_increment(depth=5):
         [prev] = fu.outputs
         futs[i] = prev
         print(prev.filepath)
+        assert(isinstance(prev, DataFuture))
 
     for key in futs:
         if key > 0:


### PR DESCRIPTION
In some cases when developing staging providers, the pipeline
test fails due to a buggy provider, but giving an error that is
not immediately clear - rather than indicating that an input
file is missing, the test instead starts counting from 0 again.

This patch adds in an explicit test for expected input files to
aid in detecting that particular failure mode.

This patch also adds checks to ensure that returned outputs are
DataFutures - this catches the case that file stage-out code is
incorrectly returning a File rather than DataFuture for that
File.