### PR TITLE
Make LocalChannel execute_wait set pgid like execute_no_wait

### DIFF
--- a/parsl/channels/base.py
+++ b/parsl/channels/base.py
@@ -22,6 +22,10 @@ class Channel(metaclass=ABCMeta):
                                 |
                                 +-------------------
 
+
+    Channels should ensure that each launched command runs in a new process
+    group, so that providers (such as AdHocProvider and LocalProvider) which
+    terminate long running commands using process groups can do so.
     """
 
     @abstractmethod

--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -65,7 +65,8 @@ class LocalChannel(Channel, RepresentationMixin):
                 stderr=subprocess.PIPE,
                 cwd=self.userhome,
                 env=current_env,
-                shell=True
+                shell=True,
+                preexec_fn=os.setpgrp
             )
             proc.wait(timeout=walltime)
             stdout = proc.stdout.read()


### PR DESCRIPTION
execute_no_wait sets the process group of launched commands so that
local and ad-hoc providers can kill those launched commands later by
killing the whole process group.

Before this commit, execute_wait did not do that, so execute_wait could
not be used in the same way - instead, processes were left in the same
process group as the parent, and local/adhoc providers kill the entire
parent process group (for example, the entire containing workflow).

This commit also amends the documentation for the Channel base class to
clarify this requirement.

This is part of the plan in issue #1448