### PR TITLE
Add decorator to catch exceptions coming out of threads and processes

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -24,6 +24,7 @@ from parsl.executors.status_handling import StatusHandlingExecutor
 from parsl.providers.provider_base import ExecutionProvider
 from parsl.data_provider.staging import Staging
 from parsl.addresses import get_all_addresses
+from parsl.process_loggers import wrap_with_logs
 
 from parsl.utils import RepresentationMixin
 from parsl.providers import LocalProvider
@@ -320,6 +321,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         jids = self.initialize_scaling()
         return jids
 
+    @wrap_with_logs
     def _queue_management_worker(self):
         """Listen to the queue for task status messages and handle them.
 

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -19,6 +19,7 @@ serialize_object = ParslSerializer().serialize
 
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.monitoring.message_type import MessageType
+from parsl.process_loggers import wrap_with_logs
 
 
 HEARTBEAT_CODE = (2 ** 32) - 1
@@ -247,6 +248,7 @@ class Interchange(object):
 
         return tasks
 
+    @wrap_with_logs(target="interchange")
     def migrate_tasks_to_internal(self, kill_event):
         """Pull tasks from the incoming tasks 0mq pipe onto the internal
         pending task queue
@@ -295,6 +297,7 @@ class Interchange(object):
                                     datetime.datetime.now(),
                                     self._ready_manager_queue[manager]))
 
+    @wrap_with_logs(target="interchange")
     def _command_server(self, kill_event):
         """ Command server to run async command to the interchange
         """
@@ -594,6 +597,7 @@ def start_file_logger(filename, name='interchange', level=logging.DEBUG, format_
     logger.addHandler(handler)
 
 
+@wrap_with_logs(target="interchange")
 def starter(comm_q, *args, **kwargs):
     """Start the interchange process
 

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -17,6 +17,8 @@ import json
 import psutil
 import multiprocessing
 
+from parsl.process_loggers import wrap_with_logs
+
 from parsl.version import VERSION as PARSL_VERSION
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.executors.high_throughput.errors import WorkerLost
@@ -214,6 +216,7 @@ class Manager(object):
         r = self.task_incoming.send(heartbeat)
         logger.debug("Return from heartbeat: {}".format(r))
 
+    @wrap_with_logs
     def pull_tasks(self, kill_event):
         """ Pull tasks from the incoming tasks 0mq pipe onto the internal
         pending task queue
@@ -294,6 +297,7 @@ class Manager(object):
                     logger.critical("[TASK_PULL_THREAD] Exiting")
                     break
 
+    @wrap_with_logs
     def push_results(self, kill_event):
         """ Listens on the pending_result_queue and sends out results via 0mq
 
@@ -330,6 +334,7 @@ class Manager(object):
 
         logger.critical("[RESULT_PUSH_THREAD] Exiting")
 
+    @wrap_with_logs
     def worker_watchdog(self, kill_event):
         """ Listens on the pending_result_queue and sends out results via 0mq
 
@@ -474,6 +479,7 @@ def execute_task(bufs):
         return user_ns.get(resultname)
 
 
+@wrap_with_logs(target="worker_log")
 def worker(worker_id, pool_id, pool_size, task_queue, result_queue, worker_queue, tasks_in_progress, cpu_affinity):
     """
 

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -11,6 +11,7 @@ from parsl.log_utils import set_file_logger
 from parsl.dataflow.states import States
 from parsl.providers.error import OptionalModuleMissing
 from parsl.monitoring.message_type import MessageType
+from parsl.process_loggers import wrap_with_logs
 
 logger = logging.getLogger("database_manager")
 
@@ -500,6 +501,7 @@ class DatabaseManager:
                                       'hostname'],
                              messages=reprocessable_first_resource_messages)
 
+    @wrap_with_logs(target="database_manager")
     def _migrate_logs_to_internal(self, logs_queue: queue.Queue, queue_tag: str, kill_event: threading.Event) -> None:
         logger.info("Starting processing for queue {}".format(queue_tag))
 
@@ -590,6 +592,7 @@ class DatabaseManager:
         self._kill_event.set()
 
 
+@wrap_with_logs(target="database_manager")
 def dbm_starter(exception_q: "queue.Queue[Tuple[str, str]]",
                 priority_msgs: "queue.Queue[Tuple[MessageType, Dict[str, Any]]]",
                 node_msgs: "queue.Queue[Dict[str, Any]]",

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -10,6 +10,7 @@ import zmq
 import queue
 from multiprocessing import Process, Queue
 from parsl.utils import RepresentationMixin
+from parsl.process_loggers import wrap_with_logs
 
 from parsl.monitoring.message_type import MessageType
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -480,6 +481,7 @@ class MonitoringRouter:
         self.logger.info("Monitoring router finished")
 
 
+@wrap_with_logs
 def router_starter(comm_q: "queue.Queue[Union[Tuple[int, int], str]]",
                    exception_q: "queue.Queue[Tuple[str, str]]",
                    priority_msgs: "queue.Queue[Tuple[Tuple[MessageType, Dict[str, Any]], int]]",
@@ -523,6 +525,7 @@ def router_starter(comm_q: "queue.Queue[Union[Tuple[int, int], str]]",
     router.logger.info("End of router_starter")
 
 
+@wrap_with_logs
 def send_first_message(try_id: int,
                        task_id: int,
                        monitoring_hub_url: str,
@@ -543,6 +546,7 @@ def send_first_message(try_id: int,
     return
 
 
+@wrap_with_logs
 def monitor(pid: int,
             try_id: int,
             task_id: int,

--- a/parsl/process_loggers.py
+++ b/parsl/process_loggers.py
@@ -1,0 +1,39 @@
+import logging
+import threading
+import functools
+
+from typing import Callable, Optional
+
+
+def wrap_with_logs(fn: Optional[Callable] = None, target: str = __name__) -> Callable:
+    """Calls the supplied function, and logs whether that
+    function raised an exception or terminated normally.
+
+    This is intended to be used around the top level functions of
+    processes and threads, where exceptions would normally not
+    go to a log.
+    """
+
+    def decorator(func):
+
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            assert func is not None
+            thread = threading.current_thread()
+            name = f"{func.__name__} on thread {thread.name}"
+            logger = logging.getLogger(target)
+
+            try:
+                r = func(*args, **kwargs)
+                logger.debug("Normal ending for {}".format(name))
+                return r
+            except Exception:
+                logger.error("Exceptional ending for {}".format(name), exc_info=True)
+                raise
+
+        return wrapped
+
+    if fn is not None:
+        return decorator(fn)
+    else:
+        return decorator

--- a/parsl/tests/test_error_handling/test_wrap_with_logs.py
+++ b/parsl/tests/test_error_handling/test_wrap_with_logs.py
@@ -1,0 +1,33 @@
+import logging
+import pytest
+
+from parsl.process_loggers import wrap_with_logs
+
+
+@wrap_with_logs
+def somefunc_ok():
+    return 5
+
+
+@wrap_with_logs
+def somefunc_exception():
+    raise RuntimeError("Deliberate failure")
+
+
+@pytest.mark.local
+def test_wrap_with_logs_ok(caplog):
+    caplog.set_level(logging.DEBUG)
+
+    # check that return value is passed back through wrap_with_logs
+    x = somefunc_ok()
+    assert x == 5
+    assert 'Normal ending' in caplog.text
+
+
+@pytest.mark.local
+def test_wrap_with_logs_exception(caplog):
+    caplog.set_level(logging.ERROR)
+    # check that exception is passed back through wrap_with_logs
+    with pytest.raises(RuntimeError):
+        somefunc_exception()
+    assert 'Exceptional ending' in caplog.text


### PR DESCRIPTION

# Description

When a thread or process raises an exception out of its top level function,
that exception does not get logged automatically. This sometimes results in
the threads appearing to silently stop without any reported error.

This patch adds a @wrap_with_logs decorator which can be used on
thread/process top level functions (or any other function) and which logs
such exceptions as they propagate upwards.

This won't catch cases where logging is sent to a logger name where
logging has not been configured for that name yet - for example, exceptions
happening before interchange or monitoring database manager have
configured their logging.


## Type of change

- New feature (non-breaking change that adds functionality)
- Code maintentance/cleanup
