### PR TITLE
Fix the correct reference of kwargs in python apps dfk.submit and include parsl_resource_specification by default

### DIFF
--- a/parsl/app/app.py
+++ b/parsl/app/app.py
@@ -67,6 +67,8 @@ class AppBase(metaclass=ABCMeta):
             self.kwargs['stderr'] = params['stderr'].default
         if 'walltime' in params:
             self.kwargs['walltime'] = params['walltime'].default
+        if 'parsl_resource_specification' in params:
+            self.kwargs['parsl_resource_specification'] = params['parsl_resource_specification'].default
         self.outputs = params['outputs'].default if 'outputs' in params else []
         self.inputs = params['inputs'].default if 'inputs' in params else []
 

--- a/parsl/app/python.py
+++ b/parsl/app/python.py
@@ -76,6 +76,6 @@ class PythonApp(AppBase):
                              fn_hash=self.func_hash,
                              cache=self.cache,
                              ignore_for_cache=self.ignore_for_cache,
-                             app_kwargs=kwargs)
+                             app_kwargs=invocation_kwargs)
 
         return app_fut


### PR DESCRIPTION
# Description

Prior to this PR, if you declare a python app with the default kwarg `parsl_resource_specification` and invoke the app without using this kwarg, parsl disregards the resource specification. This PR fixes the issue.


## Type of change

- Bug fix (non-breaking change that fixes an issue)

