### PR TITLE
Make monitoring workflow name work with recent typeguard and ignore __init.py__

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -119,11 +119,13 @@ class DataFlowKernel(object):
         else:
             for frame in inspect.stack():
                 fname = os.path.basename(str(frame.filename))
-                parsl_file_names = ['dflow.py', 'typeguard.py']
+                parsl_file_names = ['dflow.py', 'typeguard.py', '__init__.py']
                 # Find first file name not considered a parsl file
                 if fname not in parsl_file_names:
                     self.workflow_name = fname
                     break
+            else:
+                self.workflow_name = "unnamed"
 
         self.workflow_version = str(self.time_began.replace(microsecond=0))
         if self.monitoring is not None and self.monitoring.workflow_version is not None:


### PR DESCRIPTION
Recent versions of typeguard place typeguard/__init__.py in the stack instead
of typeguard.py, so the code which skipped typeguard.py in workflow name
detection didn't skip typeguard and was picking __init__.py as the workflow
name.

Probably in general __init__.py is never the right name for a workflow in
monitoring - so this PR skips that name in all circumstances.

If the code runs out of names to try, then the code now defaults to a
specific value rather than leaving the workflow name un-set.