### PR TITLE
Use repr instead of str for monitoring fail history

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -289,7 +289,7 @@ class DataFlowKernel(object):
             logger.debug("Task {} try {} failed".format(task_id, task_record['try_id']))
             # We keep the history separately, since the future itself could be
             # tossed.
-            task_record['fail_history'].append(str(e))
+            task_record['fail_history'].append(repr(e))
             task_record['fail_count'] += 1
 
             if task_record['status'] == States.dep_fail:
@@ -368,7 +368,7 @@ class DataFlowKernel(object):
             logger.debug("Task {} failed due to failure of inner join future".format(outer_task_id))
             # We keep the history separately, since the future itself could be
             # tossed.
-            task_record['fail_history'].append(str(e))
+            task_record['fail_history'].append(repr(e))
             task_record['fail_count'] += 1
 
             task_record['status'] = States.failed


### PR DESCRIPTION
repr is a better format for this field. For example, it usually
contains more context such as the exception class name:

```
>>> str(v)
'3'
>>> repr(v)
'KeyError(3)'
```

Anything expecting specific content for monitoring errors in the monitoring db will break as the format is changed.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
