### PR TITLE
Remove outdated/wrong pseudocode in dfk.submit docstring

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -643,11 +643,6 @@ class DataFlowKernel(object):
         list of executors. If the app task specifies a particular set of
         executors, it will be targeted at the specified executors.
 
-        >>> IF all deps are met:
-        >>>   send to the runnable queue and launch the task
-        >>> ELSE:
-        >>>   post the task in the pending queue
-
         Args:
             - func : A function object
 


### PR DESCRIPTION
# Description

The removed fragment of pseudocode does not reflect the current behaviour of DFK task submission.

## Type of change

- Documentation update
- Code maintentance/cleanup
