### PR TITLE
Removed check that marks a missing job as completed only if it was in…

### DIFF
--- a/parsl/providers/cobalt/cobalt.py
+++ b/parsl/providers/cobalt/cobalt.py
@@ -123,8 +123,7 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
         # squeue does not report on jobs that are not running. So we are filling in the
         # blanks for missing jobs, we might lose some information about why the jobs failed.
         for missing_job in jobs_missing:
-            if self.resources[missing_job]['status'] in ['RUNNING', 'KILLING', 'EXITING']:
-                self.resources[missing_job]['status'] = translate_table['EXITING']
+            self.resources[missing_job]['status'] = translate_table['EXITING']
 
     def submit(self, command, tasks_per_node, job_name="parsl.cobalt"):
         """ Submits the command onto an Local Resource Manager job of parallel elements.

--- a/parsl/providers/grid_engine/grid_engine.py
+++ b/parsl/providers/grid_engine/grid_engine.py
@@ -189,8 +189,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
         # Filling in missing blanks for jobs that might have gone missing
         # we might lose some information about why the jobs failed.
         for missing_job in jobs_missing:
-            if self.resources[missing_job]['status'] in ['PENDING', 'RUNNING']:
-                self.resources[missing_job]['status'] = 'COMPLETED'
+            self.resources[missing_job]['status'] = 'COMPLETED'
 
     def cancel(self, job_ids):
         ''' Cancels the resources identified by the job_ids provided by the user.

--- a/parsl/providers/lsf/lsf.py
+++ b/parsl/providers/lsf/lsf.py
@@ -127,8 +127,7 @@ class LSFProvider(ClusterProvider, RepresentationMixin):
         # squeue does not report on jobs that are not running. So we are filling in the
         # blanks for missing jobs, we might lose some information about why the jobs failed.
         for missing_job in jobs_missing:
-            if self.resources[missing_job]['status'] in ['PENDING', 'RUNNING']:
-                self.resources[missing_job]['status'] = 'COMPLETED'
+            self.resources[missing_job]['status'] = 'COMPLETED'
 
     def submit(self, command, tasks_per_node, job_name="parsl.lsf"):
         """Submit the command as an LSF job.

--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -149,8 +149,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         # squeue does not report on jobs that are not running. So we are filling in the
         # blanks for missing jobs, we might lose some information about why the jobs failed.
         for missing_job in jobs_missing:
-            if self.resources[missing_job]['status'] in ['PENDING', 'RUNNING']:
-                self.resources[missing_job]['status'] = 'COMPLETED'
+            self.resources[missing_job]['status'] = 'COMPLETED'
 
     def submit(self, command, tasks_per_node, job_name="parsl.slurm"):
         """Submit the command as a slurm job.

--- a/parsl/providers/torque/torque.py
+++ b/parsl/providers/torque/torque.py
@@ -127,8 +127,7 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
         # squeue does not report on jobs that are not running. So we are filling in the
         # blanks for missing jobs, we might lose some information about why the jobs failed.
         for missing_job in jobs_missing:
-            if self.resources[missing_job]['status'] in ['PENDING', 'RUNNING']:
-                self.resources[missing_job]['status'] = translate_table['E']
+            self.resources[missing_job]['status'] = translate_table['E']
 
     def submit(self, command, tasks_per_node, job_name="parsl.torque"):
         ''' Submits the command onto an Local Resource Manager job.


### PR DESCRIPTION
… certain state before. This check is nondeterministic and depends on the rate at which the job state changes as well as the interval at which the queuing system is polled. It is entirely possible for a job to very quickly move from queued -> running -> failed -> removed. If the check above is kept, such a job will eternally be reported as PENDING. For example:

submit():
	status = 'PENDING'
job runs and is removed from queue
status():
	if status in ['RUNNING', 'KILLING', 'EXITING']: # false, since status == 'PENDING'
		status = 'EXITING'
	# status == 'PENDING'