### PR TITLE
Fix GridEngine unable to initialise due to missing self.queue

### DIFF
--- a/parsl/providers/grid_engine/grid_engine.py
+++ b/parsl/providers/grid_engine/grid_engine.py
@@ -90,6 +90,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
                          cmd_timeout=cmd_timeout)
         self.scheduler_options = scheduler_options
         self.worker_init = worker_init
+        self.queue = queue
 
         if launcher in ['srun', 'srun_mpi']:
             logger.warning("Use of {} launcher is usually appropriate for Slurm providers. "


### PR DESCRIPTION
PR #1964 introduces a queue constructor parameter and a use elsewhere of `self.queue`, but omits any code to join one to the other.

That means that at least all GridEngine configurations appear to be unusable when passed to parsl.load() whether they use the `queue` parameter or not - they raise the below exception.

```
python sgetets.py 
Traceback (most recent call last):
  File "sgetets.py", line 30, in <module>
    parsl.load(config)
  File "/home/benc/parsl/virtualenv-3.7/lib/python3.7/site-packages/typeguard/__init__.py", line 891, in wrapper
    retval = func(*args, **kwargs)
  File "/home/benc/parsl/src/parsl/parsl/dataflow/dflow.py", line 1280, in load
    cls._dfk = DataFlowKernel(config)
  File "/home/benc/parsl/src/parsl/parsl/dataflow/dflow.py", line 84, in __init__
    logger.debug("Starting DataFlowKernel with config\n{}".format(config))
  File "/home/benc/parsl/src/parsl/parsl/utils.py", line 229, in __repr__
    if len(assemble_line(args, kwargs)) <= self.__class__.__max_width__:
  File "/home/benc/parsl/src/parsl/parsl/utils.py", line 224, in assemble_line
    kwargsl = ['{}={}'.format(k, repr(v)) for k, v in sorted(kwargs.items())]
  File "/home/benc/parsl/src/parsl/parsl/utils.py", line 224, in <listcomp>
    kwargsl = ['{}={}'.format(k, repr(v)) for k, v in sorted(kwargs.items())]
  File "/home/benc/parsl/src/parsl/parsl/utils.py", line 229, in __repr__
    if len(assemble_line(args, kwargs)) <= self.__class__.__max_width__:
  File "/home/benc/parsl/src/parsl/parsl/utils.py", line 224, in assemble_line
    kwargsl = ['{}={}'.format(k, repr(v)) for k, v in sorted(kwargs.items())]
  File "/home/benc/parsl/src/parsl/parsl/utils.py", line 224, in <listcomp>
    kwargsl = ['{}={}'.format(k, repr(v)) for k, v in sorted(kwargs.items())]
  File "/home/benc/parsl/src/parsl/parsl/utils.py", line 202, in __repr__
    raise AttributeError(template.format(self.__class__.__name__, arg))
AttributeError: class GridEngineProvider uses queue in the constructor, but does not define it as an attribute
```

cc original PR #1964 submitters: @jmoon1506  @Lanyavikins

thanks to Quentin Le Boulc'h for reporting

## To reproduce:

This code on parsl 1.1 raises the above exception:
```
from parsl.config import Config
from parsl.channels import LocalChannel
from parsl.providers import GridEngineProvider
from parsl.executors import HighThroughputExecutor

def fresh_config():
    return Config(
        executors=[
            HighThroughputExecutor(
                label='cc_in2p3_htex',
                max_workers=1,
                provider=GridEngineProvider(
                    queue="foo",
                    channel=LocalChannel(),
                    nodes_per_block=2,
                    init_blocks=2,
                    max_blocks=2,
                    walltime="00:20:00",
                    scheduler_options="",
                    worker_init=""
                ),
            )
        ],
    )


config = fresh_config()
import parsl

parsl.load(config)
```


## Type of change

- Bug fix (non-breaking change that fixes an issue)


