### PR TITLE
Regenerate outdated File doc stub

### DIFF
--- a/docs/stubs/parsl.data_provider.files.File.rst
+++ b/docs/stubs/parsl.data_provider.files.File.rst
@@ -14,55 +14,7 @@ parsl.data\_provider.files.File
    .. autosummary::
    
       ~File.__init__
-      ~File.capitalize
-      ~File.casefold
-      ~File.center
-      ~File.count
-      ~File.encode
-      ~File.endswith
-      ~File.expandtabs
-      ~File.find
-      ~File.format
-      ~File.format_map
-      ~File.get_data_future
-      ~File.index
-      ~File.is_remote
-      ~File.isalnum
-      ~File.isalpha
-      ~File.isdecimal
-      ~File.isdigit
-      ~File.isidentifier
-      ~File.islower
-      ~File.isnumeric
-      ~File.isprintable
-      ~File.isspace
-      ~File.istitle
-      ~File.isupper
-      ~File.join
-      ~File.ljust
-      ~File.lower
-      ~File.lstrip
-      ~File.maketrans
-      ~File.partition
-      ~File.replace
-      ~File.rfind
-      ~File.rindex
-      ~File.rjust
-      ~File.rpartition
-      ~File.rsplit
-      ~File.rstrip
-      ~File.set_data_future
-      ~File.split
-      ~File.splitlines
-      ~File.stage_in
-      ~File.stage_out
-      ~File.startswith
-      ~File.strip
-      ~File.swapcase
-      ~File.title
-      ~File.translate
-      ~File.upper
-      ~File.zfill
+      ~File.cleancopy
    
    
 


### PR DESCRIPTION
Previous to this commit, the File stub still contained a lot of
references to the former str superclass which was removed in
ef3f005e51 PR #880, and did not contain cleancopy() introduced
in 3e92bf7744 PR #1272