### PR TITLE
Fix human-readable text in Azure provider

### DIFF
--- a/parsl/providers/azure/azure.py
+++ b/parsl/providers/azure/azure.py
@@ -41,13 +41,13 @@ class AzureProvider(ExecutionProvider, RepresentationMixin):
     """
     A Provider for using Microsoft Azure Resources
 
-    One of 2 methods are required to authenticate: keyfile, or environment
-    variables. If  keyfile is not set, the following environment
+    One of 2 methods are required to authenticate: `key_file`, or environment
+    variables. If `key_file` is not set, the following environment
     variables must be set: `AZURE_CLIENT_ID` (the access key for
     your azure account),
-    `AZURE_CLIENT_SECRET` (the secret key for your azure account), the
+    `AZURE_CLIENT_SECRET` (the secret key for your azure account),
     `AZURE_TENANT_ID` (the session key for your azure account), and
-    AZURE_SUBSCRIPTION_ID.
+    `AZURE_SUBSCRIPTION_ID`.
 
     Parameters
     ----------
@@ -77,14 +77,13 @@ class AzureProvider(ExecutionProvider, RepresentationMixin):
         String to append to the Userdata script executed in the cloudinit phase of
         instance initialization.
     key_file : str
-        Path to json file that contains 'Azure keys'
+        Path to JSON file that contains 'Azure keys'
         The structure of the key file is as follows:
         {
             "AZURE_CLIENT_ID": (str) azure client id [from account principal],
             "AZURE_CLIENT_SECRET":(str) azure client secret [from account principal],
             "AZURE_TENANT_ID": (str) azure tenant [account] id,
             "AZURE_SUBSCRIPTION_ID": (str) azure subscription id
-
         }
     init_blocks : int
         Number of blocks to provision at the start of the run. Default is 1.
@@ -153,9 +152,9 @@ class AzureProvider(ExecutionProvider, RepresentationMixin):
             "AZURE_TENANT_ID") is not None and os.getenv("AZURE_SUBSCRIPTION_ID") is not None
 
         if key_file is None and not env_specified:
-            raise ConfigurationError("Must specify either, 'key_file', or\
-                 `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`,\
-                  and `AZURE_TENANT_ID` environment variables.")
+            raise ConfigurationError(("Must specify either: 'key_file', or "
+                                      "`AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, "
+                                      "and `AZURE_TENANT_ID` environment variables."))
 
         if key_file is None:
             self.clientid = os.getenv("AZURE_CLIENT_ID")
@@ -187,15 +186,6 @@ class AzureProvider(ExecutionProvider, RepresentationMixin):
     def get_credentials(self):
         """
         Authenticate to the Azure API
-
-        One of 2 methods are required to authenticate: keyfile, or environment
-        variables. If  keyfile is not set, the following environment
-        variables must be set: `AZURE_CLIENT_ID` (the access key for
-        your azure account),
-        `AZURE_CLIENT_SECRET` (the secret key for your azure account), the
-        `AZURE_TENANT_ID` (the session key for your azure account), and
-        AZURE_SUBSCRIPTION_ID.
-
         """
         subscription_id = self.subid
         credentials = ServicePrincipalCredentials(


### PR DESCRIPTION
* capitalisation of JSON

* long exception string literal contained long strings of
  whitespace due to indentation - change string literal
  syntax to one which avoids that

* make markup and articles consistent

* remove a duplicate comment