### PR TITLE
wq: log message incorrectly printed wq task id.

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -197,7 +197,7 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
             t.specify_file(function_data_loc, function_data_loc_remote, WORK_QUEUE_INPUT, cache=False)
             t.specify_file(function_result_loc, function_result_loc_remote, WORK_QUEUE_OUTPUT, cache=False)
             t.specify_tag(str(parsl_id))
-            logger.debug("Parsl ID: {}".format(t.id))
+            logger.debug("Parsl ID: {}".format(parsl_id))
 
             # Specify all input/output files for task
             for item in input_files:


### PR DESCRIPTION
The log messages should print the parsl_id, not the wq id (which does
not exist at that point in time anyway).