### PR TITLE
Remove python2 object superclass idiom from monitoring.

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -33,7 +33,7 @@ RESOURCE = 'resource'    # Resource table includes task resource utilization
 NODE = 'node'            # Node table include node info
 
 
-class Database(object):
+class Database:
 
     if not _sqlalchemy_enabled:
         raise OptionalModuleMissing(['sqlalchemy'],
@@ -194,7 +194,7 @@ class Database(object):
         )
 
 
-class DatabaseManager(object):
+class DatabaseManager:
     def __init__(self,
                  db_url='sqlite:///monitoring.db',
                  logdir='.',

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -58,7 +58,7 @@ def start_file_logger(filename, name='monitoring', level=logging.DEBUG, format_s
     return logger
 
 
-class UDPRadio(object):
+class UDPRadio:
 
     def __init__(self, monitoring_url, source_id=None, timeout=10):
         """
@@ -328,7 +328,7 @@ class MonitoringHub(RepresentationMixin):
         return wrapped
 
 
-class Hub(object):
+class Hub:
 
     def __init__(self,
                  hub_address,


### PR DESCRIPTION
This is a mechanism to enable python2 new-style classes which
is unnecessary noise now.

This change should not affect behaviour.