### PR TITLE
Updates to summary method to account for task getting garbage collected.

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1,5 +1,4 @@
 import atexit
-import itertools
 import logging
 import os
 import pathlib
@@ -802,42 +801,23 @@ class DataFlowKernel(object):
     def log_task_states(self):
         logger.info("Summary of tasks in DFK:")
 
-        total_summarised = 0
+        keytasks = {state: 0 for state in States}
 
-        keytasks = []
         for tid in self.tasks:
-            keytasks.append((self.tasks[tid]['status'], tid))
+            keytasks[self.tasks[tid]['status']] += 1
+        # Fetch from counters since tasks get wiped
+        keytasks[States.done] = self.tasks_completed_count
+        keytasks[States.failed] = self.tasks_failed_count
 
-        def first(t):
-            return t[0]
+        for state in States:
+            if keytasks[state]:
+                logger.info("Tasks in state {}: {}".format(str(state), keytasks[state]))
 
-        sorted_keytasks = sorted(keytasks, key=first)
-
-        grouped_sorted_keytasks = itertools.groupby(sorted_keytasks, key=first)
-
-        # caution: g is an iterator that also advances the
-        # grouped_sorted_tasks iterator, so looping over
-        # both grouped_sorted_keytasks and g can only be done
-        # in certain patterns
-
-        for k, g in grouped_sorted_keytasks:
-
-            ts = []
-
-            for t in g:
-                tid = t[1]
-                ts.append(str(tid))
-                total_summarised = total_summarised + 1
-
-            tids_string = ", ".join(ts)
-
-            logger.info("Tasks in state {}: {}".format(str(k), tids_string))
-
-        total_in_tasks = len(self.tasks)
-        if total_summarised != total_in_tasks:
-            logger.error("Task count summarisation was inconsistent: summarised {} tasks, but tasks list contains {} tasks".format(
-                total_summarised, total_in_tasks))
-
+        # Avoid double counting from dep_failed tasks which are also failed tasks
+        total_summarized = sum(keytasks.values()) - keytasks[States.dep_fail]
+        if total_summarized != self.task_count:
+            logger.error("Task count summarisation was inconsistent: summarised {} tasks, but task counters registered {} tasks".format(
+                total_summarized, self.task_count))
         logger.info("End of summary")
 
     def _create_remote_dirs_over_channel(self, provider, channel):


### PR DESCRIPTION
Summary now only lists a total count of tasks in each state. Code is
updated to rely task_count, tasks_completed_count and tasks_failed_count
rather than iterate over the tasks table.

Fixes #1559.
Must merge into master before #1560 