### PR TITLE
Correct create_monitoring_info args in ParslExecutor

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -908,7 +908,7 @@ class DataFlowKernel(object):
                 new_status = {}
                 for jid in jids:
                     new_status[jid] = JobStatus(JobState.PENDING)
-                msg = executor.create_monitoring_info(new_status)
+                msg = executor.create_monitoring_info(new_status, block_id_type='external')
                 logger.debug("Sending monitoring message {} to hub from DFK".format(msg))
                 self.monitoring.send(MessageType.BLOCK_INFO, msg)
         self.flowcontrol.add_executors(executors)

--- a/parsl/dataflow/task_status_poller.py
+++ b/parsl/dataflow/task_status_poller.py
@@ -77,7 +77,7 @@ class PollItem(ExecutorStatus):
             new_status = {}
             for id in ids:
                 new_status[id] = JobStatus(JobState.PENDING)
-            self.send_monitoring_info(new_status)
+            self.send_monitoring_info(new_status, block_id_type='external')
             self._status.update(new_status)
         return ids
 

--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -103,7 +103,7 @@ class ParslExecutor(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def create_monitoring_info(self, status: Dict[object, JobStatus]) -> List[object]:
+    def create_monitoring_info(self, status: Dict[object, JobStatus], block_id_type: str) -> List[object]:
         """Create a monitoring message for each block based on the poll status.
 
         :return: a list of dictionaries mapping to the info of each block

--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -102,13 +102,12 @@ class ParslExecutor(metaclass=ABCMeta):
         """
         pass
 
-    @abstractmethod
     def create_monitoring_info(self, status: Dict[object, JobStatus], block_id_type: str) -> List[object]:
         """Create a monitoring message for each block based on the poll status.
 
         :return: a list of dictionaries mapping to the info of each block
         """
-        pass
+        return []
 
     @abstractmethod
     def status(self) -> Dict[object, JobStatus]:

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -77,9 +77,6 @@ class StatusHandlingExecutor(ParslExecutor):
 
         return status
 
-    def create_monitoring_info(self, status: Dict[object, JobStatus], block_id_type: str) -> List[object]:
-        return []
-
     def set_bad_state_and_fail_all(self, exception: Exception):
         logger.exception("Exception: {}".format(exception))
         self._executor_exception = exception
@@ -154,9 +151,6 @@ class NoStatusHandlingExecutor(ParslExecutor):
 
     def status(self):
         return {}
-
-    def create_monitoring_info(self, status: Dict[object, JobStatus], block_id_type: str) -> List[object]:
-        return []
 
     def handle_errors(self, error_handler: "parsl.dataflow.job_error_handler.JobErrorHandler",
                       status: Dict[Any, JobStatus]) -> bool:

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -77,9 +77,6 @@ class StatusHandlingExecutor(ParslExecutor):
 
         return status
 
-    def create_monitoring_info(self, status: Dict[object, JobStatus]) -> List[object]:
-        return []
-
     def set_bad_state_and_fail_all(self, exception: Exception):
         logger.exception("Exception: {}".format(exception))
         self._executor_exception = exception
@@ -154,9 +151,6 @@ class NoStatusHandlingExecutor(ParslExecutor):
 
     def status(self):
         return {}
-
-    def create_monitoring_info(self, status: Dict[object, JobStatus]) -> List[object]:
-        return []
 
     def handle_errors(self, error_handler: "parsl.dataflow.job_error_handler.JobErrorHandler",
                       status: Dict[Any, JobStatus]) -> bool:

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -77,6 +77,9 @@ class StatusHandlingExecutor(ParslExecutor):
 
         return status
 
+    def create_monitoring_info(self, status: Dict[object, JobStatus], block_id_type: str) -> List[object]:
+        return []
+
     def set_bad_state_and_fail_all(self, exception: Exception):
         logger.exception("Exception: {}".format(exception))
         self._executor_exception = exception
@@ -151,6 +154,9 @@ class NoStatusHandlingExecutor(ParslExecutor):
 
     def status(self):
         return {}
+
+    def create_monitoring_info(self, status: Dict[object, JobStatus], block_id_type: str) -> List[object]:
+        return []
 
     def handle_errors(self, error_handler: "parsl.dataflow.job_error_handler.JobErrorHandler",
                       status: Dict[Any, JobStatus]) -> bool:


### PR DESCRIPTION
# Description

`create_monitoring_info` has a block_id_type parameter, but that isn't the case for ParslExecutor.

This PR corrects the issue.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
