### PR TITLE
Add JOBNAME to local provider 

### DIFF
--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -206,7 +206,7 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
         script_path = "{0}/{1}.sh".format(self.script_dir, job_name)
         script_path = os.path.abspath(script_path)
 
-        wrap_command = self.worker_init + '\n' + self.launcher(command, tasks_per_node, self.nodes_per_block)
+        wrap_command = self.worker_init + f'\nJOBNAME=${job_name}\n' + self.launcher(command, tasks_per_node, self.nodes_per_block)
 
         self._write_submit_script(wrap_command, script_path)
 

--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -206,7 +206,7 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
         script_path = "{0}/{1}.sh".format(self.script_dir, job_name)
         script_path = os.path.abspath(script_path)
 
-        wrap_command = self.worker_init + f'\nJOBNAME=${job_name}\n' + self.launcher(command, tasks_per_node, self.nodes_per_block)
+        wrap_command = self.worker_init + f'\nexport JOBNAME=${job_name}\n' + self.launcher(command, tasks_per_node, self.nodes_per_block)
 
         self._write_submit_script(wrap_command, script_path)
 


### PR DESCRIPTION
# Description

Unlike the other providers, LocalProvider does not set a JOBNAME environment variable. This causes havoc with some launchers that use the JOBNAME variable.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
