### PR TITLE
Allow passing GPU requirements to WQ executor

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -337,16 +337,17 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
         if resource_specification and isinstance(resource_specification, dict):
             logger.debug("Got resource specification: {}".format(resource_specification))
 
+            required_resource_types = set(['cores', 'memory', 'disk'])
             acceptable_resource_types = set(['cores', 'memory', 'disk', 'gpus'])
             keys = set(resource_specification.keys())
-            if self.autolabel:
-                if not keys.issubset(acceptable_resource_types):
-                    message = "Task resource specification only accepts these types of resources: {}".format(
-                            ', '.join(acceptable_resource_types))
-                    logger.error(message)
-                    raise ExecutorError(self, message)
 
-            elif keys != acceptable_resource_types:
+            if not keys.issubset(acceptable_resource_types):
+                message = "Task resource specification only accepts these types of resources: {}".format(
+                        ', '.join(acceptable_resource_types))
+                logger.error(message)
+                raise ExecutorError(self, message)
+
+            if not self.autolabel and not keys.issuperset(required_resource_types):
                 logger.error("Running with `autolabel=False`. In this mode, "
                              "task resource specification requires "
                              "three resources to be specified simultaneously: cores, memory, and disk")

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
 
 
 # Support structure to communicate parsl tasks to the work queue submit thread.
-ParslTaskToWq = namedtuple('ParslTaskToWq', 'id category cores memory disk env_pkg map_file function_file result_file input_files output_files')
+ParslTaskToWq = namedtuple('ParslTaskToWq', 'id category cores memory disk gpus env_pkg map_file function_file result_file input_files output_files')
 
 # Support structure to communicate final status of work queue tasks to parsl
 # result is only valid if result_received is True
@@ -333,25 +333,25 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
         cores = None
         memory = None
         disk = None
+        gpus = None
         if resource_specification and isinstance(resource_specification, dict):
             logger.debug("Got resource specification: {}".format(resource_specification))
 
-            acceptable_resource_types = set(['cores', 'memory', 'disk'])
+            acceptable_resource_types = set(['cores', 'memory', 'disk', 'gpus'])
             keys = set(resource_specification.keys())
             if self.autolabel:
                 if not keys.issubset(acceptable_resource_types):
-                    logger.error("Task resource specification only accepts "
-                                 "three types of resources: cores, memory, and disk")
-                    raise ExecutorError(self, "Task resource specification only accepts "
-                                              "three types of resources: cores, memory, and disk")
+                    message = "Task resource specification only accepts these types of resources: {}".format(
+                            ', '.join(acceptable_resource_types))
+                    logger.error(message)
+                    raise ExecutorError(self, message)
 
             elif keys != acceptable_resource_types:
                 logger.error("Running with `autolabel=False`. In this mode, "
                              "task resource specification requires "
                              "three resources to be specified simultaneously: cores, memory, and disk")
                 raise ExecutorError(self, "Task resource specification requires "
-                                          "three resources to be specified simultaneously: cores, memory, and disk, "
-                                          "and only takes these three resource types, when running with `autolabel=False`. "
+                                          "three resources to be specified simultaneously: cores, memory, and disk. "
                                           "Try setting autolabel=True if you are unsure of the resource usage")
 
             for k in keys:
@@ -361,6 +361,8 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
                     memory = resource_specification[k]
                 elif k == 'disk':
                     disk = resource_specification[k]
+                elif k == 'gpus':
+                    gpus = resource_specification[k]
 
         self.task_counter += 1
         task_id = self.task_counter
@@ -423,6 +425,7 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
                                                  cores,
                                                  memory,
                                                  disk,
+                                                 gpus,
                                                  env_pkg,
                                                  map_file,
                                                  function_file,
@@ -788,6 +791,8 @@ def _work_queue_submit_wait(task_queue=multiprocessing.Queue(),
                 t.specify_memory(task.memory)
             if task.disk is not None:
                 t.specify_disk(task.disk)
+            if task.gpus is not None:
+                t.specify_gpus(task.gpus)
 
             # Specify environment variables for the task
             if env is not None:


### PR DESCRIPTION
# Description

Update WQ executor to allow specifying GPUs.

CCTools just released version 7.2.0, which improves handling for GPUs. This PR allows Parsl apps to specify GPUs in their resource requirements, which will be passed down to WQ.

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)