### PR TITLE
Allow user to specify the resource for each task with workqueue executor

### DIFF
--- a/docs/userguide/configuring.rst
+++ b/docs/userguide/configuring.rst
@@ -202,7 +202,7 @@ To activate this feature, add resource specifications to your apps:
    .. code-block:: python
 
       @python_app
-      def compute(x, parsl_resource_specification={'cores': 1, 'memory': '1000', 'disk': '1000'}):
+      def compute(x, parsl_resource_specification={'cores': 1, 'memory': 1000, 'disk': 1000}):
           return x*2
 
 Note that ``cores``, ``memory``, and ``disk`` must be specified simultaneously if you want to use this feature,
@@ -212,16 +212,16 @@ The explanations and units for these three types of resources are listed below:
     .. code-block:: JSON
 
         {
-            "cores": "the number of cores",
-            "memory": "memory size in MB", 
-            "disk": "disk size in MB"
+            "cores": "the number of cores, type is int",
+            "memory": "memory size in MB, type is int", 
+            "disk": "disk size in MB, type is int"
         }
 
 Besides, you can also specify the resources when invoking your apps. Take the ``compute(x)`` as an example:
 
    .. code-block:: python
 
-      spec = {'cores': 1, 'memory': '500', 'disk': '500'}
+      spec = {'cores': 1, 'memory': 500, 'disk': 500}
       future = compute(x, parsl_resource_specification=spec)
 
 This ``parsl_resource_specification`` special keyword argument will inform Work Queue about the resources this app requires.

--- a/docs/userguide/configuring.rst
+++ b/docs/userguide/configuring.rst
@@ -202,11 +202,31 @@ To activate this feature, add resource specifications to your apps:
    .. code-block:: python
 
       @python_app
-      def compute(x, parsl_resource_specification={'cores': 1, 'memory': '1GiB', 'disk': '1GiB'}):
+      def compute(x, parsl_resource_specification={'cores': 1, 'memory': '1000', 'disk': '1000'}):
           return x*2
 
-This special keyword argument will inform Work Queue about the resources this app requires.
+Note that ``cores``, ``memory``, and ``disk`` must be specified simultaneously if you want to use this feature,
+and ``parsl_resource_specification`` only supports specifying these three types of resources (case-insensitive) currently.
+The explanations and units for these three types of resources are listed below:
+
+    .. code-block:: JSON
+
+        {
+            "cores": "the number of cores",
+            "memory": "memory size in MB", 
+            "disk": "disk size in MB"
+        }
+
+Besides, you can also specify the resources when invoking your apps. Take the ``compute(x)`` as an example:
+
+   .. code-block:: python
+
+      spec = {'cores': 1, 'memory': '500', 'disk': '500'}
+      future = compute(x, parsl_resource_specification=spec)
+
+This ``parsl_resource_specification`` special keyword argument will inform Work Queue about the resources this app requires.
 When placing instances of ``compute(x)``, Work Queue will run as many parallel instances as possible based on each worker node's available resources.
+
 If an app's resource requirements are not known in advance,
 Work Queue has an auto-labeling feature that measures the actual resource usage of your apps and automatically chooses resource labels for you.
 With auto-labeling, it is not necessary to provide ``parsl_resource_specification``;

--- a/docs/userguide/configuring.rst
+++ b/docs/userguide/configuring.rst
@@ -197,7 +197,10 @@ By default, Parsl only runs one app at a time on each worker node.
 However, it is possible to specify the requirements for a particular app,
 and Work Queue will automatically run as many parallel instances as possible on each node.
 Work Queue automatically detects the amount of cores, memory, and other resources available on each execution node.
-To activate this feature, add resource specifications to your apps:
+To activate this feature, add a resource specification to your apps. A resource specification is a dictionary with
+the following three (case-insensitive) keys: ``cores`` (an integer corresponding to the number of cores required by the task),
+``memory`` (an integer corresponding to the task's memory requirement in MB), and ``disk`` (an integer corresponding to
+the task's disk requirement in MB), passed to an app via the special keyword argument ``parsl_resource_specification``. The specification can be set for all app invocations via a default, for example:
 
    .. code-block:: python
 
@@ -205,19 +208,8 @@ To activate this feature, add resource specifications to your apps:
       def compute(x, parsl_resource_specification={'cores': 1, 'memory': 1000, 'disk': 1000}):
           return x*2
 
-Note that ``cores``, ``memory``, and ``disk`` must be specified simultaneously if you want to use this feature,
-and ``parsl_resource_specification`` only supports specifying these three types of resources (case-insensitive) currently.
-The explanations and units for these three types of resources are listed below:
 
-    .. code-block:: JSON
-
-        {
-            "cores": "the number of cores, type is int",
-            "memory": "memory size in MB, type is int", 
-            "disk": "disk size in MB, type is int"
-        }
-
-Besides, you can also specify the resources when invoking your apps. Take the ``compute(x)`` as an example:
+or updated when the app is invocated:
 
    .. code-block:: python
 

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -343,9 +343,13 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
                                           "three resources to be specified simultaneously: cores, memory, and disk, "
                                           "and only takes these three resource types.")
 
-            cores = resource_specification['cores']
-            memory = resource_specification['memory']
-            disk = resource_specification['disk']
+            for k in keys:
+                if k.lower() == 'cores':
+                    cores = resource_specification[k]
+                elif k.lower() == 'memory':
+                    memory = resource_specification[k]
+                elif k.lower() == 'disk':
+                    disk = resource_specification[k]
 
         self.task_counter += 1
         task_id = self.task_counter

--- a/parsl/tests/test_error_handling/test_resource_spec.py
+++ b/parsl/tests/test_error_handling/test_resource_spec.py
@@ -1,6 +1,6 @@
 import parsl
 from parsl.app.app import python_app
-#from parsl.tests.configs.local_threads import config
+# from parsl.tests.configs.local_threads import config
 # from parsl.tests.configs.htex_local import config
 from parsl.tests.configs.workqueue_ex import config
 from parsl.executors.errors import UnsupportedFeatureError, ExecutorError
@@ -25,11 +25,9 @@ def test_resource(n=2):
     fut = double(n, parsl_resource_specification=spec)
     try:
         fut.result()
-    except UnsupportedFeatureError as e:
-        print(e)
+    except UnsupportedFeatureError:
         assert not isinstance(executor, WorkQueueExecutor)
     except Exception as e:
-        print(e)
         assert isinstance(e, ExecutorError)
 
     # Specify resources with wrong types
@@ -38,11 +36,9 @@ def test_resource(n=2):
     fut = double(n, parsl_resource_specification=spec)
     try:
         fut.result()
-    except UnsupportedFeatureError as e:
-        print(e)
+    except UnsupportedFeatureError:
         assert not isinstance(executor, WorkQueueExecutor)
     except Exception as e:
-        print(e)
         assert isinstance(e, ExecutorError)
 
     # Correct specification
@@ -50,8 +46,7 @@ def test_resource(n=2):
     fut = double(n, parsl_resource_specification=spec)
     try:
         fut.result()
-    except UnsupportedFeatureError as e:
-        print(e)
+    except UnsupportedFeatureError:
         assert not isinstance(executor, WorkQueueExecutor)
     else:
         assert isinstance(executor, WorkQueueExecutor)

--- a/parsl/tests/test_error_handling/test_resource_spec.py
+++ b/parsl/tests/test_error_handling/test_resource_spec.py
@@ -1,8 +1,8 @@
 import parsl
 from parsl.app.app import python_app
 # from parsl.tests.configs.local_threads import config
-# from parsl.tests.configs.htex_local import config
-from parsl.tests.configs.workqueue_ex import config
+from parsl.tests.configs.htex_local import config
+# from parsl.tests.configs.workqueue_ex import config
 from parsl.executors.errors import UnsupportedFeatureError, ExecutorError
 from parsl.executors import WorkQueueExecutor
 

--- a/parsl/tests/test_error_handling/test_resource_spec.py
+++ b/parsl/tests/test_error_handling/test_resource_spec.py
@@ -41,8 +41,8 @@ def test_resource(n=2):
     except Exception as e:
         assert isinstance(e, ExecutorError)
 
-    # Correct specification
-    spec = {'cores': 2, 'memory': 1000, 'disk': 1000}
+    # Correct specification, case insensitive
+    spec = {'COREs': 2, 'MEMory': 1000, 'Disk': 1000}
     fut = double(n, parsl_resource_specification=spec)
     try:
         fut.result()

--- a/parsl/tests/test_error_handling/test_resource_spec.py
+++ b/parsl/tests/test_error_handling/test_resource_spec.py
@@ -1,7 +1,9 @@
 import parsl
 from parsl.app.app import python_app
-from parsl.tests.configs.local_threads import config
-from parsl.executors.errors import UnsupportedFeatureError
+#from parsl.tests.configs.local_threads import config
+# from parsl.tests.configs.htex_local import config
+from parsl.tests.configs.workqueue_ex import config
+from parsl.executors.errors import UnsupportedFeatureError, ExecutorError
 from parsl.executors import WorkQueueExecutor
 
 
@@ -11,19 +13,47 @@ def double(x, parsl_resource_specification={}):
 
 
 def test_resource(n=2):
-    spec = {'cores': 2, 'memory': '1GiB'}
+    executors = parsl.dfk().executors
+    executor = None
+    for label in executors:
+        if label != 'data_manager':
+            executor = executors[label]
+            break
+
+    # Specify incorrect number of resources
+    spec = {'cores': 2, 'memory': 1000}
     fut = double(n, parsl_resource_specification=spec)
     try:
         fut.result()
+    except UnsupportedFeatureError as e:
+        print(e)
+        assert not isinstance(executor, WorkQueueExecutor)
     except Exception as e:
-        assert isinstance(e, UnsupportedFeatureError)
+        print(e)
+        assert isinstance(e, ExecutorError)
+
+    # Specify resources with wrong types
+    # cpus is incorrect
+    spec = {'cpus': 2, 'memory': 1000, 'disk': 1000}
+    fut = double(n, parsl_resource_specification=spec)
+    try:
+        fut.result()
+    except UnsupportedFeatureError as e:
+        print(e)
+        assert not isinstance(executor, WorkQueueExecutor)
+    except Exception as e:
+        print(e)
+        assert isinstance(e, ExecutorError)
+
+    # Correct specification
+    spec = {'cores': 2, 'memory': 1000, 'disk': 1000}
+    fut = double(n, parsl_resource_specification=spec)
+    try:
+        fut.result()
+    except UnsupportedFeatureError as e:
+        print(e)
+        assert not isinstance(executor, WorkQueueExecutor)
     else:
-        executors = parsl.dfk().executors
-        executor = None
-        for label in executors:
-            if label != 'data_manager':
-                executor = executors[label]
-                break
         assert isinstance(executor, WorkQueueExecutor)
 
 

--- a/parsl/tests/test_error_handling/test_resource_spec.py
+++ b/parsl/tests/test_error_handling/test_resource_spec.py
@@ -31,7 +31,7 @@ def test_resource(n=2):
         assert isinstance(e, ExecutorError)
 
     # Specify resources with wrong types
-    # cpus is incorrect
+    # 'cpus' is incorrect, should be 'cores'
     spec = {'cpus': 2, 'memory': 1000, 'disk': 1000}
     fut = double(n, parsl_resource_specification=spec)
     try:


### PR DESCRIPTION
# Description

This PR allows users to specify the resource usage for each task in workqueue executor.

Users can define an app as:

```
@python_app
def double(x, parsl_resource_specification={}):
    return x * 2
```

Then when the app is submitted, the resource specification is like:

```
spec = {'cores': 2, 'memory': 1000, 'disk': 1000}
fut = double(n, parsl_resource_specification=spec)
```

## Type of change

Choose which options apply, and delete the ones which do not apply.


- New feature (non-breaking change that adds functionality)

