### PR TITLE
Removing serialization exception logging for every attempt

### DIFF
--- a/parsl/serialize/facade.py
+++ b/parsl/serialize/facade.py
@@ -83,7 +83,6 @@ class ParslSerializer(object):
                     # We attempt a deserialization to make sure both work.
                     method.deserialize(serialized)
                 except Exception as e:
-                    logger.exception(f"Serialization method: {method} did not work")
                     last_exception = e
                     continue
                 else:
@@ -94,7 +93,6 @@ class ParslSerializer(object):
                 try:
                     serialized = method.serialize(obj)
                 except Exception as e:
-                    logger.exception(f"Serialization method {method} did not work")
                     last_exception = e
                     continue
                 else:


### PR DESCRIPTION
# Description

The parsl.serialize module, tries a sequence of serializations methods and whenever a serialization method failed, existing behavior is to log the exception to the parsl.log which can be confusing to users since this was added only for debug. This PR
removes these logging lines completely. The module reports the exception from the last serialization method if all serialization
methods fail.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)