### PR TITLE
Remove suppress failures #1669

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -948,7 +948,7 @@ class DataFlowKernel(object):
         self.flowcontrol.close()
 
         for executor in self.executors.values():
-            if executor.managed:
+            if executor.managed and not executor.bad_state_is_set:
                 if executor.scaling_enabled:
                     job_ids = executor.provider.resources.keys()
                     executor.scale_in(len(job_ids))

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -138,9 +138,6 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         Managers attempt connecting over many different addesses to determine a viable address.
         This option sets a time limit in seconds on the connection attempt. Default is 30s.
 
-    suppress_failure : Bool
-        If set, the interchange will suppress failures rather than terminate early. Default: True
-
     heartbeat_threshold : int
         Seconds since the last message from the counterpart in the communication pair:
         (interchange, manager) after which the counterpart is assumed to be un-available. Default: 120s
@@ -177,7 +174,6 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                  heartbeat_period: int = 30,
                  poll_period: int = 10,
                  address_probe_timeout: int = 30,
-                 suppress_failure: bool = True,
                  managed: bool = True,
                  worker_logdir_root: Optional[str] = None):
 
@@ -226,7 +222,6 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         self.heartbeat_threshold = heartbeat_threshold
         self.heartbeat_period = heartbeat_period
         self.poll_period = poll_period
-        self.suppress_failure = suppress_failure
         self.run_dir = '.'
         self.worker_logdir_root = worker_logdir_root
 
@@ -429,7 +424,6 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                                           "hub_address": self.hub_address,
                                           "hub_port": self.hub_port,
                                           "logdir": "{}/{}".format(self.run_dir, self.label),
-                                          "suppress_failure": self.suppress_failure,
                                           "heartbeat_threshold": self.heartbeat_threshold,
                                           "poll_period": self.poll_period,
                                           "logging_level": logging.DEBUG if self.worker_debug else logging.INFO

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -432,11 +432,6 @@ class Interchange(object):
                                                                                                     msg['python_v'].rsplit(".", 1)[0]))
                     else:
                         # Registration has failed.
-                        self._kill_event.set()
-                        e = BadRegistration(manager, critical=False)
-                        result_package = {'task_id': -1, 'exception': serialize_object(e)}
-                        pkl_package = pickle.dumps(result_package)
-                        self.results_outgoing.send(pkl_package)
                         logger.debug("[MAIN] Suppressing bad registration from manager:{}".format(
                             manager))
 

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -71,6 +71,22 @@ class BadRegistration(Exception):
         return self.__repr__()
 
 
+class VersionMismatch(Exception):
+    ''' Manager and Interchange versions do not match
+    '''
+    def __init__(self, interchange_version, manager_version):
+        self.interchange_version = interchange_version
+        self.manager_version = manager_version
+
+    def __repr__(self):
+        return "Manager version info {} does not match interchange version info {}, causing a critical failure".format(
+            self.interchange_version,
+            self.manager_version)
+
+    def __str__(self):
+        return self.__repr__()
+
+
 class Interchange(object):
     """ Interchange is a task orchestrator for distributed systems.
 
@@ -95,7 +111,6 @@ class Interchange(object):
                  logdir=".",
                  logging_level=logging.INFO,
                  poll_period=10,
-                 suppress_failure=False,
              ):
         """
         Parameters
@@ -136,9 +151,6 @@ class Interchange(object):
         poll_period : int
              The main thread polling period, in milliseconds. Default: 10ms
 
-        suppress_failure : Bool
-             When set to True, the interchange will attempt to suppress failures. Default: False
-
         """
         self.logdir = logdir
         os.makedirs(self.logdir, exist_ok=True)
@@ -148,7 +160,6 @@ class Interchange(object):
 
         self.client_address = client_address
         self.interchange_address = interchange_address
-        self.suppress_failure = suppress_failure
         self.poll_period = poll_period
 
         logger.info("Attempting connection to client at {} on ports: {},{},{}".format(
@@ -404,32 +415,30 @@ class Interchange(object):
                         if (msg['python_v'].rsplit(".", 1)[0] != self.current_platform['python_v'].rsplit(".", 1)[0] or
                             msg['parsl_v'] != self.current_platform['parsl_v']):
                             logger.warning("[MAIN] Manager {} has incompatible version info with the interchange".format(manager))
-
-                            if self.suppress_failure is False:
-                                logger.debug("Setting kill event")
-                                self._kill_event.set()
-                                e = ManagerLost(manager, self._ready_manager_queue[manager]['hostname'])
-                                result_package = {'task_id': -1, 'exception': serialize_object(e)}
-                                pkl_package = pickle.dumps(result_package)
-                                self.results_outgoing.send(pkl_package)
-                                logger.warning("[MAIN] Sent failure reports, unregistering manager")
-                            else:
-                                logger.debug("[MAIN] Suppressing shutdown due to version incompatibility")
+                            logger.debug("Setting kill event")
+                            self._kill_event.set()
+                            e = VersionMismatch("py.v={} parsl.v={}".format(self.current_platform['python_v'].rsplit(".", 1)[0],
+                                                                            self.current_platform['parsl_v']),
+                                                "py.v={} parsl.v={}".format(msg['python_v'].rsplit(".", 1)[0],
+                                                                            msg['parsl_v'])
+                            )
+                            result_package = {'task_id': -1, 'exception': serialize_object(e)}
+                            pkl_package = pickle.dumps(result_package)
+                            self.results_outgoing.send(pkl_package)
+                            logger.warning("[MAIN] Sent failure reports, unregistering manager")
                         else:
                             logger.info("[MAIN] Manager {} has compatible Parsl version {}".format(manager, msg['parsl_v']))
                             logger.info("[MAIN] Manager {} has compatible Python version {}".format(manager,
                                                                                                     msg['python_v'].rsplit(".", 1)[0]))
                     else:
                         # Registration has failed.
-                        if self.suppress_failure is False:
-                            self._kill_event.set()
-                            e = BadRegistration(manager, critical=True)
-                            result_package = {'task_id': -1, 'exception': serialize_object(e)}
-                            pkl_package = pickle.dumps(result_package)
-                            self.results_outgoing.send(pkl_package)
-                        else:
-                            logger.debug("[MAIN] Suppressing bad registration from manager:{}".format(
-                                manager))
+                        self._kill_event.set()
+                        e = BadRegistration(manager, critical=False)
+                        result_package = {'task_id': -1, 'exception': serialize_object(e)}
+                        pkl_package = pickle.dumps(result_package)
+                        self.results_outgoing.send(pkl_package)
+                        logger.debug("[MAIN] Suppressing bad registration from manager:{}".format(
+                            manager))
 
                 else:
                     tasks_requested = int.from_bytes(message[1], "little")
@@ -579,8 +588,6 @@ if __name__ == '__main__':
                         help="REQUIRED: poll period used for main thread")
     parser.add_argument("--worker_ports", default=None,
                         help="OPTIONAL, pair of workers ports to listen on, eg --worker_ports=50001,50005")
-    parser.add_argument("--suppress_failure", action='store_true',
-                        help="Enables suppression of failures")
     parser.add_argument("-d", "--debug", action='store_true',
                         help="Count of apps to launch")
 
@@ -601,7 +608,6 @@ if __name__ == '__main__':
     logger.debug("Starting Interchange")
 
     optionals = {}
-    optionals['suppress_failure'] = args.suppress_failure
 
     if args.worker_ports:
         optionals['worker_ports'] = [int(i) for i in args.worker_ports.split(',')]


### PR DESCRIPTION
* `dfk`  does not call `shutdown` or `scale_in`, if the executor is in a bad_state to avoid hangs.
* `suppress_failures` option is now removed, this used to cover the following situations:
* manager registration fails dues to version mismatch -> Now a critical failure
* manager registration fails due to bad message -> logged and ignored
* interchange received a spurious message -> logged and ignored 
* `address_probe_timeout` is not specified to the manager if user does not specify explicitly for better backward compatibility.

The last item can be separated to a different PR. 