### PR TITLE
Adding equality/inequality operators for JobStatus

### DIFF
--- a/parsl/providers/provider_base.py
+++ b/parsl/providers/provider_base.py
@@ -34,6 +34,12 @@ class JobStatus(object):
     def terminal(self):
         return self.state.terminal
 
+    def __eq__(self, other):
+        return (self.state) == other.state
+
+    def __ne__(self, other):
+        return (self.state) != other.state
+
     def __repr__(self):
         if self.message is not None:
             return "{} ({})".format(self.state, self.message)

--- a/parsl/tests/test_regression/test_1682.py
+++ b/parsl/tests/test_regression/test_1682.py
@@ -1,0 +1,19 @@
+from parsl.providers.provider_base import JobState, JobStatus
+
+
+def test_eq():
+    """ Regression test 1 for #1682
+    """
+    assert JobStatus(JobState.RUNNING) == JobStatus(JobState.RUNNING), "Failing jobstatus equality"
+
+
+def test_ne():
+    """ Regression test 2 for #1682
+    """
+    assert JobStatus(JobState.FAILED) != JobStatus(JobState.RUNNING), "Failing inequality check"
+
+
+if __name__ == "__main__":
+
+    test_eq()
+    test_ne()


### PR DESCRIPTION
Adding __ne__ and __eq__ magic operators so that JobStatus objects can be compared.

Fixes #1682 