### PR TITLE
Log choice of executor for a task as soon as it is chosen

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -713,7 +713,7 @@ class DataFlowKernel(object):
         else:
             raise ValueError("Task {} supplied invalid type for executors: {}".format(task_id, type(executors)))
         executor = random.choice(choices)
-        logger.info("Task {} will be sent to executor {}".format(task_id, executor))
+        logger.debug("Task {} will be sent to executor {}".format(task_id, executor))
 
         # The below uses func.__name__ before it has been wrapped by any staging code.
 

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -713,6 +713,7 @@ class DataFlowKernel(object):
         else:
             raise ValueError("Task {} supplied invalid type for executors: {}".format(task_id, type(executors)))
         executor = random.choice(choices)
+        logger.info("Task {} will be sent to executor {}".format(task_id, executor))
 
         # The below uses func.__name__ before it has been wrapped by any staging code.
 


### PR DESCRIPTION
Previously this was not logged until after the task had been
successfully submitted.

## Type of change

- New feature (non-breaking change that adds functionality)
