### PR TITLE
New PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+# Description
+
+Please include a summary of the change and (optionally) which issue is fixed. Please also include
+relevant motivation and context.
+
+Fixes # (issue)
+
+## Type of change
+
+Please check the options below:
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Code maintentance/cleanup

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Fixes # (issue)
 Please check the options below:
 
 - [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
+- [ ] New feature (non-breaking change that adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update
 - [ ] Code maintentance/cleanup

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ Fixes # (issue)
 
 Please check the options below:
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] Bug fix (non-breaking change that fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update


### PR DESCRIPTION
This PR adds a template for pull requests similar to the templates we have for issues. The goal is to make sure the PR nudges contributors to write cleaner PR descriptions that can go into our changelog.