### PR TITLE
Dedupe requirements between requirements and test-requirements.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ virtualenv: ## create an activate a virtual env
 	echo "Run 'source $(VENV)/bin/activate' to activate the virtual environment"
 
 
-$(DEPS): test-requirements.txt
+$(DEPS): test-requirements.txt requirements.txt
 	pip3 install --upgrade pip
-	pip3 install -r test-requirements.txt
+	pip3 install -r test-requirements.txt -r requirements.txt
 	touch $(DEPS)
 
 .PHONY: deps

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,12 +11,5 @@ sphinx_rtd_theme
 mypy==0.761
 sqlalchemy-stubs
 Sphinx==2.2.0
-typeguard>=2.5
-paramiko
-dill
-tblib
-psutil>=5.5.1
-globus-sdk
 twine
 wheel
-pyzmq>=17.1.2


### PR DESCRIPTION
PR #1638 added several packages to test-requirements that were already
listed in requirements.txt - probably as part of an attempt to avoid
performing a parsl installation (which would lead to the requirements.txt
requirements being installed) before running tests.

This PR removes those duplicates and explicitly installs requirements.txt
alongside test-requirements.txt.

This removes some of the need to manually maintain the image of
requirements.txt inside test-requirements.txt

## Type of change

- Code maintentance/cleanup
