### PR TITLE
Use zsh compatible install syntax

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -128,7 +128,7 @@ The following instructions outline how to set up Parsl from source.
     $ cd parsl
     $ pip install .
     ( To install specific extra options from the source :)
-    $ pip install .[<optional_pacakge1>...]
+    $ pip install '.[<optional_package1>...]'
 
 3. Use Parsl!
 

--- a/docs/userguide/configuring.rst
+++ b/docs/userguide/configuring.rst
@@ -319,7 +319,7 @@ Amazon Web Services
 .. image:: ./aws_image.png
 
 .. note::
-   To use AWS with Parsl, install Parsl with AWS dependencies via ``python3 -m pip install parsl[aws]``
+   To use AWS with Parsl, install Parsl with AWS dependencies via ``python3 -m pip install 'parsl[aws]'``
 
 Amazon Web Services is a commercial cloud service which allows users to rent a range of computers and other computing services.
 The following snippet shows how Parsl can be configured to provision nodes from the Elastic Compute Cloud (EC2) service.

--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -56,7 +56,7 @@ Visualization
 To run the web dashboard utility ``parsl-visualize`` you first need to install
 its dependencies:
 
-   $ pip install parsl[monitoring]
+   $ pip install 'parsl[monitoring]'
 
 To view the web dashboard while or after a Parsl program has executed, run
 the ``parsl-visualize`` utility::

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -48,11 +48,11 @@ class Database:
     if not _sqlalchemy_enabled:
         raise OptionalModuleMissing(['sqlalchemy'],
                                     ("Default database logging requires the sqlalchemy library."
-                                     " Enable monitoring support with: pip install parsl[monitoring]"))
+                                     " Enable monitoring support with: pip install 'parsl[monitoring]'"))
     if not _sqlalchemy_utils_enabled:
         raise OptionalModuleMissing(['sqlalchemy_utils'],
                                     ("Default database logging requires the sqlalchemy_utils library."
-                                     " Enable monitoring support with: pip install parsl[monitoring]"))
+                                     " Enable monitoring support with: pip install 'parsl[monitoring]'"))
 
     Base = declarative_base()
 


### PR DESCRIPTION
Without '-marks, zsh tries to resolve our given example installer
commandlines as wildcards, resulting in errors like this:

$ pip install parsl[monitoring]
zsh: no matches found: parsl[monitoring]

## Type of change
- Documentation update
