### PR TITLE
Removed all instances of "address_by_hostname" and "address_by_query" in config examples

### DIFF
--- a/parsl/configs/Azure.py
+++ b/parsl/configs/Azure.py
@@ -26,7 +26,6 @@ config = Config(
     executors=[
         HighThroughputExecutor(
             label='azure_single_node',
-            address=address_by_query(),
             provider=AzureProvider(
                 vm_reference=vm_reference,
                 key_file='azure_key_file.json',

--- a/parsl/configs/ad_hoc.py
+++ b/parsl/configs/ad_hoc.py
@@ -1,7 +1,6 @@
 from parsl.providers import AdHocProvider
 from parsl.channels import SSHChannel
 from parsl.executors import HighThroughputExecutor
-from parsl.addresses import address_by_query
 from parsl.config import Config
 
 user_opts = {'adhoc':
@@ -16,7 +15,6 @@ config = Config(
         HighThroughputExecutor(
             label='remote_htex',
             max_workers=2,
-            address=address_by_query(),
             worker_logdir_root=user_opts['adhoc']['script_dir'],
             provider=AdHocProvider(
                 # Command to be run before starting a worker, such as:

--- a/parsl/configs/bluewaters.py
+++ b/parsl/configs/bluewaters.py
@@ -1,6 +1,5 @@
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
-from parsl.addresses import address_by_hostname
 from parsl.launchers import AprunLauncher
 from parsl.providers import TorqueProvider
 
@@ -11,7 +10,6 @@ config = Config(
             label="bw_htex",
             cores_per_worker=1,
             worker_debug=False,
-            address=address_by_hostname(),
             provider=TorqueProvider(
                 queue='normal',
                 launcher=AprunLauncher(overrides="-b -- bwpy-environ --"),

--- a/parsl/configs/cc_in2p3.py
+++ b/parsl/configs/cc_in2p3.py
@@ -2,13 +2,11 @@ from parsl.config import Config
 from parsl.channels import LocalChannel
 from parsl.providers import GridEngineProvider
 from parsl.executors import HighThroughputExecutor
-from parsl.addresses import address_by_query
 
 config = Config(
     executors=[
         HighThroughputExecutor(
             label='cc_in2p3_htex',
-            address=address_by_query(),
             max_workers=2,
             provider=GridEngineProvider(
                 channel=LocalChannel(),

--- a/parsl/configs/comet.py
+++ b/parsl/configs/comet.py
@@ -2,14 +2,12 @@ from parsl.config import Config
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
 from parsl.executors import HighThroughputExecutor
-from parsl.addresses import address_by_query
 
 
 config = Config(
     executors=[
         HighThroughputExecutor(
             label='Comet_HTEX_multinode',
-            address=address_by_query(),
             worker_logdir_root='YOUR_LOGDIR_ON_COMET',
             max_workers=2,
             provider=SlurmProvider(

--- a/parsl/configs/cooley.py
+++ b/parsl/configs/cooley.py
@@ -1,6 +1,5 @@
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
-from parsl.addresses import address_by_hostname
 from parsl.launchers import MpiRunLauncher
 from parsl.providers import CobaltProvider
 
@@ -11,7 +10,6 @@ config = Config(
             label="cooley_htex",
             worker_debug=False,
             cores_per_worker=1,
-            address=address_by_hostname(),
             provider=CobaltProvider(
                 queue='debug',
                 account='YOUR_ACCOUNT',  # project name to submit the job

--- a/parsl/configs/ec2.py
+++ b/parsl/configs/ec2.py
@@ -1,13 +1,11 @@
 from parsl.config import Config
 from parsl.providers import AWSProvider
 from parsl.executors import HighThroughputExecutor
-from parsl.addresses import address_by_query
 
 config = Config(
     executors=[
         HighThroughputExecutor(
             label='ec2_single_node',
-            address=address_by_query(),
             provider=AWSProvider(
                 # Specify your EC2 AMI id
                 'YOUR_AMI_ID',

--- a/parsl/configs/frontera.py
+++ b/parsl/configs/frontera.py
@@ -3,7 +3,6 @@ from parsl.channels import LocalChannel
 from parsl.providers import SlurmProvider
 from parsl.executors import HighThroughputExecutor
 from parsl.launchers import SrunLauncher
-from parsl.addresses import address_by_hostname
 
 
 """ This config assumes that it is used to launch parsl tasks from the login nodes
@@ -13,7 +12,6 @@ config = Config(
     executors=[
         HighThroughputExecutor(
             label="frontera_htex",
-            address=address_by_hostname(),
             max_workers=1,          # Set number of workers per node
             provider=SlurmProvider(
                 cmd_timeout=60,     # Add extra time for slow scheduler responses

--- a/parsl/configs/midway.py
+++ b/parsl/configs/midway.py
@@ -1,7 +1,6 @@
 from parsl.config import Config
 from parsl.providers import SlurmProvider
 from parsl.launchers import SrunLauncher
-from parsl.addresses import address_by_hostname
 from parsl.executors import HighThroughputExecutor
 
 config = Config(
@@ -9,7 +8,6 @@ config = Config(
         HighThroughputExecutor(
             label='Midway_HTEX_multinode',
             worker_debug=False,
-            address=address_by_hostname(),
             max_workers=2,
             provider=SlurmProvider(
                 'YOUR_PARTITION',  # Partition name, e.g 'broadwl'

--- a/parsl/configs/osg.py
+++ b/parsl/configs/osg.py
@@ -1,13 +1,11 @@
 from parsl.config import Config
 from parsl.providers import CondorProvider
 from parsl.executors import HighThroughputExecutor
-from parsl.addresses import address_by_query
 
 config = Config(
     executors=[
         HighThroughputExecutor(
             label='OSG_HTEX',
-            address=address_by_query(),
             max_workers=1,
             provider=CondorProvider(
                 nodes_per_block=1,

--- a/parsl/configs/stampede2.py
+++ b/parsl/configs/stampede2.py
@@ -2,7 +2,6 @@ from parsl.config import Config
 from parsl.providers import SlurmProvider
 from parsl.launchers import SrunLauncher
 from parsl.executors import HighThroughputExecutor
-from parsl.addresses import address_by_hostname
 from parsl.data_provider.globus import GlobusStaging
 
 
@@ -10,7 +9,6 @@ config = Config(
     executors=[
         HighThroughputExecutor(
             label='Stampede2_HTEX',
-            address=address_by_hostname(),
             max_workers=2,
             provider=SlurmProvider(
                 nodes_per_block=2,

--- a/parsl/configs/theta.py
+++ b/parsl/configs/theta.py
@@ -2,7 +2,6 @@ from parsl.config import Config
 from parsl.providers import CobaltProvider
 from parsl.launchers import AprunLauncher
 from parsl.executors import HighThroughputExecutor
-from parsl.addresses import address_by_hostname
 
 
 config = Config(
@@ -10,7 +9,6 @@ config = Config(
         HighThroughputExecutor(
             label='theta_local_htex_multinode',
             max_workers=4,
-            address=address_by_hostname(),
             provider=CobaltProvider(
                 queue='YOUR_QUEUE',
                 account='YOUR_ACCOUNT',

--- a/parsl/tests/configs/ad_hoc_cluster_htex.py
+++ b/parsl/tests/configs/ad_hoc_cluster_htex.py
@@ -1,7 +1,6 @@
 from parsl.providers import AdHocProvider
 from parsl.channels import SSHChannel
 from parsl.executors import HighThroughputExecutor
-from parsl.addresses import address_by_query
 from parsl.config import Config
 
 from typing import Any, Dict
@@ -18,7 +17,6 @@ config = Config(
         HighThroughputExecutor(
             label='remote_htex',
             max_workers=2,
-            address=address_by_query(),
             worker_logdir_root=user_opts['adhoc']['script_dir'],
             provider=AdHocProvider(
                 # Command to be run before starting a worker, such as:

--- a/parsl/tests/configs/bluewaters.py
+++ b/parsl/tests/configs/bluewaters.py
@@ -1,6 +1,5 @@
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
-from parsl.addresses import address_by_hostname
 from parsl.launchers import AprunLauncher
 from parsl.providers import TorqueProvider
 
@@ -15,7 +14,6 @@ def fresh_config():
                 cores_per_worker=1,
                 worker_debug=False,
                 max_workers=1,
-                address=address_by_hostname(),
                 provider=TorqueProvider(
                     queue='normal',
                     launcher=AprunLauncher(overrides="-b -- bwpy-environ --"),

--- a/parsl/tests/configs/comet.py
+++ b/parsl/tests/configs/comet.py
@@ -2,7 +2,6 @@ from parsl.config import Config
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
 from parsl.executors import HighThroughputExecutor
-from parsl.addresses import address_by_query
 from .user_opts import user_opts
 
 
@@ -11,7 +10,6 @@ def fresh_config():
         executors=[
             HighThroughputExecutor(
                 label='Comet_HTEX_multinode',
-                address=address_by_query(),
                 max_workers=1,
                 provider=SlurmProvider(
                     'debug',

--- a/parsl/tests/configs/cooley_htex.py
+++ b/parsl/tests/configs/cooley_htex.py
@@ -2,7 +2,6 @@
 
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
-from parsl.addresses import address_by_hostname
 from parsl.launchers import MpiRunLauncher
 from parsl.providers import CobaltProvider
 from parsl.tests.utils import get_rundir
@@ -20,7 +19,6 @@ config = Config(
             label="cooley_htex",
             worker_debug=False,
             cores_per_worker=1,
-            address=address_by_hostname(),
             provider=CobaltProvider(
                 queue='debug',
                 account=user_opts['cooley']['account'],

--- a/parsl/tests/configs/frontera.py
+++ b/parsl/tests/configs/frontera.py
@@ -3,7 +3,6 @@ from parsl.channels import LocalChannel
 from parsl.providers import SlurmProvider
 from parsl.executors import HighThroughputExecutor
 from parsl.launchers import SrunLauncher
-from parsl.addresses import address_by_hostname
 
 from .user_opts import user_opts
 """ This config assumes that it is used to launch parsl tasks from the login nodes
@@ -16,7 +15,6 @@ def fresh_config():
         executors=[
             HighThroughputExecutor(
                 label="frontera_htex",
-                address=address_by_hostname(),
                 max_workers=1,
                 provider=SlurmProvider(
                     cmd_timeout=60,     # Add extra time for slow scheduler responses

--- a/parsl/tests/configs/midway.py
+++ b/parsl/tests/configs/midway.py
@@ -1,7 +1,6 @@
 from parsl.config import Config
 from parsl.providers import SlurmProvider
 from parsl.launchers import SrunLauncher
-from parsl.addresses import address_by_hostname
 from parsl.executors import HighThroughputExecutor
 
 from .user_opts import user_opts
@@ -13,7 +12,6 @@ def fresh_config():
             HighThroughputExecutor(
                 label='Midway_HTEX_multinode',
                 worker_debug=False,
-                address=address_by_hostname(),
                 max_workers=1,
                 provider=SlurmProvider(
                     'broadwl',  # Partition name, e.g 'broadwl'

--- a/parsl/tests/configs/osg_htex.py
+++ b/parsl/tests/configs/osg_htex.py
@@ -1,7 +1,6 @@
 from parsl.config import Config
 from parsl.providers import CondorProvider
 from parsl.executors import HighThroughputExecutor
-from parsl.addresses import address_by_query
 from parsl.tests.utils import get_rundir
 
 # If you are a developer running tests, make sure to update parsl/tests/configs/user_opts.py
@@ -15,7 +14,6 @@ config = Config(
     executors=[
         HighThroughputExecutor(
             label='OSG_HTEX',
-            address=address_by_query(),
             max_workers=1,
             provider=CondorProvider(
                 nodes_per_block=1,

--- a/parsl/tests/configs/theta.py
+++ b/parsl/tests/configs/theta.py
@@ -2,7 +2,6 @@ from parsl.config import Config
 from parsl.providers import CobaltProvider
 from parsl.launchers import AprunLauncher
 from parsl.executors import HighThroughputExecutor
-from parsl.addresses import address_by_hostname
 
 from .user_opts import user_opts
 
@@ -13,7 +12,6 @@ def fresh_config():
             HighThroughputExecutor(
                 label='theta_local_htex_multinode',
                 max_workers=1,
-                address=address_by_hostname(),
                 provider=CobaltProvider(
                     queue=user_opts['theta']['queue'],
                     account=user_opts['theta']['account'],

--- a/parsl/tests/manual_tests/test_ad_hoc_htex.py
+++ b/parsl/tests/manual_tests/test_ad_hoc_htex.py
@@ -6,7 +6,6 @@ from parsl.providers import AdHocProvider
 from parsl.channels import SSHChannel
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
-from parsl.addresses import address_by_query
 
 remotes = ['midway2-login2.rcc.uchicago.edu', 'midway2-login1.rcc.uchicago.edu']
 
@@ -15,7 +14,6 @@ config = Config(
         HighThroughputExecutor(
             label='AdHoc',
             max_workers=2,
-            address=address_by_query(),
             worker_logdir_root="/scratch/midway2/yadunand/parsl_scripts",
             provider=AdHocProvider(
                 worker_init="source /scratch/midway2/yadunand/parsl_env_setup.sh",

--- a/parsl/tests/manual_tests/test_dynamic_executor.py
+++ b/parsl/tests/manual_tests/test_dynamic_executor.py
@@ -6,7 +6,6 @@ from parsl.providers import LocalProvider
 from parsl.app.app import python_app
 from parsl.launchers import SrunLauncher
 from parsl.providers.slurm.slurm import SlurmProvider
-from parsl.addresses import address_by_hostname
 
 
 config = Config(
@@ -80,7 +79,6 @@ if __name__ == "__main__":
             label="midway_htex",
             # worker_debug=True,
             cores_per_worker=1,
-            address=address_by_hostname(),
             provider=SlurmProvider(
                 'broadwl',
                 launcher=SrunLauncher(),

--- a/parsl/tests/manual_tests/test_fan_in_out_htex_remote.py
+++ b/parsl/tests/manual_tests/test_fan_in_out_htex_remote.py
@@ -4,7 +4,6 @@ from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.launchers import AprunLauncher
 from parsl.providers import CobaltProvider
-from parsl.addresses import address_by_hostname
 
 import logging
 from parsl.app.app import python_app
@@ -17,7 +16,6 @@ def local_setup():
                 label="theta_htex",
                 # worker_debug=True,
                 cores_per_worker=4,
-                address=address_by_hostname(),
                 provider=CobaltProvider(
                     queue='debug-flat-quad',
                     account='CSC249ADCD01',
@@ -33,7 +31,6 @@ def local_setup():
             )
         ],
         monitoring=MonitoringHub(
-            hub_address=address_by_hostname(),
             hub_port=55055,
             logging_level=logging.DEBUG,
             resource_monitoring_interval=10),


### PR DESCRIPTION
Pertaining to issue #1754. I made sure to remove all instances of `address_by_hostname` and `address_by_query` from code base. This is an amendment to a previous pull request, but I couldn't figure out how to fix the old one so I closed it and made a new one. :)

Let me know if there are any remaining issues and I will update accordingly.