### PR TITLE
Fix bad args for ScalingFailed constructor

### DIFF
--- a/parsl/executors/errors.py
+++ b/parsl/executors/errors.py
@@ -1,6 +1,8 @@
 """Exceptions raise by Executors."""
 from parsl.app.errors import ParslError
 
+from typing import Optional
+
 
 class ExecutorError(ParslError):
     """Base class for all exceptions.
@@ -51,7 +53,7 @@ Please checkout {} for this feature".format(self.feature,
 class ScalingFailed(ExecutorError):
     """Scaling failed due to error in Execution provider."""
 
-    def __init__(self, executor, reason):
+    def __init__(self, executor: Optional[str], reason: str):
         self.executor = executor
         self.reason = reason
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -612,7 +612,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         """Scales out the number of blocks by "blocks"
         """
         if not self.provider:
-            raise (ScalingFailed("No execution provider available"))
+            raise (ScalingFailed(None, "No execution provider available"))
         r = []
         for i in range(blocks):
             external_block_id = str(len(self.blocks))


### PR DESCRIPTION
In one place, the constructor was called with the wrong number of args,
which would result in a different exception when trying to raise this.

This PR makes provider label optional to support that use, where there
is no provider available.

This PR adds type annotations on the ScalingFailed __init__()

# Type of change

- Bug fix (non-breaking change that fixes an issue)
