### PR TITLE
Split worker-side monitoring message code based on purpose

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -315,14 +315,10 @@ class MonitoringHub(RepresentationMixin):
         """
         def wrapped(*args: List[Any], **kwargs: Dict[str, Any]) -> Any:
             # Send first message to monitoring router
-            monitor(os.getpid(),
-                    try_id,
-                    task_id,
-                    monitoring_hub_url,
-                    run_id,
-                    logging_level,
-                    sleep_dur,
-                    first_message=True)
+            send_first_message(try_id,
+                               task_id,
+                               monitoring_hub_url,
+                               run_id)
 
             # create the monitor process and start
             p = Process(target=monitor,
@@ -527,40 +523,47 @@ def router_starter(comm_q: "queue.Queue[Union[Tuple[int, int], str]]",
     router.logger.info("End of router_starter")
 
 
+def send_first_message(try_id: int,
+                       task_id: int,
+                       monitoring_hub_url: str,
+                       run_id: str) -> None:
+    import platform
+
+    radio = UDPRadio(monitoring_hub_url,
+                     source_id=task_id)
+
+    msg = {'run_id': run_id,
+           'try_id': try_id,
+           'task_id': task_id,
+           'hostname': platform.node(),
+           'first_msg': True,
+           'timestamp': datetime.datetime.now()
+    }
+    radio.send(msg)
+    return
+
+
 def monitor(pid: int,
             try_id: int,
             task_id: int,
             monitoring_hub_url: str,
             run_id: str,
             logging_level: int = logging.INFO,
-            sleep_dur: float = 10,
-            first_message: bool = False) -> None:
+            sleep_dur: float = 10) -> None:
     """Internal
     Monitors the Parsl task's resources by pointing psutil to the task's pid and watching it and its children.
     """
+    import logging
     import platform
+    import psutil
     import time
 
     radio = UDPRadio(monitoring_hub_url,
                      source_id=task_id)
 
-    if first_message:
-        msg = {'run_id': run_id,
-               'try_id': try_id,
-               'task_id': task_id,
-               'hostname': platform.node(),
-               'first_msg': first_message,
-               'timestamp': datetime.datetime.now()
-        }
-        radio.send(msg)
-        return
-
-    import psutil
-    import logging
-
     format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
     logging.basicConfig(filename='{logbase}/monitor.{task_id}.{pid}.log'.format(
-        logbase="/tmp", task_id=task_id, pid=pid), level=logging_level, format=format_string)
+        logbase="/tmp", task_id=task_id, pid=pid), level=logging.DEBUG, format=format_string)
 
     logging.debug("start of monitor")
 
@@ -585,7 +588,7 @@ def monitor(pid: int,
             d["try_id"] = try_id
             d['resource_monitoring_interval'] = sleep_dur
             d['hostname'] = platform.node()
-            d['first_msg'] = first_message
+            d['first_msg'] = False
             d['timestamp'] = datetime.datetime.now()
 
             logging.debug("getting children")

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -563,7 +563,7 @@ def monitor(pid: int,
 
     format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
     logging.basicConfig(filename='{logbase}/monitor.{task_id}.{pid}.log'.format(
-        logbase="/tmp", task_id=task_id, pid=pid), level=logging.DEBUG, format=format_string)
+        logbase="/tmp", task_id=task_id, pid=pid), level=logging_level, format=format_string)
 
     logging.debug("start of monitor")
 


### PR DESCRIPTION
Prior to this patch, monitor() performed two functions, selected by a boolean
parameter:

i) It sends a task running message, which is used to populate the task_try_running
database field.

ii) It performs periodic monitoring of the process tree that is executing the
task.

These two code paths are fairly clearly separate, and do not need to both be in
monitor.

This PR is preparation for future PRs which allow worker-side monitoring to
report task start time without forking a resource monitoring process.

## Type of change

- Code maintentance/cleanup
