### PR TITLE
Mark task as failed if launch() raises an exception

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -415,9 +415,21 @@ class DataFlowKernel(object):
                 # Acquire a lock, retest the state, launch
                 with task_record['task_launch_lock']:
                     if task_record['status'] == States.pending:
-                        exec_fu = self.launch_task(
-                            task_id, task_record['func'], *new_args, **kwargs)
+                        try:
+                            exec_fu = self.launch_task(
+                                task_id, task_record['func'], *new_args, **kwargs)
+                        except Exception as e:
+                            # task launched failed somehow. the execution might
+                            # have been launched and an exception raised after
+                            # that, though. that's hard to detect from here.
+                            # we don't attempt retries here. This is an error with submission
+                            # even though it might come from user code such as a plugged-in
+                            # executor or memoization hash function.
 
+                            logger.debug("Got an exception launching task", exc_info=True)
+                            self.tasks[task_id]['retries_left'] = 0
+                            exec_fu = Future()
+                            exec_fu.set_exception(e)
             else:
                 logger.info(
                     "Task {} failed due to dependency failure".format(task_id))
@@ -439,6 +451,11 @@ class DataFlowKernel(object):
                 try:
                     exec_fu.add_done_callback(partial(self.handle_exec_update, task_id))
                 except Exception as e:
+                    # this exception is ignored here because it is assumed that exception
+                    # comes from directly executing handle_exec_update (because exec_fu is
+                    # done already). If the callback executes later, then any exception
+                    # coming out of the callback will be ignored and not propate anywhere,
+                    # so this block attempts to keep the same behaviour here.
                     logger.error("add_done_callback got an exception {} which will be ignored".format(e))
 
                 task_record['exec_fu'] = exec_fu

--- a/parsl/tests/test_python_apps/test_memoize_bad_id_for_memo.py
+++ b/parsl/tests/test_python_apps/test_memoize_bad_id_for_memo.py
@@ -24,8 +24,14 @@ def failing_memoizer(v, output_ref=False):
 
 
 @python_app(cache=True)
-def noop_app(x, cache=True):
+def noop_app(x, inputs=[], cache=True):
     return None
+
+
+@python_app
+def sleep(t):
+    import time
+    time.sleep(t)
 
 
 def test_python_unmemoizable():
@@ -40,3 +46,17 @@ def test_python_failing_memoizer():
     """
     with pytest.raises(FailingMemoizerTestError):
         noop_app(FailingMemoizable())
+
+
+def test_python_unmemoizable_after_dep():
+    sleep_fut = sleep(1)
+    fut = noop_app(Unmemoizable(), inputs=[sleep_fut])
+    with pytest.raises(ValueError):
+        fut.result()
+
+
+def test_python_failing_memoizer_afer_dep():
+    sleep_fut = sleep(1)
+    fut = noop_app(FailingMemoizable(), inputs=[sleep_fut])
+    with pytest.raises(ValueError):
+        fut.result()

--- a/parsl/tests/test_python_apps/test_memoize_bad_id_for_memo.py
+++ b/parsl/tests/test_python_apps/test_memoize_bad_id_for_memo.py
@@ -37,15 +37,17 @@ def sleep(t):
 def test_python_unmemoizable():
     """Testing behaviour when an unmemoizable parameter is used
     """
+    fut = noop_app(Unmemoizable())
     with pytest.raises(ValueError):
-        noop_app(Unmemoizable())
+        fut.result()
 
 
 def test_python_failing_memoizer():
     """Testing behaviour when id_for_memo raises an exception
     """
+    fut = noop_app(FailingMemoizable())
     with pytest.raises(FailingMemoizerTestError):
-        noop_app(FailingMemoizable())
+        fut.result()
 
 
 def test_python_unmemoizable_after_dep():


### PR DESCRIPTION
Prior to this PR, an exception raised by launch() propagates upwards, in at least two
different ways:

* If a task has no pending dependencies, then the exception propages to the user's code which
invoked the relevant app. An example of testing this can be seen in
parsl/tests/test_python_apps/test_memoize_bad_id_for_memo.py
which expects such an exception.

* If a task has pending dependencies, then the exception propagates into the dependency Future's
callback handler, and then out of the top of that into nowhere. The user is never informed. This
behaviour was not tested in the test suite.

In both cases, anything which waits on such tasks completing (for example, via AppFuture.result()
or downstream dependencies) will hang forever as the tasks never reach a final state.

This PR places error handling code in launch_if_ready so that if launch() raises an exception
rather than returning a Future, that exception is recorded and so the task is marked as failed.

The immediate problem that this fixes is when user provided memoization code raises an exception,
parsl hangs as above, rather than reporting a task failure. This blocks PRs #1608, #1614 from
being merged.

See discussion on PR #1275