### PR TITLE
Correct links to source code

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ def linkcode_resolve(domain, info):
     if not info['module']:
         return None
     filename = info['module'].replace('.', '/')
-    return "http://github.com/Parsl/parsl/blob/master/{}.py".format(filename)
+    return "http://github.com/Parsl/parsl/tree/master/{}.py".format(filename)
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Getting 404s after clicking "source" in the rtds has been bugging me for awhile but I'd been too lazy to fix it