### PR TITLE
Reflect python 3.9 support in setup.py metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     keywords=['Workflows', 'Scientific computing'],
     entry_points={'console_scripts':


### PR DESCRIPTION
Python 3.9 has been supported by parsl since #1720

## Type of change

- Documentation update
