### PR TITLE
Fix undefined returncode bug in exception handling code

### DIFF
--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -95,7 +95,7 @@ def remote_side_bash_executor(func, *args, **kwargs):
         raise pe.AppTimeout("[{}] App exceeded walltime: {}".format(func_name, timeout))
 
     except Exception as e:
-        raise pe.AppException("[{}] App caught exception: {}".format(func_name, proc.returncode), e)
+        raise pe.AppException("[{}] App caught exception with returncode: {}".format(func_name, returncode), e)
 
     if returncode != 0:
         raise pe.AppFailure("[{}] App failed with exit code: {}".format(func_name, proc.returncode), proc.returncode)


### PR DESCRIPTION
Fixes UnboundLocalError from #1435 
Minor wording update in the exception message to clarify that the return code is in the string.