### PR TITLE
htex task prioritisation prototype

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -16,8 +16,7 @@ from parsl.executors.high_throughput import zmq_pipes
 from parsl.executors.high_throughput import interchange
 from parsl.executors.errors import (
     BadMessage, ScalingFailed,
-    DeserializationError, SerializationError,
-    UnsupportedFeatureError
+    DeserializationError, SerializationError
 )
 
 from parsl.executors.status_handling import StatusHandlingExecutor
@@ -542,12 +541,6 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         Returns:
               Future
         """
-        if resource_specification:
-            logger.error("Ignoring the resource specification. "
-                         "Parsl resource specification is not supported in HighThroughput Executor. "
-                         "Please check WorkQueueExecutor if resource specification is needed.")
-            raise UnsupportedFeatureError('resource specification', 'HighThroughput Executor', 'WorkQueue Executor')
-
         if self.bad_state_is_set:
             raise self.executor_exception
 
@@ -568,8 +561,15 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         except TypeError:
             raise SerializationError(func.__name__)
 
+        if resource_specification and "priority" in resource_specification:
+            priority = resource_specification["priority"]
+            logger.debug("Priority {} found in resource specification".format(priority))
+        else:
+            priority = None
+
         msg = {"task_id": task_id,
-               "buffer": fn_buf}
+               "buffer": fn_buf,
+               "priority": priority}
 
         # Post task to the the outgoing queue
         self.outgoing_q.put(msg)

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+import functools
 import zmq
 import os
 import sys
@@ -85,6 +86,38 @@ class VersionMismatch(Exception):
 
     def __str__(self):
         return self.__repr__()
+
+
+@functools.total_ordering
+class PriorityQueueEntry:
+    """ This class is needed because msg will be a dict, and dicts are not
+    comparable to each other (and if they were, this would be an unnecessary
+    expense because the queue only cares about priority). It provides
+    ordering of the priority ignoring the message content, and implements an
+    ordering that places None behind all other orderings, for use as a default
+    value"""
+    def __init__(self, pri, msg):
+        self.pri = pri
+        self.msg = msg
+
+    def __eq__(self, other):
+        if type(self) != type(other):
+            return NotImplemented
+        return self.pri == other.pri
+
+    def __lt__(self, other):
+        # this is deliberately inverted, so that largest priority number comes out of the queue first
+        if type(self) != type(other):
+            return NotImplemented
+        if self.pri is None:  # special case so that None is always less than every other value
+            return False  # we are more than populated priorities, and equal to None, the inverse of <
+        elif self.pri is not None and other.pri is None:
+            return True
+        else:  # self/other both not None
+            c = self.pri.__gt__(other.pri)
+            if c == NotImplemented:
+                raise RuntimeError("priority values are not comparable: {} vs {}".format(self.pri, other.pri))
+            return c
 
 
 class Interchange(object):
@@ -189,7 +222,7 @@ class Interchange(object):
             self.monitoring_enabled = True
             logger.info("Monitoring enabled and connected to hub")
 
-        self.pending_task_queue = queue.Queue(maxsize=10 ** 6)
+        self.pending_task_queue = queue.PriorityQueue(maxsize=10 ** 6)
 
         self.worker_ports = worker_ports
         self.worker_port_range = worker_port_range
@@ -247,11 +280,11 @@ class Interchange(object):
         tasks = []
         for i in range(0, count):
             try:
-                x = self.pending_task_queue.get(block=False)
+                qe = self.pending_task_queue.get(block=False)
             except queue.Empty:
                 break
             else:
-                tasks.append(x)
+                tasks.append(qe.msg)
 
         return tasks
 
@@ -281,7 +314,7 @@ class Interchange(object):
                 kill_event.set()
                 break
             else:
-                self.pending_task_queue.put(msg)
+                self.pending_task_queue.put(PriorityQueueEntry(msg['priority'], msg))
                 task_counter += 1
                 logger.debug("[TASK_PULL_THREAD] Fetched task:{}".format(task_counter))
 

--- a/parsl/tests/test_error_handling/test_resource_spec.py
+++ b/parsl/tests/test_error_handling/test_resource_spec.py
@@ -1,4 +1,5 @@
 import parsl
+import pytest
 from parsl.app.app import python_app
 # from parsl.tests.configs.local_threads import config
 from parsl.tests.configs.htex_local import config
@@ -12,6 +13,11 @@ def double(x, parsl_resource_specification={}):
     return x * 2
 
 
+@pytest.mark.skip("this test does not accomodate running the test suite"
+                  " on executors which *do* support resource specifications"
+                  " but are not the workqueue executor. In general, it is"
+                  " incorrect to assume that an arbitrary non-workqueue"
+                  " executor will raise the expected exceptionm")
 def test_resource(n=2):
     executors = parsl.dfk().executors
     executor = None


### PR DESCRIPTION
This patch has been in LSST parsl since around July 2020.

It allows explicit prioritisation of queued htex tasks, overriding the implicit queue order that was sometimes confusing/undesired in the complicated submission patterns of LSST work.

This has been used in a couple of ways: to prioritise/group all tasks of a particular type, and to prioritise/group all apps associated with a particular subset of data.

I'm putting it up for review as a draft PR because I haven't reviewed this for general usability.