### PR TITLE
Allow plain Futures to be used as dependencies

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -218,7 +218,7 @@ class DataFlowKernel(object):
             task_log_info['task_fail_history'] = ",".join(self.tasks[task_id]['fail_history'])
         task_log_info['task_depends'] = None
         if self.tasks[task_id]['depends'] is not None:
-            task_log_info['task_depends'] = ",".join([str(t.tid) for t in self.tasks[task_id]['depends']])
+            task_log_info['task_depends'] = ",".join([str(t.tid) for t in self.tasks[task_id]['depends'] if isinstance(t, AppFuture) or isinstance(t, DataFuture)])
         task_log_info['task_elapsed_time'] = None
         if self.tasks[task_id]['time_returned'] is not None:
             task_log_info['task_elapsed_time'] = (self.tasks[task_id]['time_returned'] -

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -218,7 +218,8 @@ class DataFlowKernel(object):
             task_log_info['task_fail_history'] = ",".join(self.tasks[task_id]['fail_history'])
         task_log_info['task_depends'] = None
         if self.tasks[task_id]['depends'] is not None:
-            task_log_info['task_depends'] = ",".join([str(t.tid) for t in self.tasks[task_id]['depends'] if isinstance(t, AppFuture) or isinstance(t, DataFuture)])
+            task_log_info['task_depends'] = ",".join([str(t.tid) for t in self.tasks[task_id]['depends']
+                                                      if isinstance(t, AppFuture) or isinstance(t, DataFuture)])
         task_log_info['task_elapsed_time'] = None
         if self.tasks[task_id]['time_returned'] is not None:
             task_log_info['task_elapsed_time'] = (self.tasks[task_id]['time_returned'] -

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -28,7 +28,7 @@ from parsl.dataflow.flow_control import FlowControl, FlowNoControl, Timer
 from parsl.dataflow.futures import AppFuture
 from parsl.dataflow.memoization import Memoizer
 from parsl.dataflow.rundirs import make_rundir
-from parsl.dataflow.states import States, FINAL_FAILURE_STATES
+from parsl.dataflow.states import States
 from parsl.dataflow.usage_tracking.usage import UsageTracker
 from parsl.executors.threads import ThreadPoolExecutor
 from parsl.utils import get_version, get_std_fname_mode
@@ -608,8 +608,7 @@ class DataFlowKernel(object):
                 try:
                     new_args.extend([dep.result()])
                 except Exception as e:
-                    if self.tasks[dep.tid]['status'] in FINAL_FAILURE_STATES:
-                        dep_failures.extend([e])
+                    dep_failures.extend([e])
             else:
                 new_args.extend([dep])
 
@@ -620,8 +619,7 @@ class DataFlowKernel(object):
                 try:
                     kwargs[key] = dep.result()
                 except Exception as e:
-                    if self.tasks[dep.tid]['status'] in FINAL_FAILURE_STATES:
-                        dep_failures.extend([e])
+                    dep_failures.extend([e])
 
         # Check for futures in inputs=[<fut>...]
         if 'inputs' in kwargs:
@@ -631,8 +629,7 @@ class DataFlowKernel(object):
                     try:
                         new_inputs.extend([dep.result()])
                     except Exception as e:
-                        if self.tasks[dep.tid]['status'] in FINAL_FAILURE_STATES:
-                            dep_failures.extend([e])
+                        dep_failures.extend([e])
 
                 else:
                     new_inputs.extend([dep])
@@ -737,9 +734,15 @@ class DataFlowKernel(object):
         depends = self._gather_all_deps(args, kwargs)
         self.tasks[task_id]['depends'] = depends
 
-        logger.info("Task {} submitted for App {}, waiting on tasks {}".format(task_id,
-                                                                               task_def['func_name'],
-                                                                               [fu.tid for fu in depends]))
+        depend_descs = []
+        for d in depends:
+            if isinstance(d, AppFuture) or isinstance(d, DataFuture):
+                depend_descs.append("task {}".format(d.tid))
+            else:
+                depend_descs.append(repr(d))
+        logger.info("Task {} submitted for App {}, waiting on {}".format(task_id,
+                                                                         task_def['func_name'],
+                                                                         ", ".join(depend_descs)))
 
         self.tasks[task_id]['task_launch_lock'] = threading.Lock()
 

--- a/parsl/tests/test_python_apps/test_dep_standard_futures.py
+++ b/parsl/tests/test_python_apps/test_dep_standard_futures.py
@@ -1,0 +1,35 @@
+import parsl
+from concurrent.futures import Future
+
+@parsl.python_app
+def copy_app(v):
+    return v
+
+def test_future_result_dependency():
+
+    plain_fut = Future()
+
+    parsl_fut = copy_app(plain_fut)
+
+    assert not parsl_fut.done()
+
+    message = "Test"
+
+    plain_fut.set_result(message)
+
+    assert parsl_fut.result() == message
+
+def test_future_fail_dependency():
+
+    plain_fut = Future()
+
+    parsl_fut = copy_app(plain_fut)
+
+    assert not parsl_fut.done()
+
+    plain_fut.set_result(ValueError("Plain failure"))
+
+    # TODO: be tighter on the returned exception: it should be a dependency failure exception
+    assert parsl_fut.exception() is not None
+
+

--- a/parsl/tests/test_python_apps/test_dep_standard_futures.py
+++ b/parsl/tests/test_python_apps/test_dep_standard_futures.py
@@ -30,7 +30,7 @@ def test_future_fail_dependency():
 
     assert not parsl_fut.done()
 
-    plain_fut.set_result(ValueError("Plain failure"))
+    plain_fut.set_exception(ValueError("Plain failure"))
 
     # TODO: be tighter on the returned exception: it should be a dependency failure exception
     assert parsl_fut.exception() is not None

--- a/parsl/tests/test_python_apps/test_dep_standard_futures.py
+++ b/parsl/tests/test_python_apps/test_dep_standard_futures.py
@@ -1,9 +1,11 @@
 import parsl
 from concurrent.futures import Future
 
+
 @parsl.python_app
 def copy_app(v):
     return v
+
 
 def test_future_result_dependency():
 
@@ -19,6 +21,7 @@ def test_future_result_dependency():
 
     assert parsl_fut.result() == message
 
+
 def test_future_fail_dependency():
 
     plain_fut = Future()
@@ -31,5 +34,3 @@ def test_future_fail_dependency():
 
     # TODO: be tighter on the returned exception: it should be a dependency failure exception
     assert parsl_fut.exception() is not None
-
-

--- a/parsl/tests/test_python_apps/test_dep_standard_futures.py
+++ b/parsl/tests/test_python_apps/test_dep_standard_futures.py
@@ -1,4 +1,5 @@
 import parsl
+from parsl.dataflow.error import DependencyError
 from concurrent.futures import Future
 
 
@@ -32,5 +33,4 @@ def test_future_fail_dependency():
 
     plain_fut.set_exception(ValueError("Plain failure"))
 
-    # TODO: be tighter on the returned exception: it should be a dependency failure exception
-    assert parsl_fut.exception() is not None
+    assert isinstance(parsl_fut.exception(), DependencyError)


### PR DESCRIPTION
By ensuring that plain Futures can be used as dependencies, we can be more sure that dependency code does not want to know about the parsl-internal state of dependencies, but instead only relies on what it can observe with the Future interface.

This should be useful in garbage collection work.