### PR TITLE
wq executor cleanup: move reasons of failure outside WorkQueueSubmitThread

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -252,52 +252,12 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
 
                     # Task failure
                     if status != 0 or (task_result != WORK_QUEUE_RESULT_SUCCESS and task_result != WORK_QUEUE_RESULT_OUTPUT_MISSING):
-                        logger.debug("Wrapper Script status: {}\nWorkQueue Status: {}".format(status, task_result))
-                        # Wrapper script failure
-                        if status != 0:
-                            logger.debug("WorkQueue task {} failed with status {}".format(t.id, status))
-                            reason = "Wrapper Script Failure: "
-                            if status == 1:
-                                reason += "problem parsing command line options"
-                            elif status == 2:
-                                reason += "problem loading function data"
-                            elif status == 3:
-                                reason += "problem remapping file names"
-                            elif status == 4:
-                                reason += "problem writing out function result"
-                            else:
-                                reason += "unable to process wrapper script failure with status = {}".format(status)
-                            reason += "\nTrace:\n" + str(t.output)
-                            logger.debug("WorkQueue runner script failed for task {} because {}\n".format(parsl_tid, reason))
-                        # WorkQueue system failure
-                        else:
-                            reason = "WorkQueue System Failure: "
-                            if task_result == wq.WORK_QUEUE_RESULT_INPUT_MISSING:
-                                reason += "missing input file"
-                            elif task_result == wq.WORK_QUEUE_RESULT_OUTPUT_MISSING:
-                                reason += "unable to generate output file"
-                            elif task_result == wq.WORK_QUEUE_RESULT_STDOUT_MISSING:
-                                reason += "stdout has been truncated"
-                            elif task_result == wq.WORK_QUEUE_RESULT_SIGNAL:
-                                reason += "task terminated with a signal"
-                            elif task_result == wq.WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION:
-                                reason += "task used more resources than requested"
-                            elif task_result == wq.WORK_QUEUE_RESULT_TASK_TIMEOUT:
-                                reason += "task ran past the specified end time"
-                            elif task_result == wq.WORK_QUEUE_RESULT_UNKNOWN:
-                                reason += "result could not be classified"
-                            elif task_result == wq.WORK_QUEUE_RESULT_FORSAKEN:
-                                reason += "task failed, but not a task error"
-                            elif task_result == wq.WORK_QUEUE_RESULT_MAX_RETRIES:
-                                reason += "unable to complete after specified number of retries"
-                            elif task_result == wq.WORK_QUEUE_RESULT_TASK_MAX_RUN_TIME:
-                                reason += "task ran for more than the specified time"
-                            elif task_result == wq.WORK_QUEUE_RESULT_DISK_ALLOC_FULL:
-                                reason += "task needed more space to complete task"
-                            elif task_result == wq.WORK_QUEUE_RESULT_RMONITOR_ERROR:
-                                reason += "task failed because the monitor did not produce an output"
-                            else:
-                                reason += "unable to process Work Queue system failure"
+                        logger.debug("Wrapper Script status: {}\nWorkQueue Status: {}"
+                                     .format(status, task_result))
+
+                        reason = explain_task_exit_status(t, parsl_tid)
+                        logger.debug("WorkQueue runner script failed for parsl task {} (wq {}) because:\n{}"
+                                     .format(parsl_id, t.id, reason))
 
                         msg = {"tid": parsl_tid,
                                "result_received": False,
@@ -771,3 +731,56 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
         if value is not None:
             self._run_dir = value
         return self._run_dir
+
+
+def explain_task_exit_status(wq_task, parsl_id):
+    """Returns a string with the reason why a task failed."""
+
+    status = wq_task.return_status  # aka exit code
+    wq_result = wq_task.result
+
+    if status != 0:
+        reason = "Wrapper Script Failure: "
+        if status == 1:
+            reason += "problem parsing command line options"
+        elif status == 2:
+            reason += "problem loading function data"
+        elif status == 3:
+            reason += "problem remapping file names"
+        elif status == 4:
+            reason += "problem writing out function result"
+        else:
+            reason += "unable to process wrapper script failure with status = {}".format(status)
+        reason += "\nTrace:\n" + str(wq_task.output)
+# WorkQueue system failure
+    else:
+        reason = "work queue result: "
+        if wq_result == wq.WORK_QUEUE_RESULT_SUCCESS:
+            reason += "succesful execution"
+        elif wq_result == wq.WORK_QUEUE_RESULT_INPUT_MISSING:
+            reason += "missing input file"
+        elif wq_result == wq.WORK_QUEUE_RESULT_OUTPUT_MISSING:
+            reason += "unable to generate output file"
+        elif wq_result == wq.WORK_QUEUE_RESULT_STDOUT_MISSING:
+            reason += "stdout has been truncated"
+        elif wq_result == wq.WORK_QUEUE_RESULT_SIGNAL:
+            reason += "task terminated with a signal"
+        elif wq_result == wq.WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION:
+            reason += "task used more resources than requested"
+        elif wq_result == wq.WORK_QUEUE_RESULT_TASK_TIMEOUT:
+            reason += "task ran past the specified end time"
+        elif wq_result == wq.WORK_QUEUE_RESULT_UNKNOWN:
+            reason += "result could not be classified"
+        elif wq_result == wq.WORK_QUEUE_RESULT_FORSAKEN:
+            reason += "task failed, but not a task error"
+        elif wq_result == wq.WORK_QUEUE_RESULT_MAX_RETRIES:
+            reason += "unable to complete after specified number of retries"
+        elif wq_result == wq.WORK_QUEUE_RESULT_TASK_MAX_RUN_TIME:
+            reason += "task ran for more than the specified time"
+        elif wq_result == wq.WORK_QUEUE_RESULT_DISK_ALLOC_FULL:
+            reason += "task needed more space to complete task"
+        elif wq_result == wq.WORK_QUEUE_RESULT_RMONITOR_ERROR:
+            reason += "task failed because the monitor did not produce an output"
+        else:
+            reason += "unable to process Work Queue system failure"
+    return reason

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -294,6 +294,8 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
                                 reason += "task ran for more than the specified time"
                             elif task_result == wq.WORK_QUEUE_RESULT_DISK_ALLOC_FULL:
                                 reason += "task needed more space to complete task"
+                            elif task_result == wq.WORK_QUEUE_RESULT_RMONITOR_ERROR:
+                                reason += "task failed because the monitor did not produce an output"
                             else:
                                 reason += "unable to process Work Queue system failure"
 

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -23,6 +23,7 @@ from parsl.providers.error import OptionalModuleMissing
 from parsl.executors.workqueue import workqueue_worker
 
 try:
+    import work_queue as wq
     from work_queue import WorkQueue
     from work_queue import Task
     from work_queue import WORK_QUEUE_DEFAULT_PORT
@@ -271,27 +272,27 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
                         # WorkQueue system failure
                         else:
                             reason = "WorkQueue System Failure: "
-                            if task_result == 1:
+                            if task_result == wq.WORK_QUEUE_RESULT_INPUT_MISSING:
                                 reason += "missing input file"
-                            elif task_result == 2:
+                            elif task_result == wq.WORK_QUEUE_RESULT_OUTPUT_MISSING:
                                 reason += "unable to generate output file"
-                            elif task_result == 4:
+                            elif task_result == wq.WORK_QUEUE_RESULT_STDOUT_MISSING:
                                 reason += "stdout has been truncated"
-                            elif task_result == 1 << 3:
+                            elif task_result == wq.WORK_QUEUE_RESULT_SIGNAL:
                                 reason += "task terminated with a signal"
-                            elif task_result == 2 << 3:
+                            elif task_result == wq.WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION:
                                 reason += "task used more resources than requested"
-                            elif task_result == 3 << 3:
+                            elif task_result == wq.WORK_QUEUE_RESULT_TASK_TIMEOUT:
                                 reason += "task ran past the specified end time"
-                            elif task_result == 4 << 3:
+                            elif task_result == wq.WORK_QUEUE_RESULT_UNKNOWN:
                                 reason += "result could not be classified"
-                            elif task_result == 5 << 3:
+                            elif task_result == wq.WORK_QUEUE_RESULT_FORSAKEN:
                                 reason += "task failed, but not a task error"
-                            elif task_result == 6 << 3:
+                            elif task_result == wq.WORK_QUEUE_RESULT_MAX_RETRIES:
                                 reason += "unable to complete after specified number of retries"
-                            elif task_result == 7 << 3:
+                            elif task_result == wq.WORK_QUEUE_RESULT_TASK_MAX_RUN_TIME:
                                 reason += "task ran for more than the specified time"
-                            elif task_result == 8 << 3:
+                            elif task_result == wq.WORK_QUEUE_RESULT_DISK_ALLOC_FULL:
                                 reason += "task needed more space to complete task"
                             else:
                                 reason += "unable to process Work Queue system failure"


### PR DESCRIPTION
The logic to find the reason of failure was moved to the function explain_task_exit_status.
This function also uses the symbolic names from the errors, rather than the hard-coded numbers.