### PR TITLE
Make channel.pull_file an @abstractmethod like other channel methods

### DIFF
--- a/parsl/channels/base.py
+++ b/parsl/channels/base.py
@@ -71,6 +71,7 @@ class Channel(metaclass=ABCMeta):
         '''
         pass
 
+    @abstractmethod
     def pull_file(self, remote_source, local_dir):
         ''' Transport file on the remote side to a local directory
 


### PR DESCRIPTION
This will change channel implementations behaviour, so that subclasses
without a pull_file will error rather than silently skip file transfer.
I think this does not affect any existing channel.