### PR TITLE
Move retries_left to task record, instead of on the executor Futures

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -332,7 +332,7 @@ class DataFlowKernel(object):
 
                 self.tasks[task_id]['app_fu'].set_result(future.result())
             except Exception as e:
-                if future.retries_left > 0:
+                if self.tasks[task_id]['retries_left'] > 0:
                     # ignore this exception, because assume some later
                     # parent executor, started external to this class,
                     # will provide the answer
@@ -438,7 +438,6 @@ class DataFlowKernel(object):
                     self.monitoring.send(MessageType.TASK_INFO, task_log_info)
 
                 exec_fu = Future()
-                exec_fu.retries_left = 0
                 exec_fu.set_exception(DependencyError(exceptions,
                                                       task_id,
                                                       None))
@@ -502,7 +501,7 @@ class DataFlowKernel(object):
             task_log_info = self._create_task_log_info(task_id, 'lazy')
             self.monitoring.send(MessageType.TASK_INFO, task_log_info)
 
-        exec_fu.retries_left = self._config.retries - \
+        self.tasks[task_id]['retries_left'] = self._config.retries - \
             self.tasks[task_id]['fail_count']
         logger.info("Task {} launched on executor {}".format(task_id, executor.label))
         return exec_fu

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -437,6 +437,7 @@ class DataFlowKernel(object):
                     task_log_info = self._create_task_log_info(task_id, 'lazy')
                     self.monitoring.send(MessageType.TASK_INFO, task_log_info)
 
+                self.tasks[task_id]['retries_left'] = 0
                 exec_fu = Future()
                 exec_fu.set_exception(DependencyError(exceptions,
                                                       task_id,

--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -43,9 +43,6 @@ class ParslExecutor(metaclass=ABCMeta):
     @abstractmethod
     def submit(self, func: Callable, *args: Any, **kwargs: Any) -> Future:
         """Submit.
-
-        The value returned must be a Future, with the further requirements that
-        it must be possible to assign a retries_left member slot to that object.
         """
         pass
 

--- a/parsl/tests/test_python_apps/test_depfail_propagation.py
+++ b/parsl/tests/test_python_apps/test_depfail_propagation.py
@@ -1,7 +1,6 @@
 from parsl import python_app
 from parsl.dataflow.error import DependencyError
 
-from parsl.dataflow.states import States
 
 @python_app
 def fails():

--- a/parsl/tests/test_python_apps/test_depfail_propagation.py
+++ b/parsl/tests/test_python_apps/test_depfail_propagation.py
@@ -3,7 +3,6 @@ from parsl.dataflow.error import DependencyError
 
 from parsl.dataflow.states import States
 
-
 @python_app
 def fails():
     raise ValueError("Deliberate failure")
@@ -20,10 +19,8 @@ def test_depfail_once():
     f2 = depends(f1)
 
     assert isinstance(f1.exception(), Exception)
-    assert f1.task_def['status'] == States.failed
-
+    assert not isinstance(f1.exception(), DependencyError)
     assert isinstance(f2.exception(), DependencyError)
-    assert f2.task_def['status'] == States.dep_fail
 
 
 def test_depfail_chain():
@@ -34,16 +31,10 @@ def test_depfail_chain():
     f4 = depends(f3)
 
     assert isinstance(f1.exception(), Exception)
-    assert f1.task_def['status'] == States.failed
-
+    assert not isinstance(f1.exception(), DependencyError)
     assert isinstance(f2.exception(), DependencyError)
-    assert f2.task_def['status'] == States.dep_fail
-
     assert isinstance(f3.exception(), DependencyError)
-    assert f3.task_def['status'] == States.dep_fail
-
     assert isinstance(f4.exception(), DependencyError)
-    assert f4.task_def['status'] == States.dep_fail
 
 
 def test_depfail_branches():
@@ -55,10 +46,6 @@ def test_depfail_branches():
     f3 = depends(f1)
 
     assert isinstance(f1.exception(), Exception)
-    assert f1.task_def['status'] == States.failed
-
+    assert not isinstance(f1.exception(), DependencyError)
     assert isinstance(f2.exception(), DependencyError)
-    assert f2.task_def['status'] == States.dep_fail
-
     assert isinstance(f3.exception(), DependencyError)
-    assert f3.task_def['status'] == States.dep_fail


### PR DESCRIPTION
This should not change behaviour in usual operation, but moves
the retries_left information to the task record along with other
task related information.

It also makes type-checking with mypy easier for the Futures returned
by executors as there is no longer an expectation that arbitrary
Futures will have retries_left attributes.