### PR TITLE
Fix lazy error handling test

### DIFF
--- a/parsl/tests/test_threads/test_lazy_errors.py
+++ b/parsl/tests/test_threads/test_lazy_errors.py
@@ -16,10 +16,13 @@ def test_lazy_behavior():
     def divide(a, b):
         return a / b
 
-    future = divide(10, 0)
+    futures = []
+    for i in range(0, 10):
+        futures.append(divide(10, 0))
 
-    while not future.done():
-        pass
+    for f in futures:
+        assert isinstance(f.exception(), ZeroDivisionError)
+        assert f.done()
 
     parsl.clear()
     return

--- a/parsl/tests/test_threads/test_lazy_errors.py
+++ b/parsl/tests/test_threads/test_lazy_errors.py
@@ -6,7 +6,7 @@ from parsl.tests.configs.local_threads import fresh_config
 
 @pytest.mark.local
 def test_lazy_behavior():
-    """Testing lazy errors to work"""
+    """Testing that lazy errors work"""
 
     config = fresh_config()
     config.lazy_errors = True
@@ -16,13 +16,10 @@ def test_lazy_behavior():
     def divide(a, b):
         return a / b
 
-    items = []
-    for i in range(0, 1):
-        items.append(divide(10, i))
+    future = divide(10, 0)
 
-    while True:
-        if items[0].done:
-            break
+    while not future.done():
+        pass
 
     parsl.clear()
     return


### PR DESCRIPTION
Previously this test checked that 'done' was defined on an
AppFuture, rather than checking that the result of invoking done()
was True. This commit adds the necessary '()'.

This commit also removes some unnecessary complexity in the test.