### PR TITLE
Link from dev guide to CONTRIBUTING.md

### DIFF
--- a/docs/devguide/contributing.rst
+++ b/docs/devguide/contributing.rst
@@ -3,13 +3,4 @@ Contributing
 
 Parsl is an open source project that welcomes contributions from the community.
 
-First, please be aware of `Parsl's Code of Conduct<https://github.com/Parsl/parsl/blob/master/CoC.md>`_.
-
-Contributions may take many forms from reporting issues, requesting new features
-commenting on existing issues, fixing bugs, or developing new features.
-
 If you're interested in contributing, please review our  `contributing guide <https://github.com/Parsl/parsl/blob/master/CONTRIBUTING.rst>`_.
-
-If you're looking for a good place to get started you might like to review existing Git issues (those marked with `help wanted <https://github.com/Parsl/parsl/labels/help%20wanted>`_ are a good place to start).
-
-To get involved in community discussion please `join the Parsl Slack channel <https://join.slack.com/t/parsl-project/shared_invite/enQtMzg2MDAwNjg2ODY1LTk0ZmYyZWE2NDMwYzVjZThmNTUxOWE0MzNkN2JmYjMyY2QzYzg0YTM3MDEzYjc2ZjcxZGZhMGQ1MzBmOWRiOTM>`_.


### PR DESCRIPTION
The removed text was largely a dupe of CONTRIBUTING.md, which is
better maintained.

## Type of change

- Documentation update
