### PR TITLE
Make monitoring database manager log with same style as rest of parsl

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -5,9 +5,12 @@ import os
 import time
 import datetime
 
+from parsl.log_utils import set_file_logger
 from parsl.dataflow.states import States
 from parsl.providers.error import OptionalModuleMissing
 from parsl.monitoring.message_type import MessageType
+
+logger = logging.getLogger("database_manager")
 
 try:
     import sqlalchemy as sa
@@ -208,9 +211,9 @@ class DatabaseManager:
         self.logdir = logdir
         os.makedirs(self.logdir, exist_ok=True)
 
-        self.logger = start_file_logger(
-            "{}/database_manager.log".format(self.logdir), level=logging_level)
-        self.logger.debug("Initializing Database Manager process")
+        set_file_logger("{}/database_manager.log".format(self.logdir), level=logging_level, name="database_manager")
+
+        logger.debug("Initializing Database Manager process")
 
         self.db = Database(db_url)
         self.batching_interval = batching_interval
@@ -265,7 +268,7 @@ class DatabaseManager:
             WORKFLOW_INFO and TASK_INFO messages
 
             """
-            self.logger.debug("""Checking STOP conditions: {}, {}, {}, {}, {}""".format(
+            logger.debug("""Checking STOP conditions: {}, {}, {}, {}, {}""".format(
                               self._kill_event.is_set(),
                               self.pending_priority_queue.qsize() != 0, self.pending_resource_queue.qsize() != 0,
                               priority_queue.qsize() != 0, resource_queue.qsize() != 0))
@@ -278,18 +281,18 @@ class DatabaseManager:
                                                    interval=self.batching_interval,
                                                    threshold=self.batching_threshold)
             if messages:
-                self.logger.debug(
+                logger.debug(
                     "Got {} messages from priority queue".format(len(messages)))
                 update_messages, insert_messages, all_messages = [], [], []
                 for msg_type, msg in messages:
                     if msg_type.value == MessageType.WORKFLOW_INFO.value:
                         if "python_version" in msg:   # workflow start message
-                            self.logger.debug(
+                            logger.debug(
                                 "Inserting workflow start info to WORKFLOW table")
                             self._insert(table=WORKFLOW, messages=[msg])
                             self.workflow_start_message = msg
                         else:                         # workflow end message
-                            self.logger.debug(
+                            logger.debug(
                                 "Updating workflow end info to WORKFLOW table")
                             self._update(table=WORKFLOW,
                                          columns=['run_id', 'tasks_failed_count',
@@ -311,12 +314,12 @@ class DatabaseManager:
                                 first_messages.append(
                                     left_messages.pop(msg['task_id']))
 
-                self.logger.debug(
+                logger.debug(
                     "Updating and inserting TASK_INFO to all tables")
 
                 if insert_messages:
                     self._insert(table=TASK, messages=insert_messages)
-                    self.logger.debug(
+                    logger.debug(
                         "There are {} inserted task records".format(len(inserted_tasks)))
                 if update_messages:
                     self._update(table=WORKFLOW,
@@ -339,7 +342,7 @@ class DatabaseManager:
                                                    interval=self.batching_interval,
                                                    threshold=self.batching_threshold)
             if messages:
-                self.logger.debug(
+                logger.debug(
                     "Got {} messages from node queue".format(len(messages)))
                 self._insert(table=NODE, messages=messages)
 
@@ -352,7 +355,7 @@ class DatabaseManager:
                                                    threshold=self.batching_threshold)
 
             if messages or first_messages:
-                self.logger.debug(
+                logger.debug(
                     "Got {} messages from resource queue".format(len(messages)))
                 self._insert(table=RESOURCE, messages=messages)
                 for msg in messages:
@@ -372,11 +375,11 @@ class DatabaseManager:
                                  messages=first_messages)
 
     def _migrate_logs_to_internal(self, logs_queue, queue_tag, kill_event):
-        self.logger.info("[{}_queue_PULL_THREAD] Starting".format(queue_tag))
+        logger.info("[{}_queue_PULL_THREAD] Starting".format(queue_tag))
 
         while not kill_event.is_set() or logs_queue.qsize() != 0:
-            self.logger.debug("""Checking STOP conditions for {} threads: {}, {}"""
-                              .format(queue_tag, kill_event.is_set(), logs_queue.qsize() != 0))
+            logger.debug("""Checking STOP conditions for {} threads: {}, {}"""
+                         .format(queue_tag, kill_event.is_set(), logs_queue.qsize() != 0))
             try:
                 x, addr = logs_queue.get(timeout=0.1)
             except queue.Empty:
@@ -396,35 +399,35 @@ class DatabaseManager:
         try:
             self.db.update(table=table, columns=columns, messages=messages)
         except KeyboardInterrupt:
-            self.logger.exception("KeyboardInterrupt when trying to update Table {}".format(table))
+            logger.exception("KeyboardInterrupt when trying to update Table {}".format(table))
             try:
                 self.db.rollback()
             except Exception:
-                self.logger.exception("Rollback failed")
+                logger.exception("Rollback failed")
             raise
         except Exception:
-            self.logger.exception("Got exception when trying to update Table {}".format(table))
+            logger.exception("Got exception when trying to update Table {}".format(table))
             try:
                 self.db.rollback()
             except Exception:
-                self.logger.exception("Rollback failed")
+                logger.exception("Rollback failed")
 
     def _insert(self, table, messages):
         try:
             self.db.insert(table=table, messages=messages)
         except KeyboardInterrupt:
-            self.logger.exception("KeyboardInterrupt when trying to update Table {}".format(table))
+            logger.exception("KeyboardInterrupt when trying to update Table {}".format(table))
             try:
                 self.db.rollback()
             except Exception:
-                self.logger.exception("Rollback failed")
+                logger.exception("Rollback failed")
             raise
         except Exception:
-            self.logger.exception("Got exception when trying to insert to Table {}".format(table))
+            logger.exception("Got exception when trying to insert to Table {}".format(table))
             try:
                 self.db.rollback()
             except Exception:
-                self.logger.exception("Rollback failed")
+                logger.exception("Rollback failed")
 
     def _get_messages_in_batch(self, msg_queue, interval=1, threshold=99999):
         messages = []
@@ -434,22 +437,18 @@ class DatabaseManager:
                 break
             try:
                 x = msg_queue.get(timeout=0.1)
-                # self.logger.debug("Database manager receives a message {}".format(x))
+                # logger.debug("Database manager receives a message {}".format(x))
             except queue.Empty:
-                self.logger.debug("Database manager has not received any message.")
+                logger.debug("Database manager has not received any message.")
                 break
             else:
                 messages.append(x)
         return messages
 
     def close(self):
-        if self.logger:
-            self.logger.info(
-                "Database Manager cleanup initiated.")
+        logger.info("Database Manager cleanup initiated.")
         if not self.workflow_end and self.workflow_start_message:
-            if self.logger:
-                self.logger.info(
-                    "Logging workflow end info to database due to abnormal exit")
+            logger.info("Logging workflow end info to database due to abnormal exit")
             time_completed = datetime.datetime.now()
             msg = {'time_completed': time_completed,
                    'workflow_duration': (time_completed - self.workflow_start_message['time_began']).total_seconds()}
@@ -463,37 +462,6 @@ class DatabaseManager:
         self._kill_event.set()
 
 
-def start_file_logger(filename, name='database_manager', level=logging.DEBUG, format_string=None):
-    """Add a stream log handler.
-    Parameters
-    ---------
-    filename: string
-        Name of the file to write logs to. Required.
-    name: string
-        Logger name.
-    level: logging.LEVEL
-        Set the logging level. Default=logging.DEBUG
-        - format_string (string): Set the format string
-    format_string: string
-        Format string to use.
-    Returns
-    -------
-        None.
-    """
-    if format_string is None:
-        format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
-
-    global logger
-    logger = logging.getLogger(name)
-    logger.setLevel(level)
-    handler = logging.FileHandler(filename)
-    handler.setLevel(level)
-    formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    return logger
-
-
 def dbm_starter(exception_q, priority_msgs, node_msgs, resource_msgs, *args, **kwargs):
     """Start the database manager process
 
@@ -501,16 +469,16 @@ def dbm_starter(exception_q, priority_msgs, node_msgs, resource_msgs, *args, **k
 
     """
     dbm = DatabaseManager(*args, **kwargs)
-    dbm.logger.info("Starting dbm in dbm starter")
+    logger.info("Starting dbm in dbm starter")
     try:
         dbm.start(priority_msgs, node_msgs, resource_msgs)
     except KeyboardInterrupt:
-        dbm.logger.exception("KeyboardInterrupt signal caught")
+        logger.exception("KeyboardInterrupt signal caught")
         dbm.close()
         raise
     except Exception as e:
-        dbm.logger.exception("dbm.start exception")
+        logger.exception("dbm.start exception")
         exception_q.put(("DBM", str(e)))
         dbm.close()
 
-    dbm.logger.info("End of dbm_starter")
+    logger.info("End of dbm_starter")


### PR DESCRIPTION
Using a module-global 'logger' allows log messages to be made even when
database manager object has failed to initialise properly.

This also removes some almost-duplicate code from the database manager,
replacing it with parsl's main set_file_logger.