### PR TITLE
Remove unused (and a bit broken) codepath from gather_all_deps

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -696,7 +696,7 @@ class DataFlowKernel(object):
         else:
             self.tasks[task_id] = task_def
 
-        # Get the dep count and a list of dependencies for the task
+        # Get the the list of dependencies for the task
         depends = self._gather_all_deps(args, kwargs)
         self.tasks[task_id]['depends'] = depends
 

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -696,7 +696,7 @@ class DataFlowKernel(object):
         else:
             self.tasks[task_id] = task_def
 
-        # Get the the list of dependencies for the task
+        # Get the list of dependencies for the task
         depends = self._gather_all_deps(args, kwargs)
         self.tasks[task_id]['depends'] = depends
 

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -29,7 +29,7 @@ from parsl.dataflow.flow_control import FlowControl, FlowNoControl, Timer
 from parsl.dataflow.futures import AppFuture
 from parsl.dataflow.memoization import Memoizer
 from parsl.dataflow.rundirs import make_rundir
-from parsl.dataflow.states import States, FINAL_STATES, FINAL_FAILURE_STATES
+from parsl.dataflow.states import States, FINAL_FAILURE_STATES
 from parsl.dataflow.usage_tracking.usage import UsageTracker
 from parsl.executors.threads import ThreadPoolExecutor
 from parsl.utils import get_version
@@ -525,12 +525,9 @@ class DataFlowKernel(object):
         """
         # Check the positional args
         depends = []
-        unfinished_depends = []
 
         def check_dep(d):
             if isinstance(d, Future):
-                if d.tid not in self.tasks or self.tasks[d.tid]['status'] not in FINAL_STATES:
-                    unfinished_depends.extend([d])
                 depends.extend([d])
 
         for dep in args:
@@ -545,8 +542,7 @@ class DataFlowKernel(object):
         for dep in kwargs.get('inputs', []):
             check_dep(dep)
 
-        count = len(unfinished_depends)
-        return count, depends
+        return depends
 
     def sanitize_and_wrap(self, task_id, args, kwargs):
         """This function should be called only when all the futures we track have been resolved.
@@ -701,7 +697,7 @@ class DataFlowKernel(object):
             self.tasks[task_id] = task_def
 
         # Get the dep count and a list of dependencies for the task
-        dep_cnt, depends = self._gather_all_deps(args, kwargs)
+        depends = self._gather_all_deps(args, kwargs)
         self.tasks[task_id]['depends'] = depends
 
         logger.info("Task {} submitted for App {}, waiting on tasks {}".format(task_id,


### PR DESCRIPTION
This is a bit broken because it assumes Futures have parsl specific
properties.

The code path removed is not used - similar functionality comes
from _count_deps instead.