### PR TITLE
Memoize functions like any other value

### DIFF
--- a/parsl/app/app.py
+++ b/parsl/app/app.py
@@ -4,8 +4,6 @@ The App class encapsulates a generic leaf task that can be executed asynchronous
 """
 import logging
 from abc import ABCMeta, abstractmethod
-from inspect import getsource
-from hashlib import md5
 from inspect import signature
 
 logger = logging.getLogger(__name__)
@@ -46,17 +44,6 @@ class AppBase(metaclass=ABCMeta):
         if not (isinstance(executors, list) or isinstance(executors, str)):
             logger.error("App {} specifies invalid executor option, expects string or list".format(
                 func.__name__))
-
-        if cache is True:
-            try:
-                self.fn_source = getsource(func)
-            except OSError:
-                logger.warning("Unable to get source code for app caching. Recommend creating module")
-                self.fn_source = func.__name__
-
-            self.func_hash = md5(self.fn_source.encode('utf-8')).hexdigest()
-        else:
-            self.func_hash = func.__name__
 
         params = signature(func).parameters
 

--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -160,7 +160,6 @@ class BashApp(AppBase):
         app_fut = dfk.submit(self.wrapped_remote_function,
                              app_args=args,
                              executors=self.executors,
-                             fn_hash=self.func_hash,
                              cache=self.cache,
                              ignore_for_cache=self.ignore_for_cache,
                              app_kwargs=invocation_kwargs)

--- a/parsl/app/python.py
+++ b/parsl/app/python.py
@@ -73,7 +73,6 @@ class PythonApp(AppBase):
 
         app_fut = dfk.submit(func, app_args=args,
                              executors=self.executors,
-                             fn_hash=self.func_hash,
                              cache=self.cache,
                              ignore_for_cache=self.ignore_for_cache,
                              app_kwargs=invocation_kwargs)

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -198,7 +198,7 @@ class DataFlowKernel(object):
         """
         Create the dictionary that will be included in the log.
         """
-        info_to_monitor = ['func_name', 'fn_hash', 'memoize', 'hashsum', 'fail_count', 'status',
+        info_to_monitor = ['func_name', 'memoize', 'hashsum', 'fail_count', 'status',
                            'id', 'time_invoked', 'try_time_launched', 'time_returned', 'try_time_returned', 'executor']
 
         task_log_info = {"task_" + k: task_record[k] for k in info_to_monitor}
@@ -681,7 +681,7 @@ class DataFlowKernel(object):
 
         return new_args, kwargs, dep_failures
 
-    def submit(self, func, app_args, executors='all', fn_hash=None, cache=False, ignore_for_cache=None, app_kwargs={}):
+    def submit(self, func, app_args, executors='all', cache=False, ignore_for_cache=None, app_kwargs={}):
         """Add task to the dataflow system.
 
         If the app task has the executors attributes not set (default=='all')
@@ -696,8 +696,6 @@ class DataFlowKernel(object):
             - app_args : Args to the function
             - executors (list or string) : List of executors this call could go to.
                     Default='all'
-            - fn_hash (Str) : Hash of the function and inputs
-                    Default=None
             - cache (Bool) : To enable memoization or not
             - ignore_for_cache (list) : List of kwargs to be ignored for memoization/checkpointing
             - app_kwargs (dict) : Rest of the kwargs to the fn passed as dict.
@@ -748,7 +746,6 @@ class DataFlowKernel(object):
         task_def = {'depends': None,
                     'executor': executor,
                     'func_name': func.__name__,
-                    'fn_hash': fn_hash,
                     'memoize': cache,
                     'hashsum': None,
                     'exec_fu': None,

--- a/parsl/dataflow/memoization.py
+++ b/parsl/dataflow/memoization.py
@@ -1,5 +1,6 @@
 import hashlib
 from functools import singledispatch
+from inspect import getsource
 import logging
 from parsl.serialize import serialize
 import types
@@ -43,7 +44,6 @@ def id_for_memo(obj, output_ref=False):
 @id_for_memo.register(str)
 @id_for_memo.register(int)
 @id_for_memo.register(float)
-@id_for_memo.register(types.FunctionType)
 @id_for_memo.register(type(None))
 def id_for_memo_serialize(obj, output_ref=False):
     return serialize(obj)
@@ -92,6 +92,25 @@ def id_for_memo_dict(denormalized_dict, output_ref=False):
         normalized_list.append(id_for_memo(k))
         normalized_list.append(id_for_memo(denormalized_dict[k], output_ref=output_ref))
     return serialize(normalized_list)
+
+
+@id_for_memo.register(types.FunctionType)
+def id_for_memo_function(function, output_ref=False):
+    """This produces function hash material using the source definition of the
+       function.
+
+       The standard serialize_object based approach cannot be used as it is
+       too sensitive to irrelevant facts such as the source line, meaning
+       a whitespace line added at the top of a source file will cause the hash
+       to change.
+    """
+    logger.debug("serialising id_for_memo_function for function {}, type {}".format(function, type(function)))
+    try:
+        fn_source = getsource(function)
+    except Exception as e:
+        logger.warning("Unable to get source code for app caching. Recommend creating module. Exception was: {}".format(e))
+        fn_source = function.__name__
+    return serialize(fn_source.encode('utf-8'))
 
 
 class Memoizer(object):
@@ -179,8 +198,7 @@ class Memoizer(object):
             t = t + [id_for_memo(outputs, output_ref=True)]   # TODO: use append?
 
         t = t + [id_for_memo(filtered_kw)]
-        t = t + [id_for_memo(task['func_name']),
-                 id_for_memo(task['fn_hash']),
+        t = t + [id_for_memo(task['func']),
                  id_for_memo(task['args'])]
 
         x = b''.join(t)

--- a/parsl/dataflow/memoization.py
+++ b/parsl/dataflow/memoization.py
@@ -1,5 +1,5 @@
 import hashlib
-from functools import singledispatch
+from functools import lru_cache, singledispatch
 from inspect import getsource
 import logging
 from parsl.serialize import serialize
@@ -94,7 +94,10 @@ def id_for_memo_dict(denormalized_dict, output_ref=False):
     return serialize(normalized_list)
 
 
+# the LRU cache decorator must be applied closer to the id_for_memo_function call
+# that the .register() call, so that the cache-decorated version is registered.
 @id_for_memo.register(types.FunctionType)
+@lru_cache()
 def id_for_memo_function(function, output_ref=False):
     """This produces function hash material using the source definition of the
        function.


### PR DESCRIPTION
Prior to this PR, inputs for memo hashes are generated in two places:

* in app construction, producing a func_hash by attempting to get the
  function source code

* id_for_memo hashes various things, including arguments and the app name

When the function is wrapped by some pieces of parsl, such as
remote_side_bash_executor or some file staging code, then the function is
replaced by a new function, and the original function is passed as an
additional argument.

This has the effect of id_for_memo hashing also hashing the function, in
addition to the app construction hash, and this time hashing it in a
different way - by using serialisation of the function object.

This hash-by-serialisation method was extremely fragile and would change for
probably undesirable reasons, such as source code changes elsewhere in
the source file.

This PR removes the first explicit func_hash construction, and makes all
hash generation happen with id_for_memo.

It replaces the serialisation-based hashing of functions with the source based
method previously used in the app's generation of func_hash. This now applies
to both the base function, and to functions passed as arguments.

## Type of change

- Code maintentance/cleanup
