### PR TITLE
Add per-executor resource monitoring toggle

### DIFF
--- a/docs/stubs/parsl.executors.ExtremeScaleExecutor.rst
+++ b/docs/stubs/parsl.executors.ExtremeScaleExecutor.rst
@@ -18,6 +18,7 @@ parsl.executors.ExtremeScaleExecutor
       ~ExtremeScaleExecutor.handle_errors
       ~ExtremeScaleExecutor.hold_worker
       ~ExtremeScaleExecutor.initialize_scaling
+      ~ExtremeScaleExecutor.monitor_resources
       ~ExtremeScaleExecutor.scale_in
       ~ExtremeScaleExecutor.scale_out
       ~ExtremeScaleExecutor.set_bad_state_and_fail_all

--- a/docs/stubs/parsl.executors.HighThroughputExecutor.rst
+++ b/docs/stubs/parsl.executors.HighThroughputExecutor.rst
@@ -18,6 +18,7 @@ parsl.executors.HighThroughputExecutor
       ~HighThroughputExecutor.handle_errors
       ~HighThroughputExecutor.hold_worker
       ~HighThroughputExecutor.initialize_scaling
+      ~HighThroughputExecutor.monitor_resources
       ~HighThroughputExecutor.scale_in
       ~HighThroughputExecutor.scale_out
       ~HighThroughputExecutor.set_bad_state_and_fail_all

--- a/docs/stubs/parsl.executors.LowLatencyExecutor.rst
+++ b/docs/stubs/parsl.executors.LowLatencyExecutor.rst
@@ -16,6 +16,7 @@ parsl.executors.LowLatencyExecutor
       ~LowLatencyExecutor.__init__
       ~LowLatencyExecutor.create_monitoring_info
       ~LowLatencyExecutor.handle_errors
+      ~LowLatencyExecutor.monitor_resources
       ~LowLatencyExecutor.scale_in
       ~LowLatencyExecutor.scale_out
       ~LowLatencyExecutor.set_bad_state_and_fail_all

--- a/docs/stubs/parsl.executors.ThreadPoolExecutor.rst
+++ b/docs/stubs/parsl.executors.ThreadPoolExecutor.rst
@@ -16,6 +16,7 @@ parsl.executors.ThreadPoolExecutor
       ~ThreadPoolExecutor.__init__
       ~ThreadPoolExecutor.create_monitoring_info
       ~ThreadPoolExecutor.handle_errors
+      ~ThreadPoolExecutor.monitor_resources
       ~ThreadPoolExecutor.scale_in
       ~ThreadPoolExecutor.scale_out
       ~ThreadPoolExecutor.set_bad_state_and_fail_all

--- a/docs/stubs/parsl.executors.WorkQueueExecutor.rst
+++ b/docs/stubs/parsl.executors.WorkQueueExecutor.rst
@@ -17,6 +17,7 @@ parsl.executors.WorkQueueExecutor
       ~WorkQueueExecutor.create_monitoring_info
       ~WorkQueueExecutor.handle_errors
       ~WorkQueueExecutor.initialize_scaling
+      ~WorkQueueExecutor.monitor_resources
       ~WorkQueueExecutor.run_dir
       ~WorkQueueExecutor.scale_in
       ~WorkQueueExecutor.scale_out

--- a/docs/stubs/parsl.executors.base.ParslExecutor.rst
+++ b/docs/stubs/parsl.executors.base.ParslExecutor.rst
@@ -16,6 +16,7 @@ parsl.executors.base.ParslExecutor
       ~ParslExecutor.__init__
       ~ParslExecutor.create_monitoring_info
       ~ParslExecutor.handle_errors
+      ~ParslExecutor.monitor_resources
       ~ParslExecutor.scale_in
       ~ParslExecutor.scale_out
       ~ParslExecutor.set_bad_state_and_fail_all

--- a/docs/stubs/parsl.executors.swift_t.TurbineExecutor.rst
+++ b/docs/stubs/parsl.executors.swift_t.TurbineExecutor.rst
@@ -16,6 +16,7 @@ parsl.executors.swift\_t.TurbineExecutor
       ~TurbineExecutor.__init__
       ~TurbineExecutor.create_monitoring_info
       ~TurbineExecutor.handle_errors
+      ~TurbineExecutor.monitor_resources
       ~TurbineExecutor.scale_in
       ~TurbineExecutor.scale_out
       ~TurbineExecutor.set_bad_state_and_fail_all

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -504,7 +504,8 @@ class DataFlowKernel(object):
                                                          self.monitoring.monitoring_hub_url,
                                                          self.run_id,
                                                          wrapper_logging_level,
-                                                         self.monitoring.resource_monitoring_interval)
+                                                         self.monitoring.resource_monitoring_interval,
+                                                         executor.monitor_resources())
 
         with self.submitter_lock:
             exec_fu = executor.submit(executable, self.tasks[task_id]['resource_specification'], *args, **kwargs)

--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -101,6 +101,16 @@ class ParslExecutor(metaclass=ABCMeta):
         """
         return []
 
+    def monitor_resources(self) -> bool:
+        """Should resource monitoring happen for tasks on running on this executor?
+
+        Parsl resource monitoring conflicts with execution styles which use threads, and
+        can deadlock while running.
+
+        This function allows resource monitoring to be disabled per executor implementation.
+        """
+        return True
+
     @abstractmethod
     def status(self) -> Dict[object, JobStatus]:
         """Return the status of all jobs/blocks currently known to this executor.

--- a/parsl/executors/threads.py
+++ b/parsl/executors/threads.py
@@ -104,3 +104,8 @@ class ThreadPoolExecutor(NoStatusHandlingExecutor, RepresentationMixin):
         x = self.executor.shutdown(wait=block)
         logger.debug("Done with executor shutdown")
         return x
+
+    def monitor_resources(self):
+        """Resource monitoring sometimes deadlocks when using threads, so this function
+        returns false to disable it."""
+        return False


### PR DESCRIPTION
This allows an executor implementor (not a user) to indicate
that parsl resource monitoring is not compatible with that
executor - this incompatibility arises with the
ThreadPoolExecutor as process spawning and thread spawning
do not play nicely together in python.

With this PR, ThreadPoolExecutor can be used in a configuration
with monitoring enabled.

ThreadPoolExecutor is needed for a couple of features
even when most work is done through some other executor such
as HTEX:

* the existing globus data provider

* still unmerged @join_app functionality

# Description

Please include a summary of the change and (optionally) which issue is fixed. Please also include
relevant motivation and context.

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
- Code maintentance/cleanup
