### PR TITLE
Remove unused execute_no_wait from Channels

### DIFF
--- a/docs/devguide/dev_docs.rst
+++ b/docs/devguide/dev_docs.rst
@@ -339,22 +339,22 @@ to the resource managers of compute facilities. The simplest Channel, *LocalChan
 locally on a shell, while the *SshChannel* authenticates you to remote systems.
 
 .. autoclass:: parsl.channels.base.Channel
-   :members:  execute_wait, script_dir, execute_no_wait, push_file, close
+   :members:  execute_wait, script_dir, push_file, close
 
 LocalChannel
 ^^^^^^^^^^^^
 .. autoclass:: parsl.channels.LocalChannel
-   :members:  __init__, execute_wait, execute_no_wait, push_file, script_dir, close
+   :members:  __init__, execute_wait, push_file, script_dir, close
 
 SSHChannel
 ^^^^^^^^^^^^
 .. autoclass:: parsl.channels.SSHChannel
-   :members:  __init__, execute_wait, execute_no_wait, push_file, pull_file, script_dir, close
+   :members:  __init__, execute_wait, push_file, pull_file, script_dir, close
 
 SSHILChannel
 ^^^^^^^^^^^^
 .. autoclass:: parsl.channels.SSHInteractiveLoginChannel
-   :members:  __init__, execute_wait, execute_no_wait, push_file, pull_file, script_dir, close
+   :members:  __init__, execute_wait, push_file, pull_file, script_dir, close
 
 
 

--- a/docs/stubs/parsl.channels.LocalChannel.rst
+++ b/docs/stubs/parsl.channels.LocalChannel.rst
@@ -16,7 +16,6 @@ parsl.channels.LocalChannel
       ~LocalChannel.__init__
       ~LocalChannel.abspath
       ~LocalChannel.close
-      ~LocalChannel.execute_no_wait
       ~LocalChannel.execute_wait
       ~LocalChannel.isdir
       ~LocalChannel.makedirs

--- a/docs/stubs/parsl.channels.OAuthSSHChannel.rst
+++ b/docs/stubs/parsl.channels.OAuthSSHChannel.rst
@@ -16,7 +16,6 @@ parsl.channels.OAuthSSHChannel
       ~OAuthSSHChannel.__init__
       ~OAuthSSHChannel.abspath
       ~OAuthSSHChannel.close
-      ~OAuthSSHChannel.execute_no_wait
       ~OAuthSSHChannel.execute_wait
       ~OAuthSSHChannel.isdir
       ~OAuthSSHChannel.makedirs

--- a/docs/stubs/parsl.channels.SSHChannel.rst
+++ b/docs/stubs/parsl.channels.SSHChannel.rst
@@ -16,7 +16,6 @@ parsl.channels.SSHChannel
       ~SSHChannel.__init__
       ~SSHChannel.abspath
       ~SSHChannel.close
-      ~SSHChannel.execute_no_wait
       ~SSHChannel.execute_wait
       ~SSHChannel.isdir
       ~SSHChannel.makedirs

--- a/docs/stubs/parsl.channels.SSHInteractiveLoginChannel.rst
+++ b/docs/stubs/parsl.channels.SSHInteractiveLoginChannel.rst
@@ -16,7 +16,6 @@ parsl.channels.SSHInteractiveLoginChannel
       ~SSHInteractiveLoginChannel.__init__
       ~SSHInteractiveLoginChannel.abspath
       ~SSHInteractiveLoginChannel.close
-      ~SSHInteractiveLoginChannel.execute_no_wait
       ~SSHInteractiveLoginChannel.execute_wait
       ~SSHInteractiveLoginChannel.isdir
       ~SSHInteractiveLoginChannel.makedirs

--- a/parsl/channels/base.py
+++ b/parsl/channels/base.py
@@ -12,9 +12,6 @@ class Channel(metaclass=ABCMeta):
           cmd, wtime    ------->|  execute_wait
           (ec, stdout, stderr)<-|---+
                                 |
-          cmd, wtime    ------->|  execute_no_wait
-          (ec, stdout, stderr)<-|---+
-                                |
           src, dst_dir  ------->|  push_file
              dst_path  <--------|----+
                                 |
@@ -57,22 +54,6 @@ class Channel(metaclass=ABCMeta):
 
         Returns:
             - Channel script dir
-        '''
-        pass
-
-    @abstractmethod
-    def execute_no_wait(self, cmd, walltime, envs={}, *args, **kwargs):
-        ''' Execute asynchronousely without waiting for exitcode
-
-        Args:
-            - cmd (string): Command string to execute over the channel
-            - walltime (int) : Timeout in seconds
-
-        KWargs:
-            - envs (dict) : Environment variables to push to the remote side
-
-        Returns:
-            - the type of return value is channel specific
         '''
         pass
 

--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -79,42 +79,6 @@ class LocalChannel(Channel, RepresentationMixin):
 
         return (retcode, stdout.decode("utf-8"), stderr.decode("utf-8"))
 
-    def execute_no_wait(self, cmd, walltime, envs={}):
-        ''' Synchronously execute a commandline string on the shell.
-
-        Args:
-            - cmd (string) : Commandline string to execute
-            - walltime (int) : walltime in seconds, this is not really used now.
-
-        Returns a tuple containing:
-
-           - pid : process id
-           - proc : a subprocess.Popen object
-
-        Raises:
-         None.
-        '''
-        current_env = copy.deepcopy(self._envs)
-        current_env.update(envs)
-
-        try:
-            proc = subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                cwd=self.userhome,
-                env=current_env,
-                shell=True,
-                preexec_fn=os.setpgrp
-            )
-            pid = proc.pid
-
-        except Exception as e:
-            logger.warning("Execution of command '{}' failed due to \n{}".format(cmd, e))
-            raise
-
-        return pid, proc
-
     def push_file(self, source, dest_dir):
         ''' If the source files dirpath is the same as dest_dir, a copy
         is not necessary, and nothing is done. Else a copy is made.

--- a/parsl/channels/oauth_ssh/oauth_ssh.py
+++ b/parsl/channels/oauth_ssh/oauth_ssh.py
@@ -106,32 +106,5 @@ class OAuthSSHChannel(SSHChannel):
 
         return exit_status, stdout, stderr
 
-    def execute_no_wait(self, cmd, walltime=60, envs={}):
-        ''' Execute asynchronousely without waiting for exitcode
-
-        Args:
-            - cmd (string): Commandline string to be executed on the remote side
-
-        KWargs:
-            - walltime (int): timeout to exec_command
-            - envs (dict): A dictionary of env variables
-
-        Returns:
-            - None, stdout (readable stream), stderr (readable stream)
-
-        Raises:
-            - ChannelExecFailed (reason)
-        '''
-        session = self.transport.open_session()
-        session.setblocking(0)
-
-        nbytes = 10240
-        session.exec_command(self.prepend_envs(cmd, envs))
-
-        stdout = session.recv(nbytes).decode('utf-8')
-        stderr = session.recv_stderr(nbytes).decode('utf-8')
-
-        return None, stdout, stderr
-
     def close(self):
         return self.transport.close()

--- a/parsl/channels/ssh/ssh.py
+++ b/parsl/channels/ssh/ssh.py
@@ -124,29 +124,6 @@ class SSHChannel(Channel, RepresentationMixin):
         exit_status = stdout.channel.recv_exit_status()
         return exit_status, stdout.read().decode("utf-8"), stderr.read().decode("utf-8")
 
-    def execute_no_wait(self, cmd, walltime=2, envs={}):
-        ''' Execute asynchronousely without waiting for exitcode
-
-        Args:
-            - cmd (string): Commandline string to be executed on the remote side
-            - walltime (int): timeout to exec_command
-
-        KWargs:
-            - envs (dict): A dictionary of env variables
-
-        Returns:
-            - None, stdout (readable stream), stderr (readable stream)
-
-        Raises:
-            - ChannelExecFailed (reason)
-        '''
-
-        # Execute the command
-        stdin, stdout, stderr = self.ssh_client.exec_command(
-            self.prepend_envs(cmd, envs), bufsize=-1, timeout=walltime
-        )
-        return None, stdout, stderr
-
     def push_file(self, local_source, remote_dir):
         ''' Transport a local file to a directory on a remote machine
 


### PR DESCRIPTION
This was previously used in a special case for
Local and AdHoc providers, but that special case
has been removed in previous commits.

This is the last patch in the series described in #1448. Resolves #1448.
