### PR TITLE
Remove unused MissingFutError implementation

### DIFF
--- a/docs/devguide/dev_docs.rst
+++ b/docs/devguide/dev_docs.rst
@@ -90,8 +90,6 @@ Exceptions
 
 .. autoclass:: parsl.dataflow.error.DuplicateTaskError
 
-.. autoclass:: parsl.dataflow.error.MissingFutError
-
 DataFlowKernel
 ==============
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -83,7 +83,6 @@ Reference guide
     parsl.dataflow.error.DataFlowException
     parsl.dataflow.error.ConfigurationError
     parsl.dataflow.error.DuplicateTaskError
-    parsl.dataflow.error.MissingFutError
     parsl.dataflow.error.BadCheckpoint
     parsl.dataflow.error.DependencyError
     parsl.launchers.error.BadLauncher

--- a/docs/stubs/parsl.dataflow.error.MissingFutError.rst
+++ b/docs/stubs/parsl.dataflow.error.MissingFutError.rst
@@ -1,6 +1,0 @@
-parsl.dataflow.error.MissingFutError
-====================================
-
-.. currentmodule:: parsl.dataflow.error
-
-.. autoexception:: MissingFutError

--- a/parsl/dataflow/error.py
+++ b/parsl/dataflow/error.py
@@ -16,13 +16,6 @@ class DuplicateTaskError(DataFlowException):
     """
 
 
-class MissingFutError(DataFlowException):
-    """Raised when a particular future is not found within the dataflowkernel's datastructures.
-
-    Deprecated.
-    """
-
-
 class BadCheckpoint(DataFlowException):
     """Error raised at the end of app execution due to missing output files.
 


### PR DESCRIPTION
This has been unused since commit
4cc6806ce74d91d39ba930bb1aa159643751e00b,
in March 2017