### PR TITLE
Merge two sections in handle_exec_update that have distinct ancestry

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -184,7 +184,7 @@ class DataFlowKernel(object):
 
         atexit.register(self.atexit_cleanup)
 
-    def _create_task_log_info(self, task_id):
+    def _create_task_log_info(self, task_record):
         """
         Create the dictionary that will be included in the log.
         """
@@ -192,33 +192,33 @@ class DataFlowKernel(object):
         info_to_monitor = ['func_name', 'fn_hash', 'memoize', 'hashsum', 'fail_count', 'status',
                            'id', 'time_submitted', 'time_returned', 'executor']
 
-        task_log_info = {"task_" + k: self.tasks[task_id][k] for k in info_to_monitor}
+        task_log_info = {"task_" + k: task_record[k] for k in info_to_monitor}
         task_log_info['run_id'] = self.run_id
         task_log_info['timestamp'] = datetime.datetime.now()
-        task_log_info['task_status_name'] = self.tasks[task_id]['status'].name
+        task_log_info['task_status_name'] = task_record['status'].name
         task_log_info['tasks_failed_count'] = self.tasks_failed_count
         task_log_info['tasks_completed_count'] = self.tasks_completed_count
-        task_log_info['task_inputs'] = str(self.tasks[task_id]['kwargs'].get('inputs', None))
-        task_log_info['task_outputs'] = str(self.tasks[task_id]['kwargs'].get('outputs', None))
-        task_log_info['task_stdin'] = self.tasks[task_id]['kwargs'].get('stdin', None)
-        stdout_spec = self.tasks[task_id]['kwargs'].get('stdout', None)
-        stderr_spec = self.tasks[task_id]['kwargs'].get('stderr', None)
+        task_log_info['task_inputs'] = str(task_record['kwargs'].get('inputs', None))
+        task_log_info['task_outputs'] = str(task_record['kwargs'].get('outputs', None))
+        task_log_info['task_stdin'] = task_record['kwargs'].get('stdin', None)
+        stdout_spec = task_record['kwargs'].get('stdout', None)
+        stderr_spec = task_record['kwargs'].get('stderr', None)
         try:
             stdout_name, _ = get_std_fname_mode('stdout', stdout_spec)
         except Exception as e:
-            logger.warning("Incorrect stdout format {} for Task {}".format(stdout_spec, task_id))
+            logger.warning("Incorrect stdout format {} for Task {}".format(stdout_spec, task_record['id']))
             stdout_name = str(e)
         try:
             stderr_name, _ = get_std_fname_mode('stderr', stderr_spec)
         except Exception as e:
-            logger.warning("Incorrect stderr format {} for Task {}".format(stderr_spec, task_id))
+            logger.warning("Incorrect stderr format {} for Task {}".format(stderr_spec, task_record['id']))
             stderr_name = str(e)
         task_log_info['task_stdout'] = stdout_name
         task_log_info['task_stderr'] = stderr_name
-        task_log_info['task_fail_history'] = ",".join(self.tasks[task_id]['fail_history'])
+        task_log_info['task_fail_history'] = ",".join(task_record['fail_history'])
         task_log_info['task_depends'] = None
-        if self.tasks[task_id]['depends'] is not None:
-            task_log_info['task_depends'] = ",".join([str(t.tid) for t in self.tasks[task_id]['depends']
+        if task_record['depends'] is not None:
+            task_log_info['task_depends'] = ",".join([str(t.tid) for t in task_record['depends']
                                                       if isinstance(t, AppFuture) or isinstance(t, DataFuture)])
         return task_log_info
 
@@ -257,6 +257,11 @@ class DataFlowKernel(object):
              makes this callback
         """
 
+        task_record = self.tasks[task_id]
+
+        if not future.done():
+            raise ValueError("done callback called, despite future not reporting itself as done")
+
         try:
             res = future.result()
             if isinstance(res, RemoteExceptionWrapper):
@@ -266,64 +271,50 @@ class DataFlowKernel(object):
             logger.debug("Task {} failed".format(task_id))
             # We keep the history separately, since the future itself could be
             # tossed.
-            self.tasks[task_id]['fail_history'].append(str(e))
-            self.tasks[task_id]['fail_count'] += 1
+            task_record['fail_history'].append(str(e))
+            task_record['fail_count'] += 1
 
-            if self.tasks[task_id]['status'] == States.dep_fail:
+            if task_record['status'] == States.dep_fail:
                 logger.info("Task {} failed due to dependency failure so skipping retries".format(task_id))
-            elif self.tasks[task_id]['fail_count'] <= self._config.retries:
-                self.tasks[task_id]['status'] = States.pending
+                with task_record['app_fu']._update_lock:
+                    task_record['app_fu'].set_exception(e)
+
+            elif task_record['fail_count'] <= self._config.retries:
+                task_record['status'] = States.pending
                 logger.info("Task {} marked for retry".format(task_id))
 
             else:
                 logger.exception("Task {} failed after {} retry attempts".format(task_id,
                                                                                  self._config.retries))
-                self.tasks[task_id]['status'] = States.failed
+                task_record['status'] = States.failed
                 self.tasks_failed_count += 1
-                self.tasks[task_id]['time_returned'] = datetime.datetime.now()
+                with task_record['app_fu']._update_lock:
+                    task_record['app_fu'].set_exception(e)
 
         else:
-            self.tasks[task_id]['status'] = States.done
+
+            task_record['status'] = States.done
             self.tasks_completed_count += 1
 
             logger.info("Task {} completed".format(task_id))
-            self.tasks[task_id]['time_returned'] = datetime.datetime.now()
+            task_record['time_returned'] = datetime.datetime.now()
 
-        if self.tasks[task_id]['app_fu'].stdout is not None:
-            logger.info("Standard output for task {} available at {}".format(task_id, self.tasks[task_id]['app_fu'].stdout))
-        if self.tasks[task_id]['app_fu'].stderr is not None:
-            logger.info("Standard error for task {} available at {}".format(task_id, self.tasks[task_id]['app_fu'].stderr))
+            with task_record['app_fu']._update_lock:
+                task_record['app_fu'].set_result(future.result())
+
+        if task_record['app_fu'].stdout is not None:
+            logger.info("Standard output for task {} available at {}".format(task_id, task_record['app_fu'].stdout))
+        if task_record['app_fu'].stderr is not None:
+            logger.info("Standard error for task {} available at {}".format(task_id, task_record['app_fu'].stderr))
 
         if self.monitoring:
-            task_log_info = self._create_task_log_info(task_id)
+            task_log_info = self._create_task_log_info(task_record)
             self.monitoring.send(MessageType.TASK_INFO, task_log_info)
 
         # it might be that in the course of the update, we've gone back to being
         # pending - in which case, we should consider ourself for relaunch
-        if self.tasks[task_id]['status'] == States.pending:
+        if task_record['status'] == States.pending:
             self.launch_if_ready(task_id)
-
-        with self.tasks[task_id]['app_fu']._update_lock:
-
-            if not future.done():
-                raise ValueError("done callback called, despite future not reporting itself as done")
-
-            try:
-                res = future.result()
-                if isinstance(res, RemoteExceptionWrapper):
-                    res.reraise()
-
-                self.tasks[task_id]['app_fu'].set_result(future.result())
-            except Exception as e:
-                if self.tasks[task_id]['retries_left'] > 0:
-                    # ignore this exception, because assume some later
-                    # parent executor, started external to this class,
-                    # will provide the answer
-                    pass
-                else:
-                    self.tasks[task_id]['app_fu'].set_exception(e)
-
-        return
 
     def handle_app_update(self, task_id, future):
         """This function is called as a callback when an AppFuture
@@ -423,7 +414,7 @@ class DataFlowKernel(object):
                 self.tasks_dep_fail_count += 1
 
                 if self.monitoring is not None:
-                    task_log_info = self._create_task_log_info(task_id)
+                    task_log_info = self._create_task_log_info(task_record)
                     self.monitoring.send(MessageType.TASK_INFO, task_log_info)
 
                 self.tasks[task_id]['retries_left'] = 0
@@ -492,7 +483,7 @@ class DataFlowKernel(object):
             exec_fu = executor.submit(executable, self.tasks[task_id]['resource_specification'], *args, **kwargs)
         self.tasks[task_id]['status'] = States.launched
         if self.monitoring is not None:
-            task_log_info = self._create_task_log_info(task_id)
+            task_log_info = self._create_task_log_info(self.tasks[task_id])
             self.monitoring.send(MessageType.TASK_INFO, task_log_info)
 
         self.tasks[task_id]['retries_left'] = self._config.retries - \

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -276,6 +276,7 @@ class DataFlowKernel(object):
 
             if task_record['status'] == States.dep_fail:
                 logger.info("Task {} failed due to dependency failure so skipping retries".format(task_id))
+                task_record['time_returned'] = datetime.datetime.now()
                 with task_record['app_fu']._update_lock:
                     task_record['app_fu'].set_exception(e)
 
@@ -288,6 +289,7 @@ class DataFlowKernel(object):
                                                                                  self._config.retries))
                 task_record['status'] = States.failed
                 self.tasks_failed_count += 1
+                task_record['time_returned'] = datetime.datetime.now()
                 with task_record['app_fu']._update_lock:
                     task_record['app_fu'].set_exception(e)
 

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -771,7 +771,7 @@ class DataFlowKernel(object):
         logger.debug("Task {} set to pending state with AppFuture: {}".format(task_id, task_def['app_fu']))
 
         if self.monitoring is not None:
-            task_log_info = self._create_task_log_info(task_id)
+            task_log_info = self._create_task_log_info(self.tasks[task_id])
             self.monitoring.send(MessageType.TASK_INFO, task_log_info)
 
         # at this point add callbacks to all dependencies to do a launch_if_ready


### PR DESCRIPTION
The first and second parts of handle_exec_update used to be in separate callbacks,
They were merged by #1431 to happen in the same callback, one after the other,
without more fine grained merging of behaviour.

This commit merges some of the if statements to make retry behaviour clearer.
Previously the retry behaviour was split between the two sections described aboe.

This commit will peturb the order in which post-task completion events happening.
This means that task garbage collection can happen earlier on, and so looking up
a task_id in self.tasks cannot happen so much. _create_task_log_info is modified
to take a task record, rather than a task_id, to accomodate this.