### PR TITLE
Add support for Work Queue auto labeling resources

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -201,12 +201,12 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
                 logger.error("Unable to create task: {}".format(e))
                 continue
 
-            if not autocategory or category is None:
-                t.specify_category('parsl-default')
-            else:
+            if autocategory:
                 t.specify_category(category)
                 if autolabel:
                     q.specify_category_mode(category, WORK_QUEUE_ALLOCATION_MODE_MAX_THROUGHPUT)
+            else:
+                t.specify_category('parsl-default')
 
             # Specify environment variables for the task
             if env is not None:

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -31,6 +31,7 @@ try:
     from work_queue import WORK_QUEUE_OUTPUT
     from work_queue import WORK_QUEUE_RESULT_SUCCESS
     from work_queue import WORK_QUEUE_RESULT_OUTPUT_MISSING
+    from work_queue import WORK_QUEUE_ALLOCATION_MODE_MAX
     from work_queue import cctools_debug_flags_set
     from work_queue import cctools_debug_config_file
 except ImportError:
@@ -63,6 +64,7 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
                           see_worker_output=False,
                           data_dir=".",
                           full=False,
+                          autolabel=False,
                           cancel_value=multiprocessing.Value('i', 1),
                           port=WORK_QUEUE_DEFAULT_PORT,
                           wq_log_dir=None,
@@ -101,6 +103,14 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
         q.specify_password(project_password)
     elif project_password_file:
         q.specify_password_file(project_password_file)
+    if autolabel:
+        q.enable_monitoring()
+        q.specify_category_mode(None, WORK_QUEUE_ALLOCATION_MODE_MAX)
+        # We're running individual functions so try a relatively
+        # small allocation first. Hungrier tasks will be automatically
+        # retried with higher limits.
+        q.specify_category_max_resources(None,
+                {'cores': 1, 'memory':  1024, 'disk': 10240})
 
     # Only write logs when the wq_log_dir is specified, which it most likely will be
     if wq_log_dir is not None:
@@ -423,6 +433,10 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
             must be used for programs utilizing @bash_apps.)
             Default is False.
 
+        autolabel: bool
+            Use the Resource Monitor to automatically determine resource
+            labels based on observed task behavior.
+
         init_command: str
             Command line to run before executing a task in a worker.
             Default is ''.
@@ -443,6 +457,7 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
                  env=None,
                  shared_fs=False,
                  source=False,
+                 autolabel=False,
                  init_command="",
                  full_debug=True,
                  see_worker_output=False):
@@ -470,6 +485,7 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
         self.worker_output = see_worker_output
         self.full = full_debug
         self.source = source
+        self.autolabel = autolabel
         self.cancel_value = multiprocessing.Value('i', 1)
 
         # Resolve ambiguity when password and password_file are both specified
@@ -512,6 +528,7 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
                                  "collector_queue": self.collector_queue,
                                  "see_worker_output": self.worker_output,
                                  "full": self.full,
+                                 "autolabel": self.autolabel,
                                  "cancel_value": self.cancel_value,
                                  "port": self.port,
                                  "wq_log_dir": self.wq_log_dir,

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -65,6 +65,7 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
                           data_dir=".",
                           full=False,
                           autolabel=False,
+                          autocategory=False,
                           cancel_value=multiprocessing.Value('i', 1),
                           port=WORK_QUEUE_DEFAULT_PORT,
                           wq_log_dir=None,
@@ -198,7 +199,7 @@ def WorkQueueSubmitThread(task_queue=multiprocessing.Queue(),
                 logger.error("Unable to create task: {}".format(e))
                 continue
 
-            if category is None:
+            if not autocategory or category is None:
                 t.specify_category('parsl-default')
             else:
                 t.specify_category(category)
@@ -441,6 +442,11 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
             Use the Resource Monitor to automatically determine resource
             labels based on observed task behavior.
 
+        autocategory: bool
+            Place each app in its own category by default. If all
+            invocations of an app have similar performance characteristics,
+            this will provide a reasonable set of categories automatically.
+
         init_command: str
             Command line to run before executing a task in a worker.
             Default is ''.
@@ -462,6 +468,7 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
                  shared_fs=False,
                  source=False,
                  autolabel=False,
+                 autocategory=False,
                  init_command="",
                  full_debug=True,
                  see_worker_output=False):
@@ -490,6 +497,7 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
         self.full = full_debug
         self.source = source
         self.autolabel = autolabel
+        self.autocategory = autocategory
         self.cancel_value = multiprocessing.Value('i', 1)
 
         # Resolve ambiguity when password and password_file are both specified
@@ -533,6 +541,7 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
                                  "see_worker_output": self.worker_output,
                                  "full": self.full,
                                  "autolabel": self.autolabel,
+                                 "autocategory": self.autocategory,
                                  "cancel_value": self.cancel_value,
                                  "port": self.port,
                                  "wq_log_dir": self.wq_log_dir,


### PR DESCRIPTION
This PR adds options to the Work Queue executor to turn on automatic resource labeling for submitted tasks. WQ can collect stats from running tasks to automatically determine resource requirements. Another PR (#1675) is adding explicit resource labels. This feature is useful if the resource requirements aren't known in advance or the user doesn't want to worry about it, but still wants to subdivide large workers.

This PR also introduces a complementary option to automatically assign categories to functions, with each defined function placed in its own category. WQ manages resources separately for different categories, so this complements the auto-labeling feature. If different functions have different resource requirements, WQ will measure and label each function category separately.