### PR TITLE
Fix "Task N waiting on" message when task isn't waiting on anything

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -756,9 +756,15 @@ class DataFlowKernel(object):
                 depend_descs.append("task {}".format(d.tid))
             else:
                 depend_descs.append(repr(d))
-        logger.info("Task {} submitted for App {}, waiting on {}".format(task_id,
-                                                                         task_def['func_name'],
-                                                                         ", ".join(depend_descs)))
+
+        if depend_descs != []:
+            waiting_message = "waiting on {}".format(", ".join(depend_descs))
+        else:
+            waiting_message = "not waiting on any dependency"
+
+        logger.info("Task {} submitted for App {}, {}".format(task_id,
+                                                              task_def['func_name'],
+                                                              waiting_message))
 
         self.tasks[task_id]['task_launch_lock'] = threading.Lock()
 


### PR DESCRIPTION
Before this commit, the message was awkwardly phrases as "waiting on" and then nothing further.

  Task 35 submitted for App echo_to_streams, waiting on

Now the message looks like:

  Task 35 submitted for App echo_to_streams, not waiting on any dependency