### PR TITLE
Fixes #1857 by setting remote func.__name__ manually

### DIFF
--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -129,6 +129,7 @@ class BashApp(AppBase):
         # this is done to avoid passing a function type in the args which parsl.serializer
         # doesn't support
         remote_fn = partial(update_wrapper(remote_side_bash_executor, self.func), self.func)
+        remote_fn.__name__ = self.func.__name__
         self.wrapped_remote_function = wrap_error(remote_fn)
 
     def __call__(self, *args, **kwargs):

--- a/parsl/tests/configs/local_threads.py
+++ b/parsl/tests/configs/local_threads.py
@@ -1,9 +1,13 @@
 from parsl.config import Config
 from parsl.executors.threads import ThreadPoolExecutor
+from parsl.tests.utils import get_rundir
 
 
 def fresh_config():
-    return Config(executors=[ThreadPoolExecutor()])
+    return Config(
+        executors=[ThreadPoolExecutor()],
+        run_dir=get_rundir(),
+    )
 
 
 config = fresh_config()


### PR DESCRIPTION
# Description

Manually set `func.__name__` to fix Parsl stdout log filename issue when `parsl.AUTO_LOGNAME` is set in bash_apps
Added a test case to validate the stdout format when `parsl.AUTO_LOGNAME` is set

Fixes #1857 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
