### PR TITLE
Move parsl/__init__.py log helpers to separate file

### DIFF
--- a/parsl/__init__.py
+++ b/parsl/__init__.py
@@ -8,20 +8,6 @@ To get all the required functionality, we suggest importing the library as follo
 >>> import parsl
 >>> from parsl import *
 
-Logging
--------
-
-Following the general logging philosophy of python libraries, by default
-`Parsl <https://github.com/swift-lang/swift-e-lab/>`_ doesn't log anything.
-However the following helper functions are provided for logging:
-
-1. set_stream_logger
-    This sets the logger to the StreamHandler. This is quite useful when working from
-    a Jupyter notebook.
-
-2. set_file_logger
-    This sets the logging to a file. This is ideal for reporting issues to the dev team.
-
 Constants
 ---------
 AUTO_LOGNAME
@@ -29,9 +15,6 @@ AUTO_LOGNAME
 
 """
 import logging
-import typeguard
-
-from typing import Optional
 
 from parsl.version import VERSION
 from parsl.app.app import bash_app, python_app
@@ -39,6 +22,8 @@ from parsl.executors import ThreadPoolExecutor
 from parsl.executors import IPyParallelExecutor
 from parsl.executors import HighThroughputExecutor
 from parsl.executors import ExtremeScaleExecutor
+from parsl.log_utils import set_stream_logger
+from parsl.log_utils import set_file_logger
 
 from parsl.data_provider.files import File
 
@@ -75,67 +60,6 @@ clear = DataFlowKernelLoader.clear
 load = DataFlowKernelLoader.load
 dfk = DataFlowKernelLoader.dfk
 wait_for_current_tasks = DataFlowKernelLoader.wait_for_current_tasks
-
-
-@typeguard.typechecked
-def set_stream_logger(name: str = 'parsl', level: int = logging.DEBUG, format_string: Optional[str] = None):
-    """Add a stream log handler.
-
-    Args:
-         - name (string) : Set the logger name.
-         - level (logging.LEVEL) : Set to logging.DEBUG by default.
-         - format_string (string) : Set to None by default.
-
-    Returns:
-         - None
-    """
-    if format_string is None:
-        # format_string = "%(asctime)s %(name)s [%(levelname)s] Thread:%(thread)d %(message)s"
-        format_string = "%(asctime)s %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
-
-    logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG)
-    handler = logging.StreamHandler()
-    handler.setLevel(level)
-    formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-
-    # Concurrent.futures errors are also of interest, as exceptions
-    # which propagate out of the top of a callback are logged this way
-    # and then discarded. (see #240)
-    futures_logger = logging.getLogger("concurrent.futures")
-    futures_logger.addHandler(handler)
-
-
-@typeguard.typechecked
-def set_file_logger(filename: str, name: str = 'parsl', level: int = logging.DEBUG, format_string: Optional[str] = None):
-    """Add a stream log handler.
-
-    Args:
-        - filename (string): Name of the file to write logs to
-        - name (string): Logger name
-        - level (logging.LEVEL): Set the logging level.
-        - format_string (string): Set the format string
-
-    Returns:
-       -  None
-    """
-    if format_string is None:
-        format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
-
-    logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG)
-    handler = logging.FileHandler(filename)
-    handler.setLevel(level)
-    formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-
-    # see note in set_stream_logger for notes about logging
-    # concurrent.futures
-    futures_logger = logging.getLogger("concurrent.futures")
-    futures_logger.addHandler(handler)
 
 
 class NullHandler(logging.Handler):

--- a/parsl/log_utils.py
+++ b/parsl/log_utils.py
@@ -1,0 +1,77 @@
+"""Following the general logging philosophy of python libraries, by default
+`Parsl <https://github.com/swift-lang/swift-e-lab/>`_ doesn't log anything.
+However the following helper functions are provided for logging:
+
+1. set_stream_logger
+    This sets the logger to the StreamHandler. This is quite useful when working from
+    a Jupyter notebook.
+
+2. set_file_logger
+    This sets the logging to a file. This is ideal for reporting issues to the dev team.
+
+"""
+import logging
+import typeguard
+
+from typing import Optional
+
+
+@typeguard.typechecked
+def set_stream_logger(name: str = 'parsl', level: int = logging.DEBUG, format_string: Optional[str] = None):
+    """Add a stream log handler.
+
+    Args:
+         - name (string) : Set the logger name.
+         - level (logging.LEVEL) : Set to logging.DEBUG by default.
+         - format_string (string) : Set to None by default.
+
+    Returns:
+         - None
+    """
+    if format_string is None:
+        # format_string = "%(asctime)s %(name)s [%(levelname)s] Thread:%(thread)d %(message)s"
+        format_string = "%(asctime)s %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler()
+    handler.setLevel(level)
+    formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    # Concurrent.futures errors are also of interest, as exceptions
+    # which propagate out of the top of a callback are logged this way
+    # and then discarded. (see #240)
+    futures_logger = logging.getLogger("concurrent.futures")
+    futures_logger.addHandler(handler)
+
+
+@typeguard.typechecked
+def set_file_logger(filename: str, name: str = 'parsl', level: int = logging.DEBUG, format_string: Optional[str] = None):
+    """Add a stream log handler.
+
+    Args:
+        - filename (string): Name of the file to write logs to
+        - name (string): Logger name
+        - level (logging.LEVEL): Set the logging level.
+        - format_string (string): Set the format string
+
+    Returns:
+       -  None
+    """
+    if format_string is None:
+        format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    handler = logging.FileHandler(filename)
+    handler.setLevel(level)
+    formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    # see note in set_stream_logger for notes about logging
+    # concurrent.futures
+    futures_logger = logging.getLogger("concurrent.futures")
+    futures_logger.addHandler(handler)


### PR DESCRIPTION
This is intended to allow cleaner-looking imports of logging
helper code in monitoring components.