### PR TITLE
Fix bash_app walltime test

### DIFF
--- a/parsl/tests/test_bash_apps/test_apptimeout.py
+++ b/parsl/tests/test_bash_apps/test_apptimeout.py
@@ -1,6 +1,9 @@
 import parsl
+import pytest
+
 from parsl.app.app import App
 from parsl.tests.configs.local_threads import config
+from parsl.app.errors import AppTimeout
 
 
 @App('bash')
@@ -12,13 +15,14 @@ def echo_to_file(inputs=[], outputs=[], stderr='std.err', stdout='std.out', wall
 def test_walltime():
     """Testing walltime exceeded exception """
     x = echo_to_file()
+    with pytest.raises(AppTimeout):
+        x.result()
 
-    try:
-        r = x.result()
-        print("Got result : ", r)
-    except Exception as e:
-        print(e.__class__)
-        print("Caught exception ", e)
+
+def test_walltime_longer():
+    """Test that an app that runs in less than walltime will succeed."""
+    y = echo_to_file(walltime=2)
+    y.result()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Prior to this commit, this test did not check that timeout
behaviour actually happened. After this commit, the test
checks for an AppTimeout, in the style of the python_app
test in parsl/tests/test_error_handling/test_python_walltime.py

This commit also adds a test that apps will pass without
an exception if they run within the specified walltime.