### PR TITLE
Fix status checking in LocalProvider non-LocalChannel path

### DIFF
--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -109,7 +109,7 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
 
             elif self.resources[job_id]['remote_pid']:
 
-                retcode, stdout, stderr = self.channel.execute_wait('ps -p {} &> /dev/null; echo "STATUS:$?" ',
+                retcode, stdout, stderr = self.channel.execute_wait('ps -p {} &> /dev/null; echo "STATUS:$?" '.format(self.resources[job_id]['remote_pid']),
                                                                     self.cmd_timeout)
                 for line in stdout.split('\n'):
                     if line.startswith("STATUS:"):


### PR DESCRIPTION
Prior to this commit, the pid to inspect was not properly
passed in, and the status check always returned that a
remote process was not running.

When strategy was enabled, this meant that the strategy
would keep launching blocks, even when they were starting
and running successfully.

Part of plan in issue #1448