### PR TITLE
Remove outdated HTEX module docstring

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -1,6 +1,3 @@
-"""HighThroughputExecutor builds on the Swift/T EMEWS architecture to use MPI for fast task distribution
-"""
-
 from concurrent.futures import Future
 import typeguard
 import logging


### PR DESCRIPTION
There is more description in the docstring for
HighThroughputExecutor, which is also available
via parsl.HighThroughputExecutor.