### PR TITLE
Replace bashisms with Bourne shell redirects in Local and AdHoc providers

### DIFF
--- a/parsl/providers/ad_hoc/ad_hoc.py
+++ b/parsl/providers/ad_hoc/ad_hoc.py
@@ -176,7 +176,7 @@ class AdHocProvider(ExecutionProvider, RepresentationMixin):
 
         if not isinstance(channel, LocalChannel):
             # Bash would return until the streams are closed. So we redirect to a outs file
-            final_cmd = 'bash {0} &> {0}.out & \n echo "PID:$!" '.format(script_path)
+            final_cmd = 'bash {0} > {0}.out 2>&1 & \n echo "PID:$!" '.format(script_path)
             retcode, stdout, stderr = channel.execute_wait(final_cmd, self.cmd_timeout)
             for line in stdout.split('\n'):
                 if line.startswith("PID:"):

--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -109,8 +109,8 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
 
             elif self.resources[job_id]['remote_pid']:
 
-                retcode, stdout, stderr = self.channel.execute_wait('ps -p {} > /dev/null 2> /dev/null; echo "STATUS:$?" '.format(self.resources[job_id]['remote_pid']),
-                                                                    self.cmd_timeout)
+                retcode, stdout, stderr = self.channel.execute_wait('ps -p {} > /dev/null 2> /dev/null; echo "STATUS:$?" '.format(
+                    self.resources[job_id]['remote_pid']), self.cmd_timeout)
                 for line in stdout.split('\n'):
                     if line.startswith("STATUS:"):
                         status = line.split("STATUS:")[1].strip()

--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -109,7 +109,7 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
 
             elif self.resources[job_id]['remote_pid']:
 
-                retcode, stdout, stderr = self.channel.execute_wait('ps -p {} &> /dev/null; echo "STATUS:$?" '.format(self.resources[job_id]['remote_pid']),
+                retcode, stdout, stderr = self.channel.execute_wait('ps -p {} > /dev/null 2> /dev/null; echo "STATUS:$?" '.format(self.resources[job_id]['remote_pid']),
                                                                     self.cmd_timeout)
                 for line in stdout.split('\n'):
                     if line.startswith("STATUS:"):
@@ -198,7 +198,7 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
         if not isinstance(self.channel, LocalChannel):
             logger.debug("Launching in remote mode")
             # Bash would return until the streams are closed. So we redirect to a outs file
-            cmd = 'bash {0} &> {0}.out & \n echo "PID:$!" '.format(script_path)
+            cmd = 'bash {0} > {0}.out 2>&1 & \n echo "PID:$!" '.format(script_path)
             retcode, stdout, stderr = self.channel.execute_wait(cmd, self.cmd_timeout)
             for line in stdout.split('\n'):
                 if line.startswith("PID:"):


### PR DESCRIPTION
This is to support using these code paths with the LocalChannel which will
run the commands inside /bin/sh rather than bash - and that /bin/sh
sometimes will not know &> bashisms.

This is part of the plan described in #1448 