### PR TITLE
Fix broken link to Parsl tutorial (#1787)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,9 +40,9 @@ extensions = [
     'sphinx.ext.napoleon'
 ]
 
-url = 'https://raw.githubusercontent.com/Parsl/parsl-tutorial/master/parsl-introduction.ipynb'
+url = 'https://raw.githubusercontent.com/Parsl/parsl-tutorial/master/1-parsl-introduction.ipynb'
 r = requests.get(url)
-with open(os.path.join(os.path.dirname(__file__), 'parsl-introduction.ipynb'), 'wb') as f:
+with open(os.path.join(os.path.dirname(__file__), '1-parsl-introduction.ipynb'), 'wb') as f:
     f.write(r.content)
 
 nbsphinx_execute = 'never'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,7 +59,7 @@ Parsl can be used to implement various parallel computing paradigms:
 .. toctree::
 
    quickstart
-   parsl-introduction.ipynb
+   1-parsl-introduction.ipynb
    userguide/index
    faq
    reference

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -91,7 +91,7 @@ There are several options for following the tutorial:
 
 1. Use `Binder <https://mybinder.org/v2/gh/Parsl/parsl-tutorial/master>`_  to follow the tutorial online without installing or writing any code locally. 
 2. Clone the `Parsl tutorial repository <https://github.com/Parsl/parsl-tutorial>`_ using a local Parsl installation.
-3. Read through the online `tutorial documentation <parsl-introduction>`_.
+3. Read through the online `tutorial documentation <1-parsl-introduction.html>`_.
 
 
 Usage Tracking


### PR DESCRIPTION
# Description

The link to the Parsl tutorial notebook in the Parsl docs was broken as per #1787. This was because the name of the notebook was changed in the `parsl-tutorial` repo. Simple fix.

Fixes #1787

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Documentation update