### PR TITLE
Enable the bors merge-bot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ branches:
     # This is where pull requests from "bors try" are built.
     - trying
     # Uncomment this to enable building pull requests.
-    #- master
+    - master
 
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,15 @@ install:
 os:
     - linux
 
+branches:
+  only:
+    # This is where pull requests from "bors r+" are built.
+    - staging
+    # This is where pull requests from "bors try" are built.
+    - trying
+    # Uncomment this to enable building pull requests.
+    #- master
+
 # command to run tests
 script:
     - pip install -r test-requirements.txt

--- a/bors.toml
+++ b/bors.toml
@@ -2,7 +2,7 @@ status = [
   "continuous-integration/travis-ci/push",
 ]
 
-use_squash_merge = false
+use_squash_merge = true
 
 # Uncomment this to use a two hour timeout.
 # The default is one hour.

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,9 @@
+status = [
+  "continuous-integration/travis-ci/push",
+]
+
+use_squash_merge = false
+
+# Uncomment this to use a two hour timeout.
+# The default is one hour.
+#timeout_sec = 7200


### PR DESCRIPTION
This should enable the bors merge-bot. It follows the vanilla recommendations [here](https://bors.tech/documentation/getting-started/), and further specifies that PRs should be squashed before merging.