### PR TITLE
set monitoring zmq channel linger options to 0 to prevent shutdown delay

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -370,11 +370,13 @@ class Hub(object):
 
         self._context = zmq.Context()
         self.dfk_channel = self._context.socket(zmq.DEALER)
+        self.dfk_channel.setsockopt(zmq.LINGER, 0)
         self.dfk_channel.set_hwm(0)
         self.dfk_channel.RCVTIMEO = int(self.loop_freq)  # in milliseconds
         self.dfk_channel.connect("tcp://{}:{}".format(client_address, client_port))
 
         self.ic_channel = self._context.socket(zmq.DEALER)
+        self.ic_channel.setsockopt(zmq.LINGER, 0)
         self.ic_channel.set_hwm(0)
         self.ic_channel.RCVTIMEO = int(self.loop_freq)  # in milliseconds
         self.logger.debug("hub_address: {}. hub_port_range {}".format(hub_address, hub_port_range))


### PR DESCRIPTION
As reported in #1438 , with monitoring enabled, it took 31s for a very short workflow.
This is because we recently changed the monitoring closing mechanism in PR #1403 .
But it took a long time for the `Hub` process to join because of the long zmq context termination.

This PR sets the zmq lingering option to 0, so the context will terminate immediately.

Fixes #1438 