### PR TITLE
Disable fork safety on mac

### DIFF
--- a/parsl/__init__.py
+++ b/parsl/__init__.py
@@ -15,6 +15,8 @@ AUTO_LOGNAME
 
 """
 import logging
+import os
+import platform
 
 from parsl.version import VERSION
 from parsl.app.app import bash_app, python_app
@@ -70,3 +72,6 @@ class NullHandler(logging.Handler):
 
 
 logging.getLogger('parsl').addHandler(NullHandler())
+
+if platform.system() == 'Darwin':
+    os.environ['OBJC_DISABLE_INITIALIZE_FORK_SAFETY'] = 'YES'


### PR DESCRIPTION
This is required to get HTEX working on Mac. Related to #1659.

Warning note in FAQ/HTEX pending.

@danielskatz  Could you install this from this branch and test please ?