### PR TITLE
Remove spurious } in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ workqueue_ex_test: $(WORKQUEUE_INSTALL)  ## run all tests with workqueue_ex conf
 
 .PHONY: config_local_test
 config_local_test: ## run all tests with workqueue_ex config
-	echo "$(MPI)}"
+	echo "$(MPI)"
 	parsl/executors/extreme_scale/install-mpi.sh $(MPI)
 	pip3 install ".[extreme_scale]"
 	PYTHONPATH=. pytest parsl -k "not cleannet" --config local --cov=parsl --cov-append --cov-report= --random-order


### PR DESCRIPTION
# Description

Remove a spurious } symbol in a debugging log line in the Makefile. This wasn't breaking anything, but was noise in CI output.

## Type of change

Please check the options below:

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code maintentance/cleanup
