### PR TITLE
Add name tags to AWS VPCs

### DIFF
--- a/docs/stubs/parsl.providers.AWSProvider.rst
+++ b/docs/stubs/parsl.providers.AWSProvider.rst
@@ -16,8 +16,10 @@ parsl.providers.AWSProvider
       ~AWSProvider.__init__
       ~AWSProvider.cancel
       ~AWSProvider.config_route_table
+      ~AWSProvider.create_name_tag_spec
       ~AWSProvider.create_session
       ~AWSProvider.create_vpc
+      ~AWSProvider.generate_aws_id
       ~AWSProvider.get_instance_state
       ~AWSProvider.goodbye
       ~AWSProvider.initialize_boto_client

--- a/parsl/providers/aws/aws.py
+++ b/parsl/providers/aws/aws.py
@@ -363,6 +363,8 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
         ----------
         vpc : VPC instance
             VPC in which to set up security group.
+        name : str
+            Name tag for the newly created security group.
         """
 
         tag_spec = self.create_name_tag_spec('security-group', name)
@@ -709,9 +711,30 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
         os.remove(self.config['state_file_path'])
 
     def generate_aws_id(self):
+        """Generate a new ID for AWS resources.
+
+        Returns
+        -------
+        str
+            An ID of the form 'parsl.aws.123456.789' for giving resources unique identifiers.
+        """
         return "parsl.aws.{0}".format(time.time())
 
     def create_name_tag_spec(self, resource_type, name):
+        """Create a new tag specification for a resource name.
+
+        Parameters
+        ----------
+        resource_type : str
+            The AWS resource type
+        name : str
+            The name to assign to the resource
+
+        Returns
+        -------
+        record
+            A TagSpecifications record to be passed into the creation of a new AWS resource.
+        """
         return [{"ResourceType": resource_type, "Tags": [{'Key': 'Name', 'Value': name}]}]
 
     @property

--- a/parsl/providers/aws/aws.py
+++ b/parsl/providers/aws/aws.py
@@ -286,11 +286,16 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
         Security groups are configured in function security_group.
         """
 
+        vpc_name = self.generate_aws_id()
+
         try:
+            tag_spec = self.create_name_tag_spec('vpc', vpc_name)
+
             # We use a large VPC so that the cluster can get large
             vpc = self.ec2.create_vpc(
                 CidrBlock='10.0.0.0/16',
                 AmazonProvidedIpv6CidrBlock=False,
+                TagSpecifications=tag_spec,
             )
         except Exception as e:
             # This failure will cause a full abort
@@ -313,10 +318,14 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
         # go through AZs and set up a subnet per
         for num, zone in enumerate(availability_zones['AvailabilityZones']):
             if zone['State'] == "available":
+                zone_name = zone['ZoneName']
+                tag_spec = self.create_name_tag_spec('subnet', '{0}.{1}'.format(vpc_name, zone_name))
 
                 # Create a large subnet (4000 max nodes)
                 subnet = vpc.create_subnet(
-                    CidrBlock='10.0.{}.0/20'.format(16 * num), AvailabilityZone=zone['ZoneName']
+                    CidrBlock='10.0.{}.0/20'.format(16 * num),
+                    AvailabilityZone=zone_name,
+                    TagSpecifications=tag_spec,
                 )
 
                 # Make subnet accessible
@@ -329,11 +338,19 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
             else:
                 logger.info("{} unavailable".format(zone['ZoneName']))
         # Security groups
-        self.security_group(vpc)
+        security_group_iterator = vpc.security_groups.all()
+        for security_group in security_group_iterator:
+            # this can only be the default security group for this VPC,
+            # since no other security groups have been created yet
+            security_group.create_tags(
+                Tags=[{'Key': 'Name', 'Value': '{0}.default'.format(vpc_name)}],
+            )
+
+        self.security_group(vpc, vpc_name)
         self.vpc_id = vpc.id
         return vpc
 
-    def security_group(self, vpc):
+    def security_group(self, vpc, name):
         """Create and configure a new security group.
 
         Allows all ICMP in, all TCP and UDP in within VPC.
@@ -348,8 +365,12 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
             VPC in which to set up security group.
         """
 
+        tag_spec = self.create_name_tag_spec('security-group', name)
+
         sg = vpc.create_security_group(
-            GroupName="private-subnet", Description="security group for remote executors"
+            GroupName="private-subnet",
+            Description="security group for remote executors",
+            TagSpecifications=tag_spec,
         )
 
         ip_ranges = [{'CidrIp': '10.0.0.0/16'}]
@@ -470,7 +491,7 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
             logger.warning("Exceeded instance limit ({}). Cannot continue\n".format(self.max_nodes))
             return [None]
         try:
-            tag_spec = [{"ResourceType": "instance", "Tags": [{'Key': 'Name', 'Value': job_name}]}]
+            tag_spec = self.create_name_tag_spec('instance', job_name)
 
             instance = self.ec2.create_instances(
                 MinCount=1,
@@ -484,7 +505,7 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
                 InstanceMarketOptions=spot_options,
                 InstanceInitiatedShutdownBehavior='terminate',
                 IamInstanceProfile={'Arn': self.iam_instance_profile_arn},
-                UserData=command
+                UserData=command,
             )
         except ClientError as e:
             print(e)
@@ -584,7 +605,7 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
             If at capacity, None will be returned. Otherwise, the job identifier will be returned.
         """
 
-        job_name = "parsl.aws.{0}".format(time.time())
+        job_name = self.generate_aws_id()
         wrapped_cmd = self.launcher(command,
                                     tasks_per_node,
                                     self.nodes_per_block)
@@ -686,6 +707,12 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
             raise e
         self.show_summary()
         os.remove(self.config['state_file_path'])
+
+    def generate_aws_id(self):
+        return "parsl.aws.{0}".format(time.time())
+
+    def create_name_tag_spec(self, resource_type, name):
+        return [{"ResourceType": resource_type, "Tags": [{'Key': 'Name', 'Value': name}]}]
 
     @property
     def label(self):


### PR DESCRIPTION
# Description

Adds a name tag of the form "parsl.aws.123456.789" for the newly created VPC. The same is done for associated security groups and subnets.

Fixes https://github.com/Parsl/parsl/issues/1135

## Type of change

- New feature (non-breaking change that adds functionality)
