### PR TITLE
Fix os independent paths

### DIFF
--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -94,7 +94,7 @@ class LocalChannel(Channel, RepresentationMixin):
             - FileCopyException : If file copy failed.
         '''
 
-        local_dest = dest_dir + '/' + os.path.basename(source)
+        local_dest = os.path.join(dest_dir, os.path.basename(source))
 
         # Only attempt to copy if the target dir and source dir are different
         if os.path.dirname(source) != dest_dir:

--- a/parsl/channels/ssh/ssh.py
+++ b/parsl/channels/ssh/ssh.py
@@ -160,7 +160,7 @@ class SSHChannel(Channel, RepresentationMixin):
             - FileCopyException : FileCopy failed.
 
         '''
-        remote_dest = remote_dir + '/' + os.path.basename(local_source)
+        remote_dest = os.path.join(remote_dir, os.path.basename(local_source))
 
         try:
             self.makedirs(remote_dir, exist_ok=True)
@@ -200,7 +200,7 @@ class SSHChannel(Channel, RepresentationMixin):
             - FileCopyException : FileCopy failed.
         '''
 
-        local_dest = local_dir + '/' + os.path.basename(remote_source)
+        local_dest = os.path.join(local_dir, os.path.basename(remote_source))
 
         try:
             os.makedirs(local_dir)


### PR DESCRIPTION
This change was originally added by @rantahar to a fork of `libsubmit` which means it has to be reintroduced again due to all the structural changes. 
I've found this [PR](https://github.com/Parsl/libsubmit/pull/88) a bit later and it was created not long before the project assimilation so it didn't have a chance to be merged. I'm not sure about line endings though, it looks like a reasonable thing since there is going to be Linux running on the other side.

# Description

Rather than stacking strings together it's much better to use `os` module to make it work on Windows as well.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
