### PR TITLE
breaking out the max_retries loop in zmq_pipe after message is successfully sent

### DIFF
--- a/parsl/executors/high_throughput/zmq_pipes.py
+++ b/parsl/executors/high_throughput/zmq_pipes.py
@@ -66,6 +66,8 @@ class CommandClient(object):
                     self.context.destroy()
                     self.context = zmq.Context()
                     self.create_socket_and_bind()
+                else:
+                    break
 
         if reply == '__PARSL_ZMQ_PIPES_MAGIC__':
             logger.error("Command channel run retries exhausted. Unable to run command")


### PR DESCRIPTION
# Description

Prior to this PR, the zmq_pipe would try to send every message three times regardless of whether it is sent successfully or not.
So for example, I saw three `hold_worker` logs in `interchange.log`  when dfk was exiting,
```
2020-09-24 17:24:15.871 interchange:329 [INFO]  [CMD] Received HOLD_WORKER for b'f924c9740a62'
2020-09-24 17:24:15.872 interchange:329 [INFO]  [CMD] Received HOLD_WORKER for b'f924c9740a62'
2020-09-24 17:24:15.872 interchange:329 [INFO]  [CMD] Received HOLD_WORKER for b'f924c9740a62'
```
while `parsl.log` indicated that only one `hold_worker` command was sent via the command channel
```
2020-09-24 17:24:15.871 parsl.executors.high_throughput.executor:517 [DEBUG]  [HOLD_BLOCK]: Sending hold to manager: f924c9740a62
2020-09-24 17:24:15.873 parsl.executors.high_throughput.executor:486 [DEBUG]  Sent hold request to worker: f924c9740a62
```

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
