### PR TITLE
Single node launcher error propagation

### DIFF
--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -90,7 +90,7 @@ FAILONANY() {{
             RET=1
             break
         fi
-    done    
+    done
 }}
 
 FAILONALL() {{

--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -60,31 +60,68 @@ class SingleNodeLauncher(Launcher):
     task_blocks to an integer or to a bash expression the number of invocations
     of the command to be launched can be controlled.
     """
-    def __call__(self, command, tasks_per_node, nodes_per_block):
+    def __call__(self, command, tasks_per_node, nodes_per_block, fail_on_any=False):
         """
         Args:
         - command (string): The command string to be launched
         - task_block (string) : bash evaluated string.
+        - fail_on_any: If True, return a nonzero exit code if any worker failed, otherwise zero;
+                       if False, return a nonzero exit code if all workers failed, otherwise zero.
 
         """
         task_blocks = tasks_per_node * nodes_per_block
+        if fail_on_any:
+            fail_on_any_num = 1
+        else:
+            fail_on_any_num = 0
 
         x = '''set -e
 export CORES=$(getconf _NPROCESSORS_ONLN)
 echo "Found cores : $CORES"
 WORKERCOUNT={1}
+FAILONANY={2}
+RET=0
 
-CMD ( ) {{
-{0}
+declare -a EXITCODES
+
+FAILONANY() {{
+    for I in $(seq 1 1 $WORKERCOUNT); do
+        if [ "$EXITCODES[$I]" != "0" ]; then
+            RET=1
+            break
+        fi
+    done    
 }}
-for COUNT in $(seq 1 1 $WORKERCOUNT)
-do
+
+FAILONALL() {{
+    RET=1
+    for I in $(seq 1 1 $WORKERCOUNT); do
+        if [ "$EXITCODES[$I]" == "0" ]; then
+            RET=0
+            break
+        fi
+    done
+}}
+
+CMD() {{
+{0}
+EXITCODES[$1]=$?
+}}
+for COUNT in $(seq 1 1 $WORKERCOUNT); do
     echo "Launching worker: $COUNT"
-    CMD &
+    CMD $COUNT &
 done
+
 wait
+
+if [ "$FAILONANY" == "1" ]; then
+    FAILONANY
+else
+    FAILONALL
+fi
 echo "All workers done"
-'''.format(command, task_blocks)
+exit $RET
+'''.format(command, task_blocks, fail_on_any_num)
         return x
 
 


### PR DESCRIPTION
Makes SingleNodeLauncher fail if all launched commands exit with a non-zero exit code.