### PR TITLE
Add note on installation of parsl-visualize dependencies

### DIFF
--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -53,8 +53,13 @@ configuration. Here the `MonitoringHub` is specified to use port
 Visualization
 -------------
 
-To view the web dashboard while or after a Parsl program has executed, you
-need to first run the ``parsl-visualize`` utility::
+To run the web dashboard utility ``parsl-visualize`` you first need to install
+its dependencies:
+
+   $ pip install parsl[monitoring]
+
+To view the web dashboard while or after a Parsl program has executed, run
+the ``parsl-visualize`` utility::
 
    $ parsl-visualize
 


### PR DESCRIPTION
# Description

It was not mentioned in the docs that `parsl-visualize` has some more dependencies and hot to install them.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Documentation update
