### PR TITLE
These should have been part of the job_status_class PR, but weren't.

### DIFF
--- a/parsl/providers/ad_hoc/ad_hoc.py
+++ b/parsl/providers/ad_hoc/ad_hoc.py
@@ -4,7 +4,7 @@ import time
 
 from parsl.channels import LocalChannel
 from parsl.launchers import SimpleLauncher
-from parsl.providers.provider_base import ExecutionProvider
+from parsl.providers.provider_base import ExecutionProvider, JobStatus, JobState
 from parsl.providers.error import ScriptPathError
 from parsl.utils import RepresentationMixin
 
@@ -111,7 +111,7 @@ class AdHocProvider(ExecutionProvider, RepresentationMixin):
             channel_counts = {channel: 0 for channel in self.channels}
             for job_id in self.resources:
                 channel = self.resources[job_id]['channel']
-                if self.resources[job_id]['status'] == 'RUNNING':
+                if self.resources[job_id]['status'] == JobStatus(JobState.RUNNING):
                     channel_counts[channel] = channel_counts.get(channel, 0) + 1
                 else:
                     channel_counts[channel] = channel_counts.get(channel, 0)
@@ -193,7 +193,7 @@ class AdHocProvider(ExecutionProvider, RepresentationMixin):
                 raise
 
         self.resources[job_id] = {'job_id': job_id,
-                                  'status': 'RUNNING',
+                                  'status': JobStatus(JobState.RUNNING),
                                   'cmd': final_cmd,
                                   'channel': channel,
                                   'remote_pid': remote_pid,
@@ -218,8 +218,8 @@ class AdHocProvider(ExecutionProvider, RepresentationMixin):
             status_command = "ps --pid {} | grep {}".format(self.resources[job_id]['job_id'],
                                                             self.resources[job_id]['cmd'].split()[0])
             retcode, stdout, stderr = channel.execute_wait(status_command)
-            if retcode != 0 and self.resources[job_id]['status'] == 'RUNNING':
-                self.resources[job_id]['status'] = 'FAILED'
+            if retcode != 0 and self.resources[job_id]['status'].state == JobState.RUNNING:
+                self.resources[job_id]['status'] = JobStatus(JobState.FAILED)
 
         return [self.resources[job_id]['status'] for job_id in job_ids]
 
@@ -245,7 +245,7 @@ class AdHocProvider(ExecutionProvider, RepresentationMixin):
                 rets.append(True)
             else:
                 rets.append(False)
-            self.resources[job_id]['status'] = 'COMPLETED'
+            self.resources[job_id]['status'] = JobStatus(JobState.COMPLETED)
         return rets
 
     @property


### PR DESCRIPTION
Boubou was committed earlier. The job_status_class branch/PR was missing changes to the local and ad_hoc provider. Somehow it passed tests, review, and whatnot. We should merge this.

You can check that there are no more relevant occurrences of 'PENDING', 'RUNNING', 'COMPLETED', 'CANCELLED', 'FAILED' with:
egrep -r "'PENDING'|'RUNNING'|'FAILED'|'COMPLETED'|'CANCELLED'" .

There are a few in comments, which we should fix, but this is more urgent.