### PR TITLE
Remove logging from remote_side_bash_executor

### DIFF
--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -12,25 +12,9 @@ def remote_side_bash_executor(func, *args, **kwargs):
     command-line to run, and then run that command-line using bash.
     """
     import os
-    import time
     import subprocess
-    import logging
     import parsl.app.errors as pe
-    from parsl import set_file_logger
     from parsl.utils import get_std_fname_mode
-
-    logbase = "/tmp"
-    format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
-
-    # make this name unique per invocation so that each invocation can
-    # log to its own file. It would be better to include the task_id here
-    # but that is awkward to wire through at the moment as apps do not
-    # have access to that execution context.
-    t = time.time()
-
-    logname = __name__ + "." + str(t)
-    logger = logging.getLogger(logname)
-    set_file_logger(filename='{0}/bashexec.{1}.log'.format(logbase, t), name=logname, level=logging.DEBUG, format_string=format_string)
 
     func_name = func.__name__
 
@@ -53,10 +37,7 @@ def remote_side_bash_executor(func, *args, **kwargs):
     except IndexError as e:
         raise pe.AppBadFormatting("App formatting failed for app '{}' with IndexError: {}".format(func_name, e))
     except Exception as e:
-        logger.error("Caught exception during formatting of app '{}': {}".format(func_name, e))
         raise e
-
-    logger.debug("Executable: %s", executable)
 
     # Updating stdout, stderr if values passed at call time.
 


### PR DESCRIPTION
# Description

The `remote_side_bash_executor` wraps bash commands in a python function. This function currently adds a new logger per function execution to direct log lines from each bash_app execution to its own log file, and does not close the logger file handles. This could result in the worker side running out of filehandles as we run more apps. However, we currently only report logs that are redundant given reporting we do elsewhere. This PR removes the loglines and the code that sets up the logger.

Fixes #1950 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)

Reported by Andrzej Novak.