### PR TITLE
Remove task future from executor once completed

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -387,7 +387,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                             self.set_bad_state_and_fail_all(exception)
                             break
 
-                        task_fut = self.tasks[tid]
+                        task_fut = self.tasks.pop(tid)
 
                         if 'result' in msg:
                             result = deserialize(msg['result'])


### PR DESCRIPTION
# Description

Changes HTEX to remove references to a task after it completes. Could otherwise lead to memory issue if task outputs are large.

Fixes # (issue) [Would you like me to open one?]

## Type of change

- Bug fix (non-breaking change that fixes an issue)
