### PR TITLE
Let worker handle monitoring first message exception directly and raise the exception to task exception

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -492,6 +492,7 @@ def monitor(pid,
 
     if first_message:
         msg = {'run_id': run_id,
+               'try_id': try_id,
                'task_id': task_id,
                'hostname': platform.node(),
                'first_msg': first_message,

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -301,16 +301,13 @@ class MonitoringHub(RepresentationMixin):
         """
         def wrapped(*args, **kwargs):
             # Send first message to monitoring router
-            try:
-                monitor(os.getpid(),
-                        task_id,
-                        monitoring_hub_url,
-                        run_id,
-                        logging_level,
-                        sleep_dur,
-                        first_message=True)
-            except Exception:
-                pass
+            monitor(os.getpid(),
+                    task_id,
+                    monitoring_hub_url,
+                    run_id,
+                    logging_level,
+                    sleep_dur,
+                    first_message=True)
 
             # create the monitor process and start
             p = Process(target=monitor,

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -302,6 +302,7 @@ class MonitoringHub(RepresentationMixin):
         def wrapped(*args, **kwargs):
             # Send first message to monitoring router
             monitor(os.getpid(),
+                    try_id,
                     task_id,
                     monitoring_hub_url,
                     run_id,


### PR DESCRIPTION
# Description

In PR #1839 , we changed the mechanism for monitoring's first message (used to infer the running time of a task). However, that PR silently ignores the exception for monitoring first message.

This PR lets the worker handle monitoring first message exception directly and reports back the exception to the user along with the task.

## Type of change
- Bug fix (non-breaking change that fixes an issue)

