### PR TITLE
Fix tasks_per_app plot enough to visualise a CI run

### DIFF
--- a/parsl/monitoring/visualization/plots/default/workflow_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_plots.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 import pandas as pd
 import plotly.graph_objs as go
@@ -49,11 +50,14 @@ def task_per_app_plot(task, status):
             task['task_time_running']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
         task['epoch_time_returned'] = (pd.to_datetime(
             task['task_time_returned']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
-        start = task['epoch_time_running'].min()
-        end = task['epoch_time_returned'].max()
+        start = int(task['epoch_time_running'].min())
+        end = int(task['epoch_time_returned'].max())
         tasks_per_app = {}
         all_tasks = [0] * (end - start + 1)
         for i, row in task.iterrows():
+            if math.isnan(row['epoch_time_running']):
+                # Skip rows with no running start time.
+                continue
             if row['task_func_name'] not in tasks_per_app:
                 tasks_per_app[row['task_func_name']] = [0] * (end - start + 1)
             for j in range(int(row['epoch_time_running']) + 1, int(row['epoch_time_returned']) + 1):


### PR DESCRIPTION
Before this patch, the tasks_per_app plot could not be displayed when
viewing a CI test run monitoring.db. This patch fixes the plot so
that a CI run can be visualized.

i) the plot was expecting ints, but was getting numpy.float64
from the underlying database.

ii) the plot was expecting ints, but the time_running fields are
None/NaN because checkpointed tasks never start running.