### PR TITLE
Rearrange bash app output checking codepath

### DIFF
--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -97,9 +97,7 @@ def remote_side_bash_executor(func, *args, **kwargs):
 
     missing = []
     for outputfile in kwargs.get('outputs', []):
-        fpath = outputfile
-        if type(outputfile) != str:
-            fpath = outputfile.filepath
+        fpath = outputfile.filepath
 
         if not os.path.exists(fpath):
             missing.extend([outputfile])

--- a/parsl/tests/__init__.py
+++ b/parsl/tests/__init__.py
@@ -1,0 +1,7 @@
+from parsl.dataflow.memoization import id_for_memo
+from parsl.data_provider.files import File
+
+
+@id_for_memo.register(File)
+def id_for_memo_file(file: File, output_ref: bool = False):
+    return file.url

--- a/parsl/tests/test_bash_apps/test_basic.py
+++ b/parsl/tests/test_bash_apps/test_basic.py
@@ -6,6 +6,7 @@ import time
 
 import parsl
 from parsl.app.app import bash_app
+from parsl.data_provider.files import File
 
 from parsl.tests.configs.local_threads import config
 
@@ -70,7 +71,7 @@ def test_parallel_for(n=3):
     for i in range(0, n):
         d[i] = echo_to_file(
             inputs=['Hello World {0}'.format(i)],
-            outputs=['{0}/out.{1}.txt'.format(outdir, i)],
+            outputs=[File('{0}/out.{1}.txt'.format(outdir, i))],
             stdout='{0}/std.{1}.out'.format(outdir, i),
             stderr='{0}/std.{1}.err'.format(outdir, i),
         )

--- a/parsl/tests/test_bash_apps/test_memoize.py
+++ b/parsl/tests/test_bash_apps/test_memoize.py
@@ -3,6 +3,7 @@ import os
 
 import parsl
 from parsl.app.app import bash_app
+from parsl.data_provider.files import File
 from parsl.tests.configs.local_threads import config
 
 
@@ -15,17 +16,18 @@ def test_bash_memoization(n=2):
     """Testing bash memoization
     """
     temp_filename = "test.memoization.tmp"
+    temp_file = File(temp_filename)
 
     if os.path.exists(temp_filename):
         os.remove(temp_filename)
 
     print("Launching: ", n)
-    x = fail_on_presence(outputs=[temp_filename])
+    x = fail_on_presence(outputs=[temp_file])
     x.result()
 
     d = {}
     for i in range(0, n):
-        d[i] = fail_on_presence(outputs=[temp_filename])
+        d[i] = fail_on_presence(outputs=[temp_file])
 
     for i in d:
         assert d[i].exception() is None
@@ -40,17 +42,18 @@ def test_bash_memoization_keywords(n=2):
     """Testing bash memoization
     """
     temp_filename = "test.memoization.tmp"
+    temp_file = File("test.memoization.tmp")
 
     if os.path.exists(temp_filename):
         os.remove(temp_filename)
 
     print("Launching: ", n)
-    x = fail_on_presence_kw(outputs=[temp_filename], foo={"a": 1, "b": 2})
+    x = fail_on_presence_kw(outputs=[temp_file], foo={"a": 1, "b": 2})
     x.result()
 
     d = {}
     for i in range(0, n):
-        d[i] = fail_on_presence_kw(outputs=[temp_filename], foo={"b": 2, "a": 1})
+        d[i] = fail_on_presence_kw(outputs=[temp_file], foo={"b": 2, "a": 1})
 
     for i in d:
         assert d[i].exception() is None

--- a/parsl/tests/test_bash_apps/test_multiline.py
+++ b/parsl/tests/test_bash_apps/test_multiline.py
@@ -6,6 +6,7 @@ import time
 
 import parsl
 from parsl.app.app import bash_app
+from parsl.data_provider.files import File
 from parsl.tests.configs.local_threads import config
 
 
@@ -37,9 +38,9 @@ def test_multiline():
     f = multiline(
             inputs=["Hello", "This is", "Cat!"],
             outputs=[
-                '{0}/hello.txt'.format(outdir),
-                '{0}/this.txt'.format(outdir),
-                '{0}/cat.txt'.format(outdir)
+                File('{0}/hello.txt'.format(outdir)),
+                File('{0}/this.txt'.format(outdir)),
+                File('{0}/cat.txt'.format(outdir))
             ]
     )
     print(f.result())

--- a/parsl/tests/test_data/test_file_ipp.py
+++ b/parsl/tests/test_data/test_file_ipp.py
@@ -23,7 +23,7 @@ def test_files():
         os.remove('cat_out.txt')
 
     fs = [File('data/' + f) for f in os.listdir('data')]
-    x = cat(inputs=fs, outputs=['cat_out.txt'],
+    x = cat(inputs=fs, outputs=[File('cat_out.txt')],
             stdout='f_app.out', stderr='f_app.err')
     d_x = x.outputs[0]
     print(x.result())


### PR DESCRIPTION
Previously this code assumed that a output was either:

* a string

or

* something with a .filepath attribute

and would fail if an output was anything else.

Presently, outputs of a bash app are always File objects
(with a .filepath attribute, and never anything else).

This commit tidies that codepath.