### PR TITLE
Tighten SQLAlchemy version constraints after incompatible SQLAlchemy 1.4 release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,3 +104,4 @@ Contributing
 ============
 
 We welcome contributions from the community. Please see our `contributing guide <CONTRIBUTING.rst>`_.
+

--- a/README.rst
+++ b/README.rst
@@ -104,4 +104,3 @@ Contributing
 ============
 
 We welcome contributions from the community. Please see our `contributing guide <CONTRIBUTING.rst>`_.
-

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 extras_require = {
     'monitoring' : [
-        'sqlalchemy>=1.3.0,!=1.3.4',
+        'sqlalchemy>=1.3.0,!=1.3.4,<1.4',
         'sqlalchemy_utils',
         'pydot',
         'networkx',


### PR DESCRIPTION
# Description

A recent release (1.4.0, 1.4.1) of sqlalchemy breaks the parsl[monitoring] install. This branch constraints sqlalchemy to the 1.3.x series.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
