### PR TITLE
Do not use "wait -n" in order to support bash versions older than 5.0.

### DIFF
--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -88,6 +88,7 @@ export CORES=$(getconf _NPROCESSORS_ONLN)
 [[ "{debug}" == "1" ]] && echo "Found cores : $CORES"
 WORKERCOUNT={task_blocks}
 FAILONANY={fail_on_any}
+PIDS=""
 
 CMD() {{
 {command}
@@ -95,12 +96,13 @@ CMD() {{
 for COUNT in $(seq 1 1 $WORKERCOUNT); do
     [[ "{debug}" == "1" ]] && echo "Launching worker: $COUNT"
     CMD $COUNT &
+    PIDS="$PIDS $!"
 done
 
 ALLFAILED=1
 ANYFAILED=0
-for COUNT in $(seq 1 1 $WORKERCOUNT); do
-    wait -n
+for PID in $PIDS ; do
+    wait $PID
     if [ "$?" != "0" ]; then
         ANYFAILED=1
     else


### PR DESCRIPTION
# Description

The single node launcher introduced by PR #1724 uses "wait -n". The "-n" flag was introduced in bash v5. This PR rewrites that piece of code to not use said flag.

Fixes #1797 

## Type of change

Choose which options apply, and delete the ones which do not apply.
- Bug fix (non-breaking change that fixes an issue)
