### PR TITLE
Infer submitted and running times in gantt chart

### DIFF
--- a/parsl/monitoring/visualization/plots/default/workflow_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_plots.py
@@ -20,10 +20,14 @@ def task_gantt_plot(df_task, time_completed=None):
             time_returned = datetime.datetime.now()
             if time_completed is not None:
                 time_returned = time_completed
+        if task['task_time_submitted'] is not None:
+            time_submitted = task['task_time_submitted']
+        else:
+            time_submitted = time_returned
         if task['task_time_running'] is None:
-            time_running = task['task_time_submitted']
+            time_running = time_submitted
         description = "Task ID: {}, app: {}".format(task['task_id'], task['task_func_name'])
-        dic1 = dict(Task=description, Start=task['task_time_submitted'],
+        dic1 = dict(Task=description, Start=time_submitted,
                     Finish=time_running, Resource="Pending")
         dic2 = dict(Task=description, Start=time_running,
                     Finish=time_returned, Resource="Running")


### PR DESCRIPTION
Prior to this commit, the gantt chart appeared to default to the year 2000 for some of the times
used. This mean that the default scale of the gantt chart was useless (decades, rather than
seconds) for a CI test run.

After this commit, if either the submitted or running times are None, then the return time is used.