### PR TITLE
Refresh the list of useful top level re-exports for usability

### DIFF
--- a/parsl/__init__.py
+++ b/parsl/__init__.py
@@ -20,12 +20,14 @@ import platform
 
 from parsl.version import VERSION
 from parsl.app.app import bash_app, python_app
+from parsl.config import Config
 from parsl.executors import ThreadPoolExecutor
-from parsl.executors import IPyParallelExecutor
 from parsl.executors import HighThroughputExecutor
 from parsl.executors import ExtremeScaleExecutor
+from parsl.executors import WorkQueueExecutor
 from parsl.log_utils import set_stream_logger
 from parsl.log_utils import set_file_logger
+from parsl.monitoring import MonitoringHub
 
 from parsl.data_provider.files import File
 
@@ -43,6 +45,7 @@ __all__ = [
     'python_app',
 
     # core
+    'Config',
     'DataFlowKernel',
     'File',
 
@@ -55,7 +58,10 @@ __all__ = [
     'ThreadPoolExecutor',
     'HighThroughputExecutor',
     'ExtremeScaleExecutor',
-    'IPyParallelExecutor',
+    'WorkQueueExecutor',
+
+    # monitoring
+    'MonitoringHub',
 ]
 
 clear = DataFlowKernelLoader.clear


### PR DESCRIPTION
# Description

This PR makes some more common parsl symbols re-exported at the top level, meaning that users can write more concise imports.

## Type of change

- New feature (non-breaking change that adds functionality)
