### PR TITLE
Add a test that DFK cleanup summary is output

### DIFF
--- a/parsl/tests/test_summary.py
+++ b/parsl/tests/test_summary.py
@@ -3,12 +3,27 @@ import pytest
 from parsl.tests.configs.local_threads import fresh_config
 
 
+@parsl.python_app
+def succeed():
+    pass
+
+
+@parsl.python_app
+def fail():
+    raise RuntimeError("Deliberate failure in fail() app")
+
+
 @pytest.mark.local
 def test_summary(caplog):
 
     parsl.load(fresh_config())
+
+    succeed().result()
+    fail().exception()
+
     parsl.dfk().cleanup()
     parsl.clear()
 
     assert "Summary of tasks in DFK:" in caplog.text
-
+    assert "Tasks in state States.done: 0" in caplog.text
+    assert "Tasks in state States.failed: 1" in caplog.text

--- a/parsl/tests/test_summary.py
+++ b/parsl/tests/test_summary.py
@@ -1,0 +1,14 @@
+import parsl
+import pytest
+from parsl.tests.configs.local_threads import fresh_config
+
+
+@pytest.mark.local
+def test_summary(caplog):
+
+    parsl.load(fresh_config())
+    parsl.dfk().cleanup()
+    parsl.clear()
+
+    assert "Summary of tasks in DFK:" in caplog.text
+

--- a/parsl/tests/test_summary.py
+++ b/parsl/tests/test_summary.py
@@ -25,5 +25,5 @@ def test_summary(caplog):
     parsl.clear()
 
     assert "Summary of tasks in DFK:" in caplog.text
-    assert "Tasks in state States.done: 0" in caplog.text
+    assert "Tasks in state States.done: 1" in caplog.text
     assert "Tasks in state States.failed: 1" in caplog.text


### PR DESCRIPTION
This is a test that would detect the regression #1559 (missing summary info) introduced in #1543 (garbage collection).

The test passes with the parent commit of #1543 (92a4bbc06c6cd5e46cdc307212caebd546f2db9b) but fails with #1543 applied.

I expect it to fail in CI until #1559 is fixed.