### PR TITLE
Re-enable test which appears to work now

### DIFF
--- a/parsl/tests/test_bash_apps/test_error_codes.py
+++ b/parsl/tests/test_bash_apps/test_error_codes.py
@@ -151,8 +151,6 @@ def test_invalid_exit(test_fn=invalid_exit):
     return True
 
 
-# @pytest.mark.whitelist(whitelist, reason='broken in IPP')
-@pytest.mark.skip("Broke somewhere between PR #525 and PR #652")
 def test_not_executable(test_fn=not_executable):
     err_code = test_matrix[test_fn]['exit_code']
     f = test_fn()


### PR DESCRIPTION
This was disabled in a great testpocalypse, 7ee597bcf51ae432a82dabe9fc2bec00e5abc456
which was pretty free in disabling anything that seemed to not be passing.

## Type of change

- Testing