### PR TITLE
Fixed reference to ExtremeScaleExecutor in docs.

### DIFF
--- a/docs/devguide/dev_docs.rst
+++ b/docs/devguide/dev_docs.rst
@@ -143,7 +143,7 @@ HighThroughputExecutor
 ExtremeScaleExecutor
 --------------------
 
-.. autoclass:: parsl.executors.HighThroughputExecutor
+.. autoclass:: parsl.executors.ExtremeScaleExecutor
    :members:  __init__, start, submit, scale_out, scale_in, scaling_enabled, compose_launch_cmd,
               _start_queue_management_thread, _start_local_queue_process,
               hold_worker, outstanding, connected_workers


### PR DESCRIPTION
In the API reference to the ExtremeScaleExecutor it accidentally referenced the HighThroughputExecutor resulting in the former actually being missing.