### PR TITLE
Add typeguard to user-facing app decorators

### DIFF
--- a/parsl/app/app.py
+++ b/parsl/app/app.py
@@ -3,8 +3,13 @@
 The App class encapsulates a generic leaf task that can be executed asynchronously.
 """
 import logging
+import typeguard
 from abc import ABCMeta, abstractmethod
 from inspect import signature
+from typing import List, Optional, Union
+from typing_extensions import Literal
+
+from parsl.dataflow.dflow import DataFlowKernel
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +69,13 @@ class AppBase(metaclass=ABCMeta):
         pass
 
 
-def python_app(function=None, data_flow_kernel=None, cache=False, executors='all', ignore_for_cache=None, join=False):
+@typeguard.typechecked
+def python_app(function=None,
+               data_flow_kernel: Optional[DataFlowKernel] = None,
+               cache: bool = False,
+               executors: Union[List[str], Literal['all']] = 'all',
+               ignore_for_cache: Optional[List[str]] = None,
+               join: bool = False):
     """Decorator function for making python apps.
 
     Parameters
@@ -102,7 +113,11 @@ def python_app(function=None, data_flow_kernel=None, cache=False, executors='all
     return decorator
 
 
-def join_app(function=None, data_flow_kernel=None, cache=False, ignore_for_cache=None):
+@typeguard.typechecked
+def join_app(function=None,
+             data_flow_kernel: Optional[DataFlowKernel] = None,
+             cache: bool = False,
+             ignore_for_cache: Optional[List[str]] = None):
     return python_app(function=function,
                       data_flow_kernel=data_flow_kernel,
                       cache=cache,
@@ -111,7 +126,12 @@ def join_app(function=None, data_flow_kernel=None, cache=False, ignore_for_cache
                       executors=["_parsl_internal"])
 
 
-def bash_app(function=None, data_flow_kernel=None, cache=False, executors='all', ignore_for_cache=None):
+@typeguard.typechecked
+def bash_app(function=None,
+             data_flow_kernel: Optional[DataFlowKernel] = None,
+             cache: bool = False,
+             executors: Union[List[str], Literal['all']] = 'all',
+             ignore_for_cache: Optional[List[str]] = None):
     """Decorator function for making bash apps.
 
     Parameters

--- a/parsl/data_provider/ftp.py
+++ b/parsl/data_provider/ftp.py
@@ -2,7 +2,7 @@ import ftplib
 import logging
 import os
 
-from parsl import python_app
+import parsl
 
 from parsl.utils import RepresentationMixin
 from parsl.data_provider.staging import Staging
@@ -81,4 +81,4 @@ def _ftp_stage_in(working_dir, parent_fut=None, outputs=[], _parsl_staging_inhib
 
 
 def _ftp_stage_in_app(dm, executor):
-    return python_app(executors=[executor], data_flow_kernel=dm.dfk)(_ftp_stage_in)
+    return parsl.python_app(executors=[executor], data_flow_kernel=dm.dfk)(_ftp_stage_in)

--- a/parsl/data_provider/http.py
+++ b/parsl/data_provider/http.py
@@ -2,7 +2,7 @@ import logging
 import os
 import requests
 
-from parsl import python_app
+import parsl
 
 from parsl.utils import RepresentationMixin
 from parsl.data_provider.staging import Staging
@@ -85,4 +85,4 @@ def _http_stage_in(working_dir, parent_fut=None, outputs=[], _parsl_staging_inhi
 
 
 def _http_stage_in_app(dm, executor):
-    return python_app(executors=[executor], data_flow_kernel=dm.dfk)(_http_stage_in)
+    return parsl.python_app(executors=[executor], data_flow_kernel=dm.dfk)(_http_stage_in)


### PR DESCRIPTION
This PR changes imports in file staging providers to prevent an import loop introduced by the import of DataFlowKernel into the decorator module.

`import M` is more robust against import loops than `from M import x`

## Type of change

- New feature (non-breaking change that adds functionality)
- Code maintentance/cleanup
