### PR TITLE
Log heartbeat configuration at start of process worker pool

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -611,6 +611,8 @@ if __name__ == "__main__":
         logger.info("poll_period: {}".format(args.poll))
         logger.info("address_probe_timeout: {}".format(args.address_probe_timeout))
         logger.info("Prefetch capacity: {}".format(args.prefetch_capacity))
+        logger.info("Heartbeat threshold: {}".format(args.hb_threshold))
+        logger.info("Heartbeat period: {}".format(args.hb_period))
 
         manager = Manager(task_port=args.task_port,
                           result_port=args.result_port,


### PR DESCRIPTION
Other configuration is logged here already.