### PR TITLE
Add more serialisation vs importlib testcases

### DIFF
--- a/parsl/tests/test_callables.py
+++ b/parsl/tests/test_callables.py
@@ -41,7 +41,7 @@ def test_check_import_module_function_partial():
     app(partial(some_aux_func, 1)).result()
 
 
-def test_check_importlib_function():
+def test_check_importlib_file_function():
     helper_path = pathlib.Path(__file__).parent / "callables_helper.py"
     spec = importlib.util.spec_from_file_location("dynamically_loaded_module", helper_path)
     module = importlib.util.module_from_spec(spec)
@@ -50,10 +50,22 @@ def test_check_importlib_function():
     app(some_aux_func).result()
 
 
-def test_check_importlib_function_partial():
+def test_check_importlib_file_function_partial():
     helper_path = pathlib.Path(__file__).parent / "callables_helper.py"
     spec = importlib.util.spec_from_file_location("dynamically_loaded_module", helper_path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+    some_aux_func = module.some_aux_func
+    app(partial(some_aux_func, 1)).result()
+
+
+def test_check_importlib_module_function():
+    module = importlib.import_module("parsl.tests.callables_helper")
+    some_aux_func = module.some_aux_func
+    app(some_aux_func).result()
+
+
+def test_check_importlib_module_partial():
+    module = importlib.import_module("parsl.tests.callables_helper")
     some_aux_func = module.some_aux_func
     app(partial(some_aux_func, 1)).result()


### PR DESCRIPTION
These new casese reflect a different way that importlib is now used in the
LSST DRP workflow, based on the ongoing discovery of problems related to
the new serialisation mechanism in PR #1806.

## Type of change

- New feature (non-breaking change that adds functionality)
