### PR TITLE
Mark some tests that do not work for sites without a shared file system

### DIFF
--- a/parsl/tests/site_tests/site_config_selector.py
+++ b/parsl/tests/site_tests/site_config_selector.py
@@ -73,3 +73,5 @@ def fresh_config():
         # We should skip this.
 
     return config
+
+config = fresh_config()

--- a/parsl/tests/site_tests/site_config_selector.py
+++ b/parsl/tests/site_tests/site_config_selector.py
@@ -74,4 +74,5 @@ def fresh_config():
 
     return config
 
+
 config = fresh_config()

--- a/parsl/tests/test_bash_apps/test_error_codes.py
+++ b/parsl/tests/test_bash_apps/test_error_codes.py
@@ -151,6 +151,7 @@ def test_invalid_exit(test_fn=invalid_exit):
     return True
 
 
+@pytest.mark.issue363
 def test_not_executable(test_fn=not_executable):
     err_code = test_matrix[test_fn]['exit_code']
     f = test_fn()

--- a/parsl/tests/test_docs/test_workflow4.py
+++ b/parsl/tests/test_docs/test_workflow4.py
@@ -28,6 +28,7 @@ def total(inputs=[]):
             total += int(line)
     return total
 
+
 @pytest.mark.staging_required
 def test_parallel_dataflow():
     """Test parallel dataflow from docs on Composing workflows

--- a/parsl/tests/test_docs/test_workflow4.py
+++ b/parsl/tests/test_docs/test_workflow4.py
@@ -5,6 +5,8 @@ from parsl.app.app import bash_app, python_app
 from parsl.tests.configs.local_threads import config
 from parsl.data_provider.files import File
 
+import pytest
+
 # parsl.set_stream_logger()
 
 
@@ -26,7 +28,7 @@ def total(inputs=[]):
             total += int(line)
     return total
 
-
+@pytest.mark.staging_required
 def test_parallel_dataflow():
     """Test parallel dataflow from docs on Composing workflows
     """


### PR DESCRIPTION
# Description

Some tests currently failed on sites without a shared file system (e.g., k8s). This PR marks those tests to exclude them when doing site tests.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
