### PR TITLE
Adding a staging_required marker

### DIFF
--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -88,6 +88,10 @@ def pytest_configure(config):
         'markers',
         'issue363: Marks tests that require a shared filesystem for stdout/stderr - see issue #363'
     )
+    config.addinivalue_line(
+        'markers',
+        'staging_required: Marks tests that require a staging provider, when there is no sharedFS)'
+    )
 
 
 @pytest.fixture(autouse=True, scope='session')

--- a/parsl/tests/site_tests/README.rst
+++ b/parsl/tests/site_tests/README.rst
@@ -65,4 +65,12 @@ Adding a new site
 Shared filesystem option
 ------------------------
 
-There is a new env variable "SHARED_FS_OPTIONS" to deselect tests that rely on a shared-fs. Currently we mark all these test as `issue363` (issue #363). However, there are two categories of tests in these marked tests. One category of tests rely on a share-fs to transfer `stdout` and `stderr`, and the other category of tests rely on a share-fs to transfer `input` and `output`.
+There is a new env variable "SHARED_FS_OPTIONS" to pass markers to pytest to skip certain tests.
+
+Tests that rely on stdout/stderr side-effects between apps that work on with a shared-FS can be deselected with `-k "not issue363"`
+
+When there's a shared-FS, the default NoOpStaging works. However, when there's no shared-FS some tests
+that uses File objects require a staging provider (eg. rsync). These tests can be turned off with
+`-k "not staging_required"`
+
+These can also be combined as `-k "not issue363 and not staging_required"`

--- a/parsl/tests/test_bash_apps/test_memoize.py
+++ b/parsl/tests/test_bash_apps/test_memoize.py
@@ -13,6 +13,9 @@ def fail_on_presence(outputs=[]):
     return 'if [ -f {0} ] ; then exit 1 ; else touch {0}; fi'.format(outputs[0])
 
 
+# This test is an oddity that requires a shared-FS and simply
+# won't work if there's a staging provider.
+# @pytest.mark.sharedFS_required
 @pytest.mark.issue363
 def test_bash_memoization(n=2):
     """Testing bash memoization

--- a/parsl/tests/test_bash_apps/test_pipeline.py
+++ b/parsl/tests/test_bash_apps/test_pipeline.py
@@ -37,7 +37,7 @@ def cleanup_work(depth):
             os.remove(fn)
 
 
-@pytest.mark.issue363
+@pytest.mark.staging_required
 def test_increment(depth=5):
     """Test simple pipeline A->B...->N
     """
@@ -82,7 +82,7 @@ def test_increment(depth=5):
     cleanup_work(depth)
 
 
-@pytest.mark.issue363
+@pytest.mark.staging_required
 def test_increment_slow(depth=5, dur=0.5):
     """Test simple pipeline slow (sleep.5) A->B...->N
     """

--- a/parsl/tests/test_data/test_file_apps.py
+++ b/parsl/tests/test_data/test_file_apps.py
@@ -41,7 +41,7 @@ def increment(inputs=[], outputs=[], stdout=None, stderr=None):
 
 
 @pytest.mark.usefixtures('setup_data')
-@pytest.mark.sharedFS_required
+@pytest.mark.staging_required
 def test_increment(depth=5):
     """Test simple pipeline A->B...->N
     """

--- a/parsl/tests/test_data/test_file_apps.py
+++ b/parsl/tests/test_data/test_file_apps.py
@@ -17,7 +17,7 @@ def cat(inputs=[], outputs=[], stdout=None, stderr=None):
 
 
 @pytest.mark.usefixtures('setup_data')
-@pytest.mark.issue363
+@pytest.mark.staging_required
 def test_files():
 
     if os.path.exists('cat_out.txt'):

--- a/parsl/tests/test_data/test_file_apps.py
+++ b/parsl/tests/test_data/test_file_apps.py
@@ -41,7 +41,7 @@ def increment(inputs=[], outputs=[], stdout=None, stderr=None):
 
 
 @pytest.mark.usefixtures('setup_data')
-@pytest.mark.issue363
+@pytest.mark.sharedFS_required
 def test_increment(depth=5):
     """Test simple pipeline A->B...->N
     """

--- a/parsl/tests/test_data/test_file_ipp.py
+++ b/parsl/tests/test_data/test_file_ipp.py
@@ -59,7 +59,7 @@ def test_regression_200():
         assert "Hello World" in data, "Missed data"
 
 
-@pytest.mark.issue363
+@pytest.mark.staging_required
 def test_increment(depth=5):
     """Test simple pipeline A->B...->N
     """

--- a/parsl/tests/test_data/test_file_ipp.py
+++ b/parsl/tests/test_data/test_file_ipp.py
@@ -38,7 +38,7 @@ def increment(inputs=[], outputs=[], stdout=None, stderr=None):
     """.format(i=inputs[0], o=outputs[0])
 
 
-@pytest.mark.issue363
+@pytest.mark.staging_required
 def test_regression_200():
     """Regression test for #200. Pickleablility of Files"""
 

--- a/parsl/tests/test_docs/test_workflow1.py
+++ b/parsl/tests/test_docs/test_workflow1.py
@@ -22,7 +22,7 @@ def save(message, outputs=[]):
     return 'echo {m} &> {o}'.format(m=message, o=outputs[0])
 
 
-@pytest.mark.issue363
+@pytest.mark.staging_required
 def test_procedural(N=2):
     """Procedural workflow example from docs on
     Composing a workflow

--- a/parsl/tests/test_python_apps/test_futures.py
+++ b/parsl/tests/test_python_apps/test_futures.py
@@ -55,7 +55,7 @@ def test_fut_case_1():
     return True
 
 
-@pytest.mark.issue363
+@pytest.mark.staging_required
 def test_fut_case_2():
     """Testing the behavior of DataFutures where there are no dependencies
     """
@@ -99,7 +99,7 @@ def test_fut_case_3():
     return True
 
 
-@pytest.mark.issue363
+@pytest.mark.staging_required
 def test_fut_case_4():
     """Testing the behavior of DataFutures where there are dependencies
 

--- a/parsl/tests/test_regression/test_69b.py
+++ b/parsl/tests/test_regression/test_69b.py
@@ -108,7 +108,7 @@ def cat(inputs=[], outputs=[], stdout='cat.out', stderr='cat.err'):
     return 'cat {inputs[0]} > {outputs[0]}'.format(inputs=inputs, outputs=outputs)
 
 
-@pytest.mark.issue363
+@pytest.mark.staging_required
 def test_5():
     """Testing behavior of outputs """
     # Call echo specifying the outputfile


### PR DESCRIPTION
This differentiates tests that fail due to issue363 (stdout/stderr staging issue), from tests that could pass if a staging provider is available in cases where the system doesn't have a shared-FS. 

Adds markers into the site_testing branch.