### PR TITLE
Remove unused flake8 D203 exclusion

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,4 @@
 [flake8]
-# D203: 1 blank line required before class docstring
 # E124: closing bracket does not match visual indentation
 # E126: continuation line over-indented for hanging indent
 # This one is bad. Sometimes ordering matters, conditional imports
@@ -9,7 +8,7 @@
 # https://github.com/PyCQA/pycodestyle/issues/386
 # W504: line break after binary operator
 #       (Raised by flake8 even when it is followed)
-ignore = D203, E124, E126, E402, E129, W504
+ignore = E124, E126, E402, E129, W504
 max-line-length = 160
 exclude = parsl/executors/serialize/, test_import_fail.py
 # E741 disallows ambiguous single letter names which look like numbers


### PR DESCRIPTION
D203 is now disabled by default in flake8, so a parsl
level exclusion isn't necessary any more.

See https://github.com/PyCQA/pydocstyle/issues/141