### PR TITLE
Correct the package for workqueue executor in Docs from cctools to ndcctools

### DIFF
--- a/docs/userguide/configuring.rst
+++ b/docs/userguide/configuring.rst
@@ -375,7 +375,7 @@ To utilize Work Queue with Parsl, please install the full CCTools software packa
 
    $ conda create -y --name <environment> python=<version> conda-pack
    $ conda activate <environment>
-   $ conda install -y -c conda-forge cctools parsl
+   $ conda install -y -c conda-forge ndcctools parsl
 
 This creates a Conda environment on your machine with all the necessary tools and setup needed to utilize Work Queue with the Parsl library.
 


### PR DESCRIPTION
# Description

This PR corrects the package for workqueue executor in Documentations from cctools to ndcctools

## Type of change

- Documentation update

