### PR TITLE
Add optional queue flag to Grid Engine submissions

### DIFF
--- a/parsl/providers/grid_engine/grid_engine.py
+++ b/parsl/providers/grid_engine/grid_engine.py
@@ -72,7 +72,8 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
                  walltime="00:10:00",
                  scheduler_options='',
                  worker_init='',
-                 launcher=SingleNodeLauncher()):
+                 launcher=SingleNodeLauncher(),
+                 queue=None):
         label = 'grid_engine'
         super().__init__(label,
                          channel,
@@ -141,7 +142,10 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
         self._write_submit_script(template_string, script_path, job_name, job_config)
 
         channel_script_path = self.channel.push_file(script_path, self.channel.script_dir)
-        cmd = "qsub -terse {0}".format(channel_script_path)
+        if self.queue is not None:
+            cmd = "qsub -q {0} -terse {1}".format(self.queue, channel_script_path)
+        else:
+            cmd = "qsub -terse {0}".format(channel_script_path)
         retcode, stdout, stderr = self.execute_wait(cmd, 10)
 
         if retcode == 0:


### PR DESCRIPTION
# Description

Hi. @Lanyavikins at UCSF has been getting our Parsl pipeline working with a Grid Engine scheduler. However, the job submission on Wynton requires a "queue" command line argument. Her fix is to add "queue" as an optional parameter to GridEngineProvider.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)