### PR TITLE
Make monitoring more resilient to spurious network traffic

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -451,6 +451,21 @@ class DatabaseManager:
                     self._insert(table=NODE, messages=node_info_messages)
 
                 """
+                BLOCK_INFO messages
+
+                """
+                block_info_messages = self._get_messages_in_batch(self.pending_block_queue)
+                if block_info_messages:
+                    logger.debug(
+                        "Got {} messages from block queue".format(len(block_info_messages)))
+                    # block_info_messages is possibly a nested list of dict (at different polling times)
+                    # Each dict refers to the info of a job/block at one polling time
+                    block_messages_to_insert = []  # type: List[Any]
+                    for block_msg in block_info_messages:
+                        block_messages_to_insert.extend(block_msg)
+                    self._insert(table=BLOCK, messages=block_messages_to_insert)
+
+                """
                 Resource info messages
 
                 """
@@ -480,21 +495,6 @@ class DatabaseManager:
 
                     if insert_resource_messages:
                         self._insert(table=RESOURCE, messages=insert_resource_messages)
-
-                """
-                BLOCK_INFO messages
-
-                """
-                block_info_messages = self._get_messages_in_batch(self.pending_block_queue)
-                if block_info_messages:
-                    logger.debug(
-                        "Got {} messages from block queue".format(len(block_info_messages)))
-                    # block_info_messages is possibly a nested list of dict (at different polling times)
-                    # Each dict refers to the info of a job/block at one polling time
-                    block_messages_to_insert = []  # type: List[Any]
-                    for block_msg in block_info_messages:
-                        block_messages_to_insert.extend(block_msg)
-                    self._insert(table=BLOCK, messages=block_messages_to_insert)
 
                 if reprocessable_first_resource_messages:
                     self._insert(table=STATUS, messages=reprocessable_first_resource_messages)

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -329,6 +329,8 @@ class DatabaseManager:
         # the case of multiple messages to defer.
         deferred_resource_messages = {}  # type: Dict[str, Any]
 
+        exception_happened = False
+
         while (not self._kill_event.is_set() or
                self.pending_priority_queue.qsize() != 0 or self.pending_resource_queue.qsize() != 0 or
                self.pending_node_queue.qsize() != 0 or self.pending_block_queue.qsize() != 0 or
@@ -339,167 +341,173 @@ class DatabaseManager:
             WORKFLOW_INFO and TASK_INFO messages (i.e. priority messages)
 
             """
-            logger.debug("""Checking STOP conditions: {}, {}, {}, {}, {}, {}, {}, {}, {}""".format(
-                              self._kill_event.is_set(),
-                              self.pending_priority_queue.qsize() != 0, self.pending_resource_queue.qsize() != 0,
-                              self.pending_node_queue.qsize() != 0, self.pending_block_queue.qsize() != 0,
-                              priority_queue.qsize() != 0, resource_queue.qsize() != 0,
-                              node_queue.qsize() != 0, block_queue.qsize() != 0))
+            try:
+                logger.debug("""Checking STOP conditions: {}, {}, {}, {}, {}, {}, {}, {}, {}""".format(
+                                  self._kill_event.is_set(),
+                                  self.pending_priority_queue.qsize() != 0, self.pending_resource_queue.qsize() != 0,
+                                  self.pending_node_queue.qsize() != 0, self.pending_block_queue.qsize() != 0,
+                                  priority_queue.qsize() != 0, resource_queue.qsize() != 0,
+                                  node_queue.qsize() != 0, block_queue.qsize() != 0))
 
-            # This is the list of resource messages which can be reprocessed as if they
-            # had just arrived because the corresponding first task message has been
-            # processed (corresponding by task id)
-            reprocessable_first_resource_messages = []
+                # This is the list of resource messages which can be reprocessed as if they
+                # had just arrived because the corresponding first task message has been
+                # processed (corresponding by task id)
+                reprocessable_first_resource_messages = []
 
-            # Get a batch of priority messages
-            priority_messages = self._get_messages_in_batch(self.pending_priority_queue)
-            if priority_messages:
-                logger.debug(
-                    "Got {} messages from priority queue".format(len(priority_messages)))
-                task_info_update_messages, task_info_insert_messages, task_info_all_messages = [], [], []
-                try_update_messages, try_insert_messages, try_all_messages = [], [], []
-                for msg_type, msg in priority_messages:
-                    if msg_type.value == MessageType.WORKFLOW_INFO.value:
-                        if "python_version" in msg:   # workflow start message
-                            logger.debug(
-                                "Inserting workflow start info to WORKFLOW table")
-                            self._insert(table=WORKFLOW, messages=[msg])
-                            self.workflow_start_message = msg
-                        else:                         # workflow end message
-                            logger.debug(
-                                "Updating workflow end info to WORKFLOW table")
-                            self._update(table=WORKFLOW,
-                                         columns=['run_id', 'tasks_failed_count',
-                                                  'tasks_completed_count', 'time_completed'],
-                                         messages=[msg])
-                            self.workflow_end = True
+                # Get a batch of priority messages
+                priority_messages = self._get_messages_in_batch(self.pending_priority_queue)
+                if priority_messages:
+                    logger.debug(
+                        "Got {} messages from priority queue".format(len(priority_messages)))
+                    task_info_update_messages, task_info_insert_messages, task_info_all_messages = [], [], []
+                    try_update_messages, try_insert_messages, try_all_messages = [], [], []
+                    for msg_type, msg in priority_messages:
+                        if msg_type.value == MessageType.WORKFLOW_INFO.value:
+                            if "python_version" in msg:   # workflow start message
+                                logger.debug(
+                                    "Inserting workflow start info to WORKFLOW table")
+                                self._insert(table=WORKFLOW, messages=[msg])
+                                self.workflow_start_message = msg
+                            else:                         # workflow end message
+                                logger.debug(
+                                    "Updating workflow end info to WORKFLOW table")
+                                self._update(table=WORKFLOW,
+                                             columns=['run_id', 'tasks_failed_count',
+                                                      'tasks_completed_count', 'time_completed'],
+                                             messages=[msg])
+                                self.workflow_end = True
 
-                    elif msg_type.value == MessageType.TASK_INFO.value:
+                        elif msg_type.value == MessageType.TASK_INFO.value:
+                            task_try_id = str(msg['task_id']) + "." + str(msg['try_id'])
+                            task_info_all_messages.append(msg)
+                            if msg['task_id'] in inserted_tasks:
+                                task_info_update_messages.append(msg)
+                            else:
+                                inserted_tasks.add(msg['task_id'])
+                                task_info_insert_messages.append(msg)
+
+                            try_all_messages.append(msg)
+                            if task_try_id in inserted_tries:
+                                try_update_messages.append(msg)
+                            else:
+                                inserted_tries.add(task_try_id)
+                                try_insert_messages.append(msg)
+
+                                # check if there is a left_message for this task
+                                if task_try_id in deferred_resource_messages:
+                                    reprocessable_first_resource_messages.append(
+                                        deferred_resource_messages.pop(task_try_id))
+                        else:
+                            raise RuntimeError("Unexpected message type {} received on priority queue".format(msg_type))
+
+                    logger.debug("Updating and inserting TASK_INFO to all tables")
+                    logger.debug("Updating {} TASK_INFO into workflow table".format(len(task_info_update_messages)))
+                    self._update(table=WORKFLOW,
+                                 columns=['run_id', 'tasks_failed_count',
+                                          'tasks_completed_count'],
+                                 messages=task_info_all_messages)
+
+                    if task_info_insert_messages:
+                        self._insert(table=TASK, messages=task_info_insert_messages)
+                        logger.debug(
+                            "There are {} inserted task records".format(len(inserted_tasks)))
+
+                    if task_info_update_messages:
+                        logger.debug("Updating {} TASK_INFO into task table".format(len(task_info_update_messages)))
+                        self._update(table=TASK,
+                                     columns=['task_time_invoked',
+                                              'task_time_returned',
+                                              'run_id', 'task_id',
+                                              'task_fail_count',
+                                              'task_hashsum'],
+                                     messages=task_info_update_messages)
+                    logger.debug("Inserting {} task_info_all_messages into status table".format(len(task_info_all_messages)))
+
+                    self._insert(table=STATUS, messages=task_info_all_messages)
+
+                    if try_insert_messages:
+                        logger.debug("Inserting {} TASK_INFO to try table".format(len(try_insert_messages)))
+                        self._insert(table=TRY, messages=try_insert_messages)
+                        logger.debug(
+                            "There are {} inserted task records".format(len(inserted_tasks)))
+
+                    if try_update_messages:
+                        logger.debug("Updating {} TASK_INFO into try table".format(len(try_update_messages)))
+                        self._update(table=TRY,
+                                     columns=['run_id', 'task_id', 'try_id',
+                                              'task_fail_history',
+                                              'task_try_time_launched',
+                                              'task_try_time_returned'],
+                                     messages=try_update_messages)
+
+                """
+                NODE_INFO messages
+
+                """
+                node_info_messages = self._get_messages_in_batch(self.pending_node_queue)
+                if node_info_messages:
+                    logger.debug(
+                        "Got {} messages from node queue".format(len(node_info_messages)))
+                    self._insert(table=NODE, messages=node_info_messages)
+
+                """
+                Resource info messages
+
+                """
+                resource_messages = self._get_messages_in_batch(self.pending_resource_queue)
+
+                if resource_messages:
+                    logger.debug(
+                        "Got {} messages from resource queue, {} reprocessable".format(len(resource_messages), len(reprocessable_first_resource_messages)))
+
+                    insert_resource_messages = []
+                    for msg in resource_messages:
                         task_try_id = str(msg['task_id']) + "." + str(msg['try_id'])
-                        task_info_all_messages.append(msg)
-                        if msg['task_id'] in inserted_tasks:
-                            task_info_update_messages.append(msg)
+                        if msg['first_msg']:
+                            # Update the running time to try table if first message
+                            msg['task_status_name'] = States.running.name
+                            msg['task_try_time_running'] = msg['timestamp']
+
+                            if task_try_id in inserted_tries:  # TODO: needs to become task_id and try_id, and check against inserted_tries
+                                reprocessable_first_resource_messages.append(msg)
+                            else:
+                                if task_try_id in deferred_resource_messages:
+                                    logger.error("Task {} already has a deferred resource message. Discarding previous message.".format(msg['task_id']))
+                                deferred_resource_messages[task_try_id] = msg
                         else:
-                            inserted_tasks.add(msg['task_id'])
-                            task_info_insert_messages.append(msg)
+                            # Insert to resource table if not first message
+                            insert_resource_messages.append(msg)
 
-                        try_all_messages.append(msg)
-                        if task_try_id in inserted_tries:
-                            try_update_messages.append(msg)
-                        else:
-                            inserted_tries.add(task_try_id)
-                            try_insert_messages.append(msg)
+                    if insert_resource_messages:
+                        self._insert(table=RESOURCE, messages=insert_resource_messages)
 
-                            # check if there is a left_message for this task
-                            if task_try_id in deferred_resource_messages:
-                                reprocessable_first_resource_messages.append(
-                                    deferred_resource_messages.pop(task_try_id))
-                    else:
-                        raise RuntimeError("Unexpected message type {} received on priority queue".format(msg_type))
+                """
+                BLOCK_INFO messages
 
-                logger.debug("Updating and inserting TASK_INFO to all tables")
-                logger.debug("Updating {} TASK_INFO into workflow table".format(len(task_info_update_messages)))
-                self._update(table=WORKFLOW,
-                             columns=['run_id', 'tasks_failed_count',
-                                      'tasks_completed_count'],
-                             messages=task_info_all_messages)
-
-                if task_info_insert_messages:
-                    self._insert(table=TASK, messages=task_info_insert_messages)
+                """
+                block_info_messages = self._get_messages_in_batch(self.pending_block_queue)
+                if block_info_messages:
                     logger.debug(
-                        "There are {} inserted task records".format(len(inserted_tasks)))
+                        "Got {} messages from block queue".format(len(block_info_messages)))
+                    # block_info_messages is possibly a nested list of dict (at different polling times)
+                    # Each dict refers to the info of a job/block at one polling time
+                    block_messages_to_insert = []  # type: List[Any]
+                    for block_msg in block_info_messages:
+                        block_messages_to_insert.extend(block_msg)
+                    self._insert(table=BLOCK, messages=block_messages_to_insert)
 
-                if task_info_update_messages:
-                    logger.debug("Updating {} TASK_INFO into task table".format(len(task_info_update_messages)))
-                    self._update(table=TASK,
-                                 columns=['task_time_invoked',
-                                          'task_time_returned',
-                                          'run_id', 'task_id',
-                                          'task_fail_count',
-                                          'task_hashsum'],
-                                 messages=task_info_update_messages)
-                logger.debug("Inserting {} task_info_all_messages into status table".format(len(task_info_all_messages)))
-
-                self._insert(table=STATUS, messages=task_info_all_messages)
-
-                if try_insert_messages:
-                    logger.debug("Inserting {} TASK_INFO to try table".format(len(try_insert_messages)))
-                    self._insert(table=TRY, messages=try_insert_messages)
-                    logger.debug(
-                        "There are {} inserted task records".format(len(inserted_tasks)))
-
-                if try_update_messages:
-                    logger.debug("Updating {} TASK_INFO into try table".format(len(try_update_messages)))
+                if reprocessable_first_resource_messages:
+                    self._insert(table=STATUS, messages=reprocessable_first_resource_messages)
                     self._update(table=TRY,
-                                 columns=['run_id', 'task_id', 'try_id',
-                                          'task_fail_history',
-                                          'task_try_time_launched',
-                                          'task_try_time_returned'],
-                                 messages=try_update_messages)
-
-            """
-            NODE_INFO messages
-
-            """
-            node_info_messages = self._get_messages_in_batch(self.pending_node_queue)
-            if node_info_messages:
-                logger.debug(
-                    "Got {} messages from node queue".format(len(node_info_messages)))
-                self._insert(table=NODE, messages=node_info_messages)
-
-            """
-            BLOCK_INFO messages
-
-            """
-            block_info_messages = self._get_messages_in_batch(self.pending_block_queue)
-            if block_info_messages:
-                logger.debug(
-                    "Got {} messages from block queue".format(len(block_info_messages)))
-                # block_info_messages is possibly a nested list of dict (at different polling times)
-                # Each dict refers to the info of a job/block at one polling time
-                block_messages_to_insert = []  # type: List[Any]
-                for block_msg in block_info_messages:
-                    block_messages_to_insert.extend(block_msg)
-                self._insert(table=BLOCK, messages=block_messages_to_insert)
-
-            """
-            Resource info messages
-
-            """
-            resource_messages = self._get_messages_in_batch(self.pending_resource_queue)
-
-            if resource_messages:
-                logger.debug(
-                    "Got {} messages from resource queue, {} reprocessable".format(len(resource_messages), len(reprocessable_first_resource_messages)))
-
-                insert_resource_messages = []
-                for msg in resource_messages:
-                    task_try_id = str(msg['task_id']) + "." + str(msg['try_id'])
-                    if msg['first_msg']:
-                        # Update the running time to try table if first message
-                        msg['task_status_name'] = States.running.name
-                        msg['task_try_time_running'] = msg['timestamp']
-
-                        if task_try_id in inserted_tries:  # TODO: needs to become task_id and try_id, and check against inserted_tries
-                            reprocessable_first_resource_messages.append(msg)
-                        else:
-                            if task_try_id in deferred_resource_messages:
-                                logger.error("Task {} already has a deferred resource message. Discarding previous message.".format(msg['task_id']))
-                            deferred_resource_messages[task_try_id] = msg
-                    else:
-                        # Insert to resource table if not first message
-                        insert_resource_messages.append(msg)
-
-                if insert_resource_messages:
-                    self._insert(table=RESOURCE, messages=insert_resource_messages)
-
-            if reprocessable_first_resource_messages:
-                self._insert(table=STATUS, messages=reprocessable_first_resource_messages)
-                self._update(table=TRY,
-                             columns=['task_try_time_running',
-                                      'run_id', 'task_id', 'try_id',
-                                      'hostname'],
-                             messages=reprocessable_first_resource_messages)
+                                 columns=['task_try_time_running',
+                                          'run_id', 'task_id', 'try_id',
+                                          'hostname'],
+                                 messages=reprocessable_first_resource_messages)
+            except Exception:
+                logger.exception("Exception in db loop: this might have been a malformed message, or some other error. monitoring data may have been lost")
+                exception_happened = True
+        if exception_happened:
+            raise RuntimeError("An exception happened sometime during database processing and should have been logged in database_manager.log")
 
     @wrap_with_logs(target="database_manager")
     def _migrate_logs_to_internal(self, logs_queue: queue.Queue, queue_tag: str, kill_event: threading.Event) -> None:

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -457,7 +457,7 @@ class MonitoringRouter:
                     # dfk_channel is broken in such a way that it always raises
                     # an exception? Looping on this would maybe be the wrong
                     # thing to do.
-                    self.logger.exception("Failure processing a DFK ZMQ message")
+                    self.logger.warning("Failure processing a DFK ZMQ message", exc_info=True)
 
                 try:
                     msg = self.ic_channel.recv_pyobj()

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -443,7 +443,7 @@ class MonitoringRouter:
 
                 try:
                     msg = self.dfk_channel.recv_pyobj()
-                    self.logger.info("Got ZMQ Message from DFK: {}".format(msg))
+                    self.logger.debug("Got ZMQ Message from DFK: {}".format(msg))
                     if msg[0].value == MessageType.BLOCK_INFO.value:
                         block_msgs.put((msg, 0))
                     else:

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -433,6 +433,7 @@ class MonitoringRouter:
               resource_msgs: "queue.Queue[Tuple[Dict[str, Any], str]]") -> None:
         try:
             while True:
+                self.logger.info("MONLOOP")
                 try:
                     data, addr = self.sock.recvfrom(2048)
                     msg = pickle.loads(data)

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -461,7 +461,7 @@ class MonitoringRouter:
 
                 try:
                     msg = self.ic_channel.recv_pyobj()
-                    self.logger.debug("Got ZMQ Message from interchange before handling: {}".format(msg))
+                    self.logger.debug("Got ZMQ Message from interchange: {}".format(msg))
                     if msg[0].value == MessageType.NODE_INFO.value:
                         msg[2]['last_heartbeat'] = datetime.datetime.fromtimestamp(msg[2]['last_heartbeat'])
                         msg[2]['run_id'] = self.run_id
@@ -470,8 +470,8 @@ class MonitoringRouter:
                         node_msgs.put((msg, 0))
                     elif msg[0].value == MessageType.BLOCK_INFO.value:
                         block_msgs.put((msg, 0))
-                    # TODO: else we're discarding a message here without noting that it is being discarded
-                    self.logger.debug("Got ZMQ Message from interchange: {}".format(msg))
+                    else:
+                        self.logger.error(f"Discarding message from interchange with unknown type {msg[0].value}")
                 except zmq.Again:
                     pass
 

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -433,7 +433,6 @@ class MonitoringRouter:
               resource_msgs: "queue.Queue[Tuple[Dict[str, Any], str]]") -> None:
         try:
             while True:
-                self.logger.info("MONLOOP")
                 try:
                     data, addr = self.sock.recvfrom(2048)
                     msg = pickle.loads(data)

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -275,7 +275,7 @@ class MonitoringHub(RepresentationMixin):
             self._dfk_channel.send_pyobj((mtype, message))
         except zmq.Again:
             self.logger.exception(
-                "[MONITORING] The monitoring message sent from DFK to Hub timeouts after {}ms".format(self.dfk_channel_timeout))
+                "The monitoring message sent from DFK to Hub timed-out after {}ms".format(self.dfk_channel_timeout))
 
     def close(self) -> None:
         if self.logger:
@@ -284,7 +284,7 @@ class MonitoringHub(RepresentationMixin):
         while True:
             try:
                 exception_msgs.append(self.exception_q.get(block=False))
-                self.logger.error("Either Hub or DBM process got exception.")
+                self.logger.error("There was a queued exception (Either Hub or DBM process got exception much earlier?)")
             except queue.Empty:
                 break
         if self._dfk_channel and self.monitoring_hub_active:
@@ -292,7 +292,8 @@ class MonitoringHub(RepresentationMixin):
             self._dfk_channel.close()
             if exception_msgs:
                 for exception_msg in exception_msgs:
-                    self.logger.error("{} process got exception {}. Terminating all monitoring processes.".format(exception_msg[0], exception_msg[1]))
+                    self.logger.error("{} process delivered an exception: {}. Terminating all monitoring processes immediately.".format(exception_msg[0],
+                                      exception_msg[1]))
                 self.router_proc.terminate()
                 self.dbm_proc.terminate()
             self.logger.info("Waiting for Hub to receive all messages and terminate")
@@ -430,55 +431,67 @@ class MonitoringRouter:
               node_msgs: "queue.Queue[Tuple[Dict[str, Any], int]]",
               block_msgs: "queue.Queue[Tuple[Dict[str, Any], int]]",
               resource_msgs: "queue.Queue[Tuple[Dict[str, Any], str]]") -> None:
+        try:
+            while True:
+                self.logger.info("MONLOOP")
+                try:
+                    data, addr = self.sock.recvfrom(2048)
+                    msg = pickle.loads(data)
+                    resource_msgs.put((msg, addr))
+                    self.logger.debug("Got UDP Message from {}: {}".format(addr, msg))
+                except socket.timeout:
+                    pass
 
-        while True:
-            try:
-                data, addr = self.sock.recvfrom(2048)
-                msg = pickle.loads(data)
-                resource_msgs.put((msg, addr))
-                self.logger.debug("Got UDP Message from {}: {}".format(addr, msg))
-            except socket.timeout:
-                pass
+                try:
+                    msg = self.dfk_channel.recv_pyobj()
+                    self.logger.info("Got ZMQ Message from DFK: {}".format(msg))
+                    if msg[0].value == MessageType.BLOCK_INFO.value:
+                        block_msgs.put((msg, 0))
+                    else:
+                        priority_msgs.put((msg, 0))
+                    if msg[0].value == MessageType.WORKFLOW_INFO.value and 'python_version' not in msg[1]:
+                        break
+                except zmq.Again:
+                    pass
+                except Exception:
+                    # This will catch malformed messages. What happens if the
+                    # dfk_channel is broken in such a way that it always raises
+                    # an exception? Looping on this would maybe be the wrong
+                    # thing to do.
+                    self.logger.exception("Failure processing a DFK ZMQ message")
 
-            try:
-                msg = self.dfk_channel.recv_pyobj()
-                self.logger.debug("Got ZMQ Message from DFK: {}".format(msg))
-                if msg[0].value == MessageType.BLOCK_INFO.value:
-                    block_msgs.put((msg, 0))
-                else:
-                    priority_msgs.put((msg, 0))
-                if msg[0].value == MessageType.WORKFLOW_INFO.value and 'python_version' not in msg[1]:
-                    break
-            except zmq.Again:
-                pass
+                try:
+                    msg = self.ic_channel.recv_pyobj()
+                    self.logger.debug("Got ZMQ Message from interchange before handling: {}".format(msg))
+                    if msg[0].value == MessageType.NODE_INFO.value:
+                        msg[2]['last_heartbeat'] = datetime.datetime.fromtimestamp(msg[2]['last_heartbeat'])
+                        msg[2]['run_id'] = self.run_id
+                        msg[2]['timestamp'] = msg[1]
+                        msg = (msg[0], msg[2])
+                        node_msgs.put((msg, 0))
+                    elif msg[0].value == MessageType.BLOCK_INFO.value:
+                        block_msgs.put((msg, 0))
+                    # TODO: else we're discarding a message here without noting that it is being discarded
+                    self.logger.debug("Got ZMQ Message from interchange: {}".format(msg))
+                except zmq.Again:
+                    pass
 
-            try:
-                msg = self.ic_channel.recv_pyobj()
-                self.logger.debug("Got ZMQ Message from interchange before handling: {}".format(msg))
-                if msg[0].value == MessageType.NODE_INFO.value:
-                    msg[2]['last_heartbeat'] = datetime.datetime.fromtimestamp(msg[2]['last_heartbeat'])
-                    msg[2]['run_id'] = self.run_id
-                    msg[2]['timestamp'] = msg[1]
-                    msg = (msg[0], msg[2])
-                    node_msgs.put((msg, 0))
-                elif msg[0].value == MessageType.BLOCK_INFO.value:
-                    block_msgs.put((msg, 0))
-                self.logger.debug("Got ZMQ Message from interchange: {}".format(msg))
-            except zmq.Again:
-                pass
+            self.logger.info("Monitoring router draining")
+            last_msg_received_time = time.time()
+            while time.time() - last_msg_received_time < self.atexit_timeout:
+                self.logger.info("Drain loop")
+                try:
+                    data, addr = self.sock.recvfrom(2048)
+                    msg = pickle.loads(data)
+                    resource_msgs.put((msg, addr))
+                    last_msg_received_time = time.time()
+                    self.logger.debug("Got UDP Message from {}: {}".format(addr, msg))
+                except socket.timeout:
+                    pass
 
-        last_msg_received_time = time.time()
-        while time.time() - last_msg_received_time < self.atexit_timeout:
-            try:
-                data, addr = self.sock.recvfrom(2048)
-                msg = pickle.loads(data)
-                resource_msgs.put((msg, addr))
-                last_msg_received_time = time.time()
-                self.logger.debug("Got UDP Message from {}: {}".format(addr, msg))
-            except socket.timeout:
-                pass
-
-        self.logger.info("Monitoring router finished")
+            self.logger.info("Monitoring router finishing normally")
+        finally:
+            self.logger.info("Monitoring router finished")
 
 
 @wrap_with_logs

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -479,7 +479,6 @@ class MonitoringRouter:
             self.logger.info("Monitoring router draining")
             last_msg_received_time = time.time()
             while time.time() - last_msg_received_time < self.atexit_timeout:
-                self.logger.info("Drain loop")
                 try:
                     data, addr = self.sock.recvfrom(2048)
                     msg = pickle.loads(data)

--- a/parsl/tests/test_monitoring/test_fuzz_zmq.py
+++ b/parsl/tests/test_monitoring/test_fuzz_zmq.py
@@ -1,0 +1,92 @@
+
+import logging
+import os
+import parsl
+import pytest
+import socket
+import sqlalchemy
+import time
+
+logger = logging.getLogger(__name__)
+
+from parsl.tests.configs.htex_local_alternate import fresh_config
+
+
+@parsl.python_app
+def this_app():
+    return 5
+
+
+@pytest.mark.local
+def test_row_counts():
+    if os.path.exists("monitoring.db"):
+        logger.info("Monitoring database already exists - deleting")
+        os.remove("monitoring.db")
+
+    logger.info("loading parsl")
+    parsl.load(fresh_config())
+
+    logger.info("invoking apps and waiting for result")
+
+    assert this_app().result() == 5
+    assert this_app().result() == 5
+
+    # now we've run some apps, send fuzz into the monitoring ZMQ
+    # socket, before trying to run some more tests.
+
+    # there are different kinds of fuzz:
+    # could send ZMQ messages that are weird
+    # could send random bytes to the TCP socket
+    #   the latter is what i'm most suspicious of in my present investigation
+
+    # dig out the interchange port...
+    hub_address = parsl.dfk().hub_address
+    hub_interchange_port = parsl.dfk().hub_interchange_port
+
+    # this will send a string to a new socket connection
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.connect((hub_address, hub_interchange_port))
+        s.sendall(b'fuzzing\r')
+
+    # this will send a non-object down the DFK's existing ZMQ connection
+    parsl.dfk().monitoring._dfk_channel.send(b'FuzzyByte\rSTREAM')
+
+    # this will send an unusual python object down the
+    # DFK's existing ZMQ connection. this doesn't break the router,
+    # but breaks the db_manager in a way that isn't reported until
+    # the very end of the run, and database writing is abandoned
+    # rather than completing, in this case.
+
+    # I'm unclear if this is a case we should be trying to handle.
+    parsl.dfk().monitoring._dfk_channel.send_pyobj("FUZZ3")
+
+    # hopefully long enough for any breakage to happen
+    # before attempting to run more tasks
+    time.sleep(5)
+
+    assert this_app().result() == 5
+    assert this_app().result() == 5
+
+    logger.info("cleaning up parsl")
+    parsl.dfk().cleanup()
+    parsl.clear()
+
+    # at this point, we should find one row in the monitoring database.
+
+    logger.info("checking database content")
+    engine = sqlalchemy.create_engine("sqlite:///monitoring.db")
+    with engine.begin() as connection:
+
+        result = connection.execute("SELECT COUNT(*) FROM workflow")
+        (c, ) = result.first()
+        assert c == 1
+
+        result = connection.execute("SELECT COUNT(*) FROM task")
+        (c, ) = result.first()
+        assert c == 4
+
+        result = connection.execute("SELECT COUNT(*) FROM try")
+        (c, ) = result.first()
+        assert c == 4
+
+    logger.info("all done")

--- a/parsl/tests/test_monitoring/test_fuzz_zmq.py
+++ b/parsl/tests/test_monitoring/test_fuzz_zmq.py
@@ -1,4 +1,3 @@
-
 import logging
 import os
 import parsl
@@ -7,7 +6,6 @@ import socket
 import time
 
 logger = logging.getLogger(__name__)
-
 
 
 @parsl.python_app


### PR DESCRIPTION
In practice on cori.nersc.gov on large runs, some unexpected network
traffic arrived at monitoring ports. This would sometimes crash
the monitoring system. This PR makes monitoring more likely to ignore
such traffic rather than crashing.

This PR adds some tests to generate spurious traffic.

Notes to reviewers:
I'm a little unclear about the correct way to report that
exceptions happened in the database loop: at the moment, this
ignores such exceptions and then reports a final exception
when monitoring finishes.

Another of my concerns is that there are other causes of exceptions,
not only spurious messages, and this may not be the right
handling for such messages. (for example, does a particular
socket closed exception result in the loop going into a 100%
CPU loop?)

This change most makes indentation changes. `git diff --ignore-space-change -r origin/master` can give an easier to read diff.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintentance/cleanup
