### PR TITLE
Pay attention to function substitution done by output staging

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -686,7 +686,7 @@ class DataFlowKernel(object):
         # Transform remote input files to data futures
         args, kwargs, func = self._add_input_deps(executor, args, kwargs, func)
 
-        self._add_output_deps(executor, args, kwargs, app_fu, func)
+        func = self._add_output_deps(executor, args, kwargs, app_fu, func)
 
         task_def.update({
                     'args': args,


### PR DESCRIPTION
Prior to this, staging providers were given the opportunity to
replace the app function with a staging wrapper for stageout,
but that staging wrapper was then discarded.