### PR TITLE
Unify two impls of OptionalModuleMissing exception class

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -136,6 +136,7 @@ Exceptions
     parsl.app.errors.MissingOutputs
     parsl.app.errors.NotFutureError
     parsl.app.errors.ParslError
+    parsl.errors.OptionalModuleMissing
     parsl.executors.errors.ExecutorError
     parsl.executors.errors.ScalingFailed
     parsl.executors.errors.SerializationError
@@ -148,7 +149,6 @@ Exceptions
     parsl.dataflow.error.DependencyError
     parsl.launchers.error.BadLauncher
     parsl.providers.error.ExecutionProviderException
-    parsl.providers.error.OptionalModuleMissing
     parsl.providers.error.ChannelRequired
     parsl.providers.error.ScaleOutFailed
     parsl.providers.error.SchedulerMissingArgs

--- a/docs/stubs/parsl.errors.OptionalModuleMissing.rst
+++ b/docs/stubs/parsl.errors.OptionalModuleMissing.rst
@@ -1,0 +1,6 @@
+parsl.errors.OptionalModuleMissing
+==================================
+
+.. currentmodule:: parsl.errors
+
+.. autoexception:: OptionalModuleMissing

--- a/docs/stubs/parsl.providers.error.OptionalModuleMissing.rst
+++ b/docs/stubs/parsl.providers.error.OptionalModuleMissing.rst
@@ -1,6 +1,0 @@
-parsl.providers.error.OptionalModuleMissing
-===========================================
-
-.. currentmodule:: parsl.providers.error
-
-.. autoexception:: OptionalModuleMissing

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -24,10 +24,10 @@ from parsl.serialize import pack_apply_message
 import parsl.utils as putils
 from parsl.executors.errors import ExecutorError
 from parsl.data_provider.files import File
+from parsl.errors import OptionalModuleMissing
 from parsl.executors.status_handling import NoStatusHandlingExecutor
 from parsl.providers.provider_base import ExecutionProvider
 from parsl.providers import LocalProvider, CondorProvider
-from parsl.providers.error import OptionalModuleMissing
 from parsl.executors.errors import ScalingFailed
 from parsl.executors.workqueue import exec_parsl_function
 

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, TypeVar
 
 from parsl.log_utils import set_file_logger
 from parsl.dataflow.states import States
-from parsl.providers.error import OptionalModuleMissing
+from parsl.errors import OptionalModuleMissing
 from parsl.monitoring.message_type import MessageType
 from parsl.process_loggers import wrap_with_logs
 

--- a/parsl/providers/aws/aws.py
+++ b/parsl/providers/aws/aws.py
@@ -7,7 +7,7 @@ from string import Template
 from parsl.dataflow.error import ConfigurationError
 from parsl.providers.aws.template import template_string
 from parsl.providers.provider_base import ExecutionProvider, JobState, JobStatus
-from parsl.providers.error import OptionalModuleMissing
+from parsl.errors import OptionalModuleMissing
 from parsl.utils import RepresentationMixin
 from parsl.launchers import SingleNodeLauncher
 

--- a/parsl/providers/azure/azure.py
+++ b/parsl/providers/azure/azure.py
@@ -7,7 +7,7 @@ from string import Template
 from parsl.dataflow.error import ConfigurationError
 from parsl.providers.azure.template import template_string
 from parsl.providers.provider_base import ExecutionProvider, JobState, JobStatus
-from parsl.providers.error import OptionalModuleMissing
+from parsl.errors import OptionalModuleMissing
 from parsl.utils import RepresentationMixin
 from parsl.launchers import SingleNodeLauncher
 

--- a/parsl/providers/error.py
+++ b/parsl/providers/error.py
@@ -6,20 +6,6 @@ class ExecutionProviderException(Exception):
     pass
 
 
-class OptionalModuleMissing(ExecutionProviderException):
-    ''' Error raised a required module is missing for a optional/extra provider
-    '''
-
-    def __init__(self, module_names, reason):
-        self.module_names = module_names
-        self.reason = reason
-
-    def __repr__(self):
-        return "Unable to Initialize provider.Missing:{0},  Reason:{1}".format(
-            self.module_names, self.reason
-        )
-
-
 class ChannelRequired(ExecutionProviderException):
     ''' Execution provider requires a channel.
     '''

--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -4,7 +4,7 @@ from parsl.providers.kubernetes.template import template_string
 
 logger = logging.getLogger(__name__)
 
-from parsl.providers.error import OptionalModuleMissing
+from parsl.errors import OptionalModuleMissing
 from parsl.providers.provider_base import ExecutionProvider, JobState, JobStatus
 from parsl.utils import RepresentationMixin
 


### PR DESCRIPTION
There was one at the parsl top level, and one in providers, but
these were not used uniformly:

* the monitoring system used the provider version even though
it is nothing to do with the provider system.

* the top level error was not listed in the API documentation

This will break any code that was expecting specific classes for these errors, but I've never seen any in real life.
 
## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Code maintentance/cleanup
