### PR TITLE
Make dependency exceptions only report task ID, not full exception tree

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -606,7 +606,11 @@ class DataFlowKernel(object):
                 try:
                     new_args.extend([dep.result()])
                 except Exception as e:
-                    dep_failures.extend([e])
+                    if hasattr(dep, 'task_def'):
+                        tid = dep.task_def['id']
+                    else:
+                        tid = None
+                    dep_failures.extend([(e, tid)])
             else:
                 new_args.extend([dep])
 
@@ -617,7 +621,11 @@ class DataFlowKernel(object):
                 try:
                     kwargs[key] = dep.result()
                 except Exception as e:
-                    dep_failures.extend([e])
+                    if hasattr(dep, 'task_def'):
+                        tid = dep.task_def['id']
+                    else:
+                        tid = None
+                    dep_failures.extend([(e, tid)])
 
         # Check for futures in inputs=[<fut>...]
         if 'inputs' in kwargs:
@@ -627,7 +635,11 @@ class DataFlowKernel(object):
                     try:
                         new_inputs.extend([dep.result()])
                     except Exception as e:
-                        dep_failures.extend([e])
+                        if hasattr(dep, 'task_def'):
+                            tid = dep.task_def['id']
+                        else:
+                            tid = None
+                        dep_failures.extend([(e, tid)])
 
                 else:
                     new_inputs.extend([dep])

--- a/parsl/dataflow/error.py
+++ b/parsl/dataflow/error.py
@@ -50,13 +50,13 @@ class DependencyError(DataFlowException):
     dependent_exceptions
     """
 
-    def __init__(self, dependent_exceptions, task_id):
-        self.dependent_exceptions = dependent_exceptions
+    def __init__(self, dependent_exceptions_tids, task_id):
+        self.dependent_exceptions_tids = dependent_exceptions_tids
         self.task_id = task_id
 
     def __repr__(self):
-        return "Dependency failure for task {} from: {}".format(self.task_id,
-                                                                self.dependent_exceptions)
+        dep_tids = [tid for (exception, tid) in self.dependent_exceptions_tids]
+        return "Dependency failure for task {} with failed dependencies from tasks {}".format(self.task_id, dep_tids)
 
     def __str__(self):
         return self.__repr__()


### PR DESCRIPTION
When there is a long chain of dependencies, then an early one failing generates verbose and
awkward to read exception text.

DependencyErrors are now rendered like this:

  Dependency failure for task 8 with failed dependencies from tasks [6]

## Type of change

- Code maintentance/cleanup
