### PR TITLE
Handle the case where a task does not have a hashsum for memoization

### DIFF
--- a/parsl/dataflow/memoization.py
+++ b/parsl/dataflow/memoization.py
@@ -227,7 +227,7 @@ class Memoizer(object):
         A warning is issued when a hash collision occurs during the update.
         This is not likely.
         """
-        if not self.memoize or not task['memoize']:
+        if not self.memoize or not task['memoize'] or 'hashsum' not in task:
             return
 
         if task['hashsum'] in self.memo_lookup_table:


### PR DESCRIPTION
This case was occuring when a task set for memoization fails due to a
dependency failure. In this situation, the inputs of the task have not
been hashed and stored in hashsum (and do not even exist because the
task that produces them failed).

Previously, a key error was thrown, propagating up to handle_app_update.
Now, the memo table is silently not updated.