### PR TITLE
fix a bug that task_hashsum is missing in monitoring task table

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -383,7 +383,8 @@ class DatabaseManager:
                                  columns=['task_time_invoked',
                                           'task_time_returned',
                                           'run_id', 'task_id',
-                                          'task_fail_count'],
+                                          'task_fail_count',
+                                          'task_hashsum'],
                                  messages=task_info_update_messages)
                 logger.debug("Inserting {} task_info_all_messages into status table".format(len(task_info_all_messages)))
 


### PR DESCRIPTION
# Description

PR #1727 tries to insert task info into task table when task is created. But that PR failed to update the `task_hashsum` in the task table. This PR fixes the bug and update `task_hashsum` in task table.

Fix #1850 

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change that fixes an issue)

