### PR TITLE
Job status class

### DIFF
--- a/parsl/dataflow/strategy.py
+++ b/parsl/dataflow/strategy.py
@@ -3,7 +3,7 @@ import time
 import math
 
 from parsl.executors import IPyParallelExecutor, HighThroughputExecutor, ExtremeScaleExecutor
-
+from parsl.providers.provider_base import JobState
 
 logger = logging.getLogger(__name__)
 
@@ -189,8 +189,8 @@ class Strategy(object):
             nodes_per_block = executor.provider.nodes_per_block
             parallelism = executor.provider.parallelism
 
-            running = sum([1 for x in status if x == 'RUNNING'])
-            pending = sum([1 for x in status if x == 'PENDING'])
+            running = sum([1 for x in status if x.state == JobState.RUNNING])
+            pending = sum([1 for x in status if x.state == JobState.PENDING])
             active_blocks = running + pending
             active_slots = active_blocks * tasks_per_node * nodes_per_block
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -16,7 +16,7 @@ from parsl.executors.high_throughput import zmq_pipes
 from parsl.executors.high_throughput import interchange
 from parsl.executors.errors import BadMessage, ScalingFailed, DeserializationError
 from parsl.executors.base import ParslExecutor
-from parsl.providers.provider_base import ExecutionProvider
+from parsl.providers.provider_base import ExecutionProvider, JobStatus
 from parsl.data_provider.staging import Staging
 from parsl.addresses import get_all_addresses
 
@@ -611,7 +611,7 @@ class HighThroughputExecutor(ParslExecutor, RepresentationMixin):
 
         return r
 
-    def status(self):
+    def status(self) -> List[JobStatus]:
         """Return status of all blocks."""
 
         status = self.provider.status(list(self.blocks.values()))

--- a/parsl/executors/ipp.py
+++ b/parsl/executors/ipp.py
@@ -2,9 +2,11 @@ import logging
 import os
 import pathlib
 import uuid
+from typing import List
 
 from ipyparallel import Client
 from parsl.providers import LocalProvider
+from parsl.providers.provider_base import JobStatus
 from parsl.utils import RepresentationMixin
 
 from parsl.executors.base import ParslExecutor
@@ -265,7 +267,7 @@ sleep infinity
 
         return r
 
-    def status(self):
+    def status(self) -> List[JobStatus]:
         """Returns the status of the executor via probing the execution providers."""
         if self.provider:
             status = self.provider.status(self.engines)

--- a/parsl/executors/low_latency/executor.py
+++ b/parsl/executors/low_latency/executor.py
@@ -260,7 +260,7 @@ class LowLatencyExecutor(ParslExecutor, RepresentationMixin):
     def status(self) -> List[JobStatus]:
         """Return status of all blocks."""
 
-        status = []
+        status = []  # type: List[JobStatus]
         if self.provider:
             status = self.provider.status(self.blocks)
 

--- a/parsl/executors/low_latency/executor.py
+++ b/parsl/executors/low_latency/executor.py
@@ -6,6 +6,7 @@ import logging
 import threading
 import queue
 from multiprocessing import Process, Queue
+from typing import List
 
 from ipyparallel.serialize import pack_apply_message  # ,unpack_apply_message
 from ipyparallel.serialize import deserialize_object  # ,serialize_object
@@ -14,6 +15,7 @@ from parsl.executors.low_latency import zmq_pipes
 from parsl.executors.low_latency import interchange
 from parsl.executors.errors import ScalingFailed, DeserializationError, BadMessage
 from parsl.executors.base import ParslExecutor
+from parsl.providers.provider_base import JobStatus
 
 from parsl.utils import RepresentationMixin
 from parsl.providers import LocalProvider
@@ -255,7 +257,7 @@ class LowLatencyExecutor(ParslExecutor, RepresentationMixin):
             r = self.provider.cancel(to_kill)
         return r
 
-    def status(self):
+    def status(self) -> List[JobStatus]:
         """Return status of all blocks."""
 
         status = []

--- a/parsl/providers/aws/aws.py
+++ b/parsl/providers/aws/aws.py
@@ -6,7 +6,7 @@ from string import Template
 
 from parsl.dataflow.error import ConfigurationError
 from parsl.providers.aws.template import template_string
-from parsl.providers.provider_base import ExecutionProvider
+from parsl.providers.provider_base import ExecutionProvider, JobState, JobStatus
 from parsl.providers.error import OptionalModuleMissing
 from parsl.utils import RepresentationMixin
 from parsl.launchers import SingleNodeLauncher
@@ -23,12 +23,12 @@ else:
     _boto_enabled = True
 
 translate_table = {
-    'pending': 'PENDING',
-    'running': 'RUNNING',
-    'terminated': 'COMPLETED',
-    'shutting-down': 'COMPLETED',  # (configuring),
-    'stopping': 'COMPLETED',  # We shouldn't really see this state
-    'stopped': 'COMPLETED',  # We shouldn't really see this state
+    'pending': JobState.PENDING,
+    'running': JobState.RUNNING,
+    'terminated': JobState.COMPLETED,
+    'shutting-down': JobState.COMPLETED,  # (configuring),
+    'stopping': JobState.COMPLETED,  # We shouldn't really see this state
+    'stopped': JobState.COMPLETED,  # We shouldn't really see this state
 }
 
 
@@ -557,8 +557,8 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
         for r in status['Reservations']:
             for i in r['Instances']:
                 instance_id = i['InstanceId']
-                instance_state = translate_table.get(i['State']['Name'], 'UNKNOWN')
-                self.resources[instance_id]['status'] = instance_state
+                instance_state = translate_table.get(i['State']['Name'], JobState.UNKNOWN)
+                self.resources[instance_id]['status'] = JobStatus(instance_state)
                 all_states.extend([instance_state])
 
         return all_states
@@ -595,12 +595,12 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
 
         logger.debug("Started instance_id: {0}".format(instance.instance_id))
 
-        state = translate_table.get(instance.state['Name'], "PENDING")
+        state = translate_table.get(instance.state['Name'], JobState.PENDING)
 
         self.resources[instance.instance_id] = {
             "job_id": instance.instance_id,
             "instance": instance,
-            "status": state
+            "status": JobStatus(state)
         }
 
         return instance.instance_id
@@ -632,7 +632,7 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
             logger.debug("Removed the instances: {0}".format(job_ids))
 
         for job_id in job_ids:
-            self.resources[job_id]["status"] = "COMPLETED"
+            self.resources[job_id]["status"] = JobStatus(JobState.COMPLETED)
 
         for job_id in job_ids:
             self.instances.remove(job_id)

--- a/parsl/providers/cobalt/cobalt.py
+++ b/parsl/providers/cobalt/cobalt.py
@@ -7,16 +7,17 @@ from parsl.channels import LocalChannel
 from parsl.launchers import AprunLauncher
 from parsl.providers.cobalt.template import template_string
 from parsl.providers.cluster_provider import ClusterProvider
+from parsl.providers.provider_base import JobState, JobStatus
 from parsl.utils import RepresentationMixin, wtime_to_minutes
 
 logger = logging.getLogger(__name__)
 
 translate_table = {
-    'QUEUED': 'PENDING',
-    'STARTING': 'PENDING',
-    'RUNNING': 'RUNNING',
-    'EXITING': 'COMPLETED',
-    'KILLING': 'COMPLETED'
+    'QUEUED': JobState.PENDING,
+    'STARTING': JobState.PENDING,
+    'RUNNING': JobState.RUNNING,
+    'EXITING': JobState.COMPLETED,
+    'KILLING': JobState.COMPLETED
 }
 
 
@@ -115,15 +116,15 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
                 if job_id not in self.resources:
                     continue
 
-                status = translate_table.get(parts[4], 'UNKNOWN')
+                status = translate_table.get(parts[4], JobState.UNKNOWN)
 
-                self.resources[job_id]['status'] = status
+                self.resources[job_id]['status'] = JobStatus(status)
                 jobs_missing.remove(job_id)
 
         # squeue does not report on jobs that are not running. So we are filling in the
         # blanks for missing jobs, we might lose some information about why the jobs failed.
         for missing_job in jobs_missing:
-            self.resources[missing_job]['status'] = translate_table['EXITING']
+            self.resources[missing_job]['status'] = JobStatus(JobState.COMPLETED)
 
     def submit(self, command, tasks_per_node, job_name="parsl.cobalt"):
         """ Submits the command onto an Local Resource Manager job of parallel elements.
@@ -196,7 +197,7 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
         if retcode == 0:
             # We should be getting only one line back
             job_id = stdout.strip()
-            self.resources[job_id] = {'job_id': job_id, 'status': 'PENDING'}
+            self.resources[job_id] = {'job_id': job_id, 'status': JobStatus(JobState.PENDING)}
         else:
             logger.error("Submission of command to scale_out failed: {0}".format(stderr))
             raise (ScaleOutFailed(self.__class__, "Request to submit job to local scheduler failed"))
@@ -219,7 +220,9 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
         rets = None
         if retcode == 0:
             for jid in job_ids:
-                self.resources[jid]['status'] = translate_table['KILLING']  # Setting state to cancelled
+                # ???
+                # self.resources[jid]['status'] = translate_table['KILLING']  # Setting state to cancelled
+                self.resources[jid]['status'] = JobStatus(JobState.COMPLETED)
             rets = [True for i in job_ids]
         else:
             rets = [False for i in job_ids]

--- a/parsl/providers/condor/condor.py
+++ b/parsl/providers/condor/condor.py
@@ -5,6 +5,7 @@ import time
 import typeguard
 
 from parsl.channels import LocalChannel
+from parsl.providers.provider_base import JobState, JobStatus
 from parsl.utils import RepresentationMixin
 from parsl.launchers import SingleNodeLauncher
 from parsl.providers.condor.template import template_string
@@ -19,12 +20,12 @@ from parsl.launchers.launchers import Launcher
 
 # See http://pages.cs.wisc.edu/~adesmet/status.html
 translate_table = {
-    '1': 'PENDING',
-    '2': 'RUNNING',
-    '3': 'CANCELLED',
-    '4': 'COMPLETED',
-    '5': 'FAILED',
-    '6': 'FAILED',
+    '1': JobState.PENDING,
+    '2': JobState.RUNNING,
+    '3': JobState.CANCELLED,
+    '4': JobState.COMPLETED,
+    '5': JobState.FAILED,
+    '6': JobState.FAILED,
 }
 
 
@@ -146,8 +147,8 @@ class CondorProvider(RepresentationMixin, ClusterProvider):
         for line in stdout.splitlines():
             parts = line.strip().split()
             job_id = parts[0]
-            status = translate_table.get(parts[1], 'UNKNOWN')
-            self.resources[job_id]['status'] = status
+            state = translate_table.get(parts[1], JobState.UNKNOWN)
+            self.resources[job_id]['status'] = JobStatus(state)
 
     def status(self, job_ids):
         """Get the status of a list of jobs identified by their ids.
@@ -302,7 +303,7 @@ class CondorProvider(RepresentationMixin, ClusterProvider):
         rets = None
         if retcode == 0:
             for jid in job_ids:
-                self.resources[jid]['status'] = 'CANCELLED'
+                self.resources[jid]['status'] = JobStatus(JobState.CANCELLED)
             rets = [True for i in job_ids]
         else:
             rets = [False for i in job_ids]
@@ -315,7 +316,7 @@ class CondorProvider(RepresentationMixin, ClusterProvider):
 
     def _add_resource(self, job_id):
         for jid in job_id:
-            self.resources[jid] = {'status': 'PENDING', 'size': 1}
+            self.resources[jid] = {'status': JobStatus(JobState.PENDING), 'size': 1}
         return True
 
 

--- a/parsl/providers/googlecloud/googlecloud.py
+++ b/parsl/providers/googlecloud/googlecloud.py
@@ -2,6 +2,7 @@ import atexit
 import logging
 import os
 from parsl.launchers import SingleNodeLauncher
+from parsl.providers.provider_base import JobState, JobStatus
 
 logger = logging.getLogger(__name__)
 
@@ -14,16 +15,16 @@ else:
     _google_enabled = True
 
 translate_table = {
-    'PENDING': 'PENDING',
-    'PROVISIONING': 'PENDING',
-    "STAGING": "PENDING",
-    'RUNNING': 'RUNNING',
-    'DONE': 'COMPLETED',
-    'STOPPING': 'COMPLETED',
-    'STOPPED': 'COMPLETED',
-    'TERMINATED': 'COMPLETED',
-    'SUSPENDING': 'COMPLETED',
-    'SUSPENDED': 'COMPLETED',
+    'PENDING': JobState.PENDING,
+    'PROVISIONING': JobState.PENDING,
+    "STAGING": JobState.PENDING,
+    'RUNNING': JobState.RUNNING,
+    'DONE': JobState.COMPLETED,
+    'STOPPING': JobState.COMPLETED,
+    'STOPPED': JobState.COMPLETED,
+    'TERMINATED': JobState.COMPLETED,
+    'SUSPENDING': JobState.COMPLETED,
+    'SUSPENDED': JobState.COMPLETED,
 }
 
 
@@ -130,7 +131,7 @@ class GoogleCloudProvider():
 
         instance, name = self.create_instance(command=wrapped_cmd)
         self.provisioned_blocks += 1
-        self.resources[name] = {"job_id": name, "status": translate_table[instance['status']]}
+        self.resources[name] = {"job_id": name, "status": JobStatus(translate_table[instance['status']])}
         return name
 
     def status(self, job_ids):
@@ -151,7 +152,7 @@ class GoogleCloudProvider():
         statuses = []
         for job_id in job_ids:
             instance = self.client.instances().get(instance=job_id, project=self.project_id, zone=self.zone).execute()
-            self.resources[job_id]['status'] = translate_table[instance['status']]
+            self.resources[job_id]['status'] = JobStatus(translate_table[instance['status']])
             statuses.append(translate_table[instance['status']])
         return statuses
 

--- a/parsl/providers/grid_engine/grid_engine.py
+++ b/parsl/providers/grid_engine/grid_engine.py
@@ -6,27 +6,28 @@ from parsl.channels import LocalChannel
 from parsl.providers.cluster_provider import ClusterProvider
 from parsl.providers.grid_engine.template import template_string
 from parsl.launchers import SingleNodeLauncher
+from parsl.providers.provider_base import JobState, JobStatus
 from parsl.utils import RepresentationMixin, wtime_to_minutes
 
 logger = logging.getLogger(__name__)
 
 translate_table = {
-    'qw': 'PENDING',
-    'hqw': 'PENDING',
-    'hrwq': 'PENDING',
-    'r': 'RUNNING',
-    's': 'FAILED',  # obsuspended
-    'ts': 'FAILED',
-    't': 'FAILED',  # Suspended by alarm
-    'eqw': 'FAILED',  # Error states
-    'ehqw': 'FAILED',  # ..
-    'ehrqw': 'FAILED',  # ..
-    'd': 'COMPLETED',
-    'dr': 'COMPLETED',
-    'dt': 'COMPLETED',
-    'drt': 'COMPLETED',
-    'ds': 'COMPLETED',
-    'drs': 'COMPLETES',
+    'qw': JobState.PENDING,
+    'hqw': JobState.PENDING,
+    'hrwq': JobState.PENDING,
+    'r': JobState.RUNNING,
+    's': JobState.FAILED,  # obsuspended
+    'ts': JobState.FAILED,
+    't': JobState.FAILED,  # Suspended by alarm
+    'eqw': JobState.FAILED,  # Error states
+    'ehqw': JobState.FAILED,  # ..
+    'ehrqw': JobState.FAILED,  # ..
+    'd': JobState.COMPLETED,
+    'dr': JobState.COMPLETED,
+    'dt': JobState.COMPLETED,
+    'drt': JobState.COMPLETED,
+    'ds': JobState.COMPLETED,
+    'drs': JobState.COMPLETED,
 }
 
 
@@ -148,7 +149,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
                 job_id = line.strip()
                 if not job_id:
                     continue
-                self.resources[job_id] = {'job_id': job_id, 'status': 'PENDING'}
+                self.resources[job_id] = {'job_id': job_id, 'status': JobStatus(JobState.PENDING)}
                 return job_id
         else:
             print("[WARNING!!] Submission of command to scale_out failed")
@@ -181,7 +182,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
             if parts and parts[0].lower().lower() != 'job-id' \
                     and not parts[0].startswith('----'):
                 job_id = parts[0]
-                status = translate_table.get(parts[4].lower(), 'UNKNOWN')
+                status = translate_table.get(parts[4].lower(), JobState.UNKNOWN)
                 if job_id in self.resources:
                     self.resources[job_id]['status'] = status
                     jobs_missing.remove(job_id)
@@ -189,7 +190,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
         # Filling in missing blanks for jobs that might have gone missing
         # we might lose some information about why the jobs failed.
         for missing_job in jobs_missing:
-            self.resources[missing_job]['status'] = 'COMPLETED'
+            self.resources[missing_job]['status'] = JobStatus(JobState.COMPLETED)
 
     def cancel(self, job_ids):
         ''' Cancels the resources identified by the job_ids provided by the user.
@@ -211,7 +212,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
         rets = None
         if retcode == 0:
             for jid in job_ids:
-                self.resources[jid]['status'] = "COMPLETED"
+                self.resources[jid]['status'] = JobStatus(JobState.COMPLETED)
             rets = [True for i in job_ids]
         else:
             rets = [False for i in job_ids]

--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -5,7 +5,7 @@ from parsl.providers.kubernetes.template import template_string
 logger = logging.getLogger(__name__)
 
 from parsl.providers.error import OptionalModuleMissing
-from parsl.providers.provider_base import ExecutionProvider
+from parsl.providers.provider_base import ExecutionProvider, JobState, JobStatus
 from parsl.utils import RepresentationMixin
 
 import typeguard
@@ -151,7 +151,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
                          job_name=job_name,
                          cmd_string=formatted_cmd,
                          volumes=self.persistent_volumes)
-        self.resources[pod_name] = {'status': 'RUNNING'}
+        self.resources[pod_name] = {'status': JobStatus(JobState.RUNNING)}
 
         return pod_name
 
@@ -168,7 +168,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         """
         self._status()
         # This is a hack
-        return ['RUNNING' for jid in job_ids]
+        return [JobStatus(JobState.RUNNING) for jid in job_ids]
 
     def cancel(self, job_ids):
         """ Cancels the jobs specified by a list of job ids
@@ -182,7 +182,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
             # Here we are assuming that for local, the job_ids are the process id's
             self._delete_pod(job)
 
-            self.resources[job]['status'] = 'CANCELLED'
+            self.resources[job]['status'] = JobStatus(JobState.CANCELLED)
             del self.resources[job]
         rets = [True for i in job_ids]
 

--- a/parsl/providers/lsf/lsf.py
+++ b/parsl/providers/lsf/lsf.py
@@ -6,18 +6,19 @@ from parsl.channels import LocalChannel
 from parsl.launchers import SingleNodeLauncher
 from parsl.providers.cluster_provider import ClusterProvider
 from parsl.providers.lsf.template import template_string
+from parsl.providers.provider_base import JobState, JobStatus
 from parsl.utils import RepresentationMixin, wtime_to_minutes
 
 logger = logging.getLogger(__name__)
 
 translate_table = {
-    'PEND': 'PENDING',
-    'RUN': 'RUNNING',
-    'DONE': 'COMPLETED',
-    'EXIT': 'FAILED',  # (failed),
-    'PSUSP': 'CANCELLED',
-    'USUSP': 'CANCELLED',
-    'SSUSP': 'CANCELLED',
+    'PEND': JobState.PENDING,
+    'RUN': JobState.RUNNING,
+    'DONE': JobState.COMPLETED,
+    'EXIT': JobState.FAILED,  # (failed),
+    'PSUSP': JobState.CANCELLED,
+    'USUSP': JobState.CANCELLED,
+    'SSUSP': JobState.CANCELLED,
 }
 
 
@@ -120,14 +121,14 @@ class LSFProvider(ClusterProvider, RepresentationMixin):
             parts = line.split()
             if parts and parts[0] != 'JOBID':
                 job_id = parts[0]
-                status = translate_table.get(parts[2], 'UNKNOWN')
-                self.resources[job_id]['status'] = status
+                state = translate_table.get(parts[2], JobState.UNKNOWN)
+                self.resources[job_id]['status'] = JobStatus(state)
                 jobs_missing.remove(job_id)
 
         # squeue does not report on jobs that are not running. So we are filling in the
         # blanks for missing jobs, we might lose some information about why the jobs failed.
         for missing_job in jobs_missing:
-            self.resources[missing_job]['status'] = 'COMPLETED'
+            self.resources[missing_job]['status'] = JobStatus(JobState.COMPLETED)
 
     def submit(self, command, tasks_per_node, job_name="parsl.lsf"):
         """Submit the command as an LSF job.
@@ -189,7 +190,7 @@ class LSFProvider(ClusterProvider, RepresentationMixin):
             for line in stdout.split('\n'):
                 if line.lower().startswith("job") and "is submitted to" in line.lower():
                     job_id = line.split()[1].strip('<>')
-                    self.resources[job_id] = {'job_id': job_id, 'status': 'PENDING'}
+                    self.resources[job_id] = {'job_id': job_id, 'status': JobStatus(JobState.PENDING)}
         else:
             logger.warning("Submission of command to scale_out failed")
             logger.error("Retcode:%s STDOUT:%s STDERR:%s", retcode, stdout.strip(), stderr.strip())

--- a/parsl/providers/pbspro/pbspro.py
+++ b/parsl/providers/pbspro/pbspro.py
@@ -6,6 +6,7 @@ from parsl.channels import LocalChannel
 from parsl.launchers import SingleNodeLauncher
 from parsl.providers.pbspro.template import template_string
 from parsl.providers import TorqueProvider
+from parsl.providers.provider_base import JobState, JobStatus
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +151,7 @@ class PBSProProvider(TorqueProvider):
             for line in stdout.split('\n'):
                 if line.strip():
                     job_id = line.strip()
-                    self.resources[job_id] = {'job_id': job_id, 'status': 'PENDING'}
+                    self.resources[job_id] = {'job_id': job_id, 'status': JobStatus(JobState.PENDING)}
         else:
             message = "Command '{}' failed with return code {}".format(launch_cmd, retcode)
             if (stdout is not None) and (stderr is not None):

--- a/parsl/providers/pbspro/pbspro.py
+++ b/parsl/providers/pbspro/pbspro.py
@@ -9,17 +9,6 @@ from parsl.providers import TorqueProvider
 
 logger = logging.getLogger(__name__)
 
-# From the man pages for qstat for PBS/Torque systems
-translate_table = {
-    'R': 'RUNNING',
-    'C': 'COMPLETED',  # Completed after having run
-    'E': 'COMPLETED',  # Exiting after having run
-    'H': 'HELD',  # Held
-    'Q': 'PENDING',  # Queued, and eligible to run
-    'W': 'PENDING',  # Job is waiting for it's execution time (-a option) to be reached
-    'S': 'HELD'
-}  # Suspended
-
 
 class PBSProProvider(TorqueProvider):
     """PBS Pro Execution Provider

--- a/parsl/providers/provider_base.py
+++ b/parsl/providers/provider_base.py
@@ -1,5 +1,44 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
+from enum import Enum
 from typing import Any, List, Optional
+
+
+class JobState(bytes, Enum):
+    """Defines a set of states that a job can be in"""
+
+    def __new__(cls, value, terminal):
+        # noinspection PyArgumentList
+        obj = bytes.__new__(cls, [value])
+        obj._value_ = value
+        obj.terminal = terminal
+        return obj
+
+    UNKNOWN = (0, False)
+    PENDING = (1, False)
+    RUNNING = (2, False)
+    CANCELLED = (3, True)
+    COMPLETED = (4, True)
+    FAILED = (5, True)
+    TIMEOUT = (6, True)
+    HELD = (7, False)
+
+
+class JobStatus(object):
+    """Encapsulates a job state together with other details, presently a (error) message"""
+
+    def __init__(self, state: JobState, message: str=None):
+        self.state = state
+        self.message = message
+
+    @property
+    def terminal(self):
+        return self.state.terminal
+
+    def __repr__(self):
+        if self.message is not None:
+            return "{} ({})".format(self.state, self.message)
+        else:
+            return "{}".format(self.state)
 
 
 class ExecutionProvider(metaclass=ABCMeta):
@@ -48,7 +87,7 @@ class ExecutionProvider(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def status(self, job_ids: List[Any]) -> List[str]:
+    def status(self, job_ids: List[Any]) -> List[JobStatus]:
         ''' Get the status of a list of jobs identified by the job identifiers
         returned from the submit request.
 

--- a/parsl/providers/provider_base.py
+++ b/parsl/providers/provider_base.py
@@ -26,7 +26,7 @@ class JobState(bytes, Enum):
 class JobStatus(object):
     """Encapsulates a job state together with other details, presently a (error) message"""
 
-    def __init__(self, state: JobState, message: str=None):
+    def __init__(self, state: JobState, message: str = None):
         self.state = state
         self.message = message
 

--- a/parsl/providers/torque/torque.py
+++ b/parsl/providers/torque/torque.py
@@ -4,6 +4,7 @@ import time
 
 from parsl.channels import LocalChannel
 from parsl.launchers import AprunLauncher
+from parsl.providers.provider_base import JobState, JobStatus
 from parsl.providers.torque.template import template_string
 from parsl.providers.cluster_provider import ClusterProvider
 from parsl.utils import RepresentationMixin
@@ -12,13 +13,13 @@ logger = logging.getLogger(__name__)
 
 # From the man pages for qstat for PBS/Torque systems
 translate_table = {
-    'R': 'RUNNING',
-    'C': 'COMPLETED',  # Completed after having run
-    'E': 'COMPLETED',  # Exiting after having run
-    'H': 'HELD',  # Held
-    'Q': 'PENDING',  # Queued, and eligible to run
-    'W': 'PENDING',  # Job is waiting for it's execution time (-a option) to be reached
-    'S': 'HELD'
+    'R': JobState.RUNNING,
+    'C': JobState.COMPLETED,  # Completed after having run
+    'E': JobState.COMPLETED,  # Exiting after having run
+    'H': JobState.HELD,  # Held
+    'Q': JobState.PENDING,  # Queued, and eligible to run
+    'W': JobState.PENDING,  # Job is waiting for it's execution time (-a option) to be reached
+    'S': JobState.HELD
 }  # Suspended
 
 
@@ -120,14 +121,14 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
             if not parts or parts[0].upper().startswith('JOB') or parts[0].startswith('---'):
                 continue
             job_id = parts[0]
-            status = translate_table.get(parts[4], 'UNKNOWN')
-            self.resources[job_id]['status'] = status
+            state = translate_table.get(parts[4], JobState.UNKNOWN)
+            self.resources[job_id]['status'] = JobStatus(state)
             jobs_missing.remove(job_id)
 
         # squeue does not report on jobs that are not running. So we are filling in the
         # blanks for missing jobs, we might lose some information about why the jobs failed.
         for missing_job in jobs_missing:
-            self.resources[missing_job]['status'] = translate_table['E']
+            self.resources[missing_job]['status'] = JobStatus(JobState.COMPLETED)
 
     def submit(self, command, tasks_per_node, job_name="parsl.torque"):
         ''' Submits the command onto an Local Resource Manager job.
@@ -204,7 +205,7 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
             for line in stdout.split('\n'):
                 if line.strip():
                     job_id = line.strip()
-                    self.resources[job_id] = {'job_id': job_id, 'status': 'PENDING'}
+                    self.resources[job_id] = {'job_id': job_id, 'status': JobStatus(JobState.PENDING)}
         else:
             message = "Command '{}' failed with return code {}".format(launch_cmd, retcode)
             if (stdout is not None) and (stderr is not None):
@@ -228,7 +229,7 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
         rets = None
         if retcode == 0:
             for jid in job_ids:
-                self.resources[jid]['status'] = translate_table['E']  # Setting state to exiting
+                self.resources[jid]['status'] = JobStatus(JobState.COMPLETED)  # Setting state to exiting
             rets = [True for i in job_ids]
         else:
             rets = [False for i in job_ids]


### PR DESCRIPTION
Wrap provider task status into a class. Has two purposes:
- formalize the possible states to a set defined by the JobState enum
- allow additional information to be stored, such as the cause of a failure