### PR TITLE
Allow slurm partition to be optional

### DIFF
--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -42,7 +42,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
     Parameters
     ----------
     partition : str
-        Slurm partition to request blocks from.
+        Slurm partition to request blocks from. If none, no partition slurm directive will be specified.
     channel : Channel
         Channel for accessing this provider. Possible channels include
         :class:`~parsl.channels.LocalChannel` (the default),
@@ -82,7 +82,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
 
     @typeguard.typechecked
     def __init__(self,
-                 partition: str,
+                 partition: Optional[str],
                  channel: Channel = LocalChannel(),
                  nodes_per_block: int = 1,
                  cores_per_node: Optional[int] = None,
@@ -118,6 +118,8 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         self.scheduler_options = scheduler_options + '\n'
         if exclusive:
             self.scheduler_options += "#SBATCH --exclusive\n"
+        if partition:
+            self.scheduler_options += "#SBATCH --partition={}\n".format(partition)
         self.worker_init = worker_init + '\n'
 
     def _status(self):
@@ -197,7 +199,6 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         job_config["walltime"] = wtime_to_minutes(self.walltime)
         job_config["scheduler_options"] = scheduler_options
         job_config["worker_init"] = worker_init
-        job_config["partition"] = self.partition
         job_config["user_script"] = command
 
         # Wrap the command

--- a/parsl/providers/slurm/template.py
+++ b/parsl/providers/slurm/template.py
@@ -4,7 +4,6 @@ template_string = '''#!/bin/bash
 #SBATCH --output=${submit_script_dir}/${jobname}.submit.stdout
 #SBATCH --error=${submit_script_dir}/${jobname}.submit.stderr
 #SBATCH --nodes=${nodes}
-#SBATCH --partition=${partition}
 #SBATCH --time=${walltime}
 #SBATCH --ntasks-per-node=${tasks_per_node}
 ${scheduler_options}


### PR DESCRIPTION
Some slurm configurations do not use a partition parameter, but instead
take a --qos parameter.

This change is intended to allow the partition parameter to be
suppressed (with the user then supplying a --qos parameter in
scheduler_options.

Fixes #518