### PR TITLE
Don't enable WQ resource monitor if autolabel=False

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -672,7 +672,7 @@ def _work_queue_submit_wait(task_queue=multiprocessing.Queue(),
     if wq_log_dir is not None:
         wq_master_log = os.path.join(wq_log_dir, "master_log")
         wq_trans_log = os.path.join(wq_log_dir, "transaction_log")
-        if full:
+        if full and autolabel:
             wq_resource_log = os.path.join(wq_log_dir, "resource_logs")
             q.enable_monitoring_full(dirname=wq_resource_log)
         q.specify_log(wq_master_log)


### PR DESCRIPTION
Fixes #1842.

Before, the WQ resource monitor would be enabled if debugging was enabled. We only want it enabled if `autolabel=True`.

## Type of change

- New feature (non-breaking change that adds functionality)
