### PR TITLE
Make DFK optionally not initialize any logging

### DIFF
--- a/parsl/config.py
+++ b/parsl/config.py
@@ -52,17 +52,15 @@ class Config(RepresentationMixin):
     usage_tracking : bool, optional
         Set this field to True to opt-in to Parsl's usage tracking system. Parsl only collects minimal, non personally-identifiable,
         information used for reporting to our funding agencies. Default is False.
-
     initialize_logging : bool, optional
         Make DFK optionally not initialize any logging. Log messages
-        will still be passed into the python logging system, but the
-        logging system will not by default perform any further log
-        system configuration. Most noticeably, it will not create a
-        parsl.log logfile.  The use case for this is when parsl is
-        used as a library in a bigger system which wants to configure
-        logging in a way that makes sense for that bigger system as
-        a whole.  In such a situation, parsl should step out of the way
-        and let that system do what it wants.
+        will still be passed into the python logging system under the
+        `parsl` logger name, but the logging system will not by default
+        perform any further log system configuration. Most noticeably,
+        it will not create a parsl.log logfile.  The use case for this
+        is when parsl is used as a library in a bigger system which
+        wants to configure logging in a way that makes sense for that
+        bigger system as a whole.
     """
 
     @typeguard.typechecked

--- a/parsl/config.py
+++ b/parsl/config.py
@@ -52,6 +52,17 @@ class Config(RepresentationMixin):
     usage_tracking : bool, optional
         Set this field to True to opt-in to Parsl's usage tracking system. Parsl only collects minimal, non personally-identifiable,
         information used for reporting to our funding agencies. Default is False.
+
+    initialize_logging : bool, optional
+        Make DFK optionally not initialize any logging. Log messages
+        will still be passed into the python logging system, but the
+        logging system will not by default perform any further log
+        system configuration. Most noticeably, it will not create a
+        parsl.log logfile.  The use case for this is when parsl is
+        used as a library in a bigger system which wants to configure
+        logging in a way that makes sense for that bigger system as
+        a whole.  In such a situation, parsl should step out of the way
+        and let that system do what it wants.
     """
 
     @typeguard.typechecked
@@ -68,7 +79,8 @@ class Config(RepresentationMixin):
                  strategy: Optional[str] = 'simple',
                  max_idletime: float = 120.0,
                  monitoring: Optional[MonitoringHub] = None,
-                 usage_tracking: bool = False):
+                 usage_tracking: bool = False,
+                 initialize_logging: bool = True):
         if executors is None:
             executors = [ThreadPoolExecutor()]
         self.executors = executors
@@ -94,6 +106,7 @@ class Config(RepresentationMixin):
         self.strategy = strategy
         self.max_idletime = max_idletime
         self.usage_tracking = usage_tracking
+        self.initialize_logging = initialize_logging
         self.monitoring = monitoring
 
     @property

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -77,7 +77,10 @@ class DataFlowKernel(object):
                     'see http://parsl.readthedocs.io/en/stable/stubs/parsl.config.Config.html')
         self._config = config
         self.run_dir = make_rundir(config.run_dir)
-        parsl.set_file_logger("{}/parsl.log".format(self.run_dir), level=logging.DEBUG)
+
+        if config.initialize_logging:
+            parsl.set_file_logger("{}/parsl.log".format(self.run_dir), level=logging.DEBUG)
+
         logger.debug("Starting DataFlowKernel with config\n{}".format(config))
         logger.info("Parsl version: {}".format(get_version()))
 


### PR DESCRIPTION
The use case for this is when parsl is used as a library
as part of a bigger system which wants to configure logging
in a way that makes sense for that bigger system as a whole.

In such a situation, parsl should step out of the way
and let that system do what it wants.