### PR TITLE
Remove check for file existence in channels.ssh.ssh.SSHChannel.pull_f…

### DIFF
--- a/parsl/channels/ssh/ssh.py
+++ b/parsl/channels/ssh/ssh.py
@@ -4,7 +4,7 @@ import os
 
 import paramiko
 from parsl.channels.base import Channel
-from parsl.channels.errors import BadHostKeyException, AuthException, SSHException, BadScriptPath, BadPermsScriptPath, FileCopyException, FileExists
+from parsl.channels.errors import BadHostKeyException, AuthException, SSHException, BadScriptPath, BadPermsScriptPath, FileCopyException
 from parsl.utils import RepresentationMixin
 
 logger = logging.getLogger(__name__)
@@ -192,12 +192,6 @@ class SSHChannel(Channel, RepresentationMixin):
             if e.errno != errno.EEXIST:
                 logger.exception("Failed to create local_dir: {0}".format(local_dir))
                 raise BadScriptPath(e, self.hostname)
-
-        # Easier to check this than to waste time trying to pull file and
-        # realize there's a problem.
-        if os.path.exists(local_dest):
-            logger.exception("Remote file copy will overwrite a local file:{0}".format(local_dest))
-            raise FileExists(None, self.hostname, filename=local_dest)
 
         try:
             self.sftp_client.get(remote_source, local_dest)


### PR DESCRIPTION
…ile() (fixes #1785)

# Description

The ssh channel checks if the destination file exists before transferring a file using pull_file. This can cause problems when one needs to repeatedly transfer the same file (such as when the file contains live data from a running task). Specifically, issue #1785 is a manifestation of this problem. A previous related PR, #1786, added an optional parameter to push/pull_file that allowed disabling this check. However, the discussion pointed towards the fact that the solution was overly complex for a questionable benefit. Hence this PR.

Fixes #1785

## Type of change

Choose which options apply, and delete the ones which do not apply.
- Bug fix (non-breaking change that fixes an issue)
