### PR TITLE
Pin mypy to 0.730 pending more invasive fixes in #1370

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,6 +8,6 @@ coverage
 mock>=1.0.0
 nbsphinx
 sphinx_rtd_theme
-mypy
+mypy==0.730
 sqlalchemy-stubs
 


### PR DESCRIPTION
This commit does not change any of core parsl. It changes the dependencies
that will be installed for testing, giving an older more tolerant mypy.

PR #1370 is a better but riskier fix.