### PR TITLE
Adding cmd_timeout option to GridEngineProvider

### DIFF
--- a/parsl/providers/grid_engine/grid_engine.py
+++ b/parsl/providers/grid_engine/grid_engine.py
@@ -60,6 +60,8 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
     launcher : Launcher
         Launcher for this provider. Possible launchers include
         :class:`~parsl.launchers.SingleNodeLauncher` (the default),
+    cmd_timeout : int
+        Timeout for commands made to the scheduler in seconds
     """
 
     def __init__(self,
@@ -73,6 +75,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
                  scheduler_options='',
                  worker_init='',
                  launcher=SingleNodeLauncher(),
+                 cmd_timeout: int = 10,
                  queue=None):
         label = 'grid_engine'
         super().__init__(label,
@@ -83,7 +86,8 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
                          max_blocks,
                          parallelism,
                          walltime,
-                         launcher)
+                         launcher,
+                         cmd_timeout=cmd_timeout)
         self.scheduler_options = scheduler_options
         self.worker_init = worker_init
 

--- a/parsl/providers/grid_engine/grid_engine.py
+++ b/parsl/providers/grid_engine/grid_engine.py
@@ -75,7 +75,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
                  scheduler_options='',
                  worker_init='',
                  launcher=SingleNodeLauncher(),
-                 cmd_timeout: int = 10,
+                 cmd_timeout: int = 60,
                  queue=None):
         label = 'grid_engine'
         super().__init__(label,

--- a/parsl/providers/grid_engine/grid_engine.py
+++ b/parsl/providers/grid_engine/grid_engine.py
@@ -150,7 +150,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
             cmd = "qsub -q {0} -terse {1}".format(self.queue, channel_script_path)
         else:
             cmd = "qsub -terse {0}".format(channel_script_path)
-        retcode, stdout, stderr = self.execute_wait(cmd, 10)
+        retcode, stdout, stderr = self.execute_wait(cmd)
 
         if retcode == 0:
             for line in stdout.split('\n'):
@@ -214,7 +214,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
 
         job_id_list = ' '.join(job_ids)
         cmd = "qdel {}".format(job_id_list)
-        retcode, stdout, stderr = self.execute_wait(cmd, 3)
+        retcode, stdout, stderr = self.execute_wait(cmd)
 
         rets = None
         if retcode == 0:


### PR DESCRIPTION
# Description

The GridEngineProvider doesn't currently support the `cmd_timeout` kwarg that's used to configure the duration for which the provider would wait for commands. This PR adds that.

Requested by @marinerhemant

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- Documentation update
