### PR TITLE
Fix rest of job status stuff

### DIFF
--- a/parsl/executors/ipp.py
+++ b/parsl/executors/ipp.py
@@ -6,7 +6,7 @@ from typing import List
 
 from ipyparallel import Client
 from parsl.providers import LocalProvider
-from parsl.providers.provider_base import JobStatus
+from parsl.providers.provider_base import JobStatus, JobState
 from parsl.utils import RepresentationMixin
 
 from parsl.executors.base import ParslExecutor
@@ -257,7 +257,7 @@ sleep infinity
         status = dict(zip(self.engines, self.provider.status(self.engines)))
 
         # This works for blocks=0
-        to_kill = [engine for engine in status if status[engine] == "RUNNING"][:blocks]
+        to_kill = [engine for engine in status if status[engine].state == JobState.RUNNING][:blocks]
 
         if self.provider:
             r = self.provider.cancel(to_kill)

--- a/parsl/providers/ad_hoc/ad_hoc.py
+++ b/parsl/providers/ad_hoc/ad_hoc.py
@@ -211,7 +211,7 @@ class AdHocProvider(ExecutionProvider, RepresentationMixin):
 
         Returns
         -------
-        list of status strings ['PENDING', 'COMPLETED', 'FAILED']
+        list of JobStatus objects
         """
         for job_id in job_ids:
             channel = self.resources[job_id]['channel']

--- a/parsl/providers/cluster_provider.py
+++ b/parsl/providers/cluster_provider.py
@@ -134,8 +134,7 @@ class ClusterProvider(ExecutionProvider):
              - job_ids (list) : A list of job identifiers
 
         Returns:
-             - A list of status from ['PENDING', 'RUNNING', 'CANCELLED', 'COMPLETED',
-               'FAILED', 'TIMEOUT'] corresponding to each job_id in the job_ids list.
+             - A list of JobStatus objects corresponding to each job_id in the job_ids list.
 
         Raises:
              - ExecutionProviderException or its subclasses

--- a/parsl/providers/googlecloud/googlecloud.py
+++ b/parsl/providers/googlecloud/googlecloud.py
@@ -142,8 +142,7 @@ class GoogleCloudProvider():
              - job_ids (list) : A list of job identifiers
 
         Returns:
-             - A list of status from ['PENDING', 'RUNNING', 'CANCELLED', 'COMPLETED',
-               'FAILED', 'TIMEOUT'] corresponding to each job_id in the job_ids list.
+             - A list of JobStatus objects corresponding to each job_id in the job_ids list.
 
         Raises:
              - ExecutionProviderException or its subclasses

--- a/parsl/providers/grid_engine/grid_engine.py
+++ b/parsl/providers/grid_engine/grid_engine.py
@@ -160,8 +160,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
         returned from the submit request.
 
         Returns:
-             - A list of status from ['PENDING', 'RUNNING', 'CANCELLED', 'COMPLETED',
-               'FAILED', 'TIMEOUT'] corresponding to each job_id in the job_ids list.
+             - A list of JobStatus objects corresponding to each job_id in the job_ids list.
 
         Raises:
              - ExecutionProviderException or its subclasses

--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -161,8 +161,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         Args:
              - job_ids (list) : A list of job identifiers
         Returns:
-             - A list of status from ['PENDING', 'RUNNING', 'CANCELLED', 'COMPLETED',
-               'FAILED', 'TIMEOUT'] corresponding to each job_id in the job_ids list.
+             - A list of JobStatus objects corresponding to each job_id in the job_ids list.
         Raises:
              - ExecutionProviderExceptions or its subclasses
         """

--- a/parsl/providers/provider_base.py
+++ b/parsl/providers/provider_base.py
@@ -95,8 +95,7 @@ class ExecutionProvider(metaclass=ABCMeta):
              - job_ids (list) : A list of job identifiers
 
         Returns:
-             - A list of status from ['PENDING', 'RUNNING', 'CANCELLED', 'COMPLETED',
-               'FAILED', 'TIMEOUT'] corresponding to each job_id in the job_ids list.
+             - A list of JobStatus objects corresponding to each job_id in the job_ids list.
 
         Raises:
              - ExecutionProviderException or its subclasses


### PR DESCRIPTION
Fixes docstrings for executor.status() methods and an occurrence of "RUNNING" in the IPP executor