### PR TITLE
Generalise staging inhibiting to work in more cases

### DIFF
--- a/parsl/data_provider/ftp.py
+++ b/parsl/data_provider/ftp.py
@@ -25,7 +25,7 @@ class FTPSeparateTaskStaging(Staging, RepresentationMixin):
         else:
             file.local_path = file.filename
         stage_in_app = _ftp_stage_in_app(dm, executor=executor)
-        app_fut = stage_in_app(working_dir, outputs=[file], staging_inhibit_output=True, parent_fut=parent_fut)
+        app_fut = stage_in_app(working_dir, outputs=[file], _parsl_staging_inhibit=True, parent_fut=parent_fut)
         return app_fut._outputs[0]
 
 
@@ -68,7 +68,7 @@ def in_task_transfer_wrapper(func, file, working_dir):
     return wrapper
 
 
-def _ftp_stage_in(working_dir, parent_fut=None, outputs=[], staging_inhibit_output=True):
+def _ftp_stage_in(working_dir, parent_fut=None, outputs=[], _parsl_staging_inhibit=True):
     file = outputs[0]
     if working_dir:
         os.makedirs(working_dir, exist_ok=True)

--- a/parsl/data_provider/globus.py
+++ b/parsl/data_provider/globus.py
@@ -212,14 +212,14 @@ class GlobusStaging(Staging, RepresentationMixin):
         globus_provider = _get_globus_provider(dm.dfk, executor)
         globus_provider._update_local_path(file, executor, dm.dfk)
         stage_in_app = globus_provider._globus_stage_in_app(executor=executor, dfk=dm.dfk)
-        app_fut = stage_in_app(outputs=[file], staging_inhibit_output=True, parent_fut=parent_fut)
+        app_fut = stage_in_app(outputs=[file], _parsl_staging_inhibit=True, parent_fut=parent_fut)
         return app_fut._outputs[0]
 
     def stage_out(self, dm, executor, file, app_fu):
         globus_provider = _get_globus_provider(dm.dfk, executor)
         globus_provider._update_local_path(file, executor, dm.dfk)
         stage_out_app = globus_provider._globus_stage_out_app(executor=executor, dfk=dm.dfk)
-        return stage_out_app(app_fu, inputs=[file])
+        return stage_out_app(app_fu, _parsl_staging_inhibit=True, inputs=[file])
 
     @typeguard.typechecked
     def __init__(self, endpoint_uuid: str, endpoint_path: Optional[str] = None, local_path: Optional[str] = None):
@@ -271,7 +271,7 @@ class GlobusStaging(Staging, RepresentationMixin):
 # this cannot be a class method, but must be a function, because I want
 # to be able to use partial() on it - and partial() does not work on
 # class methods
-def _globus_stage_in(provider, executor, parent_fut=None, outputs=[], staging_inhibit_output=True):
+def _globus_stage_in(provider, executor, parent_fut=None, outputs=[], _parsl_staging_inhibit=True):
     globus_ep = provider._get_globus_endpoint(executor)
     file = outputs[0]
     dst_path = os.path.join(
@@ -284,7 +284,7 @@ def _globus_stage_in(provider, executor, parent_fut=None, outputs=[], staging_in
             file.path, dst_path)
 
 
-def _globus_stage_out(provider, executor, app_fu, inputs=[]):
+def _globus_stage_out(provider, executor, app_fu, inputs=[], _parsl_staging_inhibit=True):
     """
     Although app_fu isn't directly used in the stage out code,
     it is needed as an input dependency to ensure this code

--- a/parsl/data_provider/http.py
+++ b/parsl/data_provider/http.py
@@ -28,7 +28,7 @@ class HTTPSeparateTaskStaging(Staging, RepresentationMixin):
             file.local_path = file.filename
 
         stage_in_app = _http_stage_in_app(dm, executor=executor)
-        app_fut = stage_in_app(working_dir, outputs=[file], staging_inhibit_output=True, parent_fut=parent_fut)
+        app_fut = stage_in_app(working_dir, outputs=[file], _parsl_staging_inhibit=True, parent_fut=parent_fut)
         return app_fut._outputs[0]
 
 
@@ -73,7 +73,7 @@ def in_task_transfer_wrapper(func, file, working_dir):
     return wrapper
 
 
-def _http_stage_in(working_dir, parent_fut=None, outputs=[], staging_inhibit_output=True):
+def _http_stage_in(working_dir, parent_fut=None, outputs=[], _parsl_staging_inhibit=True):
     file = outputs[0]
     if working_dir:
         os.makedirs(working_dir, exist_ok=True)

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -374,7 +374,7 @@ class DataFlowKernel(object):
 
     @staticmethod
     def check_staging_inhibited(kwargs):
-        return kwargs.get('staging_inhibit_output', False)
+        return kwargs.get('_parsl_staging_inhibit', False)
 
     def launch_if_ready(self, task_id):
         """
@@ -521,8 +521,9 @@ class DataFlowKernel(object):
         """
 
         # Return if the task is a data management task, rather than doing
-        # data managament on it.
-        if executor == 'data_manager':
+        #  data management on it.
+        if self.check_staging_inhibited(kwargs):
+            logger.debug("Not performing input staging")
             return args, kwargs, func
 
         inputs = kwargs.get('inputs', [])
@@ -569,7 +570,7 @@ class DataFlowKernel(object):
                 if newfunc:
                     func = newfunc
             else:
-                logger.debug("Not performing staging for: {}".format(repr(f)))
+                logger.debug("Not performing output staging for: {}".format(repr(f)))
                 app_fut._outputs.append(DataFuture(app_fut, f, tid=app_fut.tid))
         return func
 


### PR DESCRIPTION
When a task has input or output files, then file staging elaboration
may add in new tasks to perform that input or output staging.

Those new tasks should not themselves be further elaborated by
the staging mechanism, otherwise inappropriate staging behaviour
might be added in around the staging tasks themselves.

Prior to this inhibition, this inhibition of staging happens in
two ways, differently for stage-in and stage-out.

If the task is assigned to the 'data_manager' executor,
then no staging-in elaboration is performed on that task.

If a task has a 'staging_inhibit_output=True' keyword argument,
then no staging-out elaboration is performed on that task.

It turns out that check for the 'data_manager' executor is
not a very good test, for a couple of reasons:

  Stage-out tasks can run on arbitrary executors, just like stage-in
  tasks. It just so happens that no staging providers do that:
  HTTP/FTP have arbitrary executor stage-in tasks, but not arbitrary
  stage-out tasks; and globus staging tasks always run in the
  'data_manager' executor. If a stage-out task from some other
  staging provider runs on an arbitrary executor, then stage-in
  elaboration will not be inhibited, and a new stage-in task may
  be generated to stage in the file that is being staged out. This
  is wrong. PR#1855 adds a test to demonstrate this.

  Upcoming work for @join_apps wants to use that executor for
  executing user supplied tasks for which staging might be expected
  to happen.

The core of this PR is a change around like 524 of dflow.py
which changes stage-in elaboration to be controlled by the presence
of a boolean inhibit keyword arg, as for staging-out elaboration.

The rest of the PR renames that keywrd arg from staging_inhibit_output
to a more general and internal-looking _parsl_inhibit_staging, and
adds that annotation onto the globus stage-out code where the previous
mechanism would have inhibited it.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
