### PR TITLE
Hyperlinks for app page to task pages should be on the task ID, not app name

### DIFF
--- a/parsl/monitoring/visualization/templates/app.html
+++ b/parsl/monitoring/visualization/templates/app.html
@@ -25,7 +25,7 @@
     <thead>
       <tr>
         <th>Name</th>
-        <th>Task_ID</th>
+        <th>Task ID</th>
         <th>Dependencies</th>
         <th>Executor</th>
         <th>Started</th>
@@ -35,8 +35,8 @@
     <tbody>
       {% for t in task_summary %}
       <tr>
-        <td><a href="/workflow/{{ workflow_details['run_id'] }}/task/{{ t['task_id'] }}">{{ t.task_func_name }}</a></td>
-        <td>{{ t['task_id'] }}</td>
+        <td>{{ t.task_func_name }}</td>
+        <td><a href="/workflow/{{ workflow_details['run_id'] }}/task/{{ t['task_id'] }}">{{ t['task_id'] }}</a></td>
         <td>
         {% if t['task_depends'] %}
             {% for id in t['task_depends'].split(",") %}


### PR DESCRIPTION
What you are clicking on/choosing is a task, not an app - you are already on the page for an app.

This is already how dependencies are represented in the same table: clickable task IDs