### PR TITLE
Remove unused executor errors

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -135,11 +135,9 @@ Exceptions
     parsl.app.errors.MissingOutputs
     parsl.app.errors.NotFutureError
     parsl.app.errors.ParslError
-    parsl.executors.errors.ControllerError
     parsl.executors.errors.ExecutorError
     parsl.executors.errors.ScalingFailed
     parsl.executors.errors.SerializationError
-    parsl.executors.errors.InsufficientMPIRanks
     parsl.executors.errors.DeserializationError
     parsl.executors.errors.BadMessage
     parsl.dataflow.error.DataFlowException

--- a/docs/stubs/parsl.executors.errors.ControllerError.rst
+++ b/docs/stubs/parsl.executors.errors.ControllerError.rst
@@ -1,6 +1,0 @@
-parsl.executors.errors.ControllerError
-======================================
-
-.. currentmodule:: parsl.executors.errors
-
-.. autoexception:: ControllerError

--- a/docs/stubs/parsl.executors.errors.InsufficientMPIRanks.rst
+++ b/docs/stubs/parsl.executors.errors.InsufficientMPIRanks.rst
@@ -1,6 +1,0 @@
-parsl.executors.errors.InsufficientMPIRanks
-===========================================
-
-.. currentmodule:: parsl.executors.errors
-
-.. autoexception:: InsufficientMPIRanks

--- a/parsl/executors/errors.py
+++ b/parsl/executors/errors.py
@@ -16,20 +16,6 @@ class ExecutorError(ParslError):
         return "Executor {0} failed due to {1}".format(self.executor, self.reason)
 
 
-class InsufficientMPIRanks(ExecutorError):
-    ''' Error raised when attempting to launch a MPI worker pool with less than 2 ranks
-    '''
-
-    def __init__(self, tasks_per_node=None, nodes_per_block=None):
-        self.tasks_per_node = tasks_per_node
-        self.nodes_per_block = nodes_per_block
-
-    def __repr__(self):
-        return "MPIExecutor requires at least 2 ranks launched. \
-Ranks launched = tasks_per_node={} X nodes_per_block={}".format(self.tasks_per_node,
-                                                                self.nodes_per_block)
-
-
 class UnsupportedFeatureError(ExecutorError):
     """Error raised when attemping to use unsupported feature in an Executor"""
 
@@ -54,19 +40,6 @@ class ScalingFailed(ExecutorError):
     def __init__(self, executor, reason):
         self.executor = executor
         self.reason = reason
-
-
-class ControllerError(ExecutorError):
-    """Error raise by IPP controller."""
-
-    def __init__(self, reason):
-        self.reason = reason
-
-    def __repr__(self):
-        return "Controller init failed:Reason:{0}".format(self.reason)
-
-    def __str__(self):
-        return self.__repr__()
 
 
 class DeserializationError(ExecutorError):


### PR DESCRIPTION
Looks like ControllerError is a leftover from IPP,
and InsufficientMPIRanks is from some now discarded
MPI work.

## Type of change

- Code maintentance/cleanup
