### PR TITLE
Add batch jobs to PBS/torque job status table

### DIFF
--- a/parsl/providers/torque/torque.py
+++ b/parsl/providers/torque/torque.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 # From the man pages for qstat for PBS/Torque systems
 translate_table = {
+    'B': JobState.RUNNING,  # This state is returned for running array jobs
     'R': JobState.RUNNING,
     'C': JobState.COMPLETED,  # Completed after having run
     'E': JobState.COMPLETED,  # Exiting after having run


### PR DESCRIPTION
This bug and fix was found by @ravihansa3000 and confirmed by @benclifford.
Because array jobs report a `B` instead of `R` by the scheduler, these
jobs are seen by parsl with unknown job state. Fixes #1649.