### PR TITLE
Catch exceptions in database init (for example, DB schema errors)

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -467,9 +467,9 @@ def dbm_starter(exception_q, priority_msgs, node_msgs, resource_msgs, *args, **k
     The DFK should start this function. The args, kwargs match that of the monitoring config
 
     """
-    dbm = DatabaseManager(*args, **kwargs)
-    logger.info("Starting dbm in dbm starter")
     try:
+        dbm = DatabaseManager(*args, **kwargs)
+        logger.info("Starting dbm in dbm starter")
         dbm.start(priority_msgs, node_msgs, resource_msgs)
     except KeyboardInterrupt:
         logger.exception("KeyboardInterrupt signal caught")


### PR DESCRIPTION
Before this commit, if an exception happened in the Database __init__ call,
then the database thread would exit, and parsl would hang at shutdown.

After this commit, exceptions in database creation are handed with the
existing database exception queue.