### PR TITLE
Require PR approval before allowing bors merge

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -3,6 +3,7 @@ status = [
 ]
 
 use_squash_merge = true
+required_approvals = true
 
 # Uncomment this to use a two hour timeout.
 # The default is one hour.


### PR DESCRIPTION
I believe that if this isn't enabled, someone could merge a PR via bors without it having been approved.