### PR TITLE
Fix broken MacSafeQueue test that failed 1 in 100 times

### DIFF
--- a/parsl/tests/test_regression/test_854.py
+++ b/parsl/tests/test_regression/test_854.py
@@ -45,7 +45,7 @@ def test_mac_safe_queue_size():
     task_q = MacSafeQueue()
     result_q = MacSafeQueue()
 
-    x = random.randint(0, 100)
+    x = random.randint(1, 100)
 
     [task_q.put(i) for i in range(x)]
     assert task_q.empty() is False, "Task queue should not be empty"


### PR DESCRIPTION
This test sometimes chose to put 0 items in a queue, which then
caused the not-empty-queue assertion to fail.

This commit makes the test always put a positive number of items
in the queue under test.

Prior to this commit, this test would fail usually after about
50 loops. After this commit, it has run for 2286 loops without
fail:

 while pytest --config local parsl/tests/test_regression/test_854.py ; do echo LOOP ; done