### PR TITLE
Fix bash_app vs empty parameters, and expand #226 regression test

### DIFF
--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -122,7 +122,7 @@ class BashApp(AppBase):
         sig = signature(func)
 
         for s in sig.parameters:
-            if sig.parameters[s].default != Parameter.empty:
+            if sig.parameters[s].default is not Parameter.empty:
                 self.kwargs[s] = sig.parameters[s].default
 
     def __call__(self, *args, **kwargs):

--- a/parsl/tests/test_regression/test_226.py
+++ b/parsl/tests/test_regression/test_226.py
@@ -27,9 +27,11 @@ bar = Foo(1)
 def get_foo_x(a, b=bar, c=None):
     return b.x
 
+@bash_app
+def get_foo_x_bash(a, b=bar, c=None):
+    return "echo {}".format(b.x)
 
 data = pd.DataFrame({'x': [None, 2, [3]]})
-
 
 @python_app
 def get_dataframe(d=data):

--- a/parsl/tests/test_regression/test_226.py
+++ b/parsl/tests/test_regression/test_226.py
@@ -27,11 +27,14 @@ bar = Foo(1)
 def get_foo_x(a, b=bar, c=None):
     return b.x
 
+
 @bash_app
 def get_foo_x_bash(a, b=bar, c=None):
     return "echo {}".format(b.x)
 
+
 data = pd.DataFrame({'x': [None, 2, [3]]})
+
 
 @python_app
 def get_dataframe(d=data):


### PR DESCRIPTION
I'm a little unsure if it is safe to use parameter.empty here... I think so but it is a different
inequality to the one being tested before.

see https://github.com/Parsl/parsl/issues/226