### PR TITLE
Ignore AUTO_LOGNAME for caching

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -696,6 +696,8 @@ class DataFlowKernel(object):
         for kw in ['stdout', 'stderr']:
             if kw in app_kwargs:
                 if app_kwargs[kw] == parsl.AUTO_LOGNAME:
+                    if kw not in ignore_for_cache:
+                        ignore_for_cache += [kw]
                     app_kwargs[kw] = os.path.join(
                                 self.run_dir,
                                 'task_logs',


### PR DESCRIPTION
This adds stderr and stdout to ignore_for_cache automatically if
parsl.AUTO_LOGNAME is set. Fixes #1293.