### PR TITLE
fiddle with remote executor behaviour for better globus exceptions

### DIFF
--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -3,9 +3,7 @@ from functools import wraps
 from typing import Callable, List, Union, Any, TypeVar
 from types import TracebackType
 
-import dill
 import logging
-from tblib import Traceback
 
 from six import reraise
 
@@ -111,24 +109,29 @@ class BadStdStreamFile(ParslError):
 class RemoteExceptionWrapper:
     def __init__(self, e_type: type, e_value: Exception, traceback: TracebackType) -> None:
 
-        self.e_type = dill.dumps(e_type)
-        self.e_value = dill.dumps(e_value)
-        self.e_traceback = Traceback(traceback)
+        self.e_type = e_type
+        self.e_value = e_value
+        self.e_traceback = traceback
+
+        # self.e_type = dill.dumps(e_type)
+        # self.e_value = dill.dumps(e_value)
+        # self.e_traceback = Traceback(traceback)
 
     def reraise(self) -> None:
 
-        t = dill.loads(self.e_type)
+        # t = dill.loads(self.e_type)
 
         # the type is logged here before deserialising v and tb
         # because occasionally there are problems deserialising the
         # value (see #785, #548) and the fix is related to the
         # specific exception type.
-        logger.debug("Reraising exception of type {}".format(t))
+        # logger.debug("Reraising exception of type {}".format(t))
 
-        v = dill.loads(self.e_value)
-        tb = self.e_traceback.as_traceback()
+        # v = dill.loads(self.e_value)
+        # tb = self.e_traceback.as_traceback()
 
-        reraise(t, v, tb)
+        reraise(self.e_type, self.e_value, self.e_traceback)
+        # reraise(t, v, tb)
 
 
 R = TypeVar('R')

--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -2,10 +2,8 @@
 from functools import wraps
 from typing import Callable, List, Union, Any, TypeVar
 from types import TracebackType
-
 import logging
-
-from six import reraise
+from tblib import Traceback
 
 from parsl.data_provider.files import File
 
@@ -111,7 +109,7 @@ class RemoteExceptionWrapper:
 
         self.e_type = e_type
         self.e_value = e_value
-        self.e_traceback = traceback
+        self.e_traceback = Traceback(traceback)
 
         # self.e_type = dill.dumps(e_type)
         # self.e_value = dill.dumps(e_value)
@@ -125,12 +123,14 @@ class RemoteExceptionWrapper:
         # because occasionally there are problems deserialising the
         # value (see #785, #548) and the fix is related to the
         # specific exception type.
-        # logger.debug("Reraising exception of type {}".format(t))
+        logger.debug("Reraising exception of type {}".format(self.e_type))
 
         # v = dill.loads(self.e_value)
         # tb = self.e_traceback.as_traceback()
 
-        reraise(self.e_type, self.e_value, self.e_traceback)
+        raise self.e_value.with_traceback(self.e_traceback.as_traceback())
+
+        # reraise(self.e_type, self.e_value, self.e_traceback)
         # reraise(t, v, tb)
 
 


### PR DESCRIPTION
This removes some code from RemoteExceptionWrapper that looks like it might be irrelevant, and causing problems with local exceptions (eg #785)

# Description

Please include a summary of the change and (optionally) which issue is fixed. Please also include
relevant motivation and context.

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
- Code maintentance/cleanup
