### PR TITLE
Exit htex probe loop with first working address

### DIFF
--- a/parsl/executors/high_throughput/probe.py
+++ b/parsl/executors/high_throughput/probe.py
@@ -39,7 +39,7 @@ def probe_addresses(addresses, task_port, timeout=2):
     start_t = time.time()
 
     first_connected = None
-    while time.time() < start_t + timeout:
+    while time.time() < start_t + timeout and not first_connected:
         for addr in addr_map:
             try:
                 recv_monitor_message(addr_map[addr]['mon_sock'], zmq.NOBLOCK)


### PR DESCRIPTION
Prior to this commit, the probe will run for the entire timeout
period. This results in slow worker startup if the timeout is
manually changed to something much longer.