### PR TITLE
Fix Example WQ Configuration

### DIFF
--- a/parsl/configs/wqex_local.py
+++ b/parsl/configs/wqex_local.py
@@ -4,11 +4,10 @@ from parsl.executors import WorkQueueExecutor
 config = Config(
     executors=[
         WorkQueueExecutor(
-            label="wqex_local",
-            port=50055,
-            project_name="WorkQueue Example",
-            shared_fs=True,
-            see_worker_output=True
+            label="parsl_wq_example",
+            port=9123,
+            project_name="parsl_wq_example",
+            shared_fs=False
         )
     ]
 )


### PR DESCRIPTION
The current WQ example configuration does not work out of the box.
This fixes it:
- project_name should not have spaces
- shared_fs should be false by default for robustness
- see_worker_output is not a valid flag.