### PR TITLE
Pin mypy version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,6 +8,6 @@ coverage==4.5.4
 mock>=1.0.0
 nbsphinx
 sphinx_rtd_theme
-mypy
+mypy==0.761
 sqlalchemy-stubs
 


### PR DESCRIPTION
This stops spurious CI errors caused by mypy releases making mypy stricter.

After this PR, mypy can be upgraded by:

* changing the test-requirements.txt mypy version
* fixing whatever breaks because of that upgrade