### PR TITLE
Remove unused 'callback' entry from DFK task record

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -701,7 +701,6 @@ class DataFlowKernel(object):
                     'func_name': func.__name__,
                     'fn_hash': fn_hash,
                     'memoize': cache,
-                    'callback': None,
                     'exec_fu': None,
                     'checkpoint': None,
                     'fail_count': 0,


### PR DESCRIPTION
This is initialized to None. I cannot see it used anywhere else in
the codebase.