### PR TITLE
Workaround for missing /sbin/ip command

### DIFF
--- a/parsl/addresses.py
+++ b/parsl/addresses.py
@@ -7,7 +7,6 @@ so some experimentation will probably be needed to choose the correct one.
 """
 
 import logging
-import os
 import platform
 import requests
 import socket

--- a/parsl/addresses.py
+++ b/parsl/addresses.py
@@ -29,7 +29,17 @@ def address_by_route() -> str:
        not reachable from workers.
     """
     logger.debug("Finding address by querying local routing table")
-    addr = os.popen("/sbin/ip route get 8.8.8.8 | awk '{print $NF;exit}'").read().strip()
+    
+    if os.path.exists('/sbin/ip'):
+        addr = os.popen("/sbin/ip route get 8.8.8.8 | awk '{print $NF;exit}'").read().strip()
+    else:
+        # original author unknown
+        import socket
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80))
+        addr = s.getsockname()[0]
+        s.close()
+        
     logger.debug("Address found: {}".format(addr))
     return addr
 

--- a/parsl/addresses.py
+++ b/parsl/addresses.py
@@ -29,16 +29,13 @@ def address_by_route() -> str:
        not reachable from workers.
     """
     logger.debug("Finding address by querying local routing table")
-    
-    if os.path.exists('/sbin/ip'):
-        addr = os.popen("/sbin/ip route get 8.8.8.8 | awk '{print $NF;exit}'").read().strip()
-    else:
-        # original author unknown
-        import socket
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.connect(("8.8.8.8", 80))
-        addr = s.getsockname()[0]
-        s.close()
+
+    # original author unknown
+    import socket
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(("8.8.8.8", 80))
+    addr = s.getsockname()[0]
+    s.close()
         
     logger.debug("Address found: {}".format(addr))
     return addr

--- a/parsl/addresses.py
+++ b/parsl/addresses.py
@@ -36,7 +36,6 @@ def address_by_route() -> str:
     s.connect(("8.8.8.8", 80))
     addr = s.getsockname()[0]
     s.close()
-        
     logger.debug("Address found: {}".format(addr))
     return addr
 


### PR DESCRIPTION

# Description

Some linux distros do not come with /sbin/ip command and thus a workaround is needed for the function address_by_route.

Fixes # (issue)

## Type of change
Code

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)

