### PR TITLE
Remove **kwargs in various Channel inits

### DIFF
--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -16,7 +16,7 @@ class LocalChannel(Channel, RepresentationMixin):
     and done so infrequently that they do not need a persistent channel
     '''
 
-    def __init__(self, userhome=".", envs={}, script_dir=None, **kwargs):
+    def __init__(self, userhome=".", envs={}, script_dir=None):
         ''' Initialize the local channel. script_dir is required by set to a default.
 
         KwArgs:

--- a/parsl/channels/ssh/ssh.py
+++ b/parsl/channels/ssh/ssh.py
@@ -26,7 +26,7 @@ class SSHChannel(Channel, RepresentationMixin):
 
     '''
 
-    def __init__(self, hostname, username=None, password=None, script_dir=None, envs=None, gssapi_auth=False, skip_auth=False, port=22, **kwargs):
+    def __init__(self, hostname, username=None, password=None, script_dir=None, envs=None, gssapi_auth=False, skip_auth=False, port=22):
         ''' Initialize a persistent connection to the remote system.
         We should know at this point whether ssh connectivity is possible
 
@@ -48,7 +48,6 @@ class SSHChannel(Channel, RepresentationMixin):
         self.username = username
         self.password = password
         self.port = port
-        self.kwargs = kwargs
         self.script_dir = script_dir
         self.skip_auth = skip_auth
         self.gssapi_auth = gssapi_auth

--- a/parsl/channels/ssh_il/ssh_il.py
+++ b/parsl/channels/ssh_il/ssh_il.py
@@ -13,7 +13,7 @@ class SSHInteractiveLoginChannel(SSHChannel):
     keys are not set up.
     """
 
-    def __init__(self, hostname, username=None, password=None, script_dir=None, envs=None, **kwargs):
+    def __init__(self, hostname, username=None, password=None, script_dir=None, envs=None):
         ''' Initialize a persistent connection to the remote system.
         We should know at this point whether ssh connectivity is possible
 
@@ -32,7 +32,6 @@ class SSHInteractiveLoginChannel(SSHChannel):
         self.hostname = hostname
         self.username = username
         self.password = password
-        self.kwargs = kwargs
 
         self.ssh_client = paramiko.SSHClient()
         self.ssh_client.load_system_host_keys()


### PR DESCRIPTION
This will catch more typos in channel keyword arguments rather
than silently condemning them to the ignored kwarg dict.