### PR TITLE
Log block id in monitoring try table

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -497,6 +497,7 @@ def worker(worker_id, pool_id, pool_size, task_queue, result_queue, worker_queue
     os.environ['PARSL_WORKER_RANK'] = str(worker_id)
     os.environ['PARSL_WORKER_COUNT'] = str(pool_size)
     os.environ['PARSL_WORKER_POOL_ID'] = str(pool_id)
+    os.environ['PARSL_WORKER_BLOCK_ID'] = str(args.block_id)
 
     # Sync worker with master
     logger.info('Worker {} started'.format(worker_id))

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -156,6 +156,7 @@ class Database:
         task_id = Column('task_id', Integer, nullable=False)
         run_id = Column('run_id', Text, nullable=False)
 
+        block_id = Column('block_id', Text, nullable=True)
         hostname = Column('hostname', Text, nullable=True)
 
         task_executor = Column('task_executor', Text, nullable=False)
@@ -504,7 +505,7 @@ class DatabaseManager:
                     self._update(table=TRY,
                                  columns=['task_try_time_running',
                                           'run_id', 'task_id', 'try_id',
-                                          'hostname'],
+                                          'block_id', 'hostname'],
                                  messages=reprocessable_first_resource_messages)
             except Exception:
                 logger.exception("Exception in db loop: this might have been a malformed message, or some other error. monitoring data may have been lost")

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -548,6 +548,7 @@ def send_first_message(try_id: int,
                        monitoring_hub_url: str,
                        run_id: str) -> None:
     import platform
+    import os
 
     radio = UDPRadio(monitoring_hub_url,
                      source_id=task_id)
@@ -556,6 +557,7 @@ def send_first_message(try_id: int,
            'try_id': try_id,
            'task_id': task_id,
            'hostname': platform.node(),
+           'block_id': os.environ.get('PARSL_WORKER_BLOCK_ID'),
            'first_msg': True,
            'timestamp': datetime.datetime.now()
     }


### PR DESCRIPTION
# Description

This PR tries to set an env variable `PARSL_WORKER_BLOCK_ID` for every HTEX worker. When a task runs on a worker, monitoring extracts the block id info and logs the `block_id` into `try` table.

Fixes #1969 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Breaking change (fix or feature that would cause existing functionality to not work as expected) --- this breaks old monitoring db schema


