### PR TITLE
Use label rather than (missing) sitename in ClusterProvider exception

### DIFF
--- a/parsl/providers/cluster_provider.py
+++ b/parsl/providers/cluster_provider.py
@@ -108,7 +108,7 @@ class ClusterProvider(ExecutionProvider):
 
         except KeyError as e:
             logger.error("Missing keys for submit script : %s", e)
-            raise (SchedulerMissingArgs(e.args, self.sitename))
+            raise (SchedulerMissingArgs(e.args, self.label))
 
         except IOError as e:
             logger.error("Failed writing to submit script: %s", script_filename)


### PR DESCRIPTION
Previous to this, trying to throw this exception would have resulted
in a different exception being thrown as sitename would not be found.

This comes from benc-mypy branch