### PR TITLE
Replace executor __repr__ with executor label in periodic state report

### DIFF
--- a/parsl/dataflow/task_status_poller.py
+++ b/parsl/dataflow/task_status_poller.py
@@ -23,7 +23,7 @@ class PollItem(ExecutorStatus):
 
     def poll(self, now: float):
         if self._should_poll(now):
-            logger.debug("Polling {}".format(self._executor))
+            logger.debug("Polling {}".format(self._executor.label))
             self._status = self._executor.status()
             self._last_poll_time = now
 
@@ -71,6 +71,6 @@ class TaskStatusPoller(object):
     def add_executors(self, executors: Sequence[ParslExecutor]):
         for executor in executors:
             if executor.status_polling_interval > 0:
-                logger.debug("Adding executor {}".format(executor))
+                logger.debug("Adding executor {}".format(executor.label))
                 self._poll_items.append(PollItem(executor))
         self._strategy.add_executors(executors)

--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -32,6 +32,16 @@ class ParslExecutor(metaclass=ABCMeta):
               @typeguard the constructor, you'll have to use List[Any] here.
     """
 
+    # This __init__ method exists to provide a python 3.5 compatible type declaration
+    # for the `label` attribute. If/when python 3.5 is deprecated (see parsl issue #1553)
+    # this could be replaced with a python 3.6 style attribute type declaration.
+    #   label: str
+    # and __init__ removed.
+
+    @abstractmethod
+    def __init__(self) -> None:
+        self.label = ""  # type: str
+
     @abstractmethod
     def start(self) -> None:
         """Start the executor.


### PR DESCRIPTION
Prior to this, I was seeing 38 lines of executor configuration sent to the
parsl log file every 5 seconds.

This commit adds python 3.5 compatible code to declare the type of label,
so that `make mypy` will pass. This code is a bit ugly but can be replaced
once we drop support for Python 3.5