### PR TITLE
Fix walltime bug #1527

### DIFF
--- a/parsl/app/app.py
+++ b/parsl/app/app.py
@@ -21,7 +21,7 @@ class AppBase(metaclass=ABCMeta):
 
     """
 
-    def __init__(self, func, data_flow_kernel=None, walltime=60, executors='all', cache=False):
+    def __init__(self, func, data_flow_kernel=None, executors='all', cache=False):
         """Construct the App object.
 
         Args:
@@ -31,7 +31,6 @@ class AppBase(metaclass=ABCMeta):
              - data_flow_kernel (DataFlowKernel): The :class:`~parsl.dataflow.dflow.DataFlowKernel` responsible for
                managing this app. This can be omitted only
                after calling :meth:`parsl.dataflow.dflow.DataFlowKernelLoader.load`.
-             - walltime (int) : Walltime in seconds for the app execution.
              - executors (str|list) : Labels of the executors that this app can execute over. Default is 'all'.
              - cache (Bool) : Enable caching of this app ?
 
@@ -87,8 +86,6 @@ def App(apptype, data_flow_kernel=None, walltime=60, cache=False, executors='all
         - data_flow_kernel (DataFlowKernel): The :class:`~parsl.dataflow.dflow.DataFlowKernel` responsible for
           managing this app. This can be omitted only
           after calling :meth:`parsl.dataflow.dflow.DataFlowKernelLoader.load`.
-        - walltime (int) : Walltime for app in seconds,
-             default=60
         - executors (str|list) : Labels of the executors that this app can execute over. Default is 'all'.
         - cache (Bool) : Enable caching of the app call
              default=False
@@ -112,13 +109,12 @@ def App(apptype, data_flow_kernel=None, walltime=60, cache=False, executors='all
     def wrapper(f):
         return app_class(f,
                          data_flow_kernel=data_flow_kernel,
-                         walltime=walltime,
                          cache=cache,
                          executors=executors)
     return wrapper
 
 
-def python_app(function=None, data_flow_kernel=None, walltime=60, cache=False, executors='all'):
+def python_app(function=None, data_flow_kernel=None, cache=False, executors='all'):
     """Decorator function for making python apps.
 
     Parameters
@@ -131,8 +127,6 @@ def python_app(function=None, data_flow_kernel=None, walltime=60, cache=False, e
     data_flow_kernel : DataFlowKernel
         The :class:`~parsl.dataflow.dflow.DataFlowKernel` responsible for managing this app. This can
         be omitted only after calling :meth:`parsl.dataflow.dflow.DataFlowKernelLoader.load`. Default is None.
-    walltime : int
-        Walltime for app in seconds. Default is 60.
     executors : string or list
         Labels of the executors that this app can execute over. Default is 'all'.
     cache : bool
@@ -144,7 +138,6 @@ def python_app(function=None, data_flow_kernel=None, walltime=60, cache=False, e
         def wrapper(f):
             return PythonApp(f,
                              data_flow_kernel=data_flow_kernel,
-                             walltime=walltime,
                              cache=cache,
                              executors=executors)
         return wrapper(func)
@@ -153,7 +146,7 @@ def python_app(function=None, data_flow_kernel=None, walltime=60, cache=False, e
     return decorator
 
 
-def bash_app(function=None, data_flow_kernel=None, walltime=60, cache=False, executors='all'):
+def bash_app(function=None, data_flow_kernel=None, cache=False, executors='all'):
     """Decorator function for making bash apps.
 
     Parameters
@@ -179,7 +172,6 @@ def bash_app(function=None, data_flow_kernel=None, walltime=60, cache=False, exe
         def wrapper(f):
             return BashApp(f,
                            data_flow_kernel=data_flow_kernel,
-                           walltime=walltime,
                            cache=cache,
                            executors=executors)
         return wrapper(func)

--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -112,8 +112,8 @@ def remote_side_bash_executor(func, *args, **kwargs):
 
 class BashApp(AppBase):
 
-    def __init__(self, func, data_flow_kernel=None, walltime=60, cache=False, executors='all'):
-        super().__init__(func, data_flow_kernel=data_flow_kernel, walltime=60, executors=executors, cache=cache)
+    def __init__(self, func, data_flow_kernel=None, cache=False, executors='all'):
+        super().__init__(func, data_flow_kernel=data_flow_kernel, executors=executors, cache=cache)
         self.kwargs = {}
 
         # We duplicate the extraction of parameter defaults

--- a/parsl/app/python.py
+++ b/parsl/app/python.py
@@ -35,11 +35,10 @@ def timeout(f, seconds):
 class PythonApp(AppBase):
     """Extends AppBase to cover the Python App."""
 
-    def __init__(self, func, data_flow_kernel=None, walltime=60, cache=False, executors='all'):
+    def __init__(self, func, data_flow_kernel=None, cache=False, executors='all'):
         super().__init__(
             wrap_error(func),
             data_flow_kernel=data_flow_kernel,
-            walltime=walltime,
             executors=executors,
             cache=cache
         )

--- a/parsl/tests/test_error_handling/test_python_walltime.py
+++ b/parsl/tests/test_error_handling/test_python_walltime.py
@@ -3,7 +3,6 @@ import pytest
 import parsl
 from parsl.app.errors import AppTimeout
 
-@pytest.mark.local
 @parsl.python_app
 def my_app(walltime=1):
     import time
@@ -15,10 +14,12 @@ def test_python_walltime():
     with pytest.raises(AppTimeout):
         f.result()
 
-with pytest.raises(TypeError):
-    @pytest.mark.local
-    @parsl.python_app(walltime=1)
-    def my_app_2():
-        import time
-        time.sleep(1.2)
-        return True
+def test_python_bad_decorator_args():
+
+    with pytest.raises(TypeError):
+        @pytest.mark.local
+        @parsl.python_app(walltime=1)
+        def my_app_2():
+            import time
+            time.sleep(1.2)
+            return True

--- a/parsl/tests/test_error_handling/test_python_walltime.py
+++ b/parsl/tests/test_error_handling/test_python_walltime.py
@@ -3,16 +3,19 @@ import pytest
 import parsl
 from parsl.app.errors import AppTimeout
 
+
 @parsl.python_app
 def my_app(walltime=1):
     import time
     time.sleep(1.2)
     return True
 
+
 def test_python_walltime():
     f = my_app()
     with pytest.raises(AppTimeout):
         f.result()
+
 
 def test_python_bad_decorator_args():
 

--- a/parsl/tests/test_error_handling/test_python_walltime.py
+++ b/parsl/tests/test_error_handling/test_python_walltime.py
@@ -3,18 +3,22 @@ import pytest
 import parsl
 from parsl.app.errors import AppTimeout
 
-
+@pytest.mark.local
 @parsl.python_app
-def my_app(walltime=3):
+def my_app(walltime=1):
     import time
-    # the loop count must be substantially bigger than the walltime
-    # but not infinite - so that the test eventually terminates
-    # even if the walltime doesn't work.
-    for n in range(0, 6):
-        time.sleep(1)
-
+    time.sleep(1.2)
+    return True
 
 def test_python_walltime():
     f = my_app()
     with pytest.raises(AppTimeout):
         f.result()
+
+with pytest.raises(TypeError):
+    @pytest.mark.local
+    @parsl.python_app(walltime=1)
+    def my_app_2():
+        import time
+        time.sleep(1.2)
+        return True


### PR DESCRIPTION
`walltime` kwarg is now removed from the app decorator base and will not be supported by `@bash_app` or  `@python_app`. 
Adds a test that checks whether python_app walltime kwarg works correctly. The walltime works in second level granularity, so this test will take at least a second to trigger. 

Fixes #1527 