### PR TITLE
Tighten pytest KeyError test skipping

### DIFF
--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -106,24 +106,21 @@ def load_dfk_session(request, pytestconfig):
 
     if config != 'local':
         spec = importlib.util.spec_from_file_location('', config)
-        try:
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-            module.config.run_dir = get_rundir()  # Give unique rundir; needed running with -n=X where X > 1.
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        module.config.run_dir = get_rundir()  # Give unique rundir; needed running with -n=X where X > 1.
 
-            if DataFlowKernelLoader._dfk is not None:
-                raise ValueError("DFK didn't start as None - there was a DFK from somewhere already")
+        if DataFlowKernelLoader._dfk is not None:
+            raise ValueError("DFK didn't start as None - there was a DFK from somewhere already")
 
-            dfk = parsl.load(module.config)
+        dfk = parsl.load(module.config)
 
-            yield
+        yield
 
-            if(parsl.dfk() != dfk):
-                raise ValueError("DFK changed unexpectedly during test")
-            dfk.cleanup()
-            parsl.clear()
-        except KeyError:
-            pytest.skip('options in user_opts.py not configured for {}'.format(config))
+        if(parsl.dfk() != dfk):
+            raise ValueError("DFK changed unexpectedly during test")
+        dfk.cleanup()
+        parsl.clear()
     else:
         yield
 


### PR DESCRIPTION
Treating KeyError to mean "skip this test" rather than as a test failure only makes sense for
local tests, where some configurations do not work unless user options are supplied.

KeyErrors raised by specified-config tests should be treated as regular test failures; such
exceptions can be raised by failing test cases, and so should cause the test suite to fail.

This commit removes special casing for KeyErrors in the specified-config case, leaving it in place
for local tests.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
