### PR TITLE
Log stdout/err paths at task start as well as at completion

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -507,6 +507,9 @@ class DataFlowKernel(object):
         self._send_task_log_info(self.tasks[task_id])
 
         logger.info("Task {} launched on executor {}".format(task_id, executor.label))
+
+        self._log_std_streams(self.tasks[task_id])
+
         return exec_fu
 
     def _add_input_deps(self, executor, args, kwargs, func):

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -325,10 +325,7 @@ class DataFlowKernel(object):
             with task_record['app_fu']._update_lock:
                 task_record['app_fu'].set_result(future.result())
 
-        if task_record['app_fu'].stdout is not None:
-            logger.info("Standard output for task {} available at {}".format(task_id, task_record['app_fu'].stdout))
-        if task_record['app_fu'].stderr is not None:
-            logger.info("Standard error for task {} available at {}".format(task_id, task_record['app_fu'].stderr))
+        self._log_std_streams(task_record)
 
         # record current state for this task after we're done: maybe a new try, or maybe the old try marked as failed
         self._send_task_log_info(task_record)
@@ -1140,6 +1137,13 @@ class DataFlowKernel(object):
             raise BadCheckpoint("checkpointDirs expects a list of checkpoints")
 
         return self._load_checkpoints(checkpointDirs)
+
+    @staticmethod
+    def _log_std_streams(task_record):
+        if task_record['app_fu'].stdout is not None:
+            logger.info("Standard output for task {} available at {}".format(task_record['id'], task_record['app_fu'].stdout))
+        if task_record['app_fu'].stderr is not None:
+            logger.info("Standard error for task {} available at {}".format(task_record['id'], task_record['app_fu'].stderr))
 
 
 class DataFlowKernelLoader(object):


### PR DESCRIPTION
This is useful when examining long running tasks which did not complete,
for example because the workflow process crashed or was killed.

## Type of change

- New feature (non-breaking change that adds functionality)
