### PR TITLE
Switched the order of serializers to DillSerializer and PickleSerializer

### DIFF
--- a/parsl/serialize/concretes.py
+++ b/parsl/serialize/concretes.py
@@ -6,29 +6,6 @@ logger = logging.getLogger(__name__)
 from parsl.serialize.base import SerializerBase
 
 
-class PickleSerializer(SerializerBase):
-    """ Pickle serialization covers most python objects, with some notable exceptions:
-
-    * functions defined in a interpretor/notebook
-    * classes defined in local context and not importable using a fully qualified name
-    * clojures, generators and coroutines
-    * [sometimes] issues with wrapped/decorated functions
-    """
-
-    _identifier = b'01\n'
-    _for_code = True
-    _for_data = True
-
-    def serialize(self, data):
-        x = pickle.dumps(data)
-        return self.identifier + x
-
-    def deserialize(self, payload):
-        chomped = self.chomp(payload)
-        data = pickle.loads(chomped)
-        return data
-
-
 class DillSerializer(SerializerBase):
     """ Dill serialization works on a superset of object including the ones covered by pickle.
     However for most cases pickle is faster. For most callable objects the additional overhead
@@ -41,7 +18,7 @@ class DillSerializer(SerializerBase):
     * clojures
     """
 
-    _identifier = b'02\n'
+    _identifier = b'01\n'
     _for_code = True
     _for_data = True
 
@@ -52,4 +29,27 @@ class DillSerializer(SerializerBase):
     def deserialize(self, payload):
         chomped = self.chomp(payload)
         data = dill.loads(chomped)
+        return data
+
+
+class PickleSerializer(SerializerBase):
+    """ Pickle serialization covers most python objects, with some notable exceptions:
+
+    * functions defined in a interpretor/notebook
+    * classes defined in local context and not importable using a fully qualified name
+    * clojures, generators and coroutines
+    * [sometimes] issues with wrapped/decorated functions
+    """
+
+    _identifier = b'02\n'
+    _for_code = True
+    _for_data = True
+
+    def serialize(self, data):
+        x = pickle.dumps(data)
+        return self.identifier + x
+
+    def deserialize(self, payload):
+        chomped = self.chomp(payload)
+        data = pickle.loads(chomped)
         return data


### PR DESCRIPTION
Switched the order of serializers to DillSerializer and PickleSerializer

@benclifford We wanted to prioritize dill serializer, because dill is more reliable in some cases. For example, with the following snippet
```
    dfk = parsl.load(config)
    exe = dfk.executors['Midway_HTEX_multinode']
    f = exe.submit(square, None, 2)
    print(f.result())
```
The original order of serializers would give an error message of
`AttributeError: Can't get attribute 'square' on <module '__main__' from '/home/yrao2/.conda/envs/parsl_probe/bin/process_worker_pool.py'>`