### PR TITLE
Remove markup checkboxes that conflict with github's interpretation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,10 +7,10 @@ Fixes # (issue)
 
 ## Type of change
 
-Please check the options below:
+Choose which options apply, and delete the ones which do not apply.
 
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
-- [ ] Code maintentance/cleanup
+- Bug fix (non-breaking change that fixes an issue)
+- New feature (non-breaking change that adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- Documentation update
+- Code maintentance/cleanup


### PR DESCRIPTION
Prior to this PR, the type of PR was presented as a series of checkboxes
with the intention that applicable ones are checked.

Github interprets checkboxes in PRs as todo lists, and renders a summary of them as "n of m
completed" progess bars on the PR summary page. This is wrong and confusing.

This PR moves formatting away from that style to prevent spurious github progress bars.

## Type of change

- [ ] Code maintentance/cleanup
