### PR TITLE
Separate htex worker log directories by block id

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -474,7 +474,7 @@ def worker(worker_id, pool_id, pool_size, task_queue, result_queue, worker_queue
     Pop request from queue
     Put result into result_queue
     """
-    start_file_logger('{}/{}/worker_{}.log'.format(args.logdir, pool_id, worker_id),
+    start_file_logger('{}/block-{}/{}/worker_{}.log'.format(args.logdir, args.block_id, pool_id, worker_id),
                       worker_id,
                       name="worker_log",
                       level=logging.DEBUG if args.debug else logging.INFO)
@@ -580,10 +580,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    os.makedirs(os.path.join(args.logdir, args.uid), exist_ok=True)
+    os.makedirs(os.path.join(args.logdir, "block-{}".format(args.block_id), args.uid), exist_ok=True)
 
     try:
-        start_file_logger('{}/{}/manager.log'.format(args.logdir, args.uid),
+        start_file_logger('{}/block-{}/{}/manager.log'.format(args.logdir, args.block_id, args.uid),
                           0,
                           level=logging.DEBUG if args.debug is True else logging.INFO)
 


### PR DESCRIPTION
This commit adds an addition block level to htex worker log paths,
like this:

  .../runinfo/004/worker-nodes/block-0/627785a8965e/manager.log

This has been useful during a run with multiple large blocks to
discern which logs belong to which block.