### PR TITLE
Remove denormalized/unused monitoring db elapsed time field

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -220,10 +220,6 @@ class DataFlowKernel(object):
         if self.tasks[task_id]['depends'] is not None:
             task_log_info['task_depends'] = ",".join([str(t.tid) for t in self.tasks[task_id]['depends']
                                                       if isinstance(t, AppFuture) or isinstance(t, DataFuture)])
-        task_log_info['task_elapsed_time'] = None
-        if self.tasks[task_id]['time_returned'] is not None:
-            task_log_info['task_elapsed_time'] = (self.tasks[task_id]['time_returned'] -
-                                                  self.tasks[task_id]['time_submitted']).total_seconds()
         return task_log_info
 
     def _count_deps(self, depends):

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -132,7 +132,6 @@ class Database:
             'task_time_running', DateTime, nullable=True)
         task_time_returned = Column(
             'task_time_returned', DateTime, nullable=True)
-        task_elapsed_time = Column('task_elapsed_time', Float, nullable=True)
         task_memoize = Column('task_memoize', Text, nullable=False)
         task_hashsum = Column('task_hashsum', Text, nullable=True)
         task_inputs = Column('task_inputs', Text, nullable=True)
@@ -325,7 +324,7 @@ class DatabaseManager:
                                  messages=update_messages)
                     self._update(table=TASK,
                                  columns=['task_time_returned',
-                                          'task_elapsed_time', 'run_id', 'task_id',
+                                          'run_id', 'task_id',
                                           'task_fail_count',
                                           'task_fail_history'],
                                  messages=update_messages)

--- a/parsl/monitoring/visualization/models.py
+++ b/parsl/monitoring/visualization/models.py
@@ -66,7 +66,6 @@ class Task(db.Model):
         'task_time_running', db.DateTime, nullable=True)
     task_time_returned = db.Column(
         'task_time_returned', db.DateTime, nullable=True)
-    task_elapsed_time = db.Column('task_elapsed_time', db.Float, nullable=True)
     task_memoize = db.Column('task_memoize', db.Text, nullable=False)
     task_inputs = db.Column('task_inputs', db.Text, nullable=True)
     task_outputs = db.Column('task_outputs', db.Text, nullable=True)


### PR DESCRIPTION
Times between different task state transitions are better computed
as needed by monitoring database readers.

This field was not used by the visualization UI.