### PR TITLE
Split AppFailure into two cases: bash unix exit and workqueue failures

### DIFF
--- a/docs/devguide/dev_docs.rst
+++ b/docs/devguide/dev_docs.rst
@@ -80,7 +80,7 @@ Exceptions
 
 .. autoclass:: parsl.app.errors.AppBadFormatting
 
-.. autoclass:: parsl.app.errors.AppFailure
+.. autoclass:: parsl.app.errors.BashExitFailure
 
 .. autoclass:: parsl.app.errors.MissingOutputs
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -67,10 +67,10 @@ Reference guide
 
     parsl.app.errors.AppBadFormatting
     parsl.app.errors.AppException
-    parsl.app.errors.AppFailure
     parsl.app.errors.AppTimeout
     parsl.app.errors.BadStdStreamFile
     parsl.app.errors.BashAppNoReturn
+    parsl.app.errors.BashExitFailure
     parsl.app.errors.DependencyError
     parsl.app.errors.MissingOutputs
     parsl.app.errors.NotFutureError

--- a/docs/stubs/parsl.app.errors.AppFailure.rst
+++ b/docs/stubs/parsl.app.errors.AppFailure.rst
@@ -1,6 +1,0 @@
-parsl.app.errors.AppFailure
-===========================
-
-.. currentmodule:: parsl.app.errors
-
-.. autoexception:: AppFailure

--- a/docs/stubs/parsl.app.errors.BashExitFailure.rst
+++ b/docs/stubs/parsl.app.errors.BashExitFailure.rst
@@ -1,0 +1,6 @@
+parsl.app.errors.BashExitFailure
+================================
+
+.. currentmodule:: parsl.app.errors
+
+.. autoexception:: BashExitFailure

--- a/docs/userguide/apps.rst
+++ b/docs/userguide/apps.rst
@@ -167,5 +167,5 @@ A Bash app can only return results via files specified via ``outputs``, ``stderr
 
 If the Bash app exits with Unix exit code 0, then the AppFuture will complete. If the Bash app
 exits with any other code, this will be treated as a failure, and the AppFuture will instead
-contain an AppFailure exception. The Unix exit code can be accessed through the
-`exitcode` attribute of that AppFailure.
+contain an BashExitFailure exception. The Unix exit code can be accessed through the
+`exitcode` attribute of that BashExitFailure.

--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -91,7 +91,7 @@ def remote_side_bash_executor(func, *args, **kwargs):
         raise pe.AppException("[{}] App caught exception with returncode: {}".format(func_name, returncode), e)
 
     if returncode != 0:
-        raise pe.AppFailure("[{}] App failed with exit code: {}".format(func_name, proc.returncode), proc.returncode)
+        raise pe.BashExitFailure(func_name, proc.returncode)
 
     # TODO : Add support for globs here
 

--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -36,20 +36,23 @@ class AppBadFormatting(ParslError):
     """
 
 
-class AppFailure(AppException):
-    """An error raised during execution of an app.
+class BashExitFailure(AppException):
+    """A non-zero exit code returned from a @bash_app
 
-    What this exception contains depends entirely on context
     Contains:
-    reason(string)
+    func_name(str)
     exitcode(int)
-    retries(int/None)
     """
 
-    def __init__(self, reason, exitcode, retries=None):
-        self.reason = reason
+    def __init__(self, func_name, exitcode):
+        self.func_name = func_name
         self.exitcode = exitcode
-        self.retries = retries
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        return "App {} failed with exit code {}".format(self.func_name, self.exitcode)
 
 
 class AppTimeout(AppException):

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -14,7 +14,7 @@ import queue
 import inspect
 from ipyparallel.serialize import pack_apply_message
 
-from parsl.app.errors import AppFailure
+from parsl.app.errors import AppException
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.executors.errors import ExecutorError
 from parsl.data_provider.files import File
@@ -39,6 +39,19 @@ else:
     _work_queue_enabled = True
 
 logger = logging.getLogger(__name__)
+
+
+class WorkqueueTaskFailure(AppException):
+    """A failure executing a task in workqueue
+
+    Contains:
+    reason(string)
+    status(int)
+    """
+
+    def __init__(self, reason, status):
+        self.reason = reason
+        self.status = status
 
 
 def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
@@ -363,7 +376,7 @@ def WorkQueueCollectorThread(collector_queue=multiprocessing.Queue(),
         if received is False:
             reason = item["reason"]
             status = item["status"]
-            future.set_exception(AppFailure(reason, status))
+            future.set_exception(WorkqueueTaskFailure(reason, status))
         # Successful task
         else:
             result = item["result"]

--- a/parsl/tests/test_bash_apps/test_error_codes.py
+++ b/parsl/tests/test_bash_apps/test_error_codes.py
@@ -109,8 +109,8 @@ def test_bash_misuse(test_fn=bash_misuse):
     f = test_fn()
     try:
         f.result()
-    except pe.AppFailure as e:
-        print("Caught expected AppFailure", e)
+    except pe.BashExitFailure as e:
+        print("Caught expected BashExitFailure", e)
         assert e.exitcode == err_code, "{0} expected err_code:{1} but got {2}".format(test_fn.__name__,
                                                                                       err_code,
                                                                                       e.exitcode)
@@ -124,7 +124,7 @@ def test_command_not_found(test_fn=command_not_found):
     f = test_fn()
     try:
         f.result()
-    except pe.AppFailure as e:
+    except pe.BashExitFailure as e:
         print("Caught exception", e)
         assert e.exitcode == err_code, "{0} expected err_code:{1} but got {2}".format(test_fn.__name__,
                                                                                       err_code,


### PR DESCRIPTION
This allows the bash app unix exit code case to have better formatting.