### PR TITLE
Pin `coverage` version in CI.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@ pytest>=4.6,<5
 pytest-cov
 pytest-xdist==1.26.1
 pytest-random-order
-coverage
+coverage==4.5.4
 mock>=1.0.0
 nbsphinx
 sphinx_rtd_theme


### PR DESCRIPTION
Coverage 5.0.0 just appeared which appears to not work with pytest
properly. This patch pins coverage to 4.5.4 which is a version
which has worked successfully previously.

Coverage 5.0.0 + pytest fails with:

INTERNALERROR> coverage.misc.CoverageException: Couldn't use data file '/home/travis/build/Parsl/parsl/.coverage': UNIQUE constraint failed: meta.key

when run when no .coverage file exists. Subsequent runs do not raise
this error.