### PR TITLE
Adds Python 3.7 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
 
 env:
   global:


### PR DESCRIPTION
Adds Python 3.7 to the Travis matrix (Python 3.8 is due out soon). Unlikely to cause feature conflicts due to your upgrade cycle, but they do occasional make tweaks to `concurrent.futures`.