### PR TITLE
Allow task_hashsum to be null in monitoring

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -133,7 +133,7 @@ class Database(object):
             'task_time_returned', DateTime, nullable=True)
         task_elapsed_time = Column('task_elapsed_time', Float, nullable=True)
         task_memoize = Column('task_memoize', Text, nullable=False)
-        task_hashsum = Column('task_hashsum', Text, nullable=False)
+        task_hashsum = Column('task_hashsum', Text, nullable=True)
         task_inputs = Column('task_inputs', Text, nullable=True)
         task_outputs = Column('task_outputs', Text, nullable=True)
         task_stdin = Column('task_stdin', Text, nullable=True)


### PR DESCRIPTION
This was introduced to monitoring in PR #1584 but the
schema required it to be NOT NULL.

This field is NULL when a task fails before its hashsum is created:
specifically in testing, when a task ends with status dep_fail.

In such a case, data is not stored properly to the monitoring database.
This failure is logged in database_manager.log but is not made
obvious to the user/CI.