### PR TITLE
Add typing-extensions dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pyzmq>=17.1.2
 typeguard>=2.10
+typing-extensions
 globus-sdk
 dill
 tblib


### PR DESCRIPTION
This is needed because PR #1963 introduced code that uses this dependency.

Users get an error when installing parsl without this dependency when trying to do anything with parsl. See #2008 

It didn't break in CI, probably because the test-requirements
dependencies, such as mypy, make it be installed.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
