### PR TITLE
Specify Resources in App Decorator

### DIFF
--- a/parsl/app/app.py
+++ b/parsl/app/app.py
@@ -21,7 +21,7 @@ class AppBase(metaclass=ABCMeta):
 
     """
 
-    def __init__(self, func, data_flow_kernel=None, walltime=60, executors='all', cache=False, cores=1):
+    def __init__(self, func, data_flow_kernel=None, walltime=60, executors='all', cache=False, cores=None, disk=None, mem=None):
         """Construct the App object.
 
         Args:
@@ -45,6 +45,8 @@ class AppBase(metaclass=ABCMeta):
         self.status = 'created'
         self.executors = executors
         self.cores = cores
+        self.disk = disk
+        self.mem = mem
         self.cache = cache
         if not (isinstance(executors, list) or isinstance(executors, str)):
             logger.error("App {} specifies invalid executor option, expects string or list".format(
@@ -78,7 +80,7 @@ class AppBase(metaclass=ABCMeta):
         pass
 
 
-def App(apptype, data_flow_kernel=None, walltime=60, cache=False, cores=1, executors='all'):
+def App(apptype, data_flow_kernel=None, walltime=60, cache=False, cores=None, mem=None, disk=None, executors='all'):
     """The App decorator function.
 
     Args:
@@ -116,11 +118,13 @@ def App(apptype, data_flow_kernel=None, walltime=60, cache=False, cores=1, execu
                          walltime=walltime,
                          cache=cache,
                          cores=cores,
+                         mem=mem,
+                         disk=disk,
                          executors=executors)
     return wrapper
 
 
-def python_app(function=None, data_flow_kernel=None, walltime=60, cache=False, cores=1, executors='all'):
+def python_app(function=None, data_flow_kernel=None, walltime=60, cache=False, cores=None, mem=None, disk=None, executors='all'):
     """Decorator function for making python apps.
 
     Parameters
@@ -149,6 +153,8 @@ def python_app(function=None, data_flow_kernel=None, walltime=60, cache=False, c
                              walltime=walltime,
                              cache=cache,
                              cores=cores,
+                             mem=mem,
+                             disk=disk,
                              executors=executors)
         return wrapper(func)
     if function is not None:
@@ -156,7 +162,7 @@ def python_app(function=None, data_flow_kernel=None, walltime=60, cache=False, c
     return decorator
 
 
-def bash_app(function=None, data_flow_kernel=None, walltime=60, cache=False, cores=1, executors='all'):
+def bash_app(function=None, data_flow_kernel=None, walltime=60, cache=False, cores=None, mem=None, disk=None, executors='all'):
     """Decorator function for making bash apps.
 
     Parameters
@@ -185,6 +191,8 @@ def bash_app(function=None, data_flow_kernel=None, walltime=60, cache=False, cor
                            walltime=walltime,
                            cache=cache,
                            cores=cores,
+                           mem=mem,
+                           disk=disk,
                            executors=executors)
         return wrapper(func)
     if function is not None:

--- a/parsl/app/app.py
+++ b/parsl/app/app.py
@@ -21,7 +21,7 @@ class AppBase(metaclass=ABCMeta):
 
     """
 
-    def __init__(self, func, data_flow_kernel=None, walltime=60, executors='all', cache=False):
+    def __init__(self, func, data_flow_kernel=None, walltime=60, executors='all', cache=False, cores=1):
         """Construct the App object.
 
         Args:
@@ -44,6 +44,7 @@ class AppBase(metaclass=ABCMeta):
         self.data_flow_kernel = data_flow_kernel
         self.status = 'created'
         self.executors = executors
+        self.cores = cores
         self.cache = cache
         if not (isinstance(executors, list) or isinstance(executors, str)):
             logger.error("App {} specifies invalid executor option, expects string or list".format(
@@ -77,7 +78,7 @@ class AppBase(metaclass=ABCMeta):
         pass
 
 
-def App(apptype, data_flow_kernel=None, walltime=60, cache=False, executors='all'):
+def App(apptype, data_flow_kernel=None, walltime=60, cache=False, cores=1, executors='all'):
     """The App decorator function.
 
     Args:
@@ -114,11 +115,12 @@ def App(apptype, data_flow_kernel=None, walltime=60, cache=False, executors='all
                          data_flow_kernel=data_flow_kernel,
                          walltime=walltime,
                          cache=cache,
+                         cores=cores,
                          executors=executors)
     return wrapper
 
 
-def python_app(function=None, data_flow_kernel=None, walltime=60, cache=False, executors='all'):
+def python_app(function=None, data_flow_kernel=None, walltime=60, cache=False, cores=1, executors='all'):
     """Decorator function for making python apps.
 
     Parameters
@@ -146,6 +148,7 @@ def python_app(function=None, data_flow_kernel=None, walltime=60, cache=False, e
                              data_flow_kernel=data_flow_kernel,
                              walltime=walltime,
                              cache=cache,
+                             cores=cores,
                              executors=executors)
         return wrapper(func)
     if function is not None:
@@ -153,7 +156,7 @@ def python_app(function=None, data_flow_kernel=None, walltime=60, cache=False, e
     return decorator
 
 
-def bash_app(function=None, data_flow_kernel=None, walltime=60, cache=False, executors='all'):
+def bash_app(function=None, data_flow_kernel=None, walltime=60, cache=False, cores=1, executors='all'):
     """Decorator function for making bash apps.
 
     Parameters
@@ -181,6 +184,7 @@ def bash_app(function=None, data_flow_kernel=None, walltime=60, cache=False, exe
                            data_flow_kernel=data_flow_kernel,
                            walltime=walltime,
                            cache=cache,
+                           cores=cores,
                            executors=executors)
         return wrapper(func)
     if function is not None:

--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -119,8 +119,8 @@ def remote_side_bash_executor(func, *args, **kwargs):
 
 class BashApp(AppBase):
 
-    def __init__(self, func, data_flow_kernel=None, walltime=60, cache=False, executors='all'):
-        super().__init__(func, data_flow_kernel=data_flow_kernel, walltime=60, executors=executors, cache=cache)
+    def __init__(self, func, data_flow_kernel=None, walltime=60, cache=False, cores=1, executors='all'):
+        super().__init__(func, data_flow_kernel=data_flow_kernel, walltime=60, executors=executors, cores=cores, cache=cache)
         self.kwargs = {}
 
         # We duplicate the extraction of parameter defaults
@@ -147,6 +147,7 @@ class BashApp(AppBase):
         """
         # Update kwargs in the app definition with ones passed in at calltime
         self.kwargs.update(kwargs)
+        self.kwargs["cores"] = self.cores
 
         if self.data_flow_kernel is None:
             dfk = DataFlowKernelLoader.dfk()

--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -119,8 +119,8 @@ def remote_side_bash_executor(func, *args, **kwargs):
 
 class BashApp(AppBase):
 
-    def __init__(self, func, data_flow_kernel=None, walltime=60, cache=False, cores=1, executors='all'):
-        super().__init__(func, data_flow_kernel=data_flow_kernel, walltime=60, executors=executors, cores=cores, cache=cache)
+    def __init__(self, func, data_flow_kernel=None, walltime=60, cache=False, cores=None, mem=None, disk=None, executors='all'):
+        super().__init__(func, data_flow_kernel=data_flow_kernel, walltime=60, executors=executors, cores=cores, mem=mem, disk=disk, cache=cache)
         self.kwargs = {}
 
         # We duplicate the extraction of parameter defaults
@@ -147,7 +147,12 @@ class BashApp(AppBase):
         """
         # Update kwargs in the app definition with ones passed in at calltime
         self.kwargs.update(kwargs)
-        self.kwargs["cores"] = self.cores
+        if 'parsl_resource_specification' not in self.kwargs:
+            self.kwargs['parsl_resource_specification'] = {
+                'cores': self.cores,
+                'disk': self.disk,
+                'mem': self.mem
+            }
 
         if self.data_flow_kernel is None:
             dfk = DataFlowKernelLoader.dfk()

--- a/parsl/app/python.py
+++ b/parsl/app/python.py
@@ -35,13 +35,15 @@ def timeout(f, seconds):
 class PythonApp(AppBase):
     """Extends AppBase to cover the Python App."""
 
-    def __init__(self, func, data_flow_kernel=None, walltime=60, cache=False, cores=1, executors='all'):
+    def __init__(self, func, data_flow_kernel=None, walltime=60, cache=False, cores=None, disk=None, mem=None, executors='all'):
         super().__init__(
             wrap_error(func),
             data_flow_kernel=data_flow_kernel,
             walltime=walltime,
             executors=executors,
             cores=cores,
+            disk=disk,
+            mem=mem,
             cache=cache
         )
 
@@ -63,7 +65,12 @@ class PythonApp(AppBase):
         else:
             dfk = self.data_flow_kernel
 
-        kwargs["cores"] = self.cores
+        if 'parsl_resource_specification' not in kwargs:
+            kwargs['parsl_resource_specification'] = {
+                'cores': self.cores,
+                'mem': self.mem,
+                'disk': self.disk
+            }
 
         walltime = self.kwargs.get('walltime')
         if walltime is not None:

--- a/parsl/app/python.py
+++ b/parsl/app/python.py
@@ -35,12 +35,13 @@ def timeout(f, seconds):
 class PythonApp(AppBase):
     """Extends AppBase to cover the Python App."""
 
-    def __init__(self, func, data_flow_kernel=None, walltime=60, cache=False, executors='all'):
+    def __init__(self, func, data_flow_kernel=None, walltime=60, cache=False, cores=1, executors='all'):
         super().__init__(
             wrap_error(func),
             data_flow_kernel=data_flow_kernel,
             walltime=walltime,
             executors=executors,
+            cores=cores,
             cache=cache
         )
 
@@ -61,6 +62,8 @@ class PythonApp(AppBase):
             dfk = DataFlowKernelLoader.dfk()
         else:
             dfk = self.data_flow_kernel
+
+        kwargs["cores"] = self.cores
 
         walltime = self.kwargs.get('walltime')
         if walltime is not None:

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -564,7 +564,7 @@ class WorkQueueExecutor(ParslExecutor):
 
         # Receive resource specifications from the kwargs, then remove it
         if 'parsl_resource_specification' in kwargs:
-            resources = kwargs["parsl_resource_specification"] 
+            resources = kwargs["parsl_resource_specification"]
             kwargs.pop("parsl_resource_specification")
 
         # Add input files from the "inputs" keyword argument


### PR DESCRIPTION
Refer #1324 for issue, but this PR allows users to optionally specify resource requirements within the Parsl app decorator, which enables Work Queue to specify tasks to run with specific resource usage.

This can be done at the function level, such as:
```
@python_app(cores=4, mem=100, disk=100)
def example():
    ...
```
which would specify each function call to example() to require 4 cores, 100MB of memory, and 100MB of disk. Not all resources need to be specified: any combination of cores, memory, and disk can be specified, and if they are not listed, it will default to Work Queue's default settings (where one task consumes an entire worker). 

Additionally, users have an option to specify resource requirements _per task_, by passing in resource requirements as a keyword argument to the function. More specifically, it uses the keyword argument `parsl_resource_specification` to map to a dictionary of resource requirements. For example:
```
@python_app
def example(parsl_resource_specification={cores=2, mem=100, disk=100}):
    ...
```
This allows for the use case where a user might want to specify different resource requirements for different iterations of the same function call, such as if one function call has a much bigger input which would require more computational resources. If resources are specified in both the decorator and as an argument to the function using the `parsl_resource_specification` keyword, it defaults to using the argument values, allowing the values within the decorator to act as "default" resource specifications for the app.