### PR TITLE
Fix memo test that did not correctly enable caching

### DIFF
--- a/parsl/tests/test_python_apps/test_memoize_5.py
+++ b/parsl/tests/test_python_apps/test_memoize_5.py
@@ -9,22 +9,25 @@ def test_python_memoization(n=2):
     """Testing python memoization when func bodies differ
     This is the canonical use case.
     """
-    @python_app
-    def random_uuid(x, cache=True):
+    @python_app(cache=True)
+    def random_uuid(x):
         import uuid
         return str(uuid.uuid4())
 
     x = random_uuid(0)
+    x.result()  # allow x to complete to allow completion-time memoization to happen
+    z = random_uuid(0)
+    assert x.result() == z.result(), "Memoized results were not used"
     print(x.result())
 
-    @python_app
-    def random_uuid(x, cache=True):
+    @python_app(cache=True)
+    def random_uuid(x):
         import uuid
         print("hi")
         return str(uuid.uuid4())
 
     y = random_uuid(0)
-    assert x.result() != y.result(), "Memoized results were not used"
+    assert x.result() != y.result(), "Memoized results were incorrectly used"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This test attempts to check that caching does not happen when
a function is redefined, but it was not enabling caching at all
because cache=True was in the wrong place.

This PR puts cache=True into the right place, and adds another
assertion that checks that caching *is* working when the function
is not redefined.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
