### PR TITLE
Pin azure dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ extras_require = {
     'docs' : ['nbsphinx', 'sphinx_rtd_theme'],
     'google_cloud' : ['google-auth', 'google-api-python-client'],
     'gssapi' : ['python-gssapi'],
-    'azure' : ['azure', 'msrestazure'],
+    'azure' : ['azure<=4', 'msrestazure'],
     'workqueue': ['work_queue'],
 }
 extras_require['all'] = sum(extras_require.values(), [])


### PR DESCRIPTION
The azure dependency broke when the latest released version moved to version 5.0.0. This
commit pins azure to major version 4, which is the major version
installed in my dev environment at the moment.

That breakage was blocking CI. This commit makes a minimal change
to unblock CI.

If azure is going to be used a lot, it would make sense to test
against azure version >=5, and move to correct dependencies with
a lower bound rather than an upper bound on older dependencies.