### PR TITLE
Remove unused outputs attribute from DependencyError

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -432,8 +432,7 @@ class DataFlowKernel(object):
                 self.tasks[task_id]['retries_left'] = 0
                 exec_fu = Future()
                 exec_fu.set_exception(DependencyError(exceptions,
-                                                      task_id,
-                                                      None))
+                                                      task_id))
 
             if exec_fu:
 

--- a/parsl/dataflow/error.py
+++ b/parsl/dataflow/error.py
@@ -50,17 +50,15 @@ class DependencyError(DataFlowException):
     Args:
          - dependent_exceptions: List of exceptions
          - task_id: Identity of the task failed task
-         - outputs ?
 
     Contains:
     reason (string)
     dependent_exceptions
     """
 
-    def __init__(self, dependent_exceptions, task_id, outputs):
+    def __init__(self, dependent_exceptions, task_id):
         self.dependent_exceptions = dependent_exceptions
         self.task_id = task_id
-        self.outputs = outputs
 
     def __repr__(self):
         return "[{}] Dependency failure from: {}".format(self.task_id,


### PR DESCRIPTION
This looks like it came as a cut-and-paste from another
exception class when DependencyError was initially
implemented.