### PR TITLE
Take _get_messages_in_batch parameters from self implicitly

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -319,9 +319,7 @@ class DatabaseManager:
             reprocessable_first_resource_messages = []
 
             # Get a batch of priority messages
-            priority_messages = self._get_messages_in_batch(self.pending_priority_queue,
-                                                            interval=self.batching_interval,
-                                                            threshold=self.batching_threshold)
+            priority_messages = self._get_messages_in_batch(self.pending_priority_queue)
             if priority_messages:
                 logger.debug(
                     "Got {} messages from priority queue".format(len(priority_messages)))
@@ -410,9 +408,7 @@ class DatabaseManager:
             NODE_INFO messages
 
             """
-            node_info_messages = self._get_messages_in_batch(self.pending_node_queue,
-                                                             interval=self.batching_interval,
-                                                             threshold=self.batching_threshold)
+            node_info_messages = self._get_messages_in_batch(self.pending_node_queue)
             if node_info_messages:
                 logger.debug(
                     "Got {} messages from node queue".format(len(node_info_messages)))
@@ -422,9 +418,7 @@ class DatabaseManager:
             Resource info messages
 
             """
-            resource_messages = self._get_messages_in_batch(self.pending_resource_queue,
-                                                            interval=self.batching_interval,
-                                                            threshold=self.batching_threshold)
+            resource_messages = self._get_messages_in_batch(self.pending_resource_queue)
 
             if resource_messages:
                 logger.debug(
@@ -514,11 +508,11 @@ class DatabaseManager:
             except Exception:
                 logger.exception("Rollback failed")
 
-    def _get_messages_in_batch(self, msg_queue, interval=1, threshold=99999):
+    def _get_messages_in_batch(self, msg_queue):
         messages = []
         start = time.time()
         while True:
-            if time.time() - start >= interval or len(messages) >= threshold:
+            if time.time() - start >= self.batching_interval or len(messages) >= self.batching_threshold:
                 break
             try:
                 x = msg_queue.get(timeout=0.1)


### PR DESCRIPTION
self._get_messages_in_batch was always called with batching parameters
coming from self, so invocations look cleaner if that method looks up
the batching parameters directly.

## Type of change

- Code maintentance/cleanup
