### PR TITLE
Moving scheduler_options to prepend the PBS options block. 

### DIFF
--- a/parsl/providers/torque/template.py
+++ b/parsl/providers/torque/template.py
@@ -1,5 +1,6 @@
 template_string = '''#!/bin/bash
 
+${scheduler_options}
 #PBS -S /bin/bash
 #PBS -N ${jobname}
 #PBS -m n
@@ -7,7 +8,6 @@ template_string = '''#!/bin/bash
 #PBS -l nodes=${nodes_per_block}:ppn=${tasks_per_node}
 #PBS -o ${submit_script_dir}/${jobname}.submit.stdout
 #PBS -e ${submit_script_dir}/${jobname}.submit.stderr
-${scheduler_options}
 
 ${worker_init}
 

--- a/parsl/providers/torque/torque.py
+++ b/parsl/providers/torque/torque.py
@@ -58,6 +58,7 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
         Walltime requested per block in HH:MM:SS.
     scheduler_options : str
         String to prepend to the #PBS blocks in the submit script to the scheduler.
+        WARNING: scheduler_options should only be given #PBS strings, and should not have trailing newlines.
     worker_init : str
         Command to be run before starting a worker, such as 'module load Anaconda; source activate env'.
     launcher : Launcher


### PR DESCRIPTION
Added a note to warn users to only use PBS directives in scheduler_options.
Fixes #1744 