### PR TITLE
Rename data_manager executor for more general use

### DIFF
--- a/parsl/config.py
+++ b/parsl/config.py
@@ -32,8 +32,9 @@ class Config(RepresentationMixin):
     checkpoint_period : str, optional
         Time interval (in "HH:MM:SS") at which to checkpoint completed tasks. Only has an effect if
         `checkpoint_mode='periodic'`.
-    data_management_max_threads : int, optional
-        Maximum number of threads to allocate for the data manager to use for managing input and output transfers.
+    internal_tasks_max_threads : int, optional
+        Maximum number of threads to allocate for submit side internal tasks such as some data transfers
+        or @joinapps
         Default is 10.
     monitoring : MonitoringHub, optional
         The config to use for database monitoring. Default is None which does not log to a database.
@@ -67,7 +68,7 @@ class Config(RepresentationMixin):
                  checkpoint_files: Optional[List[str]] = None,
                  checkpoint_mode: Optional[str] = None,
                  checkpoint_period: Optional[str] = None,
-                 data_management_max_threads: int = 10,
+                 internal_tasks_max_threads: int = 10,
                  retries: int = 0,
                  run_dir: str = 'runinfo',
                  strategy: Optional[str] = 'simple',
@@ -93,7 +94,7 @@ class Config(RepresentationMixin):
         if checkpoint_mode == 'periodic' and checkpoint_period is None:
             checkpoint_period = "00:30:00"
         self.checkpoint_period = checkpoint_period
-        self.data_management_max_threads = data_management_max_threads
+        self.internal_tasks_max_threads = internal_tasks_max_threads
         self.retries = retries
         self.run_dir = run_dir
         self.strategy = strategy

--- a/parsl/data_provider/globus.py
+++ b/parsl/data_provider/globus.py
@@ -231,12 +231,12 @@ class GlobusStaging(Staging, RepresentationMixin):
     def _globus_stage_in_app(self, executor, dfk):
         executor_obj = dfk.executors[executor]
         f = partial(_globus_stage_in, self, executor_obj)
-        return python_app(executors=['data_manager'], data_flow_kernel=dfk)(f)
+        return python_app(executors=['_parsl_internal'], data_flow_kernel=dfk)(f)
 
     def _globus_stage_out_app(self, executor, dfk):
         executor_obj = dfk.executors[executor]
         f = partial(_globus_stage_out, self, executor_obj)
-        return python_app(executors=['data_manager'], data_flow_kernel=dfk)(f)
+        return python_app(executors=['_parsl_internal'], data_flow_kernel=dfk)(f)
 
     # could this happen at __init__ time?
     def initialize_globus(self):

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -163,8 +163,8 @@ class DataFlowKernel(object):
 
         self.executors = {}
         self.data_manager = DataManager(self)
-        data_manager_executor = ThreadPoolExecutor(max_threads=config.data_management_max_threads, label='data_manager')
-        self.add_executors(config.executors + [data_manager_executor])
+        parsl_internal_executor = ThreadPoolExecutor(max_threads=config.internal_tasks_max_threads, label='_parsl_internal')
+        self.add_executors(config.executors + [parsl_internal_executor])
 
         if self.checkpoint_mode == "periodic":
             try:
@@ -707,7 +707,7 @@ class DataFlowKernel(object):
         task_id = self.task_count
         self.task_count += 1
         if isinstance(executors, str) and executors.lower() == 'all':
-            choices = list(e for e in self.executors if e != 'data_manager')
+            choices = list(e for e in self.executors if e != '_parsl_internal')
         elif isinstance(executors, list):
             choices = executors
         else:

--- a/parsl/tests/test_error_handling/test_resource_spec.py
+++ b/parsl/tests/test_error_handling/test_resource_spec.py
@@ -16,7 +16,7 @@ def test_resource(n=2):
     executors = parsl.dfk().executors
     executor = None
     for label in executors:
-        if label != 'data_manager':
+        if label != '_parsl_internal':
             executor = executors[label]
             break
 


### PR DESCRIPTION
An upcoming PR to implement monad-like joins needs to execute tasks locally inside the submitting
process, just like the data_manager local executor is used for when performing some staging tasks
(globus ones).

This PR renames that local executor from data_manager to _parsl_internal to reflect that intended
broader use.

## Type of change

- Breaking change:  any external file staging providers which expect to use `data_manager` as an executor name need to change to use `_parsl_internal`
- Code maintentance/cleanup
