### PR TITLE
Fix executor error repr vs str wrong-way-round-ness

### DIFF
--- a/parsl/executors/errors.py
+++ b/parsl/executors/errors.py
@@ -12,8 +12,8 @@ class ExecutorError(ParslError):
         self.executor = executor
         self.reason = reason
 
-    def __repr__(self):
-        return "Executor {0} failed due to {1}".format(self.executor, self.reason)
+    def __str__(self):
+        return "Executor {0} failed due to: {1}".format(self.executor, self.reason)
 
 
 class InsufficientMPIRanks(ExecutorError):
@@ -38,14 +38,11 @@ class UnsupportedFeatureError(ExecutorError):
         self.current_executor = current_executor
         self.target_executor = target_executor
 
-    def __repr__(self):
+    def __str__(self):
         return "The {} feature is unsupported in {}. \
 Please checkout {} for this feature".format(self.feature,
                                             self.current_executor,
                                             self.target_executor)
-
-    def __str__(self):
-        return self.__repr__()
 
 
 class ScalingFailed(ExecutorError):
@@ -76,7 +73,7 @@ class DeserializationError(ExecutorError):
     def __init__(self, reason):
         self.reason = reason
 
-    def __repr__(self):
+    def __str__(self):
         return "Failed to deserialize return objects. Reason:{}".format(self.reason)
 
 
@@ -88,12 +85,9 @@ class SerializationError(ExecutorError):
         self.fname = fname
         self.troubleshooting = "https://parsl.readthedocs.io/en/latest/faq.html#addressing-serializationerror"
 
-    def __repr__(self):
+    def __str__(self):
         return "Failed to serialize data objects for {}. Refer {} ".format(self.fname,
                                                                            self.troubleshooting)
-
-    def __str__(self):
-        return self.__repr__()
 
 
 class BadMessage(ExecutorError):
@@ -103,5 +97,5 @@ class BadMessage(ExecutorError):
     def __init__(self, reason):
         self.reason = reason
 
-    def __repr__(self):
+    def __str__(self):
         return "Received an unsupported message. Reason:{}".format(self.reason)


### PR DESCRIPTION
str should be more informal/human readable, and repr should be more
python syntax

see:
  https://docs.python.org/3/reference/datamodel.html#object.__str__
  https://docs.python.org/3/reference/datamodel.html#object.__repr__

Before this PR (eg for a ScalingFailed error, which inherits its
str/repr behaviour from executorerror):

>>> str(ex)
('local', 'Attempts to provision nodes via provider has failed')
>>> repr(ex)
Executor local failed due to Attempts to provision nodes via provider has failed

After this, the object default repr is used instead of overriding,
and where repr() was previously overridden to provide human readable text,
that is changed to be the str() representation.

So, the example ScalingFailed error looks like:

>>> str(ex)
'Executor local failed due to: Attempts to provision nodes via provider has failed'
>>> repr(ex)
"ScalingFailed('local', 'Attempts to provision nodes via provider has failed')"

## Type of change

- Code maintentance/cleanup
