### PR TITLE
Rearrange Makefile and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,6 @@ os:
 
 # command to run tests
 script:
-    # This uses all of the configurations and tests as the base from which to
-    # run mypy checks - these are likely to capture most of the code used in
-    # parsl
-    - make mypy
-
       # do this before any testing, but not in-between tests
     - make clean_coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,6 @@ os:
 
 # command to run tests
 script:
-    - make flake8
-    - make lint
-
     # This uses all of the configurations and tests as the base from which to
     # run mypy checks - these are likely to capture most of the code used in
     # parsl

--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,7 @@ htex_local_test: ## run all tests with htex_local config
 
 .PHONY: htex_local_alternate_test
 htex_local_alternate_test: ## run all tests with htex_local config
-	echo "$(MPI)}"
-	parsl/executors/extreme_scale/install-mpi.sh $(MPI)
-	pip3 install ".[extreme_scale,monitoring]"
+	pip3 install ".[monitoring]"
 	PYTHONPATH=.  pytest parsl -k "not cleannet" --config parsl/tests/configs/htex_local_alternate.py --cov=parsl --cov-append --cov-report= --random-order
 
 $(WORKQUEUE_INSTALL):
@@ -75,7 +73,6 @@ work_queue_killcmd := $(if $(work_queue_procs), "kill" "-3" $(procs), "echo" "no
 
 .PHONY: workqueue_ex_test
 workqueue_ex_test: $(WORKQUEUE_INSTALL)  ## run all tests with workqueue_ex config
-	pip3 install ".[extreme_scale]"
 	@$(work_queue_killcmd)
 	work_queue_worker localhost 9000  &> /dev/null &
 	PYTHONPATH=.:/tmp/cctools/lib/python3.5/site-packages  pytest parsl -k "not cleannet" --config parsl/tests/configs/workqueue_ex.py --cov=parsl --cov-append --cov-report= --random-order --bodge-dfk-per-test

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ config_local_test: ## run all tests with workqueue_ex config
 	PYTHONPATH=. pytest parsl -k "not cleannet" --config local --cov=parsl --cov-append --cov-report= --random-order
 
 .PHONY: test ## run all tests with all config types
-test: clean_coverage lint flake8 local_thread_test htex_local_test htex_local_alternate_test workqueue_ex_test  config_local_test ## run all tests
+test: clean_coverage lint flake8 mypy local_thread_test htex_local_test htex_local_alternate_test workqueue_ex_test  config_local_test ## run all tests
 
 .PHONY: tag
 tag: ## create a tag in git. to run, do a 'make VERSION="version string" tag

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,8 @@ workqueue_ex_test: $(WORKQUEUE_INSTALL)  ## run all tests with workqueue_ex conf
 
 .PHONY: config_local_test
 config_local_test: ## run all tests with workqueue_ex config
+	echo "$(MPI)}"
+	parsl/executors/extreme_scale/install-mpi.sh $(MPI)
 	pip3 install ".[extreme_scale]"
 	PYTHONPATH=. pytest parsl -k "not cleannet" --config local --cov=parsl --cov-append --cov-report= --random-order
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ virtualenv: ## create an activate a virtual env
 	echo "Run 'source $(VENV)/bin/activate' to activate the virtual environment"
 
 
-$(DEPS): virtualenv test-requirements.txt
+$(DEPS): test-requirements.txt
 	pip3 install --upgrade pip
 	pip3 install -r test-requirements.txt
 	touch $(DEPS)

--- a/Makefile
+++ b/Makefile
@@ -52,15 +52,15 @@ mypy: ## run mypy checks
 	MYPYPATH=$(CWD)/mypy-stubs mypy parsl/app/ parsl/channels/ parsl/dataflow/ parsl/data_provider/ parsl/launchers parsl/providers/
 
 .PHONY: local_thread_test
-local_thread_test: $(DEPS) ## run all tests with local_thread config
+local_thread_test: ## run all tests with local_thread config
 	pytest parsl -k "not cleannet" --config parsl/tests/configs/local_threads.py --cov=parsl --cov-append --cov-report= --random-order
 
 .PHONY: htex_local_test
-htex_local_test: $(DEPS) ## run all tests with htex_local config
+htex_local_test: ## run all tests with htex_local config
 	PYTHONPATH=.  pytest parsl -k "not cleannet" --config parsl/tests/configs/htex_local.py --cov=parsl --cov-append --cov-report= --random-order
 
 .PHONY: htex_local_alternate_test
-htex_local_alternate_test: $(DEPS) ## run all tests with htex_local config
+htex_local_alternate_test: ## run all tests with htex_local config
 	echo "$(MPI)}"
 	parsl/executors/extreme_scale/install-mpi.sh $(MPI)
 	pip3 install ".[extreme_scale,monitoring]"
@@ -74,7 +74,7 @@ work_queue_procs := $(shell ps aux | grep -E -e "[0-9]+:[0-9]+ work_queue_worker
 work_queue_killcmd := $(if $(work_queue_procs), "kill" "-3" $(procs), "echo" "no work_queue_workers to running")
 
 .PHONY: workqueue_ex_test
-workqueue_ex_test: $(DEPS) $(WORKQUEUE_INSTALL)  ## run all tests with workqueue_ex config
+workqueue_ex_test: $(WORKQUEUE_INSTALL)  ## run all tests with workqueue_ex config
 	pip3 install ".[extreme_scale]"
 	@$(work_queue_killcmd)
 	work_queue_worker localhost 9000  &> /dev/null &
@@ -82,12 +82,12 @@ workqueue_ex_test: $(DEPS) $(WORKQUEUE_INSTALL)  ## run all tests with workqueue
 	@$(work_queue_killcmd)
 
 .PHONY: config_local_test
-config_local_test: $(DEPS) ## run all tests with workqueue_ex config
+config_local_test: ## run all tests with workqueue_ex config
 	pip3 install ".[extreme_scale]"
 	PYTHONPATH=. pytest parsl -k "not cleannet" --config local --cov=parsl --cov-append --cov-report= --random-order
 
 .PHONY: test ## run all tests with all config types
-test: $(DEPS) clean_coverage lint flake8 local_thread_test htex_local_test htex_local_alternate_test workqueue_ex_test  config_local_test ## run all tests
+test: clean_coverage lint flake8 local_thread_test htex_local_test htex_local_alternate_test workqueue_ex_test  config_local_test ## run all tests
 
 .PHONY: tag
 tag: ## create a tag in git. to run, do a 'make VERSION="version string" tag


### PR DESCRIPTION
This PR rearranges the Makefile to:
 - allow use of the Makefile in an existing python environment rather than forcing a new `venv`. This allows `make test` to be used to test against development environments
 - removes the use of a venv in CI. CI provides a container environment for the entire system, so a python level virtual environment is unnecessary
 - removes a duplicate execution of module linting and flake8
 - makes mypy be executed the same as lint/flake8
 - installs optional dependencies in the targets that need them - prior to this, optional dependencies were sometimes installed in a different target that happens to execute in the correct order in `make test`