### PR TITLE
Fix use of previously removed reg_time monitoring field

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -416,7 +416,6 @@ class Interchange(object):
 
                     try:
                         msg = json.loads(message[1].decode('utf-8'))
-                        # msg['reg_time'] = datetime.datetime.strptime(msg['reg_time'], "%Y-%m-%d %H:%M:%S")
                         reg_flag = True
                     except Exception:
                         logger.warning("[MAIN] Got Exception reading registration message from manager: {}".format(

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -416,7 +416,7 @@ class Interchange(object):
 
                     try:
                         msg = json.loads(message[1].decode('utf-8'))
-                        msg['reg_time'] = datetime.datetime.strptime(msg['reg_time'], "%Y-%m-%d %H:%M:%S")
+                        # msg['reg_time'] = datetime.datetime.strptime(msg['reg_time'], "%Y-%m-%d %H:%M:%S")
                         reg_flag = True
                     except Exception:
                         logger.warning("[MAIN] Got Exception reading registration message from manager: {}".format(

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -8,7 +8,6 @@ import platform
 import threading
 import pickle
 import time
-import datetime
 import queue
 import uuid
 import zmq
@@ -204,7 +203,7 @@ class Manager(object):
                'dir': os.getcwd(),
                'cpu_count': psutil.cpu_count(logical=False),
                'total_memory': psutil.virtual_memory().total,
-               'reg_time': datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+               # 'reg_time': datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         }
         b_msg = json.dumps(msg).encode('utf-8')
         return b_msg

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -203,7 +203,6 @@ class Manager(object):
                'dir': os.getcwd(),
                'cpu_count': psutil.cpu_count(logical=False),
                'total_memory': psutil.virtual_memory().total,
-               # 'reg_time': datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         }
         b_msg = json.dumps(msg).encode('utf-8')
         return b_msg

--- a/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
@@ -97,7 +97,7 @@ def resource_time_series(tasks, type='psutil_process_time_user', label='CPU user
 def worker_efficiency(task, node):
     try:
         node['epoch_time'] = (pd.to_datetime(
-            node['reg_time']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
+            node['timestamp']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
         task['epoch_time_start'] = (pd.to_datetime(
             task['task_try_time_launched']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
         task['epoch_time_running'] = (pd.to_datetime(
@@ -141,7 +141,7 @@ def resource_efficiency(resource, node, label='CPU'):
         resource['epoch_time'] = (pd.to_datetime(
             resource['timestamp']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
         node['epoch_time'] = (pd.to_datetime(
-            node['reg_time']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
+            node['timestamp']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
         resource = resource.sort_values(by='epoch_time')
         start = min(resource['epoch_time'].min(), node['epoch_time'].min())
         end = resource['epoch_time'].max()


### PR DESCRIPTION
PR 1876 removed the reg_time field from the monitoring database but did not remove attempts to use it from the visualization code, or code that initialises it on the sending side.

Visualization was broken because of this.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintentance/cleanup
