### PR TITLE
Rework __repr__ and __str__ for OptionalModuleMissing

### DIFF
--- a/parsl/errors.py
+++ b/parsl/errors.py
@@ -1,15 +1,17 @@
 from parsl.app.errors import ParslError
 
+from typing import List
+
 
 class OptionalModuleMissing(ParslError):
     ''' Error raised when a required module is missing for a optional/extra component
     '''
 
-    def __init__(self, module_names, reason):
+    def __init__(self, module_names: List[str], reason: str):
         self.module_names = module_names
         self.reason = reason
 
-    def __repr__(self):
-        return "The functionality requested requires a missing optional module:{0},  Reason:{1}".format(
+    def __str__(self) -> str:
+        return "The functionality requested requires missing optional modules {0}, because: {1}".format(
             self.module_names, self.reason
         )


### PR DESCRIPTION
__repr__ should be quasi-machine-readable, and __str__ human readable
    
See PR #1966, commit a423955f4a9e03cf6986a6e21d285cf46fa3bc88, for further context.
    
    Before:
    
    >>> str(e)
    "(['mymod'], 'this test needs demonstrating')"
    >>> repr(e)
    "The functionality requested requires a missing optional module:['mymod'],  Reason:this test needs demonstrating"
    
    After:
    
    >>> str(e)
    "The functionality requested requires missing optional modules ['mymod'], because: this test needs demonstrating"
    >>> repr(e)
    "OptionalModuleMissing(['mymod'], 'this test needs demonstrating')"


## Type of change

- Code maintentance/cleanup
