### PR TITLE
Fix jumbled legends and colors in workflow dags

### DIFF
--- a/parsl/monitoring/visualization/plots/default/workflow_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_plots.py
@@ -165,7 +165,6 @@ def workflow_dag_plot(df_tasks, group_by_apps=True):
     G.add_edges_from(edges)
 
     node_positions = nx.nx_pydot.pydot_layout(G, prog='dot')
-    node_traces = []
 
     if group_by_apps:
         groups_list = {app: (i, None) for i, app in enumerate(

--- a/parsl/monitoring/visualization/plots/default/workflow_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_plots.py
@@ -199,7 +199,6 @@ def workflow_dag_plot(df_tasks, group_by_apps=True):
         x, y = node_positions[node]
         if group_by_apps:
             name = dic['task_func_name'][node]
-            index, color = groups_list[name]
         else:
             if dic['task_time_returned'][node] is not None:
                 name = 'Completed'
@@ -209,7 +208,7 @@ def workflow_dag_plot(df_tasks, group_by_apps=True):
                 name = "Pending"
             else:
                 name = "Unknown"
-            index, color = groups_list[name]
+        index, color = groups_list[name]
         node_traces[index]['x'] += tuple([x])
         node_traces[index]['y'] += tuple([y])
         node_traces[index]['text'] += tuple(

--- a/parsl/monitoring/visualization/plots/default/workflow_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_plots.py
@@ -208,7 +208,7 @@ def workflow_dag_plot(df_tasks, group_by_apps=True):
                 name = "Pending"
             else:
                 name = "Unknown"
-        index, color = groups_list[name]
+        index, _ = groups_list[name]
         node_traces[index]['x'] += tuple([x])
         node_traces[index]['y'] += tuple([y])
         node_traces[index]['text'] += tuple(

--- a/parsl/monitoring/visualization/plots/default/workflow_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_plots.py
@@ -194,7 +194,7 @@ def workflow_dag_plot(df_tasks, group_by_apps=True):
                 color=color,
                 size=11,
                 line=dict(width=1, color='rgb(0,0,0)')))
-        node_traces[index]=node_trace
+        node_traces[index] = node_trace
 
     for node in node_positions:
         x, y = node_positions[node]

--- a/parsl/monitoring/visualization/plots/default/workflow_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_plots.py
@@ -176,12 +176,14 @@ def workflow_dag_plot(df_tasks, group_by_apps=True):
     node_traces = []
 
     if group_by_apps:
-        groups_list = {app: i for i, app in enumerate(
+        groups_list = {app: (i, None) for i, app in enumerate(
             df_tasks['task_func_name'].unique())}
     else:
-        groups_list = {'Pending': (0, 'gray'), "Running": (1, 'blue'), 'Completed': (2, 'green')}
+        groups_list = {'Pending': (0, 'gray'), "Running": (1, 'blue'), 'Completed': (2, 'green'), 'Unknown': (3, 'red')}
 
-    for k, _ in groups_list.items():
+    node_traces = [...] * len(groups_list)
+
+    for k, (index, color) in groups_list.items():
         node_trace = go.Scatter(
             x=[],
             y=[],
@@ -197,16 +199,16 @@ def workflow_dag_plot(df_tasks, group_by_apps=True):
             name=k,          # legend app_name here
             marker=dict(
                 showscale=False,
-                # color='rgb(200,0,0)',
+                color=color,
                 size=11,
                 line=dict(width=1, color='rgb(0,0,0)')))
-        node_traces.append(node_trace)
+        node_traces[index]=node_trace
 
     for node in node_positions:
         x, y = node_positions[node]
         if group_by_apps:
             name = dic['task_func_name'][node]
-            index = groups_list[name]
+            index, color = groups_list[name]
         else:
             if dic['task_time_returned'][node] is not None:
                 name = 'Completed'
@@ -214,8 +216,9 @@ def workflow_dag_plot(df_tasks, group_by_apps=True):
                 name = "Running"
             elif dic['task_time_submitted'][node] is not None:
                 name = "Pending"
+            else:
+                name = "Unknown"
             index, color = groups_list[name]
-            node_traces[index]['marker']['color'] = color
         node_traces[index]['x'] += tuple([x])
         node_traces[index]['y'] += tuple([y])
         node_traces[index]['text'] += tuple(


### PR DESCRIPTION
Prior to this, colours and labels for jobs in the two DAG graphs were
jumbled up.

The code incorrectly assumed that iterating over a dict would iterate in
the order that the entries appear in a hard-coded literal dict in the
source tree.

For example:

The code assumed that the first element added to the node_traces list, and
thus the element referred to by node_traces[0], would be the element in
groups_list with value (0,...)

This incorrect assumption led to adding DAG nodes to the wrong Scatter
object.

This patch changes the way that the node_traces list is constructed by
populating it with marker places and then using index notation to set the
appropriate entry in the list based on hard-coded index.

Further, that wrong scatter object then had its colour mutated. This patch
sets the colour correctly on initial creation and does not change it again.

For the DAG coloured by state plot, the naming if-statement had no final
else: case, leading to some nodes being incorrectly labelled. This patch
adds an 'Unknown' case which is reached, for example, in jobs which are
never launched due to dependency failure.