### PR TITLE
Fix worker efficiency plot when tasks are still in progress

### DIFF
--- a/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
@@ -112,9 +112,14 @@ def worker_efficiency(task, node):
 
         for i, row in task.iterrows():
             if math.isnan(row['epoch_time_running']):
-                # skip tasks with no running start time.
+                # skip tasks with no running start time or return time.
                 continue
-            for j in range(int(row['epoch_time_running']), int(row['epoch_time_returned']) + 1):
+            if math.isnan(row['epoch_time_returned']):
+                # there is no end time for this, so we should assume the "end" time
+                etr = endtime = end
+            else:
+                etr = int(row['epoch_time_returned'])
+            for j in range(int(row['epoch_time_running']), etr + 1):
                 worker_plot[j - start] += 1
         fig = go.Figure(
             data=[go.Scatter(x=list(range(0, end - start + 1)),

--- a/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
@@ -112,7 +112,7 @@ def worker_efficiency(task, node):
 
         for i, row in task.iterrows():
             if math.isnan(row['epoch_time_running']):
-                # skip tasks with no running start time or return time.
+                # skip tasks with no running start time
                 continue
             if math.isnan(row['epoch_time_returned']):
                 # there is no end time for this, so we should assume the "end" time

--- a/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
@@ -116,7 +116,7 @@ def worker_efficiency(task, node):
                 continue
             if math.isnan(row['epoch_time_returned']):
                 # there is no end time for this, so we should assume the "end" time
-                etr = endtime = end
+                etr = end
             else:
                 etr = int(row['epoch_time_returned'])
             for j in range(int(row['epoch_time_running']), etr + 1):


### PR DESCRIPTION
# Description

Prior to this PR, this plot would crash. After this PR, this plot regards task without an end time as still in progress and occupying a worker.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
