### PR TITLE
Fixed mismatch in state_file name

### DIFF
--- a/parsl/providers/aws/aws.py
+++ b/parsl/providers/aws/aws.py
@@ -210,7 +210,7 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
         We do not want to create a new VPC and new identical security groups, so we save
         information about them in a file between runs.
         """
-        fh = open('awsproviderstate.json', 'w')
+        fh = open(self.state_file, 'w')
         state = {}
         state['vpcID'] = self.vpc_id
         state['sgID'] = self.sg_id

--- a/parsl/providers/aws/aws.py
+++ b/parsl/providers/aws/aws.py
@@ -139,7 +139,7 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
         self.launcher = launcher
         self.linger = linger
         self.resources = {}
-        self.state_file = state_file if state_file is not None else '.ec2_{}.json'.format(self.label)
+        self.state_file = state_file if state_file is not None else 'awsproviderstate.json'
 
         env_specified = os.getenv("AWS_ACCESS_KEY_ID") is not None and os.getenv("AWS_SECRET_ACCESS_KEY") is not None
         if profile is None and key_file is None and not env_specified:


### PR DESCRIPTION
# Description

This pull request will fix a mismatch of state_file names in the AWS provider config. 

Context:
1. When someone initialises a AWS Provider Object, the code looks for a file named 'ec2_{name}.json' to see if a VPC has already been created or not. 
2. If it doesn't find a file of that name, it'll create a new VPC and save the information in a file called 'awsproviderstate.json'.

The problem here is that, the code looks for a state file name ('ec2_{name}.json') that is never created because a new VPC is always stored in 'awsproviderstate.json'. This means that the code will NEVER find the json file by default and it always ends up creating a new VPC. This means that the user will hit their VPC limit very quickly.

Fixes: By making the state_file name consistent between the 'code that creates VPCs' and 'code that looks for existing VPCs', it  will pull up existing VPCs rather than creating a new one everytime.

## Type of change
- Bug fix (non-breaking change that fixes an issue)