### PR TITLE
Check for errors in renamed hub.log, now monitoring_router.log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,11 @@ script:
     - cd ..
 
     # assert that none of the runs in this test have put an ERROR message into a
-    # database manager log file or monitoring hub log file. It would be better if
+    # database manager log file or monitoring router log file. It would be better if
     # the tests themselves failed immediately when there was a monitoring error, but
     # in the absence of that, this is a dirty way to check.
     - bash -c '! grep ERROR runinfo*/*/database_manager.log'
-    - bash -c '! grep ERROR runinfo*/*/hub.log'
+    - bash -c '! grep ERROR runinfo*/*/monitoring_router.log'
 
     # check that 'all' install target works, even though we aren't doing any further
     # testing of what is installed


### PR DESCRIPTION
PR #1711 renamed the Hub component of monitoring to
MonitoringRouter and renamed the log file accordingly, but
did not make this change to CI.