### PR TITLE
change the theta config path and add an option to AprunLauncher

### DIFF
--- a/parsl/configs/theta.py
+++ b/parsl/configs/theta.py
@@ -14,10 +14,12 @@ config = Config(
             provider=CobaltProvider(
                 queue='YOUR_QUEUE',
                 account='YOUR_ACCOUNT',
-                launcher=AprunLauncher(),
+                launcher=AprunLauncher(overrides="-d 64"),
                 walltime='00:30:00',
                 nodes_per_block=2,
                 init_blocks=1,
+                min_blocks=1,
+                max_blocks=1,
                 # string to prepend to #COBALT blocks in the submit
                 # script to the scheduler eg: '#COBALT -t 50'
                 scheduler_options='',


### PR DESCRIPTION
This PR
(1) renames the Theta config path
(2) adds `min_blocks` and `max_blocks` to show how users can configure the scaling on Theta
(3) add `overrides="-d 64"` to AprunLauncher, which can deploy the workers across all the 64 cores on compute nodes.