### PR TITLE
Fix Torque job_id truncation

### DIFF
--- a/parsl/providers/torque/torque.py
+++ b/parsl/providers/torque/torque.py
@@ -124,7 +124,7 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
             job_id = parts[0]  # likely truncated
             for long_job_id in job_ids:
                 if long_job_id.startswith(job_id):
-                    logger.debug(f'coersed jobid {job_id} -> {long_job_id}')
+                    logger.debug('coerced job_id %s -> %s', job_id, long_job_id)
                     job_id = long_job_id
                     break
             state = translate_table.get(parts[4], JobState.UNKNOWN)

--- a/parsl/providers/torque/torque.py
+++ b/parsl/providers/torque/torque.py
@@ -111,6 +111,7 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
               [status...] : Status list of all jobs
         '''
 
+        job_ids = list(self.resources.keys())
         job_id_list = ' '.join(self.resources.keys())
 
         jobs_missing = list(self.resources.keys())
@@ -120,7 +121,12 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
             parts = line.split()
             if not parts or parts[0].upper().startswith('JOB') or parts[0].startswith('---'):
                 continue
-            job_id = parts[0]
+            job_id = parts[0]  # likely truncated
+            for long_job_id in job_ids:
+                if long_job_id.startswith(job_id):
+                    logger.debug(f'coersed jobid {job_id} -> {long_job_id}')
+                    job_id = long_job_id
+                    break
             state = translate_table.get(parts[4], JobState.UNKNOWN)
             self.resources[job_id]['status'] = JobStatus(state)
             jobs_missing.remove(job_id)


### PR DESCRIPTION
This is a simple naive fix to a critical issue with the Torque provider.

The implementation of the Torque provider keeps track of running jobs using the output it got from the `qsub` command which gives a full hostname. But the status method runs `qstat` whose output typically provides truncated job_id values.

In my case (on Purdue's Brown cluster):

```
$ qsub ...
6058223.brown-adm.rcac.purdue.edu
```
```
$ qstat 6058223.brown-adm.rcac.purdue.edu ...

Job ID                    Name             User            Time Use S Queue
------------------------- ---------------- --------------- -------- - -----
6058223.brown-adm         ...96831.6737266 glentner               0 Q debug
```

This results in an almost immediate `KeyError` being raised on startup and a full panic.

All this fix does to resolve the issue is to check existing "long form" job_id values to see if it _starts with_ the job_id it got from `qstat`. Since Torque job ID values are always NUM.HOSTNAME format I think this is pretty safe. I'm open to suggestions though.

Note: We're almost done migrating all our clusters at Purdue to Slurm. I tried to get this tested before I didn't have Torque available -- a time horizon now measured in days! 🤣