### PR TITLE
Updating all cluster providers with max_blocks default of 1 from 10

### DIFF
--- a/parsl/providers/cobalt/cobalt.py
+++ b/parsl/providers/cobalt/cobalt.py
@@ -61,7 +61,7 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
                  nodes_per_block=1,
                  init_blocks=0,
                  min_blocks=0,
-                 max_blocks=10,
+                 max_blocks=1,
                  parallelism=1,
                  walltime="00:10:00",
                  account=None,

--- a/parsl/providers/condor/condor.py
+++ b/parsl/providers/condor/condor.py
@@ -84,7 +84,7 @@ class CondorProvider(RepresentationMixin, ClusterProvider):
                  mem_per_slot: Optional[float] = None,
                  init_blocks: int = 1,
                  min_blocks: int = 0,
-                 max_blocks: int = 10,
+                 max_blocks: int = 1,
                  parallelism: float = 1,
                  environment: Optional[Dict[str, str]] = None,
                  project: str = '',

--- a/parsl/providers/grid_engine/grid_engine.py
+++ b/parsl/providers/grid_engine/grid_engine.py
@@ -67,7 +67,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
                  nodes_per_block=1,
                  init_blocks=1,
                  min_blocks=0,
-                 max_blocks=10,
+                 max_blocks=1,
                  parallelism=1,
                  walltime="00:10:00",
                  scheduler_options='',

--- a/parsl/providers/lsf/lsf.py
+++ b/parsl/providers/lsf/lsf.py
@@ -71,7 +71,7 @@ class LSFProvider(ClusterProvider, RepresentationMixin):
                  nodes_per_block=1,
                  init_blocks=1,
                  min_blocks=0,
-                 max_blocks=10,
+                 max_blocks=1,
                  parallelism=1,
                  walltime="00:10:00",
                  scheduler_options='',

--- a/parsl/providers/pbspro/pbspro.py
+++ b/parsl/providers/pbspro/pbspro.py
@@ -63,7 +63,7 @@ class PBSProProvider(TorqueProvider):
                  cpus_per_node=1,
                  init_blocks=1,
                  min_blocks=0,
-                 max_blocks=100,
+                 max_blocks=1,
                  parallelism=1,
                  launcher=SingleNodeLauncher(),
                  walltime="00:20:00",

--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -89,7 +89,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
                  mem_per_node: Optional[int] = None,
                  init_blocks: int = 1,
                  min_blocks: int = 0,
-                 max_blocks: int = 10,
+                 max_blocks: int = 1,
                  parallelism: float = 1,
                  walltime: str = "00:10:00",
                  scheduler_options: str = '',

--- a/parsl/providers/torque/torque.py
+++ b/parsl/providers/torque/torque.py
@@ -75,7 +75,7 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
                  nodes_per_block=1,
                  init_blocks=1,
                  min_blocks=0,
-                 max_blocks=100,
+                 max_blocks=1,
                  parallelism=1,
                  launcher=AprunLauncher(),
                  walltime="00:20:00",


### PR DESCRIPTION
This only touches the default config values for max_blocks.

This is added to avoid the situation of Parsl provisioning multiple jobs when the strategy assumes conservatively that each node will give one worker when doesn't know the number of workers that a node can support. 