### PR TITLE
Remove unused RESOURCE_INFO message tag

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -344,7 +344,7 @@ class DatabaseManager:
                 self._insert(table=NODE, messages=messages)
 
             """
-            RESOURCE_INFO messages
+            Resource info messages
 
             """
             messages = self._get_messages_in_batch(self.pending_resource_queue,

--- a/parsl/monitoring/message_type.py
+++ b/parsl/monitoring/message_type.py
@@ -6,9 +6,6 @@ class MessageType(Enum):
     # Reports any task related info such as launch, completion etc.
     TASK_INFO = 0
 
-    # Reports of resource utilization on a per-task basis
-    RESOURCE_INFO = 1
-
     # Top level workflow information
     WORKFLOW_INFO = 2
 

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -96,7 +96,6 @@ class UDPRadio:
         ---------
 
         message_type: monitoring.MessageType (enum)
-            In this case message type is RESOURCE_INFO most often
         task_id: int
             Task identifier of the task for which resource monitoring is being reported
         message: object


### PR DESCRIPTION
Resource messages are delivered via their own queue
and do not need a tag.