### PR TITLE
Remove denormalised workflow duration from monitoring db

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -135,7 +135,6 @@ class DataFlowKernel(object):
                 'parsl_version': get_version(),
                 "time_began": self.time_began,
                 'time_completed': None,
-                'workflow_duration': None,
                 'run_id': self.run_id,
                 'workflow_name': self.workflow_name,
                 'workflow_version': self.workflow_version,
@@ -946,7 +945,6 @@ class DataFlowKernel(object):
                                   'tasks_completed_count': self.tasks_completed_count,
                                   "time_began": self.time_began,
                                   'time_completed': self.time_completed,
-                                  'workflow_duration': (self.time_completed - self.time_began).total_seconds(),
                                   'run_id': self.run_id, 'rundir': self.run_dir})
 
             self.monitoring.close()

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -100,7 +100,6 @@ class Database:
         workflow_version = Column(Text, nullable=True)
         time_began = Column(DateTime, nullable=False)
         time_completed = Column(DateTime, nullable=True)
-        workflow_duration = Column(Float, nullable=True)
         host = Column(Text, nullable=False)
         user = Column(Text, nullable=False)
         rundir = Column(Text, nullable=False)
@@ -297,8 +296,7 @@ class DatabaseManager:
                                 "Updating workflow end info to WORKFLOW table")
                             self._update(table=WORKFLOW,
                                          columns=['run_id', 'tasks_failed_count',
-                                                  'tasks_completed_count', 'time_completed',
-                                                  'workflow_duration'],
+                                                  'tasks_completed_count', 'time_completed'],
                                          messages=[msg])
                             self.workflow_end = True
 

--- a/parsl/monitoring/visualization/models.py
+++ b/parsl/monitoring/visualization/models.py
@@ -17,7 +17,6 @@ class Workflow(db.Model):
     workflow_version = db.Column(db.Text, nullable=True)
     time_began = db.Column(db.DateTime, nullable=False)  # Why not date?
     time_completed = db.Column(db.DateTime)
-    workflow_duration = db.Column(db.Float)
     host = db.Column(db.Text, nullable=False)
     user = db.Column(db.Text, nullable=False)
     rundir = db.Column(db.Text, nullable=False)

--- a/parsl/monitoring/visualization/templates/app.html
+++ b/parsl/monitoring/visualization/templates/app.html
@@ -11,7 +11,7 @@
     <li><b>Workflow name:</b>  <a href="/workflow/{{ workflow_details['run_id'] }}/">{{ workflow_details['workflow_name'] }}<a/></li>
     <li><b>Started:</b>  {{ workflow_details['time_began'] | timeformat }}</li>
     <li><b>Completed:</b>  {{ workflow_details['time_completed'] | timeformat }}</li>
-    <li><b>Workflow duration:</b>  {{ workflow_details['workflow_duration'] | timeformat }}</li>
+    <li><b>Workflow duration:</b>  {{ (workflow_details['time_began'], workflow_details['time_completed']) | durationformat }}</li>
     <li><b>Owner:</b>  {{ workflow_details['user'] }}</li>
     <li><b>Host:</b>  {{ workflow_details['host'] }}</li>
     <li><b>Run directory:</b>  {{ workflow_details['rundir'] }}</li>

--- a/parsl/monitoring/visualization/templates/dag.html
+++ b/parsl/monitoring/visualization/templates/dag.html
@@ -10,7 +10,7 @@
 <ul>
     <li><b>Started:</b>  {{ workflow_details['time_began'] | timeformat }}</li>
     <li><b>Completed:</b>  {{ workflow_details['time_completed'] | timeformat }}</li>
-    <li><b>Workflow duration:</b>  {{ (workflow_details['time_began'] - workflow_details['time_completed']) | durationformat }}</li>
+    <li><b>Workflow duration:</b>  {{ (workflow_details['time_began'], workflow_details['time_completed']) | durationformat }}</li>
     <li><b>Owner:</b>  {{ workflow_details['user'] }}</li>
     <li><b>Host:</b>  {{ workflow_details['host'] }}</li>
     <li><b>Run directory:</b>  {{ workflow_details['rundir'] }}</li>

--- a/parsl/monitoring/visualization/templates/dag.html
+++ b/parsl/monitoring/visualization/templates/dag.html
@@ -10,7 +10,7 @@
 <ul>
     <li><b>Started:</b>  {{ workflow_details['time_began'] | timeformat }}</li>
     <li><b>Completed:</b>  {{ workflow_details['time_completed'] | timeformat }}</li>
-    <li><b>Workflow duration:</b>  {{ workflow_details['workflow_duration'] | timeformat }}</li>
+    <li><b>Workflow duration:</b>  {{ (workflow_details['time_began'] - workflow_details['time_completed']) | durationformat }}</li>
     <li><b>Owner:</b>  {{ workflow_details['user'] }}</li>
     <li><b>Host:</b>  {{ workflow_details['host'] }}</li>
     <li><b>Run directory:</b>  {{ workflow_details['rundir'] }}</li>

--- a/parsl/monitoring/visualization/templates/resource_usage.html
+++ b/parsl/monitoring/visualization/templates/resource_usage.html
@@ -10,7 +10,7 @@
 <ul>
     <li><b>Started:</b>  {{ workflow_details['time_began'] | timeformat }}</li>
     <li><b>Completed:</b>  {{ workflow_details['time_completed'] | timeformat }}</li>
-    <li><b>Workflow duration:</b>  {{ workflow_details['workflow_duration'] | timeformat }}</li>
+    <li><b>Workflow duration:</b>  {{ (workflow_details['time_began'], workflow_details['time_completed']) | durationformat }}</li>
     <li><b>Owner:</b>  {{ workflow_details['user'] }}</li>
     <li><b>Host:</b>  {{ workflow_details['host'] }}</li>
     <li><b>Run directory:</b>  {{ workflow_details['rundir'] }}</li>

--- a/parsl/monitoring/visualization/templates/task.html
+++ b/parsl/monitoring/visualization/templates/task.html
@@ -12,7 +12,7 @@
     <li><b>Workflow name:</b>  <a href="/workflow/{{ workflow_details['run_id'] }}/">{{ workflow_details['workflow_name'] }}<a/></li>
     <li><b>Started:</b>  {{ workflow_details['time_began'] | timeformat }}</li>
     <li><b>Completed:</b>  {{ workflow_details['time_completed'] | timeformat }}</li>
-    <li><b>Workflow duration:</b>  {{ workflow_details['workflow_duration']| timeformat }}</li>
+    <li><b>Workflow duration:</b>  {{ (workflow_details['time_began'], workflow_details['time_completed']) | durationformat }}</li>
     <li><b>Owner:</b>  {{ workflow_details['user'] }}</li>
     <li><b>task_func_name:</b>   <a href="/workflow/{{ workflow_details['run_id'] }}/app/{{ task_details['task_func_name'] }}">{{ task_details['task_func_name'] }}</a></li>
     <li><b>task_id:</b>  {{ task_details['task_id'] }}</li>

--- a/parsl/monitoring/visualization/templates/workflow.html
+++ b/parsl/monitoring/visualization/templates/workflow.html
@@ -14,7 +14,7 @@
         <ul>
             <li><b>Started:</b>  {{ workflow_details['time_began'] | timeformat}}</li>
             <li><b>Completed:</b>  {{ workflow_details['time_completed'] | timeformat }}</li>
-            <li><b>Workflow duration:</b>  {{ workflow_details['workflow_duration'] | timeformat }}</li>
+            <li><b>Workflow duration:</b>  {{ (workflow_details['time_began'], workflow_details['time_completed']) | durationformat }}</li>
             <li><b>Owner:</b>  {{ workflow_details['user'] }}</li>
             <li><b>Host:</b>  {{ workflow_details['host'] }}</li>
             <li><b>Run directory:</b>  {{ workflow_details['rundir'] }}</li>

--- a/parsl/monitoring/visualization/templates/workflows_summary.html
+++ b/parsl/monitoring/visualization/templates/workflows_summary.html
@@ -24,7 +24,7 @@
         <td>{{ w.workflow_version }}</td>
         <td>{{ w.user }}</td>
         <td>{{ w.status }}</td>
-        <td>{{ w.workflow_duration | timeformat }}</td>
+        <td>{{ (w.time_began, w.time_completed) | durationformat }}</td>
         <td>
              <span class="task task-complete">{{ w['tasks_completed_count'] }}</span>
              <span class="task task-failed">{{ w['tasks_failed_count'] }}</span>

--- a/parsl/monitoring/visualization/views.py
+++ b/parsl/monitoring/visualization/views.py
@@ -19,11 +19,23 @@ def format_time(value):
         return str(datetime.timedelta(seconds=round(value)))
     elif isinstance(value, datetime.datetime):
         return value.replace(microsecond=0)
+    elif isinstance(value, datetime.timedelta):
+        rounded_timedelta = datetime.timedelta(days=value.days, seconds=value.seconds)
+        return rounded_timedelta
     else:
         return "Incorrect time format found (neither float nor datetime.datetime object)"
 
 
+def format_duration(value):
+    (start, end) = value
+    if start and end:
+        return format_time(end-start)
+    else:
+        return "-"
+
+
 app.jinja_env.filters['timeformat'] = format_time
+app.jinja_env.filters['durationformat'] = format_duration
 
 
 @app.route('/')

--- a/parsl/monitoring/visualization/views.py
+++ b/parsl/monitoring/visualization/views.py
@@ -29,7 +29,7 @@ def format_time(value):
 def format_duration(value):
     (start, end) = value
     if start and end:
-        return format_time(end-start)
+        return format_time(end - start)
     else:
         return "-"
 


### PR DESCRIPTION
This value be computed from other fields in the database,
so should not be stored in the DB:

  duration = time_completed - time_began

Previously, the workflow duration was reported as None/NULL
when a workflow was not finished. This PR adds a helper
which provides NULL-aware subtraction for cases where
time_completed is null.