### PR TITLE
Rework hub_channel usage to be more obviously thread safe

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -181,14 +181,6 @@ class Interchange(object):
         self.hub_address = hub_address
         self.hub_port = hub_port
 
-        self.monitoring_enabled = False
-        if hub_address and hub_port:
-            self.hub_channel = self.context.socket(zmq.DEALER)
-            self.hub_channel.set_hwm(0)
-            self.hub_channel.connect("tcp://{}:{}".format(hub_address, hub_port))
-            self.monitoring_enabled = True
-            logger.info("Monitoring enabled and connected to hub")
-
         self.pending_task_queue = queue.Queue(maxsize=10 ** 6)
 
         self.worker_ports = worker_ports
@@ -285,12 +277,23 @@ class Interchange(object):
                 task_counter += 1
                 logger.debug("[TASK_PULL_THREAD] Fetched task:{}".format(task_counter))
 
-    def _send_monitoring_info(self, manager):
-        if self.monitoring_enabled:
+    def _create_monitoring_channel(self):
+        if self.hub_address and self.hub_port:
+            logger.info("Connecting to monitoring")
+            hub_channel = self.context.socket(zmq.DEALER)
+            hub_channel.set_hwm(0)
+            hub_channel.connect("tcp://{}:{}".format(self.hub_address, self.hub_port))
+            logger.info("Monitoring enabled and connected to hub")
+            return hub_channel
+        else:
+            return None
+
+    def _send_monitoring_info(self, hub_channel, manager):
+        if hub_channel:
             logger.info("Sending message {} to hub".format(self._ready_manager_queue[manager]))
-            self.hub_channel.send_pyobj((MessageType.NODE_INFO,
-                                         datetime.datetime.now(),
-                                         self._ready_manager_queue[manager]))
+            hub_channel.send_pyobj((MessageType.NODE_INFO,
+                                    datetime.datetime.now(),
+                                    self._ready_manager_queue[manager]))
 
     def _command_server(self, kill_event):
         """ Command server to run async command to the interchange
@@ -298,13 +301,7 @@ class Interchange(object):
         logger.debug("[COMMAND] Command Server Starting")
 
         # Need to create a new ZMQ socket for command server thread
-        monitoring_enabled = False
-        if self.hub_address and self.hub_port:
-            hub_channel = self.context.socket(zmq.DEALER)
-            hub_channel.set_hwm(0)
-            hub_channel.connect("tcp://{}:{}".format(self.hub_address, self.hub_port))
-            monitoring_enabled = True
-            logger.info("[COMMAND] Monitoring enabled and connected to hub")
+        hub_channel = self._create_monitoring_channel()
 
         while not kill_event.is_set():
             try:
@@ -343,11 +340,7 @@ class Interchange(object):
                     if manager in self._ready_manager_queue:
                         self._ready_manager_queue[manager]['active'] = False
                         reply = True
-                        if monitoring_enabled:
-                            logger.info("[COMMAND] Sending message {} to hub".format(self._ready_manager_queue[manager]))
-                            hub_channel.send_pyobj((MessageType.NODE_INFO,
-                                                    datetime.datetime.now(),
-                                                    self._ready_manager_queue[manager]))
+                        self._send_monitoring_info(hub_channel, manager)
                     else:
                         reply = False
 
@@ -375,6 +368,8 @@ class Interchange(object):
         TODO: Move task receiving to a thread
         """
         logger.info("Incoming ports bound")
+
+        hub_channel = self._create_monitoring_channel()
 
         if poll_period is None:
             poll_period = self.poll_period
@@ -439,7 +434,7 @@ class Interchange(object):
                         logger.info("[MAIN] Adding manager: {} to ready queue".format(manager))
                         self._ready_manager_queue[manager].update(msg)
                         logger.info("[MAIN] Registration info for manager {}: {}".format(manager, msg))
-                        self._send_monitoring_info(manager)
+                        self._send_monitoring_info(hub_channel, manager)
 
                         if (msg['python_v'].rsplit(".", 1)[0] != self.current_platform['python_v'].rsplit(".", 1)[0] or
                             msg['parsl_v'] != self.current_platform['parsl_v']):
@@ -547,7 +542,7 @@ class Interchange(object):
                 logger.warning("[MAIN] Too many heartbeats missed for manager {}".format(manager))
                 if self._ready_manager_queue[manager]['active']:
                     self._ready_manager_queue[manager]['active'] = False
-                    self._send_monitoring_info(manager)
+                    self._send_monitoring_info(hub_channel, manager)
 
                 for tid in self._ready_manager_queue[manager]['tasks']:
                     try:


### PR DESCRIPTION
Instances of hub_channel aren't threadsafe. This PR moves away from having
one magic self.* channel, and another as a local in a thread, to creating
all channels as locals in threads.

monitoring_enabled is replaced by hub_channel becoming an optional, with
None signalling the same as !monitoring_enabled.

_send_monitoring_info gets a new parameter, hub_channel, which means it can
now be used in more places, reducing some code duplication.

This is in preparation for some upcoming PRs which allow the htex messaging
connections to be used for sending monitoring messages from the worker
side, instead of the monitoring system running its own monitoring
network connections.

This PR should not affect monitoring behaviour.

## Type of change

- Code maintentance/cleanup
