### PR TITLE
Added developer friendly Makefile; added ssh_keyfile name to SSHChannel 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,5 +77,4 @@ coverage: test ## show the coverage report
 
 .PHONY: clean
 clean: ## remove venv and flush out
-	rm -rf $(VENV) dist *.egg-info .mypy_cache
-	find . -name __pycache__ | xargs --no-run-if-empty rm -rf
+	rm -rf $(VENV) dist *.egg-info .mypy_cache build .pytest_cache .coverage

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,81 @@
+SHELL := $(shell which bash) # Use bash instead of bin/sh as shell
+SYS_PYTHON := $(shell which python3.7 || echo ".python_is_missing")
+GIT := $(shell which git || echo ".git_is_missing")
+VENV = .venv
+VENV_BIN := $(VENV)/bin
+PIP := $(VENV_BIN)/pip
+DEPS := $(VENV)/.deps
+PYTHON := $(VENV_BIN)/python3
+PYTEST := $(VENV_BIN)/pytest
+export PATH := $(VENV_BIN):$(PATH)
+
+.PHONY: help
+help: ## me
+	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+$(VENV):
+	$(SYS_PYTHON) -m venv $(VENV)
+
+$(DEPS): $(VENV) test-requirements.txt
+	$(PIP) install --upgrade pip
+	$(PIP) install -r test-requirements.txt
+	touch $(DEPS)
+
+.PHONY: deps
+deps: $(DEPS) ## install the dependencies
+
+.PHONY:
+lint: ## run linter script
+	parsl/tests/lint-inits.sh
+
+.PHONY: flake
+flake:  ## run flake
+	$(VENV_BIN)/flake8 parsl/
+
+
+.PHONY: clean_coverage
+clean_coverage:
+	rm -f .coverage
+
+
+.PHONY: test
+test: $(DEPS) clean_coverage lint flake local_thread_test ## run all tests
+
+
+.PHONY: local_thread_test
+local_thread_test: $(DEPS) clean_coverage lint flake ## run all tests with local_thread config
+	$(PYTEST) parsl -k "not cleannet" --config parsl/tests/configs/local_threads.py --cov=parsl --cov-append --cov-report= --random-order
+
+
+.PHONY: local_thread_test
+htex_local_test: $(DEPS) clean_coverage lint flake ## run all tests with htex_local config
+	$(PYTEST) parsl -k "not cleannet" --config parsl/tests/configs/htex_local.py --cov=parsl --cov-append --cov-report= --random-order
+
+
+.PHONY: tag
+tag: ## create a tag in git. to run, do a 'make VERSION="version string" tag
+	./tag_and_release.sh create_tag $(VERSION)
+
+
+.PHONY: package
+package: ## package up a distribution.
+	./tag_and_release.sh package
+
+
+.PHONY: deploy
+deploy: ## deploy the distribution
+	./tag_and_release.sh release
+
+
+.PHONY: release
+release: deps tag package deploy   ## create a release. To run, do a 'make VERSION="version string"  release'
+
+
+coverage: test ## show the coverage report
+	$(VENV_BIN)/coverage report
+
+
+.PHONY: clean
+clean: ## remove venv and flush out
+	rm -rf $(VENV) dist *.egg-info .mypy_cache
+	find . -name __pycache__ | xargs --no-run-if-empty rm -rf

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ For Developers
     $ git clone https://github.com/Parsl/parsl
 
 
-3. Build and Test::
+2. Build and Test::
 
     $ make   # show all available makefile targets
     $ make deps # create a local pip .venv environment

--- a/README.rst
+++ b/README.rst
@@ -61,12 +61,19 @@ For Developers
 
     $ git clone https://github.com/Parsl/parsl
 
-2. Install::
+
+3. Build and Test::
+
+    $ make   # show all available makefile targets
+    $ make deps # create a local pip .venv environment
+    $ make test # make tests
+
+3. Install::
 
     $ cd parsl
     $ python3 setup.py install
 
-3. Use Parsl!
+4. Use Parsl!
 
 Requirements
 ============

--- a/parsl/channels/ssh/ssh.py
+++ b/parsl/channels/ssh/ssh.py
@@ -26,7 +26,7 @@ class SSHChannel(Channel, RepresentationMixin):
 
     '''
 
-    def __init__(self, hostname, username=None, password=None, script_dir=None, envs=None, gssapi_auth=False, skip_auth=False, port=22):
+    def __init__(self, hostname, username=None, password=None, script_dir=None, envs=None, gssapi_auth=False, skip_auth=False, port=22, key_filename=None):
         ''' Initialize a persistent connection to the remote system.
         We should know at this point whether ssh connectivity is possible
 
@@ -40,6 +40,7 @@ class SSHChannel(Channel, RepresentationMixin):
             - script_dir (string) : Full path to a script dir where
               generated scripts could be sent to.
             - envs (dict) : A dictionary of environment variables to be set when executing commands
+            - key_filename (string or list): the filename, or list of filenames, of optional private key(s)
 
         Raises:
         '''
@@ -72,6 +73,7 @@ class SSHChannel(Channel, RepresentationMixin):
                 allow_agent=True,
                 gss_auth=gssapi_auth,
                 gss_kex=gssapi_auth,
+                key_filename=key_filename
             )
             t = self.ssh_client.get_transport()
             self.sftp_client = paramiko.SFTPClient.from_transport(t)

--- a/tag_and_release.sh
+++ b/tag_and_release.sh
@@ -1,19 +1,23 @@
 #!/bin/bash
-
-VERSION=$1
-
-PARSL_VERSION=$(python3 -c "import parsl; print(parsl.__version__)")
-
-if [[ $PARSL_VERSION == $VERSION ]]
-then
-    echo "Version requested matches package version: $VERSION"
-else
-    echo "[ERROR] Version mismatch. User request:$VERSION while package version is:$PARSL_VERSION"
-    exit -1
-fi
-
+set -euf -o pipefail
 
 create_tag () {
+    if [ -z "$1" ]
+      then
+        VERSION="unknown"
+      else
+        VERSION=$1
+    fi
+
+    PARSL_VERSION=$(python3 -c "import parsl; print(parsl.__version__)")
+
+    if [[ $PARSL_VERSION == "$VERSION" ]]
+    then
+        echo "Version requested matches package version: $VERSION"
+    else
+        echo "[ERROR] Version mismatch. User request: '$VERSION' while package version is: '$PARSL_VERSION'"
+        exit 1
+    fi
 
     echo "Creating tag"
     git tag -a "$VERSION" -m "Parsl $VERSION"
@@ -23,9 +27,9 @@ create_tag () {
 
 }
 
+package() {
 
-release () {
-    rm dist/*
+    rm -f dist/*
 
     echo "======================================================================="
     echo "Starting clean builds"
@@ -36,14 +40,15 @@ release () {
     echo "======================================================================="
     echo "Done with builds"
     echo "======================================================================="
-    sleep 1
+
+
+}
+
+release () {
     echo "======================================================================="
     echo "Push to PyPi. This will require your username and password"
     echo "======================================================================="
     twine upload dist/*
 }
 
-
-create_tag
-release
-
+"$@"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,3 +11,13 @@ sphinx_rtd_theme
 mypy==0.761
 sqlalchemy-stubs
 Sphinx==2.2.0
+typeguard>=2.5
+paramiko
+dill
+tblib
+ipyparallel
+psutil>=5.5.1
+globus-sdk
+flake8
+twine
+wheel


### PR DESCRIPTION
This commit does two things.

First, it adds a developer friendly Makefile at the root of the project. When run with no args, it will show what targets it offers:

```
$ make      
clean                          remove venv and flush out
coverage                       show the coverage report
deploy                         deploy the distribution
deps                           install the dependencies
flake                          run flake
help                           me
htex_local_test                run all tests with htex_local config
lint                           run linter script
local_thread_test              run all tests with local_thread config
package                        package up a distribution.
release                        create a release. To run, do a 'make VERSION="version string"  release'
tag                            create a tag in git. to run, do a 'make VERSION="version string" tag
test                           run all tests
```

The targets has sensible dependencies; ie, a `make test` will build the python environment for you (via `make deps`). 

Right now,`make test` only runs the `local_thread_test`s and the `htex_local_test` configs. More work can be done to add the other config types as make targets (see the .travis.yml file for all the options). 

For the `make release` workflow, the `tag_and_release.sh` script now passes shellcheck. It's usage has changed to support the new make targets; before, you'd just run the script, now you run the script with the function to call as an argument. 

2) `ssh_keyfile` is now being passed into SSHChannel, and passed along to the Paramiko connect. There is an argument to be made for passing this in via `**kwargs`; this is the minimum change needed.

Please note that it appears that the integration scripts to test this sort of thing are run manually; I'll be testing this tomorrow morning in my local uat environment, so please hold off merging until then in case this PR sails through :-) 

Final thing to note, running all the tests dumps all sorts of .out, .err, and .txt files in various places from the current working directory where make is invoked. Probably all the tests should output to just one place, but this is a larger bit of work to cleanup. 


