### PR TITLE
Correct Scaling with SimpleLauncher+ClusterProvider

### DIFF
--- a/parsl/dataflow/strategy.py
+++ b/parsl/dataflow/strategy.py
@@ -4,6 +4,7 @@ import math
 
 from parsl.executors import IPyParallelExecutor, HighThroughputExecutor, ExtremeScaleExecutor
 from parsl.launchers import SimpleLauncher
+from parsl.providers.cluster_provider import ClusterProvider
 from parsl.providers.provider_base import JobState
 
 logger = logging.getLogger(__name__)
@@ -188,7 +189,8 @@ class Strategy(object):
                 tasks_per_node = executor.ranks_per_node
 
             # Determine the number of nodes per block
-            if hasattr(executor.provider, 'launcher') and isinstance(executor.provider.launcher, SimpleLauncher):
+            if isinstance(executor.provider, ClusterProvider) \
+                    and isinstance(executor.provider.launcher, SimpleLauncher):
                 # Parsl only launches one worker. That one worker can access >1 compute node
                 nodes_per_block = 1
             else:

--- a/parsl/dataflow/strategy.py
+++ b/parsl/dataflow/strategy.py
@@ -3,6 +3,7 @@ import time
 import math
 
 from parsl.executors import IPyParallelExecutor, HighThroughputExecutor, ExtremeScaleExecutor
+from parsl.launchers import SimpleLauncher
 from parsl.providers.provider_base import JobState
 
 logger = logging.getLogger(__name__)
@@ -186,7 +187,13 @@ class Strategy(object):
             elif isinstance(executor, ExtremeScaleExecutor):
                 tasks_per_node = executor.ranks_per_node
 
-            nodes_per_block = executor.provider.nodes_per_block
+            # Determine the number of nodes per block
+            if hasattr(executor.provider, 'launcher') and isinstance(executor.provider.launcher, SimpleLauncher):
+                # Parsl only launches one worker. That one worker can access >1 compute node
+                nodes_per_block = 1
+            else:
+                # Assume that Parsl launchers a single worker on each node
+                nodes_per_block = executor.provider.nodes_per_block
             parallelism = executor.provider.parallelism
 
             running = sum([1 for x in status if x.state == JobState.RUNNING])


### PR DESCRIPTION
Parsl does not correctly determine the number of active slots when using a SimpleLauncher as part of a ClusterProvider. The current code assumes that you launch a single worker per compute node, which is not the case for SimpleLauncher.