### PR TITLE
Log UDP received message as soon as it is received.

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -487,9 +487,9 @@ class MonitoringRouter:
                 try:
                     data, addr = self.sock.recvfrom(2048)
                     msg = pickle.loads(data)
+                    self.logger.debug("Got UDP Message from {}: {}".format(addr, msg))
                     resource_msgs.put((msg, addr))
                     last_msg_received_time = time.time()
-                    self.logger.debug("Got UDP Message from {}: {}".format(addr, msg))
                 except socket.timeout:
                     pass
 


### PR DESCRIPTION
Previously after receiving a UDP message, there was a potential block on subsequent delivery to a queue before the log happened.


# Description

Please include a summary of the change and (optionally) which issue is fixed. Please also include
relevant motivation and context.

## Type of change

- Code maintentance/cleanup
