### PR TITLE
Remove broken/unused provisioned_blocks attribute of providers

### DIFF
--- a/parsl/providers/cluster_provider.py
+++ b/parsl/providers/cluster_provider.py
@@ -63,7 +63,6 @@ class ClusterProvider(ExecutionProvider):
         self.min_blocks = min_blocks
         self.max_blocks = max_blocks
         self.parallelism = parallelism
-        self.provisioned_blocks = 0
         self.launcher = launcher
         self.walltime = walltime
         self.cmd_timeout = cmd_timeout

--- a/parsl/providers/cobalt/cobalt.py
+++ b/parsl/providers/cobalt/cobalt.py
@@ -151,10 +151,6 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
 
         """
 
-        if self.provisioned_blocks >= self.max_blocks:
-            logger.warning("[%s] at capacity, cannot add more blocks now", self.label)
-            return None
-
         account_opt = '-A {}'.format(self.account) if self.account is not None else ''
 
         job_name = "parsl.{0}.{1}".format(job_name, time.time())

--- a/parsl/providers/condor/condor.py
+++ b/parsl/providers/condor/condor.py
@@ -107,7 +107,6 @@ class CondorProvider(RepresentationMixin, ClusterProvider):
                          walltime,
                          launcher,
                          cmd_timeout=cmd_timeout)
-        self.provisioned_blocks = 0
         self.cores_per_slot = cores_per_slot
         self.mem_per_slot = mem_per_slot
 
@@ -201,10 +200,6 @@ class CondorProvider(RepresentationMixin, ClusterProvider):
         """
 
         logger.debug("Attempting to launch")
-        if self.provisioned_blocks >= self.max_blocks:
-            template = "Provider {} is currently using {} blocks while max_blocks is {}; no blocks will be added"
-            logger.warning(template.format(self.label, self.provisioned_blocks, self.max_blocks))
-            return None
 
         job_name = "parsl.{0}.{1}".format(job_name, time.time())
 

--- a/parsl/providers/googlecloud/googlecloud.py
+++ b/parsl/providers/googlecloud/googlecloud.py
@@ -105,7 +105,6 @@ class GoogleCloudProvider():
 
         # Dictionary that keeps track of jobs, keyed on job_id
         self.resources = {}
-        self.provisioned_blocks = 0
         atexit.register(self.bye)
 
     def submit(self, command, tasks_per_node, job_name="parsl.gcs"):
@@ -130,7 +129,6 @@ class GoogleCloudProvider():
                                     1)
 
         instance, name = self.create_instance(command=wrapped_cmd)
-        self.provisioned_blocks += 1
         self.resources[name] = {"job_id": name, "status": JobStatus(translate_table[instance['status']])}
         return name
 
@@ -173,7 +171,6 @@ class GoogleCloudProvider():
             try:
                 self.delete_instance(job_id)
                 statuses.append(True)
-                self.provisioned_blocks -= 1
             except Exception:
                 statuses.append(False)
         return statuses

--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -47,7 +47,6 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
                  move_files=None):
         self.channel = channel
         self._label = 'local'
-        self.provisioned_blocks = 0
         self.nodes_per_block = nodes_per_block
         self.launcher = launcher
         self.worker_init = worker_init

--- a/parsl/providers/lsf/lsf.py
+++ b/parsl/providers/lsf/lsf.py
@@ -147,10 +147,6 @@ class LSFProvider(ClusterProvider, RepresentationMixin):
             If at capacity, returns None; otherwise, a string identifier for the job
         """
 
-        if self.provisioned_blocks >= self.max_blocks:
-            logger.warning("LSF provider '{}' is at capacity (no more blocks will be added)".format(self.label))
-            return None
-
         job_name = "{0}.{1}".format(job_name, time.time())
 
         script_path = "{0}/{1}.submit".format(self.script_dir, job_name)

--- a/parsl/providers/pbspro/pbspro.py
+++ b/parsl/providers/pbspro/pbspro.py
@@ -106,10 +106,6 @@ class PBSProProvider(TorqueProvider):
             Identifier for the job
         """
 
-        if self.provisioned_blocks >= self.max_blocks:
-            logger.warning("[%s] at capacity, cannot add more blocks now", self.label)
-            return None
-
         job_name = "{0}.{1}".format(job_name, time.time())
 
         script_path = os.path.abspath("{0}/{1}.submit".format(self.script_dir, job_name))

--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -175,10 +175,6 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
             If at capacity, returns None; otherwise, a string identifier for the job
         """
 
-        if self.provisioned_blocks >= self.max_blocks:
-            logger.warning("Slurm provider '{}' is at capacity (no more blocks will be added)".format(self.label))
-            return None
-
         scheduler_options = self.scheduler_options
         worker_init = self.worker_init
         if self.mem_per_node is not None:

--- a/parsl/providers/torque/torque.py
+++ b/parsl/providers/torque/torque.py
@@ -97,7 +97,6 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
         self.queue = queue
         self.scheduler_options = scheduler_options
         self.worker_init = worker_init
-        self.provisioned_blocks = 0
         self.template_string = template_string
 
         # Dictionary that keeps track of jobs, keyed on job_id
@@ -162,10 +161,6 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
              - job_id: (string) Identifier for the job
 
         '''
-
-        if self.provisioned_blocks >= self.max_blocks:
-            logger.warning("[%s] at capacity, cannot add more blocks now", self.label)
-            return None
 
         # Set job name
         job_name = "parsl.{0}.{1}".format(job_name, time.time())


### PR DESCRIPTION
See #921.

Block status information comes from provider.status() now