### PR TITLE
Prevent globus transfers to fail after 60 seconds 

### DIFF
--- a/parsl/data_provider/globus.py
+++ b/parsl/data_provider/globus.py
@@ -98,10 +98,11 @@ class Globus(object):
             task = tc.get_task(task['task_id'])
             # Get the last error Globus event
             events = tc.task_event_list(task['task_id'], num_results=1, filter='is_error:1')
+            try:
+                event = next(events)
             # No error reported,  the transfer is still running
-            if zip([None], events):
+            except StopIteration:
                 continue
-            event = events.data[0]
             # Print the error event to stderr and Parsl file log if it was not yet printed
             if event['time'] != last_event_time:
                 last_event_time = event['time']

--- a/parsl/data_provider/globus.py
+++ b/parsl/data_provider/globus.py
@@ -98,6 +98,9 @@ class Globus(object):
             task = tc.get_task(task['task_id'])
             # Get the last error Globus event
             events = tc.task_event_list(task['task_id'], num_results=1, filter='is_error:1')
+            # No error reported,  the transfer is still running
+            if zip([None], events):
+                continue
             event = events.data[0]
             # Print the error event to stderr and Parsl file log if it was not yet printed
             if event['time'] != last_event_time:


### PR DESCRIPTION
Current globus transfer error checking mechanism assumes  `task_event_list()` to return non-empty iterable and fails it is it empty. If the transfer is still running, then function call `task_event_list(task['task_id'], num_results=1, filter='is_error:1')` returns empty list and causes the code to fail in the next line when it attempts to access the first element of the result from the function `event = events.data[0]`. This change checks `events` and continues if the result is None

Fixes #1170 and #1317 by checking the size of globus event
list before accessing the first element since it can be empty