### PR TITLE
Rename Hub class because it clashes cognitively with MonitoringHub

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -222,21 +222,21 @@ class MonitoringHub(RepresentationMixin):
         self.resource_msgs = Queue()
         self.node_msgs = Queue()
 
-        self.queue_proc = Process(target=hub_starter,
-                                  args=(comm_q, self.exception_q, self.priority_msgs, self.node_msgs, self.resource_msgs),
-                                  kwargs={"hub_address": self.hub_address,
-                                          "hub_port": self.hub_port,
-                                          "hub_port_range": self.hub_port_range,
-                                          "client_address": self.client_address,
-                                          "client_port": self.dfk_port,
-                                          "logdir": self.logdir,
-                                          "logging_level": logging.DEBUG if self.monitoring_debug else logging.INFO,
-                                          "run_id": run_id
-                                  },
-                                  name="Monitoring-Queue-Process",
-                                  daemon=True,
+        self.router_proc = Process(target=router_starter,
+                                   args=(comm_q, self.exception_q, self.priority_msgs, self.node_msgs, self.resource_msgs),
+                                   kwargs={"hub_address": self.hub_address,
+                                           "hub_port": self.hub_port,
+                                           "hub_port_range": self.hub_port_range,
+                                           "client_address": self.client_address,
+                                           "client_port": self.dfk_port,
+                                           "logdir": self.logdir,
+                                           "logging_level": logging.DEBUG if self.monitoring_debug else logging.INFO,
+                                           "run_id": run_id
+                                   },
+                                   name="Monitoring-Router-Process",
+                                   daemon=True,
         )
-        self.queue_proc.start()
+        self.router_proc.start()
 
         self.dbm_proc = Process(target=dbm_starter,
                                 args=(self.exception_q, self.priority_msgs, self.node_msgs, self.resource_msgs,),
@@ -248,7 +248,7 @@ class MonitoringHub(RepresentationMixin):
                                 daemon=True,
         )
         self.dbm_proc.start()
-        self.logger.info("Started the Hub process {} and DBM process {}".format(self.queue_proc.pid, self.dbm_proc.pid))
+        self.logger.info("Started the Hub process {} and DBM process {}".format(self.router_proc.pid, self.dbm_proc.pid))
 
         try:
             udp_dish_port, ic_port = comm_q.get(block=True, timeout=120)
@@ -283,10 +283,10 @@ class MonitoringHub(RepresentationMixin):
             if exception_msgs:
                 for exception_msg in exception_msgs:
                     self.logger.info("{} process got exception {}. Terminating all monitoring processes.".format(exception_msg[0], exception_msg[1]))
-                self.queue_proc.terminate()
+                self.router_proc.terminate()
                 self.dbm_proc.terminate()
             self.logger.info("Waiting for Hub to receive all messages and terminate")
-            self.queue_proc.join()
+            self.router_proc.join()
             self.logger.debug("Finished waiting for Hub termination")
             if len(exception_msgs) == 0:
                 self.priority_msgs.put(("STOP", 0))
@@ -328,7 +328,7 @@ class MonitoringHub(RepresentationMixin):
         return wrapped
 
 
-class Hub:
+class MonitoringRouter:
 
     def __init__(self,
                  hub_address,
@@ -368,10 +368,10 @@ class Hub:
 
         """
         os.makedirs(logdir, exist_ok=True)
-        self.logger = start_file_logger("{}/hub.log".format(logdir),
-                                        name="hub",
+        self.logger = start_file_logger("{}/monitoring_router.log".format(logdir),
+                                        name="monitoring_router",
                                         level=logging_level)
-        self.logger.debug("Hub starting")
+        self.logger.debug("Monitoring router starting")
 
         self.hub_port = hub_port
         self.hub_address = hub_address
@@ -454,20 +454,20 @@ class Hub:
             except socket.timeout:
                 pass
 
-        self.logger.info("Hub finished")
+        self.logger.info("Monitoring router finished")
 
 
-def hub_starter(comm_q, exception_q, priority_msgs, node_msgs, resource_msgs, *args, **kwargs):
-    hub = Hub(*args, **kwargs)
-    comm_q.put((hub.hub_port, hub.ic_port))
-    hub.logger.info("Starting Hub in Hub starter")
+def router_starter(comm_q, exception_q, priority_msgs, node_msgs, resource_msgs, *args, **kwargs):
+    router = MonitoringRouter(*args, **kwargs)
+    comm_q.put((router.hub_port, router.ic_port))
+    router.logger.info("Starting MonitoringRouter in router_starter")
     try:
-        hub.start(priority_msgs, node_msgs, resource_msgs)
+        router.start(priority_msgs, node_msgs, resource_msgs)
     except Exception as e:
-        hub.logger.exception("hub.start exception")
+        router.logger.exception("router.start exception")
         exception_q.put(('Hub', str(e)))
 
-    hub.logger.info("End of hub starter")
+    router.logger.info("End of router_starter")
 
 
 def monitor(pid,


### PR DESCRIPTION
There is now a MonitoringHub, containing a component called MonitoringRouter