### PR TITLE
Fix pytest warnings introduced in #1568

### DIFF
--- a/parsl/tests/test_bash_apps/test_memoize_ignore_args.py
+++ b/parsl/tests/test_bash_apps/test_memoize_ignore_args.py
@@ -5,19 +5,19 @@ from parsl.app.app import bash_app
 
 
 @bash_app(cache=True, ignore_for_cache=['x'])
-def test_app(x):
+def oneshot_app(x):
     if x != 0:
         raise RuntimeError("App was executed when it should not have been")
     return "true"
 
 
 def test_memo_same_at_definition():
-    test_app(x=0).result()  # this should be executed
-    test_app(x=1).result()  # this should be memoized, and will raise a RuntimeError if actually executed
+    oneshot_app(x=0).result()  # this should be executed
+    oneshot_app(x=1).result()  # this should be memoized, and will raise a RuntimeError if actually executed
 
 
 @bash_app(cache=True, ignore_for_cache=['stdout'])
-def test_no_checkpoint_stdout(stdout=None):
+def no_checkpoint_stdout_app(stdout=None):
     return "echo X"
 
 
@@ -28,16 +28,16 @@ def test_memo_stdout():
     if os.path.exists(path_x):
         os.remove(path_x)
 
-    test_no_checkpoint_stdout(stdout=path_x).result()
+    no_checkpoint_stdout_app(stdout=path_x).result()
     assert os.path.exists(path_x)
 
     # this should be memoized, so not create benc.test.y
     path_y = "test.memo.stdout.y"
     assert not os.path.exists(path_y)
-    test_no_checkpoint_stdout(stdout=path_y).result()
+    no_checkpoint_stdout_app(stdout=path_y).result()
     assert not os.path.exists(path_y)
 
     # this should also be memoized, so not create an arbitrary name
-    z_fut = test_no_checkpoint_stdout(stdout=parsl.AUTO_LOGNAME)
+    z_fut = no_checkpoint_stdout_app(stdout=parsl.AUTO_LOGNAME)
     z_fut.result()
     assert not os.path.exists(z_fut.stdout)


### PR DESCRIPTION
Tests introduced in PR #1568 included definitions called test_*
that were not pytest tests. pytest issues a warning about these.

This commit renames those definitions to stop the warning.