### PR TITLE
Fix for racecondition in usage tracking at cleanup

### DIFF
--- a/parsl/dataflow/usage_tracking/usage.py
+++ b/parsl/dataflow/usage_tracking/usage.py
@@ -10,7 +10,6 @@ import sys
 import platform
 import multiprocessing as mp
 
-from parsl.dataflow.states import FINAL_FAILURE_STATES
 from parsl.version import VERSION as PARSL_VERSION
 
 logger = logging.getLogger(__name__)
@@ -179,8 +178,7 @@ class UsageTracker (object):
 
         site_count = len([x for x in self.dfk.config.executors if x.managed])
 
-        app_fails = len([t for t in self.dfk.tasks if
-                         self.dfk.tasks[t]['status'] in FINAL_FAILURE_STATES])
+        app_fails = self.dfk.tasks_failed_count + self.tasks_dep_fail_count
 
         message = {'uuid': self.uuid,
                    'end': time.time(),

--- a/parsl/dataflow/usage_tracking/usage.py
+++ b/parsl/dataflow/usage_tracking/usage.py
@@ -178,7 +178,7 @@ class UsageTracker (object):
 
         site_count = len([x for x in self.dfk.config.executors if x.managed])
 
-        app_fails = self.dfk.tasks_failed_count + self.tasks_dep_fail_count
+        app_fails = self.dfk.tasks_failed_count + self.dfk.tasks_dep_fail_count
 
         message = {'uuid': self.uuid,
                    'end': time.time(),


### PR DESCRIPTION
# Description

This PR fixes a race-condition in usagetracking by using task counters in the DFK instead of the current mechanism of iterating on the DFK.tasks table. This avoid any issues arising from the tasks table's keys changing while it's being iterated on.

Fixes #1986 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
