### PR TITLE
Fix source mode in Work Queue executor

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -739,8 +739,8 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
             function_info = {"byte code": pack_apply_message(parsl_fn, parsl_fn_args, parsl_fn_kwargs,
                                                              buffer_threshold=1024 * 1024,
                                                              item_threshold=1024)}
-            with open(fn_path, "wb") as f_out:
-                pickle.dump(function_info, f_out)
+        with open(fn_path, "wb") as f_out:
+            pickle.dump(function_info, f_out)
 
     def scale_out(self, *args, **kwargs):
         """Scale out method. Not implemented.


### PR DESCRIPTION
I found a bug in the WQ executor that prevents any tasks from starting when `source=True`.

The steps to actually write out the serialized function were under the default non-source branch, so configuring the executor with `source=True` resulted in no function info being written. Work Queue of course failed with missing inputs before actually running anything.

Also, the error message was kind of confusing (`unable to process wrapper script failure with status = -1`). I think the worker wrapper is in flux, would it be better to say something here to the effect of "this is probably a bug in Parsl" in case a user happens get into an invalid state?

cc @btovar  @yadudoc