### PR TITLE
String formatting

### DIFF
--- a/parsl/addresses.py
+++ b/parsl/addresses.py
@@ -58,7 +58,9 @@ def address_by_query(timeout: float = 30) -> str:
         logger.debug("Address found: {}".format(addr))
         return addr
     else:
-        raise RuntimeError("Remote service returned unexpected HTTP status code {}".format(response.status_code))
+        msg = (f"Remote service returned unexpected HTTP status code "
+               f"{response.status_code}")
+        raise RuntimeError(msg)
 
 
 def address_by_hostname() -> str:

--- a/parsl/channels/errors.py
+++ b/parsl/channels/errors.py
@@ -14,7 +14,7 @@ class ChannelError(Exception):
         self.hostname = hostname
 
     def __repr__(self) -> str:
-        return "Hostname:{0}, Reason:{1}".format(self.hostname, self.reason)
+        return f"Hostname:{self.hostname}, Reason:{self.reason}"
 
     def __str__(self) -> str:
         return self.__repr__()
@@ -72,8 +72,8 @@ class FileExists(ChannelError):
     '''
 
     def __init__(self, e: Exception, hostname: str, filename: Optional[str] = None) -> None:
-        super().__init__("File name collision in channel transport phase: {}".format(filename),
-                         e, hostname)
+        super().__init__(f"File name collision in channel transport phase: "
+                         f"{filename}", e, hostname)
 
 
 class AuthException(ChannelError):
@@ -112,4 +112,4 @@ class FileCopyException(ChannelError):
     '''
 
     def __init__(self, e: Exception, hostname: str) -> None:
-        super().__init__("File copy failed due to {0}".format(e), e, hostname)
+        super().__init__(f"File copy failed due to {e}", e, hostname)

--- a/parsl/channels/ssh/ssh.py
+++ b/parsl/channels/ssh/ssh.py
@@ -74,7 +74,8 @@ class SSHChannel(Channel, RepresentationMixin):
 
     def _connect(self):
         if not self._is_connected():
-            logger.debug(f"connecting to {self.hostname}:{self.port}")
+            logger.debug("connecting to {0}:{1}".format(self.hostname,
+                                                        self.port))
             try:
                 self.ssh_client.connect(
                     self.hostname,
@@ -113,8 +114,9 @@ class SSHChannel(Channel, RepresentationMixin):
         env.update(self.envs)
 
         if len(env.keys()) > 0:
-            env_vars = ' '.join(['{}={}'.format(key, value) for key, value in env.items()])
-            return 'env {0} {1}'.format(env_vars, cmd)
+            env_vars = ' '.join([f'{key}={value}' for key, value in
+                                 env.items()])
+            return f'env {env_vars} {cmd}'
         return cmd
 
     def execute_wait(self, cmd, walltime=2, envs={}):
@@ -252,9 +254,9 @@ class SSHChannel(Channel, RepresentationMixin):
             If False, raise an OSError if the target directory already exists.
         """
         if exist_ok is False and self.isdir(path):
-            raise OSError('Target directory {} already exists'.format(path))
+            raise OSError(f'Target directory {path} already exists')
 
-        self.execute_wait('mkdir -p {}'.format(path))
+        self.execute_wait(f'mkdir -p {path}')
         self._valid_sftp_client().chmod(path, mode)
 
     def abspath(self, path):

--- a/parsl/channels/ssh_il/ssh_il.py
+++ b/parsl/channels/ssh_il/ssh_il.py
@@ -68,7 +68,7 @@ class SSHInteractiveLoginChannel(SSHChannel):
 
         transport = self.ssh_client.get_transport()
 
-        il_password = getpass.getpass('Enter {0} Logon password :'.format(hostname))
+        il_password = getpass.getpass(f'Enter {hostname} Logon password :')
         transport.auth_password(username, il_password)
 
         self.sftp_client = paramiko.SFTPClient.from_transport(transport)

--- a/parsl/config.py
+++ b/parsl/config.py
@@ -116,6 +116,7 @@ class Config(RepresentationMixin):
         labels = [e.label for e in executors]
         duplicates = [e for n, e in enumerate(labels) if e in labels[:n]]
         if len(duplicates) > 0:
-            raise ConfigurationError('Executors must have unique labels ({})'.format(
-                ', '.join(['label={}'.format(repr(d)) for d in duplicates])))
+            labels_ = ', '.join([f'label={repr(d)}' for d in duplicates])
+            msg = f'Executors must have unique labels ({labels_})'
+            raise ConfigurationError(msg)
         self._executors = executors

--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -53,7 +53,7 @@ class DataManager(object):
 
         logger.debug("reached end of staging provider list")
         # if we reach here, we haven't found a suitable staging mechanism
-        raise ValueError("Executor {} cannot stage file {}".format(executor, repr(file)))
+        raise ValueError(f"Executor {executor} cannot stage file {repr(file)}")
 
     def optionally_stage_in(self, input, func, executor):
         if isinstance(input, DataFuture):
@@ -94,7 +94,7 @@ class DataManager(object):
 
         logger.debug("reached end of staging provider list")
         # if we reach here, we haven't found a suitable staging mechanism
-        raise ValueError("Executor {} cannot stage file {}".format(executor, repr(file)))
+        raise ValueError(f"Executor {executor} cannot stage file {repr(file)}")
 
     def stage_in(self, file: File, input: Any, executor: str) -> Any:
         """Transport the input from the input source to the executor, if it is file-like,
@@ -135,7 +135,7 @@ class DataManager(object):
 
         logger.debug("reached end of staging provider list")
         # if we reach here, we haven't found a suitable staging mechanism
-        raise ValueError("Executor {} cannot stage file {}".format(executor, repr(file)))
+        raise ValueError(f"Executor {executor} cannot stage file {repr(file)}")
 
     def stage_out(self, file: File, executor: str, app_fu: Future) -> Optional[Future]:
         """Transport the file from the local filesystem to the remote Globus endpoint.
@@ -163,4 +163,5 @@ class DataManager(object):
 
         logger.debug("reached end of staging provider list")
         # if we reach here, we haven't found a suitable staging mechanism
-        raise ValueError("Executor {} cannot stage out file {}".format(executor, repr(file)))
+        raise ValueError(f"Executor {executor} cannot stage out file "
+                         f"{repr(file)}")

--- a/parsl/data_provider/files.py
+++ b/parsl/data_provider/files.py
@@ -58,12 +58,13 @@ class File(object):
         return self.filepath
 
     def __repr__(self) -> str:
-        content = "{0} at 0x{1:x} url={2} scheme={3} netloc={4} path={5} filename={6}".format(
-            self.__class__, id(self), self.url, self.scheme, self.netloc, self.path, self.filename)
+        content = (f"{self.__class__} at 0x{id(self):x} url={self.url} "
+                   f"scheme={self.scheme} netloc={self.netloc} path={self.path}"
+                   f" filename={self.filename}")
         if self.local_path is not None:
-            content += " local_path={0}".format(self.local_path)
+            content += f" local_path={self.local_path}"
 
-        return "<{}>".format(content)
+        return f"<{content}>"
 
     def __fspath__(self) -> str:
         return self.filepath
@@ -87,4 +88,4 @@ class File(object):
         if self.scheme in ['file']:
             return self.path
         else:
-            raise ValueError("No local_path set for {}".format(repr(self)))
+            raise ValueError(f"No local_path set for {repr(self)}")

--- a/parsl/data_provider/ftp.py
+++ b/parsl/data_provider/ftp.py
@@ -60,7 +60,7 @@ def in_task_transfer_wrapper(func, file, working_dir):
             ftp = ftplib.FTP(file.netloc)
             ftp.login()
             ftp.cwd(os.path.dirname(file.path))
-            ftp.retrbinary('RETR {}'.format(file.filename), f.write)
+            ftp.retrbinary(f'RETR {file.filename}', f.write)
             ftp.quit()
 
         result = func(*args, **kwargs)
@@ -76,7 +76,7 @@ def _ftp_stage_in(working_dir, parent_fut=None, outputs=[], _parsl_staging_inhib
         ftp = ftplib.FTP(file.netloc)
         ftp.login()
         ftp.cwd(os.path.dirname(file.path))
-        ftp.retrbinary('RETR {}'.format(file.filename), f.write)
+        ftp.retrbinary(f'RETR {file.filename}', f.write)
         ftp.quit()
 
 

--- a/parsl/data_provider/globus.py
+++ b/parsl/data_provider/globus.py
@@ -40,7 +40,8 @@ def _get_globus_provider(dfk, executor_label):
         if isinstance(provider, GlobusStaging):
             return provider
 
-    raise Exception('No suitable Globus endpoint defined for executor {}'.format(executor_label))
+    raise Exception(f'No suitable Globus endpoint defined for executor '
+                    f'{executor_label}')
 
 
 def get_globus():
@@ -84,8 +85,8 @@ class Globus(object):
         try:
             task = tc.submit_transfer(td)
         except Exception as e:
-            raise Exception('Globus transfer from {}{} to {}{} failed due to error: {}'.format(
-                src_ep, src_path, dst_ep, dst_path, e))
+            raise Exception(f'Globus transfer from {src_ep}{src_path} to '
+                            f'{dst_ep}{dst_path} failed due to error: {e}')
 
         last_event_time = None
         """
@@ -122,8 +123,10 @@ class Globus(object):
             logger.debug('Globus Transfer task: {}'.format(task))
             events = tc.task_event_list(task['task_id'], num_results=1, filter='is_error:1')
             event = events.data[0]
-            raise Exception('Globus transfer {}, from {}{} to {}{} failed due to error: "{}"'.format(
-                task['task_id'], src_ep, src_path, dst_ep, dst_path, event['details']))
+            raise Exception(f"Globus transfer {task['task_id']}, "
+                            f"from {task['task_id']}{src_path} to "
+                            f"{dst_ep}{dst_path} failed due to error: "
+                            f"'{event['details']}'")
 
     @classmethod
     def _load_tokens_from_file(cls, filepath):
@@ -151,7 +154,8 @@ class Globus(object):
             refresh_tokens=True)
 
         url = client.oauth2_get_authorize_url()
-        print('Please visit the following URL to provide authorization: \n{}'.format(url))
+        print(f'Please visit the following URL to provide authorization: '
+              f'\n{url}')
         auth_code = get_input('Enter the auth code: ').strip()
         token_response = client.oauth2_exchange_code_for_tokens(auth_code)
         return token_response.by_resource_server

--- a/parsl/data_provider/http.py
+++ b/parsl/data_provider/http.py
@@ -16,7 +16,8 @@ class HTTPSeparateTaskStaging(Staging, RepresentationMixin):
     system on the executor."""
 
     def can_stage_in(self, file):
-        logger.debug("HTTPSeparateTaskStaging checking file {}".format(repr(file)))
+        logger.debug("HTTPSeparateTaskStaging checking file "
+                     "{}".format(repr(file)))
         return file.scheme == 'http' or file.scheme == 'https'
 
     def stage_in(self, dm, executor, file, parent_fut):

--- a/parsl/data_provider/rsync.py
+++ b/parsl/data_provider/rsync.py
@@ -77,11 +77,9 @@ def in_task_stage_in_wrapper(func, file, working_dir, hostname):
             os.makedirs(working_dir, exist_ok=True)
 
         logger.debug("rsync in_task_stage_in_wrapper calling rsync")
-        r = os.system("rsync {hostname}:{permanent_filepath} {worker_filepath}".format(hostname=hostname,
-                                                                                       permanent_filepath=file.path,
-                                                                                       worker_filepath=file.local_path))
+        r = os.system(f"rsync {hostname}:{file.path} {file.local_path}")
         if r != 0:
-            raise RuntimeError("rsync returned {}, a {}".format(r, type(r)))
+            raise RuntimeError(f"rsync returned {r}, a {type(r)}")
         logger.debug("rsync in_task_stage_in_wrapper calling wrapped function")
         result = func(*args, **kwargs)
         logger.debug("rsync in_task_stage_in_wrapper returned from wrapped function")
@@ -97,12 +95,11 @@ def in_task_stage_out_wrapper(func, file, working_dir, hostname):
 
         logger.debug("rsync in_task_stage_out_wrapper calling wrapped function")
         result = func(*args, **kwargs)
-        logger.debug("rsync in_task_stage_out_wrapper returned from wrapped function, calling rsync")
-        r = os.system("rsync {worker_filepath} {hostname}:{permanent_filepath}".format(hostname=hostname,
-                                                                                       permanent_filepath=file.path,
-                                                                                       worker_filepath=file.local_path))
+        logger.debug("rsync in_task_stage_out_wrapper returned from wrapped "
+                     "function, calling rsync")
+        r = os.system(f"rsync {file.local_path} {hostname}:{file.path}")
         if r != 0:
-            raise RuntimeError("rsync returned {}, a {}".format(r, type(r)))
+            raise RuntimeError(f"rsync returned {r}, a {type(r)}")
         logger.debug("rsync in_task_stage_out_wrapper returned from rsync")
         return result
     return wrapper

--- a/parsl/dataflow/error.py
+++ b/parsl/dataflow/error.py
@@ -56,7 +56,8 @@ class DependencyError(DataFlowException):
 
     def __repr__(self):
         dep_tids = [tid for (exception, tid) in self.dependent_exceptions_tids]
-        return "Dependency failure for task {} with failed dependencies from tasks {}".format(self.task_id, dep_tids)
+        return (f"Dependency failure for task {self.task_id} with failed "
+                f"dependencies from tasks {dep_tids}")
 
     def __str__(self):
         return self.__repr__()

--- a/parsl/dataflow/flow_control.py
+++ b/parsl/dataflow/flow_control.py
@@ -162,10 +162,7 @@ class Timer(object):
         self._wake_up_time = time.time() + 1
 
         self._kill_event = threading.Event()
-        if name is None:
-            name = "Timer-Thread-{}".format(id(self))
-        else:
-            name = "{}-Timer-Thread-{}".format(name, id(self))
+        name = f"{'' if name is None else f'{name}-'}Timer-Thread-{id(self)}"
         self._thread = threading.Thread(target=self._wake_up_timer, args=(self._kill_event,), name=name)
         self._thread.daemon = True
         self._thread.start()
@@ -222,7 +219,7 @@ if __name__ == "__main__":
 
     def cback(*args):
         print("*" * 40)
-        print("Callback at {0} with args : {1}".format(time.time(), args))
+        print(f"Callback at {time.time()} with args : {args}")
         print("*" * 40)
 
     fc = FlowControl(cback)
@@ -238,4 +235,4 @@ if __name__ == "__main__":
             print("Exiting ...")
             break
         else:
-            print("Continuing.. got[%s]", x)
+            print(f"Continuing.. got[{x}]")

--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -115,6 +115,4 @@ class AppFuture(Future):
         return self._outputs
 
     def __repr__(self):
-        return '<%s super=%s>' % (
-            self.__class__.__name__,
-            super().__repr__())
+        return f'<{self.__class__.__name__} super={super().__repr__()}>'

--- a/parsl/dataflow/job_error_handler.py
+++ b/parsl/dataflow/job_error_handler.py
@@ -40,14 +40,14 @@ class JobErrorHandler(object):
         count = 1
         for js in status.values():
             if js.message is not None:
-                err = err + "{}. {}\n".format(count, js.message)
+                err = err + f"{count}. {js.message}\n"
                 count += 1
             stdout = js.stdout_summary
             if stdout:
-                err = err + "\tSTDOUT: {}\n".format(stdout)
+                err = err + f"\tSTDOUT: {stdout}\n"
             stderr = js.stderr_summary
             if stderr:
-                err = err + "\tSTDOUT: {}\n".format(stderr)
+                err = err + f"\tSTDOUT: {stderr}\n"
 
         if len(err) == 0:
             err = "[No error message received]"

--- a/parsl/dataflow/memoization.py
+++ b/parsl/dataflow/memoization.py
@@ -39,7 +39,7 @@ def id_for_memo(obj, output_ref=False):
     where an output filename points at memoization time.
     """
     logger.error("id_for_memo attempted on unknown type {}".format(type(obj)))
-    raise ValueError("unknown type for memoization: {}".format(type(obj)))
+    raise ValueError(f"unknown type for memoization: {type(obj)}")
 
 
 @id_for_memo.register(str)

--- a/parsl/dataflow/rundirs.py
+++ b/parsl/dataflow/rundirs.py
@@ -29,7 +29,7 @@ def make_rundir(path: str) -> str:
         if prev_rundirs:
             # Since we globbed on files named as 0-9
             x = sorted([int(os.path.basename(x)) for x in prev_rundirs])[-1]
-            current_rundir = os.path.join(path, '{0:03}'.format(x + 1))
+            current_rundir = os.path.join(path, f'{x + 1:03}')
 
         os.makedirs(current_rundir)
         logger.debug("Parsl run initializing in rundir: {0}".format(current_rundir))

--- a/parsl/dataflow/task_status_poller.py
+++ b/parsl/dataflow/task_status_poller.py
@@ -33,7 +33,7 @@ class PollItem(ExecutorStatus):
             context = zmq.Context()
             self.hub_channel = context.socket(zmq.DEALER)
             self.hub_channel.set_hwm(0)
-            self.hub_channel.connect("tcp://{}:{}".format(hub_address, hub_port))
+            self.hub_channel.connect(f"tcp://{hub_address}:{hub_port}")
             logger.info("Monitoring enabled on task status poller")
 
     def _should_poll(self, now: float):

--- a/parsl/dataflow/usage_tracking/usage.py
+++ b/parsl/dataflow/usage_tracking/usage.py
@@ -118,9 +118,10 @@ class UsageTracker (object):
         self.config = self.dfk.config
         self.uuid = str(uuid.uuid4())
         self.parsl_version = PARSL_VERSION
-        self.python_version = "{}.{}.{}".format(sys.version_info.major,
-                                                sys.version_info.minor,
-                                                sys.version_info.micro)
+
+        self.python_version = (f"{sys.version_info.major}."
+                               f"{sys.version_info.minor}."
+                               f"{sys.version_info.micro}")
         self.tracking_enabled = self.check_tracking_enabled()
         logger.debug("Tracking status: {}".format(self.tracking_enabled))
         self.initialized = False  # Once first message is sent this will be True

--- a/parsl/errors.py
+++ b/parsl/errors.py
@@ -10,6 +10,6 @@ class OptionalModuleMissing(ParslError):
         self.reason = reason
 
     def __repr__(self):
-        return "The functionality requested requires a missing optional module:{0},  Reason:{1}".format(
-            self.module_names, self.reason
-        )
+        msg = (f"The functionality requested requires a missing optional module"
+               f":{self.module_names},  Reason:{self.reason}")
+        return msg

--- a/parsl/executors/errors.py
+++ b/parsl/executors/errors.py
@@ -15,7 +15,7 @@ class ExecutorError(ParslError):
         self.reason = reason
 
     def __str__(self):
-        return "Executor {0} failed due to: {1}".format(self.executor, self.reason)
+        return f"Executor {self.executor} failed due to: {self.reason}"
 
 
 class UnsupportedFeatureError(ExecutorError):
@@ -27,10 +27,7 @@ class UnsupportedFeatureError(ExecutorError):
         self.target_executor = target_executor
 
     def __str__(self):
-        return "The {} feature is unsupported in {}. \
-Please checkout {} for this feature".format(self.feature,
-                                            self.current_executor,
-                                            self.target_executor)
+        return f"The {self.feature} feature is unsupported in {self.current_executor}. Please checkout {self.target_executor} for this feature"
 
 
 class ScalingFailed(ExecutorError):
@@ -49,7 +46,7 @@ class DeserializationError(ExecutorError):
         self.reason = reason
 
     def __str__(self):
-        return "Failed to deserialize return objects. Reason:{}".format(self.reason)
+        return f"Failed to deserialize return objects. Reason:{self.reason}"
 
 
 class SerializationError(ExecutorError):
@@ -61,8 +58,7 @@ class SerializationError(ExecutorError):
         self.troubleshooting = "https://parsl.readthedocs.io/en/latest/faq.html#addressing-serializationerror"
 
     def __str__(self):
-        return "Failed to serialize data objects for {}. Refer {} ".format(self.fname,
-                                                                           self.troubleshooting)
+        return f"Failed to serialize data objects for {self.fname}. Refer {self.troubleshooting} "
 
 
 class BadMessage(ExecutorError):
@@ -73,4 +69,4 @@ class BadMessage(ExecutorError):
         self.reason = reason
 
     def __str__(self):
-        return "Received an unsupported message. Reason:{}".format(self.reason)
+        return f"Received an unsupported message. Reason:{self.reason}"

--- a/parsl/executors/extreme_scale/executor.py
+++ b/parsl/executors/extreme_scale/executor.py
@@ -176,17 +176,17 @@ class ExtremeScaleExecutor(HighThroughputExecutor, RepresentationMixin):
 
         debug_opts = "--debug" if self.worker_debug else ""
         l_cmd = self.launch_cmd.format(debug=debug_opts,
-                                       task_url="tcp://{}:{}".format(self.address,
-                                                                     self.worker_task_port),
-                                       result_url="tcp://{}:{}".format(self.address,
-                                                                       self.worker_result_port),
+                                       task_url=f"tcp://{self.address}:"
+                                                f"{self.worker_task_port}",
+                                       result_url=f"tcp://{self.address}:"
+                                                  f"{self.worker_result_port}",
                                        cores_per_worker=self.cores_per_worker,
                                        # This is here only to support the exex mpiexec call
                                        ranks_per_node=self.ranks_per_node,
                                        nodes_per_block=self.provider.nodes_per_block,
                                        heartbeat_period=self.heartbeat_period,
                                        heartbeat_threshold=self.heartbeat_threshold,
-                                       logdir="{}/{}".format(self.run_dir, self.label))
+                                       logdir=f"{self.run_dir}/{self.label}")
         self.launch_cmd = l_cmd
         logger.debug("Launch command: {}".format(self.launch_cmd))
 

--- a/parsl/executors/extreme_scale/mpi_worker_pool.py
+++ b/parsl/executors/extreme_scale/mpi_worker_pool.py
@@ -94,9 +94,9 @@ class Manager(object):
         """ Creates a registration message to identify the worker to the interchange
         """
         msg = {'parsl_v': PARSL_VERSION,
-               'python_v': "{}.{}.{}".format(sys.version_info.major,
-                                             sys.version_info.minor,
-                                             sys.version_info.micro),
+               'python_v': f"{sys.version_info.major}."
+                           f"{sys.version_info.minor}."
+                           f"{sys.version_info.micro}",
                'os': platform.system(),
                'hostname': platform.node(),
                'dir': os.getcwd(),
@@ -368,8 +368,7 @@ def execute_task(bufs):
                     kwargname: kwargs,
                     resultname: resultname})
 
-    code = "{0} = {1}(*{2}, **{3})".format(resultname, fname,
-                                           argname, kwargname)
+    code = f"{resultname} = {fname}(*{argname}, **{kwargname})"
 
     try:
         logger.debug("[RUNNER] Executing: {0}".format(code))
@@ -486,14 +485,14 @@ if __name__ == "__main__":
 
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
-    print("Starting rank: {}".format(rank))
+    print(f"Starting rank: {rank}")
 
     os.makedirs(args.logdir, exist_ok=True)
 
     # set_stream_logger()
     try:
         if rank == 0:
-            start_file_logger('{}/manager.mpi_rank_{}.log'.format(args.logdir, rank),
+            start_file_logger(f'{args.logdir}/manager.mpi_rank_{rank}.log',
                               rank,
                               level=logging.DEBUG if args.debug is True else logging.INFO)
 
@@ -509,7 +508,7 @@ if __name__ == "__main__":
             logger.debug("Finalizing MPI Comm")
             comm.Abort()
         else:
-            start_file_logger('{}/worker.mpi_rank_{}.log'.format(args.logdir, rank),
+            start_file_logger(f'{args.logdir}/worker.mpi_rank_{rank}.log',
                               rank,
                               level=logging.DEBUG if args.debug is True else logging.INFO)
             worker(comm, rank)

--- a/parsl/executors/high_throughput/errors.py
+++ b/parsl/executors/high_throughput/errors.py
@@ -6,7 +6,8 @@ class WorkerLost(Exception):
         self.hostname = hostname
 
     def __repr__(self):
-        return "Task failure due to loss of worker {} on host {}".format(self.worker_id, self.hostname)
+        return (f"Task failure due to loss of worker {self.worker_id} "
+                f"on host {self.hostname}")
 
     def __str__(self):
         return self.__repr__()

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -266,10 +266,10 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
 
         address_probe_timeout_string = ""
         if self.address_probe_timeout:
-            address_probe_timeout_string = "--address_probe_timeout={}".format(self.address_probe_timeout)
-        worker_logdir = "{}/{}".format(self.run_dir, self.label)
+            address_probe_timeout_string = f"--address_probe_timeout={self.address_probe_timeout}"
+        worker_logdir = f"{self.run_dir}/{self.label}"
         if self.worker_logdir_root is not None:
-            worker_logdir = "{}/{}".format(self.worker_logdir_root, self.label)
+            worker_logdir = f"{self.worker_logdir_root}/{self.label}"
 
         l_cmd = self.launch_cmd.format(debug=debug_opts,
                                        prefetch_capacity=self.prefetch_capacity,
@@ -414,11 +414,11 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                                 elif isinstance(s, Exception):
                                     task_fut.set_exception(s)
                                 else:
-                                    raise ValueError("Unknown exception-like type received: {}".format(type(s)))
+                                    raise ValueError(f"Unknown exception-like type received: {type(s)}")
                             except Exception as e:
                                 # TODO could be a proper wrapped exception?
                                 task_fut.set_exception(
-                                    DeserializationError("Received exception, but handling also threw an exception: {}".format(e)))
+                                    DeserializationError(f"Received exception, but handling also threw an exception: {e}"))
                         else:
                             raise BadMessage("Message received is neither result or exception")
 
@@ -448,7 +448,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                                           "worker_port_range": self.worker_port_range,
                                           "hub_address": self.hub_address,
                                           "hub_port": self.hub_port,
-                                          "logdir": "{}/{}".format(self.run_dir, self.label),
+                                          "logdir": f"{self.run_dir}/{self.label}",
                                           "heartbeat_threshold": self.heartbeat_threshold,
                                           "poll_period": self.poll_period,
                                           "logging_level": logging.DEBUG if self.worker_debug else logging.INFO
@@ -491,7 +491,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
         worker_id : str
             Worker id to be put on hold
         """
-        c = self.command_client.run("HOLD_WORKER;{}".format(worker_id))
+        c = self.command_client.run(f"HOLD_WORKER;{worker_id}")
         logger.debug("Sent hold request to worker: {}".format(worker_id))
         return c
 
@@ -613,7 +613,7 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
                 block_ids.append(block_id)
             except Exception as ex:
                 self._fail_job_async(block_id,
-                                     "Failed to start block {}: {}".format(block_id, ex))
+                                     f"Failed to start block {block_id}: {ex}")
         return block_ids
 
     def _launch_block(self, block_id: str) -> Any:

--- a/parsl/executors/high_throughput/probe.py
+++ b/parsl/executors/high_throughput/probe.py
@@ -30,7 +30,7 @@ def probe_addresses(addresses, task_port, timeout=2):
     for addr in addresses:
         socket = context.socket(zmq.DEALER)
         socket.setsockopt(zmq.LINGER, 0)
-        url = "tcp://{}:{}".format(addr, task_port)
+        url = f"tcp://{addr}:{task_port}"
         logger.debug("Trying to connect back on {}".format(url))
         socket.connect(url)
         addr_map[addr] = {'sock': socket,
@@ -69,7 +69,7 @@ class TestWorker(object):
 
         address = probe_addresses(addresses, port)
         print("Viable address :", address)
-        self.task_incoming.connect("tcp://{}:{}".format(address, port))
+        self.task_incoming.connect(f"tcp://{address}:{port}")
         print("Here")
 
     def heartbeat(self):
@@ -78,7 +78,7 @@ class TestWorker(object):
         HEARTBEAT_CODE = (2 ** 32) - 1
         heartbeat = (HEARTBEAT_CODE).to_bytes(4, "little")
         r = self.task_incoming.send(heartbeat)
-        print("Return from heartbeat: {}".format(r))
+        print(f"Return from heartbeat: {r}")
 
 
 if __name__ == "__main__":

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -124,8 +124,8 @@ class Manager(object):
                 raise Exception("No viable address found")
             else:
                 logger.info("Connection to Interchange successful on {}".format(ix_address))
-                task_q_url = "tcp://{}:{}".format(ix_address, task_port)
-                result_q_url = "tcp://{}:{}".format(ix_address, result_port)
+                task_q_url = f"tcp://{ix_address}:{task_port}"
+                result_q_url = f"tcp://{ix_address}:{result_port}"
                 logger.info("Task url : {}".format(task_q_url))
                 logger.info("Result url : {}".format(result_q_url))
         except Exception:
@@ -190,9 +190,9 @@ class Manager(object):
         """ Creates a registration message to identify the worker to the interchange
         """
         msg = {'parsl_v': PARSL_VERSION,
-               'python_v': "{}.{}.{}".format(sys.version_info.major,
-                                             sys.version_info.minor,
-                                             sys.version_info.micro),
+               'python_v': f"{sys.version_info.major}."
+                           f"{sys.version_info.minor}."
+                           f"{sys.version_info.micro}",
                'worker_count': self.worker_count,
                'uid': self.uid,
                'block_id': self.block_id,
@@ -369,7 +369,7 @@ class Manager(object):
                                                                      self.ready_worker_queue,
                                                                      self._tasks_in_progress,
                                                                      self.cpu_affinity
-                                                                 ), name="HTEX-Worker-{}".format(worker_id))
+                                                                 ), name=f"HTEX-Worker-{worker_id}")
                     self.procs[worker_id] = p
                     logger.info("[WORKER_WATCHDOG_THREAD] Worker {} has been restarted".format(worker_id))
                 time.sleep(self.poll_period)
@@ -395,7 +395,7 @@ class Manager(object):
                                                              self.ready_worker_queue,
                                                              self._tasks_in_progress,
                                                              self.cpu_affinity
-                                                         ), name="HTEX-Worker-{}".format(worker_id))
+                                                         ), name=f"HTEX-Worker-{worker_id}")
             p.start()
             self.procs[worker_id] = p
 
@@ -462,8 +462,7 @@ def execute_task(bufs):
                     kwargname: kwargs,
                     resultname: resultname})
 
-    code = "{0} = {1}(*{2}, **{3})".format(resultname, fname,
-                                           argname, kwargname)
+    code = f"{resultname} = {fname}(*{argname}, **{kwargname})"
     try:
         # logger.debug("[RUNNER] Executing: {0}".format(code))
         exec(code, user_ns, user_ns)
@@ -486,7 +485,7 @@ def worker(worker_id, pool_id, pool_size, task_queue, result_queue, worker_queue
     Pop request from queue
     Put result into result_queue
     """
-    start_file_logger('{}/block-{}/{}/worker_{}.log'.format(args.logdir, args.block_id, pool_id, worker_id),
+    start_file_logger(f'{args.logdir}/block-{args.block_id}/{pool_id}/worker_{worker_id}.log',
                       worker_id,
                       name="worker_log",
                       level=logging.DEBUG if args.debug else logging.INFO)
@@ -515,7 +514,7 @@ def worker(worker_id, pool_id, pool_size, task_queue, result_queue, worker_queue
         elif cpu_affinity == "alternating":
             my_cores = avail_cores[worker_id::pool_size]
         else:
-            raise ValueError("Affinity strategy {} is not supported".format(cpu_affinity))
+            raise ValueError(f"Affinity strategy {cpu_affinity} is not supported")
 
         # Set the affinity for this worker
         os.sched_setaffinity(0, my_cores)
@@ -622,10 +621,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    os.makedirs(os.path.join(args.logdir, "block-{}".format(args.block_id), args.uid), exist_ok=True)
+    os.makedirs(os.path.join(args.logdir, f"block-{args.block_id}", args.uid), exist_ok=True)
 
     try:
-        start_file_logger('{}/block-{}/{}/manager.log'.format(args.logdir, args.block_id, args.uid),
+        start_file_logger(f'{args.logdir}/block-{args.block_id}/{args.uid}/manager.log',
                           0,
                           level=logging.DEBUG if args.debug is True else logging.INFO)
 

--- a/parsl/executors/high_throughput/zmq_pipes.py
+++ b/parsl/executors/high_throughput/zmq_pipes.py
@@ -38,11 +38,11 @@ class CommandClient(object):
         self.zmq_socket = self.context.socket(zmq.REQ)
         self.zmq_socket.setsockopt(zmq.LINGER, 0)
         if self.port is None:
-            self.port = self.zmq_socket.bind_to_random_port("tcp://{}".format(self.ip_address),
+            self.port = self.zmq_socket.bind_to_random_port(f"tcp://{self.ip_address}",
                                                             min_port=self.port_range[0],
                                                             max_port=self.port_range[1])
         else:
-            self.zmq_socket.bind("tcp://{}:{}".format(self.ip_address, self.port))
+            self.zmq_socket.bind(f"tcp://{self.ip_address}:{self.port}")
 
     def run(self, message, max_retries=3):
         """ This function needs to be fast at the same time aware of the possibility of
@@ -97,7 +97,7 @@ class TasksOutgoing(object):
         self.context = zmq.Context()
         self.zmq_socket = self.context.socket(zmq.DEALER)
         self.zmq_socket.set_hwm(0)
-        self.port = self.zmq_socket.bind_to_random_port("tcp://{}".format(ip_address),
+        self.port = self.zmq_socket.bind_to_random_port(f"tcp://{ip_address}",
                                                         min_port=port_range[0],
                                                         max_port=port_range[1])
         self.poller = zmq.Poller()
@@ -146,7 +146,7 @@ class ResultsIncoming(object):
         self.context = zmq.Context()
         self.results_receiver = self.context.socket(zmq.DEALER)
         self.results_receiver.set_hwm(0)
-        self.port = self.results_receiver.bind_to_random_port("tcp://{}".format(ip_address),
+        self.port = self.results_receiver.bind_to_random_port(f"tcp://{ip_address}",
                                                               min_port=port_range[0],
                                                               max_port=port_range[1])
 

--- a/parsl/executors/low_latency/executor.py
+++ b/parsl/executors/low_latency/executor.py
@@ -86,7 +86,7 @@ class LowLatencyExecutor(StatusHandlingExecutor, RepresentationMixin):
             l_cmd = self.launch_cmd.format(  # debug=debug_opts,
                 task_url=self.worker_task_url,
                 workers_per_node=self.workers_per_node,
-                logdir="{}/{}".format(self.run_dir, self.label))
+                logdir=f"{self.run_dir}/{self.label}")
             self.launch_cmd = l_cmd
             logger.debug("Launch command: {}".format(self.launch_cmd))
 
@@ -134,8 +134,7 @@ class LowLatencyExecutor(StatusHandlingExecutor, RepresentationMixin):
                 "Interchange has not completed initialization in 120s. Aborting")
             raise Exception("Interchange failed to start")
 
-        self.worker_task_url = "tcp://{}:{}".format(
-            self.address, worker_port)
+        self.worker_task_url = f"tcp://{self.address}:{worker_port}"
 
     def _start_queue_management_thread(self):
         """ TODO: docstring """
@@ -171,12 +170,12 @@ class LowLatencyExecutor(StatusHandlingExecutor, RepresentationMixin):
                 logger.warning("Task: {} has returned with an exception")
                 try:
                     s = deserialize(msg['exception'])
-                    exception = ValueError("Remote exception description: {}".format(s))
+                    exception = ValueError(f"Remote exception description: {s}")
                     task_fut.set_exception(exception)
                 except Exception as e:
                     # TODO could be a proper wrapped exception?
                     task_fut.set_exception(
-                        DeserializationError("Received exception, but handling also threw an exception: {}".format(e)))
+                        DeserializationError(f"Received exception, but handling also threw an exception: {e}"))
 
             else:
                 raise BadMessage(
@@ -240,7 +239,7 @@ class LowLatencyExecutor(StatusHandlingExecutor, RepresentationMixin):
                         self._fail_job_async(None, "Failed to launch block")
                     self.blocks.extend([block])
                 except Exception as ex:
-                    self._fail_job_async(None, "Failed to launch block: {}".format(ex))
+                    self._fail_job_async(None, f"Failed to launch block: {ex}")
             else:
                 logger.error("No execution provider available")
                 r = None

--- a/parsl/executors/low_latency/interchange.py
+++ b/parsl/executors/low_latency/interchange.py
@@ -25,8 +25,8 @@ class Interchange(object):
 
         self.result_outgoing.set_hwm(0)
 
-        task_address = "tcp://{}:{}".format(client_address, client_ports[0])
-        result_address = "tcp://{}:{}".format(client_address, client_ports[1])
+        task_address = f"tcp://{client_address}:{client_ports[0]}"
+        result_address = f"tcp://{client_address}:{client_ports[1]}"
         self.task_incoming.connect(task_address)
         self.result_outgoing.connect(result_address)
 
@@ -37,7 +37,7 @@ class Interchange(object):
         self.worker_port_range = worker_port_range
 
         if self.worker_port:
-            worker_task_address = "tcp://*:{}".format(self.worker_port)
+            worker_task_address = f"tcp://*:{self.worker_port}"
             self.worker_messages.bind(worker_task_address)
             logger.debug("Worker task address: {}".format(worker_task_address))
 

--- a/parsl/executors/low_latency/lowlatency_worker.py
+++ b/parsl/executors/low_latency/lowlatency_worker.py
@@ -31,8 +31,7 @@ def execute_task(f, args, kwargs, user_ns):
                     kwargname: kwargs,
                     resultname: resultname})
 
-    code = "{0} = {1}(*{2}, **{3})".format(resultname, fname,
-                                           argname, kwargname)
+    code = f"{resultname} = {fname}(*{argname}, **{kwargname})"
     try:
         exec(code, user_ns, user_ns)
 
@@ -60,7 +59,7 @@ def start_file_logger(filename, rank, name='parsl', level=logging.DEBUG, format_
     try:
         os.makedirs(os.path.dirname(filename), 511, True)
     except Exception as e:
-        print("Caught exception with trying to make log dirs: {}".format(e))
+        print(f"Caught exception with trying to make log dirs: {e}")
 
     if format_string is None:
         format_string = "%(asctime)s %(name)s:%(lineno)d Rank:{0} [%(levelname)s]  %(message)s".format(
@@ -81,7 +80,7 @@ def worker(worker_id, task_url, debug=True, logdir="workers", uid="1"):
     TODO : Cleanup debug, logdir and uid to function correctly
     """
 
-    start_file_logger('{}/{}/worker_{}.log'.format(logdir, uid, worker_id),
+    start_file_logger(f'{logdir}/{uid}/worker_{worker_id}.log',
                       0,
                       level=logging.DEBUG if debug is True else logging.INFO)
 

--- a/parsl/executors/low_latency/zmq_pipes.py
+++ b/parsl/executors/low_latency/zmq_pipes.py
@@ -14,7 +14,7 @@ class TasksOutgoing(object):
         self.context = zmq.Context()
         self.zmq_socket = self.context.socket(zmq.DEALER)
         self.zmq_socket.set_hwm(0)
-        self.port = self.zmq_socket.bind_to_random_port("tcp://{}".format(ip_address),
+        self.port = self.zmq_socket.bind_to_random_port(f"tcp://{ip_address}",
                                                         min_port=port_range[0],
                                                         max_port=port_range[1])
         self.poller = zmq.Poller()
@@ -42,7 +42,7 @@ class ResultsIncoming(object):
         self.zmq_socket = self.context.socket(zmq.DEALER)
         self.zmq_socket.set_hwm(0)
         self.port = self.zmq_socket.bind_to_random_port(
-            "tcp://{}".format(ip_address),
+            f"tcp://{ip_address}",
             min_port=port_range[0],
             max_port=port_range[1])
 

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -61,7 +61,7 @@ class StatusHandlingExecutor(ParslExecutor):
         as failed and report it in status()
         """
         if block_id is None:
-            block_id = "failed-block-{}".format(self._generated_block_id_counter)
+            block_id = f"failed-block-{self._generated_block_id_counter}"
             self._generated_block_id_counter += 1
         self._simulated_status[block_id] = JobStatus(JobState.FAILED, message)
 

--- a/parsl/executors/swift_t.py
+++ b/parsl/executors/swift_t.py
@@ -78,8 +78,7 @@ def runner(incoming_q, outgoing_q):
                         kwargname: kwargs,
                         resultname: resultname})
 
-        code = "{0} = {1}(*{2}, **{3})".format(resultname, fname,
-                                               argname, kwargname)
+        code = f"{resultname} = {fname}(*{argname}, **{kwargname})"
 
         try:
             logger.debug("[RUNNER] Executing: {0}".format(code))

--- a/parsl/executors/workqueue/exec_parsl_function.py
+++ b/parsl/executors/workqueue/exec_parsl_function.py
@@ -121,7 +121,7 @@ def encode_function(user_namespace, fn, fn_name, fn_args, fn_kwargs):
 def encode_source_code_function(user_namespace, fn, fn_name, args_name, kwargs_name, result_name):
     # We drop the first line as it names the parsl decorator used (i.e., @python_app)
     source = fn.split('\n')[1:]
-    fn_app = "{0} = {1}(*{2}, **{3})".format(result_name, fn_name, args_name, kwargs_name)
+    fn_app = f"{result_name} = {fn_name}(*{args_name}, **{kwargs_name})"
 
     source.append(fn_app)
 
@@ -131,7 +131,7 @@ def encode_source_code_function(user_namespace, fn, fn_name, args_name, kwargs_n
 
 def encode_byte_code_function(user_namespace, fn, fn_name, args_name, kwargs_name, result_name):
     user_namespace.update({fn_name: fn})
-    code = "{0} = {1}(*{2}, **{3})".format(result_name, fn_name, args_name, kwargs_name)
+    code = f"{result_name} = {fn_name}(*{args_name}, **{kwargs_name})"
     return code
 
 
@@ -179,7 +179,7 @@ if __name__ == "__main__":
         try:
             (map_file, function_file, result_file) = sys.argv[1:]
         except ValueError:
-            print("Usage:\n\t{} function result mapping\n".format(sys.argv[0]))
+            print(f"Usage:\n\t{sys.argv[0]} function result mapping\n")
             raise
 
         try:

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -251,7 +251,7 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
             self.address = socket.gethostname()
 
         if self.project_password_file is not None and not os.path.exists(self.project_password_file):
-            raise WorkQueueFailure('Could not find password file: {}'.format(self.project_password_file))
+            raise WorkQueueFailure(f'Could not find password file: {self.project_password_file}')
 
         if self.project_password_file is not None:
             if os.path.exists(self.project_password_file) is False:
@@ -318,7 +318,7 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
             'result': Pickled file that (will) contain the result of the function.
             'map': Pickled file with a dict between local parsl names, and remote work queue names.
         """
-        task_dir = "{:04d}".format(task_id)
+        task_dir = f"{task_id:04d}"
         return os.path.join(self.function_data_dir, task_dir, *path_components)
 
     def submit(self, func, resource_specification, *args, **kwargs):
@@ -447,13 +447,13 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
     def _construct_worker_command(self):
         worker_command = self.worker_executable
         if self.project_password_file:
-            worker_command += ' --password {}'.format(self.project_password_file)
+            worker_command += f' --password {self.project_password_file}'
         if self.worker_options:
-            worker_command += ' {}'.format(self.worker_options)
+            worker_command += f' {self.worker_options}'
         if self.project_name:
-            worker_command += ' -M {}'.format(self.project_name)
+            worker_command += f' -M {self.project_name}'
         else:
-            worker_command += ' {} {}'.format(self.address, self.port)
+            worker_command += f' {self.address} {self.port}'
 
         logger.debug("Using worker command: {}".format(worker_command))
         return worker_command
@@ -541,7 +541,7 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
             logger.debug("Skipping analysis of %s, previously got %s", fn_name, self.cached_envs[fn_id])
             return self.cached_envs[fn_id]
         source_code = inspect.getsource(fn).encode()
-        pkg_dir = os.path.join(tempfile.gettempdir(), "python_package-{}".format(os.geteuid()))
+        pkg_dir = os.path.join(tempfile.gettempdir(), f"python_package-{os.geteuid()}")
         os.makedirs(pkg_dir, exist_ok=True)
         with tempfile.NamedTemporaryFile(suffix='.yaml') as spec:
             logger.info("Analyzing dependencies of %s", fn_name)
@@ -552,7 +552,7 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
             with open(spec.name, mode='rb') as f:
                 spec_hash = hashlib.sha256(f.read()).hexdigest()
                 logger.debug("Spec hash for %s is %s", fn_name, spec_hash)
-                pkg = os.path.join(pkg_dir, "pack-{}.tar.gz".format(spec_hash))
+                pkg = os.path.join(pkg_dir, f"pack-{spec_hash}.tar.gz")
             if os.access(pkg, os.R_OK):
                 self.cached_envs[fn_id] = pkg
                 logger.debug("Cached package for %s found at %s", fn_name, pkg)
@@ -766,8 +766,7 @@ def _work_queue_submit_wait(task_queue=multiprocessing.Queue(),
 
             pkg_pfx = ""
             if task.env_pkg is not None:
-                pkg_pfx = "./{} -e {} ".format(os.path.basename(package_run_script),
-                                               os.path.basename(task.env_pkg))
+                pkg_pfx = f"./{os.path.basename(package_run_script)} -e {os.path.basename(task.env_pkg)} "
 
             # Create command string
             logger.debug(launch_cmd)

--- a/parsl/launchers/error.py
+++ b/parsl/launchers/error.py
@@ -10,4 +10,4 @@ class BadLauncher(ExecutionProviderException):
         self.reason = reason
 
     def __repr__(self):
-        return "Bad Launcher provided:{0} Reason:{1}".format(self.launcher, self.reason)
+        return f"Bad Launcher provided:{self.launcher} Reason:{self.reason}"

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -257,7 +257,7 @@ class DatabaseManager:
         self.logdir = logdir
         os.makedirs(self.logdir, exist_ok=True)
 
-        set_file_logger("{}/database_manager.log".format(self.logdir), level=logging_level,
+        set_file_logger(f"{self.logdir}/database_manager.log", level=logging_level,
                         format_string="%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s] [%(threadName)s %(thread)d] %(message)s",
                         name="database_manager")
 
@@ -401,7 +401,7 @@ class DatabaseManager:
                                     reprocessable_first_resource_messages.append(
                                         deferred_resource_messages.pop(task_try_id))
                         else:
-                            raise RuntimeError("Unexpected message type {} received on priority queue".format(msg_type))
+                            raise RuntimeError(f"Unexpected message type {msg_type} received on priority queue")
 
                     logger.debug("Updating and inserting TASK_INFO to all tables")
                     logger.debug("Updating {} TASK_INFO into workflow table".format(len(task_info_update_messages)))

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -84,7 +84,7 @@ class UDPRadio:
             self.scheme, self.ip, port = (x.strip('/') for x in monitoring_url.split(':'))
             self.port = int(port)
         except Exception:
-            raise Exception("Failed to parse monitoring url: {}".format(monitoring_url))
+            raise Exception(f"Failed to parse monitoring url: {monitoring_url}")
 
         self.sock = socket.socket(socket.AF_INET,
                                   socket.SOCK_DGRAM,
@@ -214,7 +214,7 @@ class MonitoringHub(RepresentationMixin):
         self._dfk_channel = self._context.socket(zmq.DEALER)
         self._dfk_channel.setsockopt(zmq.SNDTIMEO, self.dfk_channel_timeout)
         self._dfk_channel.set_hwm(0)
-        self.dfk_port = self._dfk_channel.bind_to_random_port("tcp://{}".format(self.client_address),
+        self.dfk_port = self._dfk_channel.bind_to_random_port(f"tcp://{self.client_address}",
                                                               min_port=self.client_port_range[0],
                                                               max_port=self.client_port_range[1])
 
@@ -261,11 +261,11 @@ class MonitoringHub(RepresentationMixin):
 
         if isinstance(comm_q_result, str):
             self.logger.error(f"MonitoringRouter sent an error message: {comm_q_result}")
-            raise RuntimeError("MonitoringRouter failed to start: {comm_q_result}")
+            raise RuntimeError(f"MonitoringRouter failed to start: {comm_q_result}")
 
         udp_dish_port, ic_port = comm_q_result
 
-        self.monitoring_hub_url = "udp://{}:{}".format(self.hub_address, udp_dish_port)
+        self.monitoring_hub_url = f"udp://{self.hub_address}:{udp_dish_port}"
         return ic_port
 
     # TODO: tighten the Any message format
@@ -334,7 +334,7 @@ class MonitoringHub(RepresentationMixin):
                                   run_id,
                                   logging_level,
                                   sleep_dur),
-                            name="Monitor-Wrapper-{}".format(task_id))
+                            name=f"Monitor-Wrapper-{task_id}")
                 p.start()
             else:
                 p = None
@@ -390,7 +390,7 @@ class MonitoringRouter:
 
         """
         os.makedirs(logdir, exist_ok=True)
-        self.logger = start_file_logger("{}/monitoring_router.log".format(logdir),
+        self.logger = start_file_logger(f"{logdir}/monitoring_router.log",
                                         name="monitoring_router",
                                         level=logging_level)
         self.logger.debug("Monitoring router starting")
@@ -421,7 +421,7 @@ class MonitoringRouter:
         self.dfk_channel.setsockopt(zmq.LINGER, 0)
         self.dfk_channel.set_hwm(0)
         self.dfk_channel.RCVTIMEO = int(self.loop_freq)  # in milliseconds
-        self.dfk_channel.connect("tcp://{}:{}".format(client_address, client_port))
+        self.dfk_channel.connect(f"tcp://{client_address}:{client_port}")
 
         self.ic_channel = self._context.socket(zmq.DEALER)
         self.ic_channel.setsockopt(zmq.LINGER, 0)
@@ -477,7 +477,7 @@ class MonitoringRouter:
                     elif msg[0] == MessageType.BLOCK_INFO:
                         block_msgs.put((msg, 0))
                     else:
-                        self.logger.error(f"Discarding message from interchange with unknown type {msg[0].value}")
+                        self.logger.error("Discarding message from interchange with unknown type {}".format(msg[0].value))
                 except zmq.Again:
                     pass
 
@@ -585,8 +585,7 @@ def monitor(pid: int,
                      source_id=task_id)
 
     format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
-    logging.basicConfig(filename='{logbase}/monitor.{task_id}.{pid}.log'.format(
-        logbase="/tmp", task_id=task_id, pid=pid), level=logging_level, format=format_string)
+    logging.basicConfig(filename=f'/tmp/monitor.{task_id}.{pid}.log', level=logging_level, format=format_string)
 
     logging.debug("start of monitor")
 

--- a/parsl/monitoring/visualization/app.py
+++ b/parsl/monitoring/visualization/app.py
@@ -8,7 +8,7 @@ def cli_run():
     """ Instantiates the Monitoring viz server
     """
     parser = argparse.ArgumentParser(description='Parsl visualization tool')
-    parser.add_argument('db_path', type=str, default="sqlite:///{cwd}/monitoring.db".format(cwd=os.getcwd()),
+    parser.add_argument('db_path', type=str, default=f"sqlite:///{os.getcwd()}/monitoring.db",
                         nargs="?", help='Database path in the format sqlite:///<absolute_path_to_db>')
     parser.add_argument('-p', '--port', type=int, default=8080,
                         help='Port at which the monitoring Viz Server is hosted. Default: 8080')

--- a/parsl/monitoring/visualization/plots/default/workflow_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_plots.py
@@ -23,7 +23,7 @@ def task_gantt_plot(df_task, df_status, time_completed=None):
     for i, task in df_task.iterrows():
         task_id = task['task_id']
 
-        description = "Task ID: {}, app: {}".format(task['task_id'], task['task_func_name'])
+        description = f"Task ID: {task['task_id']}, app: {task['task_func_name']}"
 
         statuses = df_status.loc[df_status['task_id'] == task_id].sort_values(by=['timestamp'])
 
@@ -110,7 +110,7 @@ def task_per_app_plot(task, status):
                              title="Tasks per app"))
         return plot(fig, show_link=False, output_type="div", include_plotlyjs=False)
     except Exception as e:
-        return "The tasks per app plot cannot be generated because of exception {}.".format(e)
+        return f"The tasks per app plot cannot be generated because of exception {e}."
 
 
 def total_tasks_plot(df_task, df_status, columns=20):
@@ -250,8 +250,7 @@ def workflow_dag_plot(df_tasks, group_by_apps=True):
         index, _ = groups_list[name]
         node_traces[index]['x'] += tuple([x])
         node_traces[index]['y'] += tuple([y])
-        node_traces[index]['text'] += tuple(
-            ["{}:{}".format(dic['task_func_name'][node], node)])
+        node_traces[index]['text'] += tuple([f"{dic['task_func_name'][node]}:{node}"])
 
     # The edges will be drawn as lines:
     edge_trace = go.Scatter(

--- a/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
@@ -198,4 +198,4 @@ def resource_efficiency(resource, node, label='CPU'):
         return plot(fig, show_link=False, output_type="div", include_plotlyjs=False)
     except Exception as e:
         print(e)
-        return "The resource efficiency plot cannot be generated because of exception {}.".format(e)
+        return f"The resource efficiency plot cannot be generated because of exception {e}."

--- a/parsl/providers/ad_hoc/ad_hoc.py
+++ b/parsl/providers/ad_hoc/ad_hoc.py
@@ -155,10 +155,10 @@ class AdHocProvider(ExecutionProvider, RepresentationMixin):
             logger.warning("All Channels in Ad-Hoc provider are in use")
             return None
 
-        job_name = "{0}.{1}".format(job_name, time.time())
+        job_name = f"{job_name}.{time.time()}"
 
         # Set script path
-        script_path = "{0}/{1}.sh".format(self.script_dir, job_name)
+        script_path = f"{self.script_dir}/{job_name}.sh"
         script_path = os.path.abspath(script_path)
 
         wrap_command = self.worker_init + '\n' + self.launcher(command, tasks_per_node, self.nodes_per_block)
@@ -174,7 +174,7 @@ class AdHocProvider(ExecutionProvider, RepresentationMixin):
             script_path = channel.push_file(script_path, channel.script_dir)
 
         # Bash would return until the streams are closed. So we redirect to a outs file
-        final_cmd = 'bash {0} > {0}.out 2>&1 & \n echo "PID:$!" '.format(script_path)
+        final_cmd = f'bash {script_path} > {script_path}.out 2>&1 & \n echo "PID:$!" '
         retcode, stdout, stderr = channel.execute_wait(final_cmd, self.cmd_timeout)
         for line in stdout.split('\n'):
             if line.startswith("PID:"):
@@ -205,8 +205,7 @@ class AdHocProvider(ExecutionProvider, RepresentationMixin):
         """
         for job_id in job_ids:
             channel = self.resources[job_id]['channel']
-            status_command = "ps --pid {} | grep {}".format(self.resources[job_id]['job_id'],
-                                                            self.resources[job_id]['cmd'].split()[0])
+            status_command = f"ps --pid {self.resources[job_id]['job_id']} | grep {self.resources[job_id]['cmd'].split()[0]}"
             retcode, stdout, stderr = channel.execute_wait(status_command)
             if retcode != 0 and self.resources[job_id]['status'].state == JobState.RUNNING:
                 self.resources[job_id]['status'] = JobStatus(JobState.FAILED)
@@ -229,7 +228,7 @@ class AdHocProvider(ExecutionProvider, RepresentationMixin):
         rets = []
         for job_id in job_ids:
             channel = self.resources[job_id]['channel']
-            cmd = "kill -TERM -$(ps -o pgid= {} | grep -o '[0-9]*')".format(self.resources[job_id]['job_id'])
+            cmd = f"kill -TERM -$(ps -o pgid= {self.resources[job_id]['job_id']} | grep -o '[0-9]*')"
             retcode, stdout, stderr = channel.execute_wait(cmd)
             if retcode == 0:
                 rets.append(True)

--- a/parsl/providers/aws/aws.py
+++ b/parsl/providers/aws/aws.py
@@ -319,11 +319,11 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
         for num, zone in enumerate(availability_zones['AvailabilityZones']):
             if zone['State'] == "available":
                 zone_name = zone['ZoneName']
-                tag_spec = self.create_name_tag_spec('subnet', '{0}.{1}'.format(vpc_name, zone_name))
+                tag_spec = self.create_name_tag_spec('subnet', f'{vpc_name}.{zone_name}')
 
                 # Create a large subnet (4000 max nodes)
                 subnet = vpc.create_subnet(
-                    CidrBlock='10.0.{}.0/20'.format(16 * num),
+                    CidrBlock=f'10.0.{16 * num}.0/20',
                     AvailabilityZone=zone_name,
                     TagSpecifications=tag_spec,
                 )
@@ -343,7 +343,7 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
             # this can only be the default security group for this VPC,
             # since no other security groups have been created yet
             security_group.create_tags(
-                Tags=[{'Key': 'Name', 'Value': '{0}.default'.format(vpc_name)}],
+                Tags=[{'Key': 'Name', 'Value': f'{vpc_name}.default'}],
             )
 
         self.security_group(vpc, vpc_name)
@@ -707,16 +707,16 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
     def show_summary(self):
         """Print human readable summary of current AWS state to log and to console."""
         self.get_instance_state()
-        status_string = "EC2 Summary:\n\tVPC IDs: {}\n\tSubnet IDs: \
-{}\n\tSecurity Group ID: {}\n\tRunning Instance IDs: {}\n".format(
-            self.vpc_id, self.sn_ids, self.sg_id, self.instances
-        )
-        status_string += "\tInstance States:\n\t\t"
+        status_string = (f"EC2 Summary:\n"
+                         f"\tVPC IDs: {self.vpc_id}\n"
+                         f"\tSubnet IDs: {self.sn_ids}\n"
+                         f"\tSecurity Group ID: {self.sg_id}\n"
+                         f"\tRunning Instance IDs: {self.instances}\n"
+                         f"\tInstance States:\n\t\t")
         self.get_instance_state()
         for state in self.instance_states.keys():
-            status_string += "Instance ID: {}  State: {}\n\t\t".format(
-                state, self.instance_states[state]
-            )
+            status_string += (f"Instance ID: {state}  "
+                              f"State: {self.instance_states[state]}\n\t\t")
         status_string += "\n"
         logger.info(status_string)
         return status_string
@@ -759,7 +759,7 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
         str
             An ID of the form 'parsl.aws.123456.789' for giving resources unique identifiers.
         """
-        return "parsl.aws.{0}".format(time.time())
+        return f"parsl.aws.{time.time()}"
 
     def create_name_tag_spec(self, resource_type, name):
         """Create a new tag specification for a resource name.

--- a/parsl/providers/azure/azure.py
+++ b/parsl/providers/azure/azure.py
@@ -244,7 +244,7 @@ class AzureProvider(ExecutionProvider, RepresentationMixin):
                                                   self.vm_reference)
 
         # Uniqueness strategy from AWS provider
-        job_name = "{0}-parsl-azure".format(str(time.time()).replace(".", ""))
+        job_name = f"{str(time.time()).replace('.', '')}-parsl-azure"
 
         async_vm_creation = self.compute_client.\
             virtual_machines.create_or_update(
@@ -397,16 +397,15 @@ class AzureProvider(ExecutionProvider, RepresentationMixin):
         try:
             logger.info('Creating (or updating) Subnet')
             async_subnet_creation = self.network_client.subnets.create_or_update(
-                self.group_name, self.vnet_name, "{}.subnet".format(
-                    self.group_name), {'address_prefix': '10.0.0.0/20'})
+                self.group_name, self.vnet_name, f"{self.group_name}.subnet",
+                {'address_prefix': '10.0.0.0/20'})
             subnet_info = async_subnet_creation.result()
 
             self.resources["subnets"][subnet_info.id] = subnet_info
 
         except CloudError as e:
             if "InUse" in str(e):
-                subnet_info = self.network_client.subnets.get(self.group_name, self.vnet_name, "{}.subnet".format(
-                        self.group_name))
+                subnet_info = self.network_client.subnets.get(self.group_name, self.vnet_name, f"{self.group_name}.subnet")
                 self.resources["subnets"][subnet_info.id] = subnet_info
                 logger.info('Found Existing Subnet. Proceeding.')
             else:
@@ -416,12 +415,12 @@ class AzureProvider(ExecutionProvider, RepresentationMixin):
         async_nic_creation = self.network_client.network_interfaces.\
             create_or_update(
                 self.group_name,
-                "{}.{}.nic".format(self.group_name, time.time()), {
+                f"{self.group_name}.{time.time()}.nic", {
                     'location':
                     self.location,
                     'ip_configurations': [{
                         'name':
-                        "{}.ip.config".format(self.group_name),
+                        f"{self.group_name}.ip.config",
                         'subnet': {
                             'id': subnet_info.id
                         }
@@ -443,7 +442,7 @@ class AzureProvider(ExecutionProvider, RepresentationMixin):
         return {
             'location': self.region,
             'os_profile': {
-                'computer_name': "{}.{}".format(self.vnet_name, time.time()),
+                'computer_name': f"{self.vnet_name}.{time.time()}",
                 'admin_username': self.vm_reference["admin_username"],
                 'admin_password': self.vm_reference["password"]
             },
@@ -470,7 +469,7 @@ class AzureProvider(ExecutionProvider, RepresentationMixin):
 
         Each instance gets one disk"""
         logger.info('Create (empty) managed Data Disk')
-        name = '{}.{}'.format(self.group_name, time.time())
+        name = f'{self.group_name}.{time.time()}'
         async_disk_creation = self.compute_client.disks.create_or_update(
             self.group_name, name, {
                 'location': self.location,

--- a/parsl/providers/cluster_provider.py
+++ b/parsl/providers/cluster_provider.py
@@ -68,8 +68,9 @@ class ClusterProvider(ExecutionProvider):
         self.cmd_timeout = cmd_timeout
         if not callable(self.launcher):
             raise(BadLauncher(self.launcher,
-                              "Launcher for executor: {} is of type: {}. Expects a parsl.launcher.launcher.Launcher or callable".format(
-                                  label, type(self.launcher))))
+                              f"Launcher for executor: {label} is of type: "
+                              f"{type(self.launcher)}. Expects a "
+                              f"parsl.launcher.launcher.Launcher or callable"))
 
         self.script_dir = None
 

--- a/parsl/providers/cobalt/cobalt.py
+++ b/parsl/providers/cobalt/cobalt.py
@@ -151,11 +151,11 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
 
         """
 
-        account_opt = '-A {}'.format(self.account) if self.account is not None else ''
+        account_opt = f'-A {self.account}' if self.account is not None else ''
 
-        job_name = "parsl.{0}.{1}".format(job_name, time.time())
+        job_name = f"parsl.{job_name}.{time.time()}"
 
-        script_path = "{0}/{1}.submit".format(self.script_dir, job_name)
+        script_path = f"{self.script_dir}/{job_name}.submit"
         script_path = os.path.abspath(script_path)
 
         job_config = {}
@@ -168,15 +168,16 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
         # Wrap the command
         job_config["user_script"] = self.launcher(command, tasks_per_node, self.nodes_per_block)
 
-        queue_opt = '-q {}'.format(self.queue) if self.queue is not None else ''
+        queue_opt = f'-q {self.queue}' if self.queue is not None else ''
 
         logger.debug("Writing submit script")
         self._write_submit_script(template_string, script_path, job_name, job_config)
 
         channel_script_path = self.channel.push_file(script_path, self.channel.script_dir)
 
-        command = 'qsub -n {0} {1} -t {2} {3} {4}'.format(
-            self.nodes_per_block, queue_opt, wtime_to_minutes(self.walltime), account_opt, channel_script_path)
+        command = (f'qsub -n {self.nodes_per_block} {queue_opt} '
+                   f'-t {wtime_to_minutes(self.walltime)} '
+                   f'{account_opt} {channel_script_path}')
         logger.debug("Executing {}".format(command))
 
         retcode, stdout, stderr = self.execute_wait(command)
@@ -212,7 +213,7 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
         """
 
         job_id_list = ' '.join(job_ids)
-        retcode, stdout, stderr = self.execute_wait("qdel {0}".format(job_id_list))
+        retcode, stdout, stderr = self.execute_wait(f"qdel {job_id_list}")
         rets = None
         if retcode == 0:
             for jid in job_ids:

--- a/parsl/providers/error.py
+++ b/parsl/providers/error.py
@@ -15,9 +15,8 @@ class ChannelRequired(ExecutionProviderException):
         self.reason = reason
 
     def __repr__(self):
-        return "Unable to Initialize provider.Provider:{0}, Reason:{1}".format(
-            self.provider, self.reason
-        )
+        return (f"Unable to Initialize provider.Provider:{self.provider}, "
+                f"Reason:{self.reason}")
 
 
 class ScaleOutFailed(ExecutionProviderException):
@@ -29,7 +28,7 @@ class ScaleOutFailed(ExecutionProviderException):
         self.reason = reason
 
     def __str__(self):
-        return "Unable to scale out {} provider: {}".format(self.provider, self.reason)
+        return f"Unable to scale out {self.provider} provider: {self.reason}"
 
 
 class SchedulerMissingArgs(ExecutionProviderException):
@@ -41,7 +40,8 @@ class SchedulerMissingArgs(ExecutionProviderException):
         self.sitename = sitename
 
     def __repr__(self):
-        return "SchedulerMissingArgs: Pool:{0} Arg:{1}".format(self.sitename, self.missing_keywords)
+        return (f"SchedulerMissingArgs: Pool:{self.sitename} "
+                f"Arg:{self.missing_keywords}")
 
 
 class ScriptPathError(ExecutionProviderException):
@@ -53,7 +53,8 @@ class ScriptPathError(ExecutionProviderException):
         self.reason = reason
 
     def __repr__(self):
-        return "Unable to write submit script:{0} Reason:{1}".format(self.script_path, self.reason)
+        return (f"Unable to write submit script:{self.script_path} "
+                f"Reason:{self.reason}")
 
 
 class SubmitException(ExecutionProviderException):
@@ -68,7 +69,5 @@ class SubmitException(ExecutionProviderException):
 
     def __repr__(self):
         # TODO: make this more user-friendly
-        return "Cannot launch task {0}: {1}; stdout={2}, stderr={3}".format(self.task_name,
-                                                                            self.message,
-                                                                            self.stdout,
-                                                                            self.stderr)
+        return (f"Cannot launch task {self.task_name}: {self.message}; "
+                f"stdout={self.stdout}, stderr={self.stderr}")

--- a/parsl/providers/googlecloud/googlecloud.py
+++ b/parsl/providers/googlecloud/googlecloud.py
@@ -165,7 +165,7 @@ class GoogleCloudProvider():
         self.cancel([i for i in list(self.resources)])
 
     def create_instance(self, command=""):
-        name = "parslauto{}".format(self.num_instances)
+        name = f"parslauto{self.num_instances}"
         self.num_instances += 1
         compute = self.client
         project = self.project_id
@@ -174,7 +174,7 @@ class GoogleCloudProvider():
         source_disk_image = image_response['selfLink']
 
         # Configure the machine
-        machine_type = "zones/{}/machineTypes/{}".format(self.zone, self.instance_type)
+        machine_type = f"zones/{self.zone}/machineTypes/{self.instance_type}"
         startup_script = command
 
         config = {

--- a/parsl/providers/grid_engine/grid_engine.py
+++ b/parsl/providers/grid_engine/grid_engine.py
@@ -134,10 +134,10 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
         '''
 
         # Set job name
-        job_name = "{0}.{1}".format(job_name, time.time())
+        job_name = f"{job_name}.{time.time()}"
 
         # Set script path
-        script_path = "{0}/{1}.submit".format(self.script_dir, job_name)
+        script_path = f"{self.script_dir}/{job_name}.submit"
         script_path = os.path.abspath(script_path)
 
         job_config = self.get_configs(command, tasks_per_node)
@@ -146,10 +146,8 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
         self._write_submit_script(template_string, script_path, job_name, job_config)
 
         channel_script_path = self.channel.push_file(script_path, self.channel.script_dir)
-        if self.queue is not None:
-            cmd = "qsub -q {0} -terse {1}".format(self.queue, channel_script_path)
-        else:
-            cmd = "qsub -terse {0}".format(channel_script_path)
+        cmd = f"qsub " if self.queue is None else f"qsub -q {self.queue} "
+        cmd += f"-terse {channel_script_path}"
         retcode, stdout, stderr = self.execute_wait(cmd)
 
         if retcode == 0:
@@ -213,7 +211,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
         '''
 
         job_id_list = ' '.join(job_ids)
-        cmd = "qdel {}".format(job_id_list)
+        cmd = f"qdel {job_id_list}"
         retcode, stdout, stderr = self.execute_wait(cmd)
 
         rets = None

--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -144,13 +144,10 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         """
 
         cur_timestamp = str(time.time() * 1000).split(".")[0]
-        job_name = "{0}-{1}".format(job_name, cur_timestamp)
+        job_name = f"{job_name}-{cur_timestamp}"
 
-        if not self.pod_name:
-            pod_name = '{}'.format(job_name)
-        else:
-            pod_name = '{}-{}'.format(self.pod_name,
-                                      cur_timestamp)
+        pod_name = f"{self.pod_name if self.pod_name else job_name}"
+        pod_name += f"-{cur_timestamp}"
 
         formatted_cmd = template_string.format(command=cmd_string,
                                                worker_init=self.worker_init)
@@ -251,7 +248,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         # Create the enviornment variables and command to initiate IPP
         environment_vars = client.V1EnvVar(name="TEST", value="SOME DATA")
 
-        launch_args = ["-c", "{0};".format(cmd_string)]
+        launch_args = ["-c", f"{cmd_string};"]
 
         volume_mounts = []
         # Create mount paths for the volumes

--- a/parsl/providers/provider_base.py
+++ b/parsl/providers/provider_base.py
@@ -46,10 +46,8 @@ class JobStatus(object):
         return self.state.status_name
 
     def __repr__(self):
-        if self.message is not None:
-            return "{} ({})".format(self.state, self.message)
-        else:
-            return "{}".format(self.state)
+        return (f"{self.state}"
+                f"{'' if self.message is None else f' ({self.message})'}")
 
     @property
     def stdout(self):

--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -124,9 +124,9 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         if exclusive:
             self.scheduler_options += "#SBATCH --exclusive\n"
         if partition:
-            self.scheduler_options += "#SBATCH --partition={}\n".format(partition)
+            self.scheduler_options += f"#SBATCH --partition={partition}\n"
         if account:
-            self.scheduler_options += "#SBATCH --account={}\n".format(account)
+            self.scheduler_options += f"#SBATCH --account={account}\n"
         self.worker_init = worker_init + '\n'
 
     def _status(self):
@@ -139,7 +139,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
               [status...] : Status list of all jobs
         '''
         job_id_list = ','.join(self.resources.keys())
-        cmd = "squeue --job {0}".format(job_id_list)
+        cmd = f"squeue --job {job_id_list}"
         logger.debug("Executing sqeueue")
         retcode, stdout, stderr = self.execute_wait(cmd)
         logger.debug("sqeueue returned")
@@ -185,16 +185,16 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         scheduler_options = self.scheduler_options
         worker_init = self.worker_init
         if self.mem_per_node is not None:
-            scheduler_options += '#SBATCH --mem={}g\n'.format(self.mem_per_node)
-            worker_init += 'export PARSL_MEMORY_GB={}\n'.format(self.mem_per_node)
+            scheduler_options += f'#SBATCH --mem={self.mem_per_node}g\n'
+            worker_init += f'export PARSL_MEMORY_GB={self.mem_per_node}\n'
         if self.cores_per_node is not None:
             cpus_per_task = math.floor(self.cores_per_node / tasks_per_node)
-            scheduler_options += '#SBATCH --cpus-per-task={}'.format(cpus_per_task)
-            worker_init += 'export PARSL_CORES={}\n'.format(cpus_per_task)
+            scheduler_options += f'#SBATCH --cpus-per-task={cpus_per_task}'
+            worker_init += f'export PARSL_CORES={cpus_per_task}\n'
 
-        job_name = "{0}.{1}".format(job_name, time.time())
+        job_name = f"{job_name}.{time.time()}"
 
-        script_path = "{0}/{1}.submit".format(self.script_dir, job_name)
+        script_path = f"{self.channel.script_dir}/{job_name}.submit"
         script_path = os.path.abspath(script_path)
 
         logger.debug("Requesting one block with {} nodes".format(self.nodes_per_block))
@@ -223,7 +223,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
             logger.debug("not moving files")
             channel_script_path = script_path
 
-        retcode, stdout, stderr = self.execute_wait("sbatch {0}".format(channel_script_path))
+        retcode, stdout, stderr = self.execute_wait(f"sbatch {channel_script_path}")
 
         job_id = None
         if retcode == 0:
@@ -247,7 +247,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         '''
 
         job_id_list = ' '.join(job_ids)
-        retcode, stdout, stderr = self.execute_wait("scancel {0}".format(job_id_list))
+        retcode, stdout, stderr = self.execute_wait(f"scancel {job_id_list}")
         rets = None
         if retcode == 0:
             for jid in job_ids:

--- a/parsl/serialize/base.py
+++ b/parsl/serialize/base.py
@@ -43,7 +43,8 @@ class SerializerBase(object):
         """
         s_id, payload = payload.split(b'\n', 1)
         if (s_id + b'\n') != self.identifier:
-            raise TypeError("Buffer does not start with parsl.serialize identifier:{}".format(self.identifier))
+            raise TypeError(f"Buffer does not start with parsl.serialize "
+                            f"identifier:{self.identifier}")
         return payload
 
     def enable_caching(self, maxsize=128):

--- a/parsl/serialize/facade.py
+++ b/parsl/serialize/facade.py
@@ -105,7 +105,9 @@ class ParslSerializer(object):
             raise last_exception
 
         if len(serialized) > buffer_threshold:
-            logger.warning(f"Serialized object exceeds buffer threshold of {buffer_threshold} bytes, this could cause overflows")
+            logger.warning("Serialized object exceeds buffer threshold of {} "
+                           "bytes, this could cause "
+                           "overflows".format(buffer_threshold))
         return serialized
 
     def deserialize(self, payload):
@@ -122,7 +124,9 @@ class ParslSerializer(object):
         elif header in self.methods_for_data:
             result = self.methods_for_data[header].deserialize(payload)
         else:
-            raise TypeError("Invalid header: {} in data payload. Buffer is either corrupt or not created by ParslSerializer".format(header))
+            raise TypeError(f"Invalid header: {header} in data payload. Buffer "
+                            f"is either corrupt or not created by "
+                            f"ParslSerializer")
 
         return result
 
@@ -168,6 +172,7 @@ class ParslSerializer(object):
             deserialized = self.deserialize(current)
             unpacked.extend([deserialized])
 
-        assert len(unpacked) == 3, "Unpack expects 3 buffers, got {}".format(len(unpacked))
+        assert len(unpacked) == 3, (f"Unpack expects 3 buffers, "
+                                    f"got {len(unpacked)}")
 
         return unpacked

--- a/parsl/tests/configs/user_opts.py
+++ b/parsl/tests/configs/user_opts.py
@@ -44,32 +44,37 @@ user_opts = {
     },
     # 'comet': {
     #     'username': COMET_USERNAME,
-    #     'script_dir': '/home/{}/parsl_scripts'.format(COMET_USERNAME),
+    #     'script_dir': f'/home/{COMET_USERNAME}/parsl_scripts',
     #     'scheduler_options': "",
-    #     'worker_init': 'export PATH:/home/{}/anaconda3/bin/:$PATH; source activate parsl_0.5.0_py3.6;'.format(COMET_USERNAME),
+    #     'worker_init': (f'export '
+    #                     f'PATH:/home/{COMET_USERNAME}/anaconda3/bin/:$PATH; '
+    #                     f'source activate parsl_0.5.0_py3.6;'),
     # },
     # 'midway': {
     #     'username': MIDWAY_USERNAME,
-    #     'script_dir': '/scratch/midway2/{}/parsl_scripts'.format(MIDWAY_USERNAME),
+    #     'script_dir': f'/scratch/midway2/{MIDWAY_USERNAME}/parsl_scripts',
     #     'scheduler_options': "",
-    #     'worker_init': 'cd /scratch/midway2/{}/parsl_scripts; module load Anaconda3/5.1.0; source activate parsl_testing;'.format(MIDWAY_USERNAME),
+    #     'worker_init': (f'cd '
+    #                     f'/scratch/midway2/{MIDWAY_USERNAME}/parsl_scripts; '
+    #                     f'module load Anaconda3/5.1.0; '
+    #                     f'source activate parsl_testing;'),
     # },
     # 'osg': {
     #     'username': OSG_USERNAME,
-    #     'script_dir': '/home/{}/parsl_scripts'.format(OSG_USERNAME),
+    #     'script_dir': f'/home/{OSG_USERNAME}/parsl_scripts',
     #     'scheduler_options': "",
     #     'worker_init' : 'module load python/3.5.2; python3 -m venv parsl_env; source parsl_env/bin/activate; python3 -m pip install parsl==0.5.2'
     # },
     # 'cori': {
     #     'username': CORI_USERNAME,
-    #     'script_dir': "/global/homes/y/{}/parsl_scripts".format(CORI_USERNAME),
+    #     'script_dir': f"/global/homes/y/{CORI_USERNAME}/parsl_scripts",
     #     'scheduler_options': "#SBATCH --constraint=haswell",
     #     "worker_init": """module load python/3.6-anaconda-4.4 ;
     #     source activate parsl_env_3.6"""
     # },
     # 'swan': {
     #     'username': SWAN_USERNAME,
-    #     'script_dir' : "/home/users/{}/parsl_scripts".format(SWAN_USERNAME),
+    #     'script_dir' : f"/home/users/{SWAN_USERNAME}/parsl_scripts",
     #     'scheduler_options': "",
     #     'worker_init': "module load cray-python/3.6.1.1; source parsl_env/bin/activate"
     # },
@@ -77,7 +82,7 @@ user_opts = {
     #     'username': ALCF_USERNAME,
     #     "account": ALCF_ALLOCATION,
     #     'scheduler_options': "",
-    #     "worker_init": "source /home/{}/setup_cooley_env.sh".format(ALCF_USERNAME),
+    #     "worker_init": f"source /home/{ALCF_USERNAME}/setup_cooley_env.sh",
     #     # Once you log onto Cooley, get the ip address of the login machine
     #     # by running >> ip addr show | grep -o 10.236.1.[0-9]*
     #     'public_ip': '10.236.1.193'
@@ -114,7 +119,7 @@ user_opts = {
     #     'username': ALCF_USERNAME,
     #     "account": ALCF_ALLOCATION,
     #     'scheduler_options': "",
-    #     "worker_init": "source /home/{}/setup_theta_env.sh".format(ALCF_USERNAME),
+    #     "worker_init": f"source /home/{ALCF_USERNAME}/setup_theta_env.sh"
     #     # Once you log onto theta, get the ip address of the login machine
     #     # by running >> ip addr show | grep -o 10.236.1.[0-9]*
     #     'public_ip': '10.236.1.193'

--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -23,7 +23,7 @@ def dumpstacks(sig, frame):
         thread_names = {thread.ident: thread.name for thread in threading.enumerate()}
         tf = sys._current_frames()
         for thread_id, frame in tf.items():
-            s += '\n\nThread: %s (%d)' % (thread_names[thread_id], thread_id)
+            s += f'\n\nThread: {thread_names[thread_id]} ({thread_id})'
             s += ''.join(traceback.format_stack(frame))
     except Exception:
         s = traceback.format_exc()
@@ -177,14 +177,14 @@ def apply_masks(request, pytestconfig):
     if m is not None:
         if os.path.abspath(config) not in chain.from_iterable([glob(x) for x in m.args]):
             if 'reason' not in m.kwargs:
-                pytest.skip("config '{}' not in whitelist".format(config))
+                pytest.skip(f"config '{config}' not in whitelist")
             else:
                 pytest.skip(m.kwargs['reason'])
     m = request.node.get_closest_marker('blacklist')
     if m is not None:
         if os.path.abspath(config) in chain.from_iterable([glob(x) for x in m.args]):
             if 'reason' not in m.kwargs:
-                pytest.skip("config '{}' is in blacklist".format(config))
+                pytest.skip(f"config '{config}' is in blacklist")
             else:
                 pytest.skip(m.kwargs['reason'])
     m = request.node.get_closest_marker('local')
@@ -238,7 +238,7 @@ def pytest_make_collect_report(collector):
         if call.excinfo.errisinstance(KeyError):
             outcome = "skipped"
             r = collector._repr_failure_py(call.excinfo, "line").reprcrash
-            message = "{} not configured in user_opts.py".format(r.message.split()[-1])
+            message = f"{r.message.split()[-1]} not configured in user_opts.py"
             longrepr = (str(r.path), r.lineno, message)
         elif call.excinfo.errisinstance(skip_exceptions):
             outcome = "skipped"

--- a/parsl/tests/integration/latency.py
+++ b/parsl/tests/integration/latency.py
@@ -36,7 +36,7 @@ import parsl
 @parsl.python_app
 def python_app():
     import platform
-    return "Hello from {0}".format(platform.uname())
+    return f"Hello from {platform.uname()}"
 
 
 @parsl.python_app
@@ -44,7 +44,7 @@ def python_app_slow(duration):
     import platform
     import time
     time.sleep(duration)
-    return "Hello from {0}".format(platform.uname())
+    return f"Hello from {platform.uname()}"
 
 
 @parsl.python_app
@@ -109,23 +109,21 @@ def test_python(count):
     min_latency = min(latency) * 1000
     max_latency = max(latency) * 1000
     avg_latency = average(latency) * 1000
-    print("Latency   |   Min:{0:0.3}ms Max:{1:0.3}ms Average:{2:0.3}ms".format(min_latency,
-                                                                               max_latency,
-                                                                               avg_latency))
+    print(f"Latency   |   Min:{min_latency:0.3}ms Max:{max_latency:0.3}ms "
+          f"Average:{avg_latency:0.3}ms")
 
     min_rtt = min(rtt) * 1000
     max_rtt = max(rtt) * 1000
     avg_rtt = average(rtt) * 1000
 
-    print("Roundtrip |   Min:{0:0.3}ms Max:{1:0.3}ms Average:{2:0.3}ms".format(min_rtt,
-                                                                               max_rtt,
-                                                                               avg_rtt))
+    print(f"Roundtrip |   Min:{min_rtt:0.3}ms Max:{max_rtt:0.3}ms "
+          f"Average:{avg_rtt:0.3}ms")
 
 
 def test_bash():
     import os
     fname = os.path.basename(__file__)
 
-    x = bash_app(stdout="{0}.out".format(fname))
+    x = bash_app(stdout=f"{fname}.out")
     print("Waiting ....")
     print(x.result())

--- a/parsl/tests/integration/test_apps/HEDM_processlayer/process_layer.py
+++ b/parsl/tests/integration/test_apps/HEDM_processlayer/process_layer.py
@@ -29,24 +29,24 @@ dfk = DataFlowKernel(executors=[workers])
 
 def create_dirs(cwd):
 
-    for dir in ['relax.01', 'relax.02', 'relax.03']:
-        rel_dir = '{0}/{1}'.format(cwd, dir)
+    for dir_ in ['relax.01', 'relax.02', 'relax.03']:
+        rel_dir = f'{cwd}/{dir_}'
         if os.path.exists(rel_dir):
             shutil.rmtree(rel_dir)
         os.makedirs(rel_dir)
-        for i in range(0, random.randint(1, 5)):
-            rdir = '{0}/{1}'.format(rel_dir, i)
+        for i in range(random.randint(1, 5)):
+            rdir = f'{rel_dir}/{i}'
             os.makedirs(rdir)
-            with open('{0}/results'.format(rdir), 'w') as f:
-                f.write("{0} {1} - test data\n".format(i, dir))
+            with open(f'{rdir}/results', 'w') as f:
+                f.write(f"{i} {dir_} - test data\n")
 
-    for dir in ['neb01', 'neb02', 'neb03', 'neb04']:
-        rel_dir = '{0}/{1}'.format(cwd, dir)
+    for dir_ in ['neb01', 'neb02', 'neb03', 'neb04']:
+        rel_dir = f'{cwd}/{dir_}'
         if os.path.exists(rel_dir):
             shutil.rmtree(rel_dir)
         os.makedirs(rel_dir)
-        with open('{0}/{1}.txt'.format(rel_dir, dir), 'w') as f:
-            f.write("{0} test data\n".format(rel_dir))
+        with open(f'{rel_dir}/{dir_}.txt', 'w') as f:
+            f.write(f"{rel_dir} test data\n")
 
 
 @python_app(data_flow_kernel=dfk)
@@ -94,7 +94,7 @@ def main(count):
     for i in range(count):
         if i % 1000:
             print("Launching light : ", i)
-        outname = 'outputs/light{0}'.format(i)
+        outname = f'outputs/light{i}'
         loop1 = light_app('.', 0, inputs=[c1], outputs=[
                           outname + '.txt'], stdout=outname + '.out')
         light_loop.extend([loop1])
@@ -111,7 +111,7 @@ def main(count):
     # Foreach parallel loop 10K calls
     for i in lines:
         i = i.strip()
-        outname = 'outputs/mid{0}'.format(i)
+        outname = f'outputs/mid{i}'
         loop1 = light_app('.', 0, inputs=[c1], outputs=[
                           outname + '.txt'], stdout=outname + '.out')
         mid_loop.extend([loop1])

--- a/parsl/tests/integration/test_apps/vasp/vasp_example.py
+++ b/parsl/tests/integration/test_apps/vasp/vasp_example.py
@@ -36,24 +36,24 @@ dfk = DataFlowKernel(workers)
 
 def create_dirs(cwd):
 
-    for dir in ['relax.01', 'relax.02', 'relax.03']:
-        rel_dir = '{0}/{1}'.format(cwd, dir)
+    for dir_ in ['relax.01', 'relax.02', 'relax.03']:
+        rel_dir = f'{cwd}/{dir_}'
         if os.path.exists(rel_dir):
             shutil.rmtree(rel_dir)
         os.makedirs(rel_dir)
-        for i in range(0, random.randint(1, 5)):
-            rdir = '{0}/{1}'.format(rel_dir, i)
+        for i in range(random.randint(1, 5)):
+            rdir = f'{rel_dir}/{i}'
             os.makedirs(rdir)
-            with open('{0}/results'.format(rdir), 'w') as f:
-                f.write("{0} {1} - test data\n".format(i, dir))
+            with open(f'{rdir}/results', 'w') as f:
+                f.write(f"{i} {dir_} - test data\n")
 
-    for dir in ['neb01', 'neb02', 'neb03', 'neb04']:
-        rel_dir = '{0}/{1}'.format(cwd, dir)
+    for dir_ in ['neb01', 'neb02', 'neb03', 'neb04']:
+        rel_dir = f'{cwd}/{dir_}'
         if os.path.exists(rel_dir):
             shutil.rmtree(rel_dir)
         os.makedirs(rel_dir)
-        with open('{0}/{1}.txt'.format(rel_dir, dir), 'w') as f:
-            f.write("{0} test data\n".format(rel_dir))
+        with open(f'{rel_dir}/{dir_}.txt', 'w') as f:
+            f.write(f"{rel_dir} test data\n")
 
 
 @python_app(data_flow_kernel=dfk)
@@ -81,14 +81,14 @@ if __name__ == "__main__":
     ls_fu, [res] = ls(pwd, outputs=['results'])
 
     dir_fus = {}
-    for dir in ls_fu.result():
-        if dir.startswith('relax') and os.path.isdir(dir):
-            print("Launching {0}".format(dir))
-            dir_fus[dir] = catter(dir, outputs=['{0}.allresults'.format(dir)],
-                                  stderr='{0}.stderr'.format(dir))
+    for dir_ in ls_fu.result():
+        if dir_.startswith('relax') and os.path.isdir(dir_):
+            print(f"Launching {dir_}")
+            dir_fus[dir_] = catter(dir_, outputs=[f'{dir_}.allresults'],
+                                   stderr=f'{dir_}.stderr')
 
-    for dir in dir_fus:
+    for dir_ in dir_fus:
         try:
-            print(dir_fus[dir][0].result())
+            print(dir_fus[dir_][0].result())
         except Exception as e:
-            print("Caught exception{0}  on {1}".format(e, dir))
+            print(f"Caught exception{e} on {dir_}")

--- a/parsl/tests/integration/test_channels/test_scp_1.py
+++ b/parsl/tests/integration/test_channels/test_scp_1.py
@@ -41,7 +41,7 @@ def test_connect_1():
 
     for site in sites.values():
         out = connect_and_list(site['url'], site['uname'])
-        print("Sitename :{0}  hostname:{1}".format(site['url'], out))
+        print(f"Sitename :{site['url']}  hostname:{out}")
 
 
 if __name__ == "__main__":

--- a/parsl/tests/integration/test_channels/test_ssh_1.py
+++ b/parsl/tests/integration/test_channels/test_ssh_1.py
@@ -14,7 +14,7 @@ def test_midway():
     url = 'midway.rcc.uchicago.edu'
     uname = 'yadunand'
     out = connect_and_list(url, uname)
-    print("Sitename :{0}  hostname:{1}".format(url, out))
+    print(f"Sitename :{url}  hostname:{out}")
 
 
 def test_beagle():
@@ -23,7 +23,7 @@ def test_beagle():
     url = 'login04.beagle.ci.uchicago.edu'
     uname = 'yadunandb'
     out = connect_and_list(url, uname)
-    print("Sitename :{0}  hostname:{1}".format(url, out))
+    print(f"Sitename :{url}  hostname:{out}")
 
 
 def test_osg():
@@ -32,7 +32,7 @@ def test_osg():
     url = 'login.osgconnect.net'
     uname = 'yadunand'
     out = connect_and_list(url, uname)
-    print("Sitename :{0}  hostname:{1}".format(url, out))
+    print(f"Sitename :{url}  hostname:{out}")
 
 
 def test_cori():
@@ -41,7 +41,7 @@ def test_cori():
     url = 'cori.nersc.gov'
     uname = 'yadunand'
     out = connect_and_list(url, uname)
-    print("Sitename :{0}  hostname:{1}".format(url, out))
+    print(f"Sitename :{url}  hostname:{out}")
 
 
 if __name__ == "__main__":

--- a/parsl/tests/integration/test_channels/test_ssh_errors.py
+++ b/parsl/tests/integration/test_channels/test_ssh_errors.py
@@ -13,7 +13,7 @@ def test_error_1():
     try:
         connect_and_list("bad.url.gov", "ubuntu")
     except Exception as e:
-        assert type(e) == SSHException, "Expected SSException, got: {0}".format(e)
+        assert type(e) == SSHException, f"Expected SSException, got: {e}"
 
 
 def test_error_2():
@@ -22,7 +22,7 @@ def test_error_2():
     except SSHException:
         print("Caught the right exception")
     else:
-        raise Exception("Expected SSException, got: {0}".format(e))
+        raise Exception(f"Expected SSException, got: {e}")
 
 
 def test_error_3():
@@ -33,7 +33,7 @@ def test_error_3():
     except BadHostKeyException as e:
         print("Caught exception BadHostKeyException: ", e)
     else:
-        assert False, "Expected SSException, got: {0}".format(e)
+        assert False, f"Expected SSException, got: {e}"
 
 
 if __name__ == "__main__":
@@ -41,6 +41,6 @@ if __name__ == "__main__":
     tests = [test_error_1, test_error_2, test_error_3]
 
     for test in tests:
-        print("---------Running : {0}---------------".format(test))
+        print(f"---------Running : {test}---------------")
         test()
         print("----------------------DONE--------------------------")

--- a/parsl/tests/integration/test_channels/test_ssh_file_transport.py
+++ b/parsl/tests/integration/test_channels/test_ssh_file_transport.py
@@ -9,22 +9,22 @@ def connect_and_list(hostname, username):
     return out
 
 
-def test_push(conn, fname="test001.txt"):
+def test_push(conn_, fname="test001.txt"):
 
     with open(fname, 'w') as f:
         f.write("Hello from parsl.ssh testing\n")
 
-    conn.push_file(fname, "/tmp")
-    ec, out, err = conn.execute_wait("ls /tmp/{0}".format(fname))
+    conn_.push_file(fname, "/tmp")
+    ec, out, err = conn_.execute_wait(f"ls /tmp/{fname}")
     print(ec, out, err)
 
 
-def test_pull(conn, fname="test001.txt"):
+def test_pull(conn_, fname="test001.txt"):
 
     local = "foo"
-    conn.pull_file("/tmp/{0}".format(fname), local)
+    conn_.pull_file(f"/tmp/{fname}", local)
 
-    with open("{0}/{1}".format(local, fname), 'r') as f:
+    with open(f"{local}/{fname}", 'r') as f:
         print(f.readlines())
 
 

--- a/parsl/tests/integration/test_channels/test_ssh_interactive.py
+++ b/parsl/tests/integration/test_channels/test_ssh_interactive.py
@@ -15,7 +15,7 @@ def test_cooley():
     url = 'cooley.alcf.anl.gov'
     uname = 'yadunand'
     out = connect_and_list(url, uname)
-    print("Sitename :{0}  hostname:{1}".format(url, out))
+    print(f"Sitename :{url}  hostname:{out}")
     return
 
 

--- a/parsl/tests/integration/test_stress/test_python_ipp.py
+++ b/parsl/tests/integration/test_stress/test_python_ipp.py
@@ -21,7 +21,7 @@ def test_stress(count=1000):
     for i in range(count):
         x[i] = increment(i)
     end = time.time()
-    print("Launched {0} tasks in {1} s".format(count, end - start))
+    print(f"Launched {count} tasks in {end - start} s")
 
 
 if __name__ == '__main__':

--- a/parsl/tests/integration/test_stress/test_python_simple.py
+++ b/parsl/tests/integration/test_stress/test_python_simple.py
@@ -21,11 +21,11 @@ def test_stress(count=1000):
         f = increment(i)
         x.append(f)
     end = time.time()
-    print("Launched {0} tasks in {1:.2f} s".format(count, end - start))
+    print(f"Launched {count} tasks in { end - start:.2f} s")
 
     [f.result() for f in x]
     end = time.time()
-    print("Completed {0} tasks in {1:.2f} s".format(count, end - start))
+    print(f"Completed {count} tasks in {end - start:.2f} s")
 
 
 if __name__ == '__main__':

--- a/parsl/tests/integration/test_stress/test_python_threads.py
+++ b/parsl/tests/integration/test_stress/test_python_threads.py
@@ -24,7 +24,7 @@ def test_stress(count=1000):
     for i in range(count):
         x[i] = increment(i)
     end = time.time()
-    print("Launched {0} tasks in {1} s".format(count, end - start))
+    print(f"Launched {count} tasks in {end - start} s")
 
 
 if __name__ == '__main__':

--- a/parsl/tests/low_latency/executor.py
+++ b/parsl/tests/low_latency/executor.py
@@ -65,7 +65,7 @@ def dealer_executor(f_all, args_all, kwargs_all, num_tasks, return_dict,
 
     context = zmq.Context()
     dealer = context.socket(zmq.DEALER)
-    dealer.bind("tcp://*:{}".format(port))
+    dealer.bind(f"tcp://*:{port}")
 
     poller = zmq.Poller()
     poller.register(dealer, zmq.POLLIN)
@@ -144,7 +144,7 @@ if __name__ == "__main__":
         ip = address_by_interface("eth0")
         with open(CLIENT_IP_FILE, "w") as fh:
             fh.write(ip)
-        print("Wrote IP address {} to file {}".format(ip, CLIENT_IP_FILE))
+        print(f"Wrote IP address {ip} to file {CLIENT_IP_FILE}")
 
     # Parameters for worker requests
     def f_all():
@@ -180,10 +180,9 @@ if __name__ == "__main__":
     # Print stats
     label = "[DEALER-INTERCHANGE-REP]" if args.interchange else "[DEALER-REP]"
     s = stdev(serialization_times) if len(serialization_times) > 1 else 0
-    print("{} Avg Serialization Time\n"
-          "Mean = {:=10.4f} us, Stdev = {:=10.4f} us"
-          .format(label, mean(serialization_times), s))
+    print(f"{label} Avg Serialization Time\n"
+          f"Mean = {mean(serialization_times):=10.4f} us, "
+          f"Stdev = {s:=10.4f} us")
     s = stdev(execution_times) if len(execution_times) > 1 else 0
-    print("{} Avg Execution Time\n"
-          "Mean = {:=10.4f} us, Stdev = {:=10.4f} us"
-          .format(label, mean(execution_times), s))
+    print(f"{label} Avg Execution Time\n"
+          f"Mean = {mean(execution_times):=10.4f} us, Stdev = {s:=10.4f} us")

--- a/parsl/tests/low_latency/interchange.py
+++ b/parsl/tests/low_latency/interchange.py
@@ -50,13 +50,13 @@ if __name__ == "__main__":
     if not args.localhost:
         with open(CLIENT_IP_FILE, "r") as fh:
             client_ip = fh.read().strip()
-        print("Read IP {} from file {}".format(client_ip, CLIENT_IP_FILE))
+        print(f"Read IP {client_ip} from file {CLIENT_IP_FILE}")
 
         interchange_ip = address_by_interface("eth0")
         with open(INTERCHANGE_IP_FILE, "w") as fh:
             fh.write(interchange_ip)
-        print("Wrote IP address {} to file {}"
-              .format(interchange_ip, INTERCHANGE_IP_FILE))
+        print(f"Wrote IP address {interchange_ip} "
+              f"to file {INTERCHANGE_IP_FILE}")
     else:
         client_ip = "localhost"
 

--- a/parsl/tests/low_latency/utils.py
+++ b/parsl/tests/low_latency/utils.py
@@ -8,7 +8,7 @@ def ping_time(ip, n=5):
     Note: This function is inherently platform specific.
     It currently works on Midway.
     """
-    cmd = "ping {} -c {}".format(ip, n)
+    cmd = f"ping {ip} -c {n}"
     p = subprocess.Popen(cmd.split(" "), stdout=subprocess.PIPE)
     output = str(p.communicate()[0])
     stats = output.split("\n")[-1].split(" = ")[-1].split("/")

--- a/parsl/tests/low_latency/worker.py
+++ b/parsl/tests/low_latency/worker.py
@@ -34,8 +34,7 @@ def execute_task(f, args, kwargs, user_ns):
                     kwargname: kwargs,
                     resultname: resultname})
 
-    code = "{0} = {1}(*{2}, **{3})".format(resultname, fname,
-                                           argname, kwargname)
+    code = f"{resultname} = {fname}(*{argname}, **{kwargname})"
     try:
         exec(code, user_ns, user_ns)
 
@@ -70,8 +69,7 @@ def dealer_worker(worker_id, ip="localhost", port=5560):
         reply = {"result": result, "worker_id": worker_id}
         socket.send_multipart([bufs[0]] + serialize_object(reply))
 
-        print("Worker {} received {} tasks"
-              .format(worker_id, len(task_ids_received)))
+        print(f"Worker {worker_id} received {len(task_ids_received)} tasks")
 
 
 if __name__ == "__main__":
@@ -91,8 +89,8 @@ if __name__ == "__main__":
         ip_file = INTERCHANGE_IP_FILE if args.interchange else CLIENT_IP_FILE
         with open(ip_file, "r") as fh:
             ip = fh.read().strip()
-        print("Read IP {} from file {}".format(ip, ip_file))
-        print("Ping time to IP {}: {} us".format(ip, ping_time(ip)))
+        print(f"Read IP {ip} from file {ip_file}")
+        print(f"Ping time to IP {ip}: {ping_time(ip)} us")
     else:
         ip = "localhost"
 

--- a/parsl/tests/manual_tests/plain_executor.py
+++ b/parsl/tests/manual_tests/plain_executor.py
@@ -26,7 +26,7 @@ def call_sleep(size):
     primers = [double(i) for i in range(0, 2)]
     [p.result() for p in primers]
     delta = time.time() - start
-    print("Priming done in {:10.4f} s".format(delta))
+    print(f"Priming done in {delta:10.4f} s")
 
     start = time.time()
     tasks = [sleep(0) for _ in range(0, size)]
@@ -34,8 +34,8 @@ def call_sleep(size):
         task.result()
 
     delta = time.time() - start
-    print("Time to complete {} tasks: {:8.3f} s".format(args.count, delta))
-    print("Throughput : {:8.3f} Tasks/s".format(int(args.count) / delta))
+    print(f"Time to complete {args.count} tasks: {delta:8.3f} s")
+    print(f"Throughput : {int(args.count) / delta:8.3f} Tasks/s")
 
 
 def call_double(size, executor):
@@ -45,9 +45,9 @@ def call_double(size, executor):
     primers = [executor.submit(double, i) for i in range(0, 2)]
     print("Got results : ", [p.result() for p in primers])
     delta = time.time() - start
-    print("Priming done in {:10.4f} s".format(delta))
+    print(f"Priming done in {delta:10.4f} s")
 
-    print("Launching tasks: {}".format(size))
+    print(f"Launching tasks: {size}")
     start = time.time()
     tasks = [executor.submit(double, i) for i in range(0, size)]
 
@@ -56,8 +56,8 @@ def call_double(size, executor):
 
     delta = time.time() - start
 
-    print("Time to complete {} tasks: {:8.3f} s".format(args.count, delta))
-    print("Throughput : {:8.3f} Tasks/s".format(int(args.count) / delta))
+    print(f"Time to complete {args.count} tasks: {delta:8.3f} s")
+    print(f"Throughput : {int(args.count) / delta:8.3f} Tasks/s")
 
 
 def measure_latency(size, executor):
@@ -67,9 +67,9 @@ def measure_latency(size, executor):
     primers = [executor.submit(double, i) for i in range(0, 2)]
     print("Got results : ", [p.result() for p in primers])
     delta = time.time() - start
-    print("Priming done in {:10.4f} s".format(delta))
+    print(f"Priming done in {delta:10.4f} s")
 
-    print("Launching tasks: {}".format(size))
+    print(f"Launching tasks: {size}")
 
     start_all = time.time()
     tasks = []
@@ -83,11 +83,9 @@ def measure_latency(size, executor):
 
     delta_all = time.time() - start_all
 
-    print("Time to complete {} tasks: {:8.3f} s".format(args.count, delta_all))
-    print("Latency avg:{:8.3f}ms  min:{:8.3f}ms  max:{:8.3f}ms".format(
-        1000 * sum(tasks) / len(tasks),
-        1000 * min(tasks),
-        1000 * max(tasks)))
+    print(f"Time to complete {args.count} tasks: {delta_all:8.3f} s")
+    print(f"Latency avg:{1000 * sum(tasks) / len(tasks):8.3f}ms  "
+          f"min:{1000 * min(tasks):8.3f}ms  max:{1000 * max(tasks):8.3f}ms")
 
 
 if __name__ == '__main__':

--- a/parsl/tests/manual_tests/test_basic.py
+++ b/parsl/tests/manual_tests/test_basic.py
@@ -144,7 +144,7 @@ if __name__ == '__main__':
     if args.sitespec:
         c = None
         try:
-            exec("import parsl; from {} import config".format(args.sitespec))
+            exec(f"import parsl; from {args.sitespec} import config")
             parsl.load(c)
         except Exception:
             print("Failed to load the requested config : ", args.sitespec)

--- a/parsl/tests/manual_tests/test_htex_worker_loss.py
+++ b/parsl/tests/manual_tests/test_htex_worker_loss.py
@@ -81,7 +81,7 @@ def test_simple(n=2, dur=10):
     job_ids = dfk.executors['htex_local'].provider.resources.keys()
     dfk.executors['htex_local'].provider.cancel(job_ids)
     print("Result : ", x.result())
-    print("Duration : {0}s".format(time.time() - start))
+    print(f"Duration : {time.time() - start}s")
     print("[TEST STATUS] test_parallel_for [SUCCESS]")
     return True
 
@@ -110,7 +110,7 @@ def test_manager_fail(n=2, dur=10):
     print("We should see suppression of the failure")
     print('*' * 80)
 
-    print("Duration : {0}s".format(time.time() - start))
+    print(f"Duration : {time.time() - start}s")
     print("[TEST STATUS] test_parallel_for [SUCCESS]")
     dfk = parsl.dfk()
     for i in range(200):

--- a/parsl/tests/manual_tests/test_log_filter.py
+++ b/parsl/tests/manual_tests/test_log_filter.py
@@ -44,11 +44,11 @@ def test_platform(n=2):
     dfk = parsl.dfk()
     dfk.cleanup()
 
-    with open("{}/parsl.log".format(dfk.run_dir)) as f:
+    with open(f"{dfk.run_dir}/parsl.log") as f:
 
         for line in f.readlines():
             if any(skip in line for skip in skip_tags):
-                raise Exception("Logline {} contains a skip tag".format(line))
+                raise Exception(f"Logline {line} contains a skip tag")
     return True
 
 
@@ -65,7 +65,7 @@ if __name__ == '__main__':
     if args.sitespec:
         c = None
         try:
-            exec("import parsl; from {} import config".format(args.sitespec))
+            exec(f"import parsl; from {args.sitespec} import config")
             parsl.load(c)
         except Exception:
             print("Failed to load the requested config : ", args.sitespec)

--- a/parsl/tests/manual_tests/test_memory_limits.py
+++ b/parsl/tests/manual_tests/test_memory_limits.py
@@ -56,8 +56,9 @@ def test_simple(mem_per_worker):
     dfk = parsl.dfk()
     connected = dfk.executors['htex_local'].connected_workers
     print("Connected : ", connected)
-    assert expected_workers == connected, "Expected {} workers, instead got {} workers".format(expected_workers,
-                                                                                               connected)
+    assert expected_workers == connected, (f"Expected {expected_workers} "
+                                           f"workers, instead got {connected} "
+                                           f"workers")
     parsl.clear()
     return True
 

--- a/parsl/tests/manual_tests/test_oauth_ssh.py
+++ b/parsl/tests/manual_tests/test_oauth_ssh.py
@@ -5,7 +5,7 @@ def test_channel():
     channel = OAuthSSHChannel(hostname='ssh.demo.globus.org', username='yadunand')
     x, stdout, stderr = channel.execute_wait('ls')
     print(x, stdout, stderr)
-    assert x == 0, "Expected exit code 0, got {}".format(x)
+    assert x == 0, f"Expected exit code 0, got {x}"
 
 
 if __name__ == '__main__':

--- a/parsl/tests/manual_tests/test_worker_count.py
+++ b/parsl/tests/manual_tests/test_worker_count.py
@@ -41,13 +41,14 @@ def test_worker(n=2, sleep=0):
     manager_ids = set([f[0] for f in foo])
     worker_ids = set([f[1] for f in foo])
 
-    print("Got workers : {}".format(worker_ids))
-    assert len(manager_ids) == 1, "Expected only 1 manager id, got ids : {}".format(
-        manager_ids)
-    assert len(worker_ids) == EXPECTED_WORKERS, "Expected {} workers, instead got {}".format(EXPECTED_WORKERS,
-                                                                                             len(worker_ids))
+    print(f"Got workers : {worker_ids}")
+    assert len(manager_ids) == 1, (f"Expected only 1 manager id, got ids: "
+                                   f"{manager_ids}")
+    assert len(worker_ids) == EXPECTED_WORKERS, (f"Expected {EXPECTED_WORKERS} "
+                                                 f"workers, instead got "
+                                                 f"{len(worker_ids)}")
 
-    print("Duration : {0}s".format(time.time() - start))
+    print(f"Duration : {0time.time() - start}s")
     print("[TEST STATUS] test_parallel_for [SUCCESS]")
     return d
 

--- a/parsl/tests/site_tests/site_config_selector.py
+++ b/parsl/tests/site_tests/site_config_selector.py
@@ -5,7 +5,7 @@ import socket
 
 def fresh_config():
     hostname = os.getenv('PARSL_HOSTNAME', platform.uname().node)
-    print("Loading config for {}".format(hostname))
+    print(f"Loading config for {hostname}")
 
     if 'thetalogin' in hostname:
         from parsl.tests.configs.theta import fresh_config

--- a/parsl/tests/site_tests/test_provider.py
+++ b/parsl/tests/site_tests/test_provider.py
@@ -37,7 +37,8 @@ def test_provider():
 
     # At this point we should have 1 job
     _, current_jobs = executor._get_block_and_job_ids()
-    assert len(current_jobs) == 1, "Expected 1 job at init, got {}".format(len(current_jobs))
+    assert len(current_jobs) == 1, (f"Expected 1 job at init, "
+                                    f"got {len(current_jobs)}")
 
     logger.info("Getting provider status (1)")
     status = provider.status(current_jobs)

--- a/parsl/tests/site_tests/test_site.py
+++ b/parsl/tests/site_tests/test_site.py
@@ -41,7 +41,7 @@ def test_platform(n=2, sleep_dur=10):
         d.append(x)
 
     pinfo = set([i.result()for i in d])
-    assert len(pinfo) == 2, "Expected two nodes, instead got {}".format(pinfo)
+    assert len(pinfo) == 2, f"Expected two nodes, instead got {pinfo}"
 
     print("Test passed")
 

--- a/parsl/tests/sites/test_ec2.py
+++ b/parsl/tests/sites/test_ec2.py
@@ -16,7 +16,7 @@ def python_app_2():
     import threading
     import time
     time.sleep(1)
-    return "Hello from PID[{}] TID[{}]".format(os.getpid(), threading.current_thread())
+    return f"Hello from PID[{os.getpid()}] TID[{threading.current_thread()}]"
 
 
 @python_app(executors=['ec2_single_node'])
@@ -25,7 +25,7 @@ def python_app_1():
     import threading
     import time
     time.sleep(1)
-    return "Hello from PID[{}] TID[{}]".format(os.getpid(), threading.current_thread())
+    return f"Hello from PID[{os.getpid()}] TID[{threading.current_thread()}]"
 
 
 @parsl.bash_app
@@ -59,7 +59,7 @@ def test_bash():
     import os
     fname = os.path.basename(__file__)
 
-    x = bash_app(stdout="{0}.out".format(fname))
+    x = bash_app(stdout=f"{fname}.out")
     print("Waiting ....")
     print(x.result())
 

--- a/parsl/tests/sites/test_local_adhoc.py
+++ b/parsl/tests/sites/test_local_adhoc.py
@@ -15,7 +15,7 @@ def python_app_2():
     import threading
     import time
     time.sleep(1)
-    return "Hello from PID[{}] TID[{}]".format(os.getpid(), threading.current_thread())
+    return f"Hello from PID[{os.getpid()}] TID[{threading.current_thread()}]"
 
 
 @python_app
@@ -24,7 +24,7 @@ def python_app_1():
     import threading
     import time
     time.sleep(1)
-    return "Hello from PID[{}] TID[{}]".format(os.getpid(), threading.current_thread())
+    return f"Hello from PID[{os.getpid()}] TID[{threading.current_thread()}]"
 
 
 @python_app
@@ -58,6 +58,6 @@ def test_bash():
     import os
     fname = os.path.basename(__file__)
 
-    x = bash_app(stdout="{0}.out".format(fname))
+    x = bash_app(stdout=f"{fname}.out")
     print("Waiting ....")
     print(x.result())

--- a/parsl/tests/sites/test_local_exex.py
+++ b/parsl/tests/sites/test_local_exex.py
@@ -16,7 +16,7 @@ def python_app_2():
     import threading
     import time
     time.sleep(1)
-    return "Hello from PID[{}] TID[{}]".format(os.getpid(), threading.current_thread())
+    return f"Hello from PID[{os.getpid()}] TID[{threading.current_thread()}]"
 
 
 @python_app(executors=['Extreme_Local'])
@@ -25,7 +25,7 @@ def python_app_1():
     import threading
     import time
     time.sleep(1)
-    return "Hello from PID[{}] TID[{}]".format(os.getpid(), threading.current_thread())
+    return f"Hello from PID[{os.getpid()}] TID[{threading.current_thread()}]"
 
 
 @parsl.bash_app
@@ -59,6 +59,6 @@ def test_bash():
     import os
     fname = os.path.basename(__file__)
 
-    x = bash_app(stdout="{0}.out".format(fname))
+    x = bash_app(stdout=f"{fname}.out")
     print("Waiting ....")
     print(x.result())

--- a/parsl/tests/test_bash_apps/test_basic.py
+++ b/parsl/tests/test_bash_apps/test_basic.py
@@ -18,14 +18,14 @@ def echo_to_file(inputs=[], outputs=[], stderr='std.err', stdout='std.out'):
     res = ""
     for i in inputs:
         for o in outputs:
-            res += "echo {} >& {}".format(i, o)
+            res += f"echo {i} >& {o}"
     return res
 
 
 @bash_app
 def foo(x, y, z=10, stdout=None, label=None):
-    return """echo {0} {1} {z}
-    """.format(x, y, z=z)
+    return f"""echo {x} {y} {z}
+    """
 
 
 @pytest.mark.issue363
@@ -42,14 +42,14 @@ def test_command_format_1():
     print("[test_command_format_1] foo_future: ", foo_future)
     contents = None
 
-    assert foo_future.result() == 0, "BashApp exited with an error code : {0}".format(
-        foo_future.result())
+    assert foo_future.result() == 0, (f"BashApp exited with an error code: "
+                                      f"{foo_future.result()}")
 
     with open(stdout, 'r') as stdout_f:
         contents = stdout_f.read()
 
-    assert contents == '1 4 10\n', 'Output does not match expected string "1 4 10", Got: "{0}"'.format(
-        contents)
+    assert contents == '1 4 10\n', (f'Output does not match expected string '
+                                    f'"1 4 10", Got: "{contents}"')
     return True
 
 
@@ -64,19 +64,22 @@ def test_auto_log_filename_format():
     print("[test_auto_log_filename_format] foo_future: ", foo_future)
     contents = None
 
-    assert foo_future.result() == 0, "BashApp exited with an error code : {0}".format(
-        foo_future.result())
+    assert foo_future.result() == 0, (f"BashApp exited with an error code: "
+                                      f"{foo_future.result()}")
 
     log_fpath = foo_future.stdout
     log_pattern = fr".*/task_\d+_foo_{app_label}"
-    assert re.match(log_pattern, log_fpath), 'Output file "{0}" does not match pattern "{1}"'.format(
-        log_fpath, log_pattern)
-    assert os.path.exists(log_fpath), 'Output file does not exist "{0}"'.format(log_fpath)
+    assert re.match(log_pattern, log_fpath), (f'Output file "{log_fpath}" does '
+                                              f'not match pattern '
+                                              f'"{log_pattern}"')
+    assert os.path.exists(log_fpath), (f'Output file does not exist '
+                                       f'"{log_fpath}"')
     with open(log_fpath, 'r') as stdout_f:
         contents = stdout_f.read()
 
-    assert contents == '1 {0} 10\n'.format(rand_int), \
-        'Output does not match expected string "1 {0} 10", Got: "{1}"'.format(rand_int, contents)
+    assert contents == f'1 {rand_int} 10\n', (f'Output does not match expected '
+                                              f'string "1 {rand_int} 10", '
+                                              f'Got: "{contents}"')
     return True
 
 
@@ -96,21 +99,21 @@ def test_parallel_for(n=3):
     start = time.time()
     for i in range(0, n):
         d[i] = echo_to_file(
-            inputs=['Hello World {0}'.format(i)],
-            outputs=[File('{0}/out.{1}.txt'.format(outdir, i))],
-            stdout='{0}/std.{1}.out'.format(outdir, i),
-            stderr='{0}/std.{1}.err'.format(outdir, i),
+            inputs=[f'Hello World {i}'],
+            outputs=[File(f'{outdir}/out.{i}.txt')],
+            stdout=f'{outdir}/std.{i}.out',
+            stderr=f'{outdir}/std.{i}.err'
         )
 
     assert len(
-        d.keys()) == n, "Only {0}/{1} keys in dict".format(len(d.keys()), n)
+        d.keys()) == n, f"Only {len(d.keys())}/{n} keys in dict"
 
     [d[i].result() for i in d]
-    print("Duration : {0}s".format(time.time() - start))
+    print(f"Duration : {time.time() - start}s")
     stdout_file_count = len(
         [item for item in os.listdir(outdir) if item.endswith('.out')])
-    assert stdout_file_count == n, "Only {0}/{1} files in '{2}' ".format(len(os.listdir('outputs/')),
-                                                                         n, outdir)
+    assert stdout_file_count == n, (f"Only {len(os.listdir('outputs/'))}/{n} "
+                                    f"files in '{outdir}' ")
     print("[TEST STATUS] test_parallel_for [SUCCESS]")
     return d
 

--- a/parsl/tests/test_bash_apps/test_error_codes.py
+++ b/parsl/tests/test_bash_apps/test_error_codes.py
@@ -78,10 +78,10 @@ def test_bash_formatting():
     f = bad_format()
     try:
         f.result()
-    except Exception as e:
-        print("Caught exception", e)
-        assert isinstance(
-            e, parsl.app.errors.AppBadFormatting), "Expected AppBadFormatting got : {0}".format(e)
+    except Exception as e_:
+        print("Caught exception", e_)
+        assert isinstance(e_, parsl.app.errors.AppBadFormatting), (
+            f"Expected AppBadFormatting got: {e_}")
     return True
 
 
@@ -92,11 +92,11 @@ def test_div_0(test_fn=div_0):
     f = test_fn()
     try:
         f.result()
-    except Exception as e:
-        print("Caught exception", e)
-        assert e.exitcode == err_code, "{0} expected err_code:{1} but got {2}".format(test_fn.__name__,
-                                                                                      err_code,
-                                                                                      e.exitcode)
+    except Exception as e_:
+        print("Caught exception", e_)
+        assert e_.exitcode == err_code, (f"{test_fn.__name__} "
+                                         f"expected err_code:{err_code} "
+                                         f"but got {e_.exitcode}")
     print(os.listdir('.'))
     os.remove('std.err')
     os.remove('std.out')
@@ -109,11 +109,11 @@ def test_bash_misuse(test_fn=bash_misuse):
     f = test_fn()
     try:
         f.result()
-    except pe.BashExitFailure as e:
-        print("Caught expected BashExitFailure", e)
-        assert e.exitcode == err_code, "{0} expected err_code:{1} but got {2}".format(test_fn.__name__,
-                                                                                      err_code,
-                                                                                      e.exitcode)
+    except pe.BashExitFailure as e_:
+        print("Caught expected BashExitFailure", e_)
+        assert e_.exitcode == err_code, (f"{test_fn.__name__} "
+                                         f"expected err_code:{err_code} "
+                                         f"but got {e_.exitcode}")
     os.remove('std.err')
     os.remove('std.out')
 
@@ -124,11 +124,11 @@ def test_command_not_found(test_fn=command_not_found):
     f = test_fn()
     try:
         f.result()
-    except pe.BashExitFailure as e:
-        print("Caught exception", e)
-        assert e.exitcode == err_code, "{0} expected err_code:{1} but got {2}".format(test_fn.__name__,
-                                                                                      err_code,
-                                                                                      e.exitcode)
+    except pe.BashExitFailure as e_:
+        print("Caught exception", e_)
+        assert e_.exitcode == err_code, (f"{test_fn.__name__} "
+                                         f"expected err_code:{err_code} "
+                                         f"but got {e_.exitcode}")
 
     os.remove('std.err')
     os.remove('std.out')
@@ -141,11 +141,11 @@ def test_invalid_exit(test_fn=invalid_exit):
     f = test_fn()
     try:
         f.result()
-    except Exception as e:
-        print("Caught exception", e)
-        assert e.exitcode == err_code, "{0} expected err_code:{1} but got {2}".format(test_fn.__name__,
-                                                                                      err_code,
-                                                                                      e.exitcode)
+    except Exception as e_:
+        print("Caught exception", e_)
+        assert e_.exitcode == err_code, (f"{test_fn.__name__} "
+                                         f"expected err_code:{err_code} "
+                                         f"but got {e_.exitcode}")
     os.remove('std.err')
     os.remove('std.out')
     return True
@@ -157,11 +157,11 @@ def test_not_executable(test_fn=not_executable):
     f = test_fn()
     try:
         f.result()
-    except Exception as e:
-        print("Caught exception", e)
-        assert e.exitcode == err_code, "{0} expected err_code:{1} but got {2}".format(test_fn.__name__,
-                                                                                      err_code,
-                                                                                      e.exitcode)
+    except Exception as e_:
+        print("Caught exception", e_)
+        assert e_.exitcode == err_code, (f"{test_fn.__name__} "
+                                         f"expected err_code:{err_code} "
+                                         f"but got {e_.exitcode}")
     os.remove('std.err')
     os.remove('std.out')
     return True
@@ -172,11 +172,11 @@ def run_app(test_fn, err_code):
     print(f)
     try:
         f.result()
-    except Exception as e:
-        print("Caught exception", e)
-        assert e.exitcode == err_code, "{0} expected err_code:{1} but got {2}".format(test_fn.__name__,
-                                                                                      err_code,
-                                                                                      e.exitcode)
+    except Exception as e_:
+        print("Caught exception", e_)
+        assert e_.exitcode == err_code, (f"{test_fn.__name__} "
+                                         f"expected err_code:{err_code} "
+                                         f"but got {e_.exitcode}")
     os.remove('std.err')
     os.remove('std.out')
     return True
@@ -200,7 +200,7 @@ if __name__ == '__main__':
         try:
             run_app(test, test_matrix[test]['exit_code'])
         except AssertionError as e:
-            print("Test {0:15} [FAILED]".format(test.__name__))
-            print("Caught error : {0}".format(e))
+            print(f"Test {test.__name__:15} [FAILED]")
+            print(f"Caught error : {e}")
         else:
-            print("Test {0:15} [SUCCESS]".format(test.__name__))
+            print(f"Test {test.__name__:15} [SUCCESS]")

--- a/parsl/tests/test_bash_apps/test_file_bug_1.py
+++ b/parsl/tests/test_bash_apps/test_file_bug_1.py
@@ -21,7 +21,7 @@ def app1(inputs=[], outputs=[], stdout=None, stderr=None, mock=False):
 def app2(inputs=[], outputs=[], stdout=None, stderr=None, mock=False):
 
     with open('somefile.txt', 'w') as f:
-        f.write("%s\n" % inputs[0])
+        f.write(f"{inputs[0]}\n")
     cmd_line = """echo '{inputs[0]}' > {outputs[0]}"""
     return cmd_line
 

--- a/parsl/tests/test_bash_apps/test_kwarg_storage.py
+++ b/parsl/tests/test_bash_apps/test_kwarg_storage.py
@@ -5,8 +5,8 @@ from parsl.app.app import bash_app
 
 @bash_app
 def foo(z=2, stdout=None):
-    return """echo {val}
-    """.format(val=z)
+    return f"""echo {z}
+    """
 
 
 @pytest.mark.issue363
@@ -22,8 +22,8 @@ def test_command_format_1():
     print("app_fu : ", app_fu)
     contents = None
 
-    assert app_fu.result() == 0, "BashApp exited with an error code : {0}".format(
-        app_fu.result())
+    assert app_fu.result() == 0, (f"BashApp exited with an error code: "
+                                  f"{app_fu.result()}")
 
     with open(stdout, 'r') as stdout_f:
         contents = stdout_f.read()
@@ -32,8 +32,8 @@ def test_command_format_1():
     if os.path.exists('stdout_file'):
         os.remove(stdout)
 
-    assert contents == '2\n', 'Output does not match expected string "2", Got: "{0}"'.format(
-        contents)
+    assert contents == '2\n', (f'Output does not match expected string "2", '
+                               f'Got: "{contents}"')
 
 # ===========
 
@@ -45,8 +45,8 @@ def test_command_format_1():
     print("app_fu : ", app_fu)
     contents = None
 
-    assert app_fu.result() == 0, "BashApp exited with an error code : {0}".format(
-        app_fu.result())
+    assert app_fu.result() == 0, (f"BashApp exited with an error code: "
+                                  f"{app_fu.result()}")
 
     with open(stdout, 'r') as stdout_f:
         contents = stdout_f.read()
@@ -55,8 +55,8 @@ def test_command_format_1():
     if os.path.exists('stdout_file'):
         os.remove(stdout)
 
-    assert contents == '3\n', 'Output does not match expected string "3", Got: "{0}"'.format(
-        contents)
+    assert contents == '3\n', (f'Output does not match expected string "3", '
+                               f'Got: "{contents}"')
 
 # ===========
     stdout = os.path.abspath('std.out.2')
@@ -67,8 +67,8 @@ def test_command_format_1():
     print("app_fu : ", app_fu)
     contents = None
 
-    assert app_fu.result() == 0, "BashApp exited with an error code : {0}".format(
-        app_fu.result())
+    assert app_fu.result() == 0, (f"BashApp exited with an error code: "
+                                  f"{app_fu.result()}")
 
     with open(stdout, 'r') as stdout_f:
         contents = stdout_f.read()
@@ -77,8 +77,8 @@ def test_command_format_1():
     if os.path.exists('stdout_file'):
         os.remove(stdout)
 
-    assert contents == '4\n', 'Output does not match expected string "4", Got: "{0}"'.format(
-        contents)
+    assert contents == '4\n', (f'Output does not match expected string "4", '
+                               f'Got: "{contents}"')
 
 # ===========
     stdout = os.path.abspath('std.out.3')
@@ -89,8 +89,8 @@ def test_command_format_1():
     print("app_fu : ", app_fu)
     contents = None
 
-    assert app_fu.result() == 0, "BashApp exited with an error code : {0}".format(
-        app_fu.result())
+    assert app_fu.result() == 0, (f"BashApp exited with an error code: "
+                                  f"{app_fu.result()}")
 
     with open(stdout, 'r') as stdout_f:
         contents = stdout_f.read()
@@ -99,6 +99,6 @@ def test_command_format_1():
     if os.path.exists('stdout_file'):
         os.remove(stdout)
 
-    assert contents == '2\n', 'Output does not match expected string "2", Got: "{0}"'.format(
-        contents)
+    assert contents == '2\n', (f'Output does not match expected string "2", '
+                               f'Got: "{contents}"')
     return True

--- a/parsl/tests/test_bash_apps/test_memoize.py
+++ b/parsl/tests/test_bash_apps/test_memoize.py
@@ -10,7 +10,7 @@ from parsl.tests.configs.local_threads import config
 
 @bash_app(cache=True)
 def fail_on_presence(outputs=[]):
-    return 'if [ -f {0} ] ; then exit 1 ; else touch {0}; fi'.format(outputs[0])
+    return f'if [ -f {outputs[0]} ] ; then exit 1 ; else touch {outputs[0]}; fi'
 
 
 # This test is an oddity that requires a shared-FS and simply
@@ -42,7 +42,7 @@ def test_bash_memoization(n=2):
 
 @bash_app(cache=True)
 def fail_on_presence_kw(outputs=[], foo={}):
-    return 'if [ -f {0} ] ; then exit 1 ; else touch {0}; fi'.format(outputs[0])
+    return f'if [ -f {outputs[0]} ] ; then exit 1 ; else touch {outputs[0]}; fi'
 
 
 # This test is an oddity that requires a shared-FS and simply

--- a/parsl/tests/test_bash_apps/test_multiline.py
+++ b/parsl/tests/test_bash_apps/test_multiline.py
@@ -16,12 +16,12 @@ def multiline(
         outputs=[],
         stderr=os.path.abspath('std.err'),
         stdout=os.path.abspath('std.out')):
-    return """echo {inputs[0]} &> {outputs[0]}
+    return f"""echo {inputs[0]} &> {outputs[0]}
     echo {inputs[1]} &> {outputs[1]}
     echo {inputs[2]} &> {outputs[2]}
     echo "Testing STDOUT"
     echo "Testing STDERR" 1>&2
-    """.format(inputs=inputs, outputs=outputs)
+    """
 
 
 @pytest.mark.issue363
@@ -38,9 +38,9 @@ def test_multiline():
     f = multiline(
             inputs=["Hello", "This is", "Cat!"],
             outputs=[
-                File('{0}/hello.txt'.format(outdir)),
-                File('{0}/this.txt'.format(outdir)),
-                File('{0}/cat.txt'.format(outdir))
+                File(f'{outdir}/hello.txt'),
+                File(f'{outdir}/this.txt'),
+                File(f'{outdir}/cat.txt')
             ]
     )
     print(f.result())

--- a/parsl/tests/test_bash_apps/test_pipeline.py
+++ b/parsl/tests/test_bash_apps/test_pipeline.py
@@ -12,27 +12,27 @@ from parsl.tests.configs.local_threads import config
 
 @bash_app
 def increment(inputs=[], outputs=[], stdout=None, stderr=None):
-    cmd_line = """
+    cmd_line = f"""
     if ! [ -f {inputs[0]} ] ; then exit 43 ; fi
     x=$(cat {inputs[0]})
     echo $(($x+1)) > {outputs[0]}
-    """.format(inputs=inputs, outputs=outputs)
+    """
     return cmd_line
 
 
 @bash_app
 def slow_increment(dur, inputs=[], outputs=[], stdout=None, stderr=None):
-    cmd_line = """
+    cmd_line = f"""
     x=$(cat {inputs[0]})
     echo $(($x+1)) > {outputs[0]}
-    sleep {0}
-    """.format(dur, inputs=inputs, outputs=outputs)
+    sleep {dur}
+    """
     return cmd_line
 
 
 def cleanup_work(depth):
-    for i in range(0, depth):
-        fn = "test{0}.txt".format(i)
+    for i in range(depth):
+        fn = f"test{i}.txt"
         if os.path.exists(fn):
             os.remove(fn)
 
@@ -51,14 +51,14 @@ def test_increment(depth=5):
     prev = File("test0.txt")
     futs = {}
     for i in range(1, depth):
-        print("Launching {0} with {1}".format(i, prev))
+        print(f"Launching {i} with {prev}")
         assert(isinstance(prev, DataFuture) or isinstance(prev, File))
-        output = File("test{0}.txt".format(i))
+        output = File(f"test{i}.txt")
         fu = increment(inputs=[prev],  # Depend on the future from previous call
                        # Name the file to be created here
                        outputs=[output],
-                       stdout="incr{0}.out".format(i),
-                       stderr="incr{0}.err".format(i))
+                       stdout=f"incr{i}.out",
+                       stderr=f"incr{i}.err")
         [prev] = fu.outputs
         futs[i] = prev
         print(prev.filepath)
@@ -72,12 +72,16 @@ def test_increment(depth=5):
 
             # this test is a bit close to a test of the specific implementation
             # of File
-            assert file.local_path is None, "File on local side has overridden local_path, file: {}".format(repr(file))
-            assert file.filepath == "test{0}.txt".format(key), "Submit side filepath has not been preserved over execution"
+            assert file.local_path is None, (f"File on local side has "
+                                             f"overridden local_path, "
+                                             f"file: {repr(file)}")
+            assert file.filepath == f"test{key}.txt", ("Submit side filepath "
+                                                       "has not been preserved "
+                                                       "over execution")
 
             data = open(filename, 'r').read().strip()
-            assert data == str(
-                key), "[TEST] incr failed for key: {0} got data: {1} from filename {2}".format(key, data, filename)
+            assert data == str(key), (f"[TEST] incr failed for key: {key} got "
+                                      f"data: {data} from filename {filename}")
 
     cleanup_work(depth)
 
@@ -97,15 +101,15 @@ def test_increment_slow(depth=5, dur=0.5):
     futs = {}
     print("************** Type: ", type(dur), dur)
     for i in range(1, depth):
-        print("Launching {0} with {1}".format(i, prev))
-        output = File("test{0}.txt".format(i))
+        print(f"Launching {i} with {dur}")
+        output = File(f"test{i}.txt")
         fu = slow_increment(dur,
                             # Depend on the future from previous call
                             inputs=[prev],
                             # Name the file to be created here
                             outputs=[output],
-                            stdout="incr{0}.out".format(i),
-                            stderr="incr{0}.err".format(i))
+                            stdout=f"incr{i}.out",
+                            stderr=f"incr{i}.err")
         [prev] = fu.outputs
         futs[i] = prev
         print(prev.filepath)
@@ -114,8 +118,8 @@ def test_increment_slow(depth=5, dur=0.5):
         if key > 0:
             fu = futs[key]
             data = open(fu.result().filepath, 'r').read().strip()
-            assert data == str(
-                key), "[TEST] incr failed for key: {0} got: {1}".format(key, data)
+            assert data == str(key), (f"[TEST] incr failed for key: "
+                                      f"{key} got: {data}")
 
     cleanup_work(depth)
 

--- a/parsl/tests/test_bash_apps/test_stdout.py
+++ b/parsl/tests/test_bash_apps/test_stdout.py
@@ -11,7 +11,7 @@ from parsl.tests.configs.local_threads import config
 
 @bash_app
 def echo_to_streams(msg, stderr='std.err', stdout='std.out'):
-    return 'echo "{0}"; echo "{0}" >&2'.format(msg)
+    return f'echo "{msg}"; echo "{msg}" >&2'
 
 
 whitelist = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'configs', '*threads*')
@@ -49,7 +49,8 @@ def test_bad_stdout_specs(spec):
         fn.result()
     except Exception as e:
         assert isinstance(
-            e, perror.BadStdStreamFile), "Expected BadStdStreamFile, got: {0}".format(type(e))
+            e, perror.BadStdStreamFile), (f"Expected BadStdStreamFile, "
+                                          f"got: {type(e)}")
     else:
         assert False, "Did not raise expected exception BadStdStreamFile"
 
@@ -70,7 +71,8 @@ def test_bad_stderr_file():
         fn.result()
     except Exception as e:
         assert isinstance(
-            e, perror.BadStdStreamFile), "Expected BadStdStreamFile, got: {0}".format(type(e))
+            e, perror.BadStdStreamFile), (f"Expected BadStdStreamFile, "
+                                          f"got: {type(e)}")
     else:
         assert False, "Did not raise expected exception BadStdStreamFile"
 
@@ -92,7 +94,8 @@ def test_stdout_truncate():
     echo_to_streams('hi', stdout=out, stderr=err).result()
     len2 = len(open(out[0]).readlines())
 
-    assert len1 == len2 == 1, "Line count of output files should both be 1, but: len1={} len2={}".format(len1, len2)
+    assert len1 == len2 == 1, (f"Line count of output files should both be 1, "
+                               f"but: len1={len1} len2={len2}")
 
     os.system('rm -f ' + out[0] + ' ' + err)
 
@@ -112,7 +115,8 @@ def test_stdout_append():
     echo_to_streams('hi', stdout=out, stderr=err).result()
     len2 = len(open(out).readlines())
 
-    assert len1 == 1 and len2 == 2, "Line count of output files should be 1 and 2, but:  len1={} len2={}".format(len1, len2)
+    assert len1 == 1 and len2 == 2, (f"Line count of output files should be "
+                                     f"1 and 2, but:  len1={len1} len2={len2}")
 
     os.system('rm -f ' + out + ' ' + err)
 

--- a/parsl/tests/test_checkpointing/test_periodic.py
+++ b/parsl/tests/test_checkpointing/test_periodic.py
@@ -58,7 +58,7 @@ def test_periodic(n=4):
     # Here we will check if the loglines came back with 5 seconds deltas
     print("Rundir: ", dfk.run_dir)
 
-    with open("{}/parsl.log".format(dfk.run_dir), 'r') as f:
+    with open(f"{dfk.run_dir}/parsl.log", 'r') as f:
         log_lines = f.readlines()
         expected_msg = "]  Done checkpointing"
         expected_msg2 = "]  No tasks checkpointed in this pass"

--- a/parsl/tests/test_checkpointing/test_python_checkpoint_1.py
+++ b/parsl/tests/test_checkpointing/test_python_checkpoint_1.py
@@ -35,13 +35,11 @@ def test_initial_checkpoint_write(n=2):
 
     cptpath = cpt_dir + '/dfk.pkl'
     print("Path exists : ", os.path.exists(cptpath))
-    assert os.path.exists(
-        cptpath), "DFK checkpoint missing: {0}".format(cptpath)
+    assert os.path.exists(cptpath), f"DFK checkpoint missing: {cptpath}"
 
     cptpath = cpt_dir + '/tasks.pkl'
     print("Path exists : ", os.path.exists(cptpath))
-    assert os.path.exists(
-        cptpath), "Tasks checkpoint missing: {0}".format(cptpath)
+    assert os.path.exists(cptpath), f"Tasks checkpoint missing: {cptpath}"
 
     run_dir = parsl.dfk().run_dir
     parsl.clear()

--- a/parsl/tests/test_checkpointing/test_regression_232.py
+++ b/parsl/tests/test_checkpointing/test_regression_232.py
@@ -24,8 +24,8 @@ def test_regress_232_task_exit(count=2):
     if os.path.exists("test.txt"):
         os.remove("test.txt")
 
-    proc = subprocess.Popen("python3 {} -n {} -m task_exit".format(checkpoint_file, count),
-                            shell=True)
+    proc = subprocess.Popen(f"python3 {checkpoint_file} "
+                            f"-n {count} -m task_exit", shell=True)
 
     # Poll for at least 3 seconds
     for i in range(30):
@@ -36,9 +36,9 @@ def test_regress_232_task_exit(count=2):
     proc.send_signal(signal.SIGINT)
     proc.wait()
     # We need to wait after the signal to make sure files were closed and such
-    last = os.path.abspath(
-        'runinfo/{0}/checkpoint'.format(sorted(os.listdir('runinfo/'))[-1]))
-    checkpoint_file = "{}/tasks.pkl".format(last)
+    last = os.path.abspath(f"runinfo/{sorted(os.listdir('runinfo/'))[-1]}"
+                           f"/checkpoint")
+    checkpoint_file = f"{last}/tasks.pkl"
 
     with open(checkpoint_file, 'rb') as f:
         tasks = []
@@ -50,8 +50,8 @@ def test_regress_232_task_exit(count=2):
             print("Caught error")
             pass
         print("Tasks from cache : ", tasks)
-        assert len(tasks) == count, "Expected {} checkpoint events, got {}".format(
-            1, len(tasks))
+        assert len(tasks) == count, (f"Expected {1} checkpoint events, "
+                                     f"got {len(tasks)}")
 
 
 @pytest.mark.local
@@ -62,15 +62,15 @@ def test_regress_232_dfk_exit(count=2):
     cwd = os.path.dirname(os.path.realpath(__file__))
     checkpoint_file = os.path.join(cwd, 'checkpointed.py')
 
-    proc = subprocess.Popen("python3 {} -n {} -m dkf_exit".format(checkpoint_file, count),
+    proc = subprocess.Popen(f"python3 {checkpoint_file} -n {count} -m dkf_exit",
                             shell=True)
     proc.send_signal(signal.SIGINT)
     # We need to wait after the signal to make sure files were closed and such
     proc.wait()
 
-    last = os.path.abspath(
-        'runinfo/{0}/checkpoint'.format(sorted(os.listdir('runinfo/'))[-1]))
-    checkpoint_file = "{}/tasks.pkl".format(last)
+    last = os.path.abspath(f"runinfo/{sorted(os.listdir('runinfo/'))[-1]}"
+                           f"/checkpoint")
+    checkpoint_file = f"{last}/tasks.pkl"
 
     print(checkpoint_file, "now exists")
     with open(checkpoint_file, 'rb') as f:
@@ -82,8 +82,8 @@ def test_regress_232_dfk_exit(count=2):
         except EOFError:
             pass
         print("Tasks from cache : ", tasks)
-        assert len(tasks) == count, "Expected {} checkpoint events, got {}".format(
-            1, len(tasks))
+        assert len(tasks) == count, (f"Expected {1} checkpoint events, "
+                                     f"got {len(tasks)}")
 
 
 if __name__ == "__main__":

--- a/parsl/tests/test_checkpointing/test_regression_239.py
+++ b/parsl/tests/test_checkpointing/test_regression_239.py
@@ -53,7 +53,8 @@ def test_regression_239():
     """
 
     rundir = run_checkpointed()
-    with time_limited_open("{}/checkpoint/tasks.pkl".format(rundir), 'rb', seconds=2) as f:
+    with time_limited_open(f"{rundir}/checkpoint/tasks.pkl", 'rb',
+                           seconds=2) as f:
         tasks = []
         try:
             while f:
@@ -62,7 +63,8 @@ def test_regression_239():
         except EOFError:
             pass
         print("Tasks from cache : ", tasks)
-        assert len(tasks) == 1, "Expected {} checkpoint events, got {}".format(1, len(tasks))
+        assert len(tasks) == 1, (f"Expected {1} checkpoint events, "
+                                 f"got {len(tasks)}")
 
 
 @pytest.mark.local
@@ -72,7 +74,8 @@ def test_checkpointing_at_dfk_exit():
     """
 
     rundir = run_checkpointed(mode="dfk_exit")
-    with time_limited_open("{}/checkpoint/tasks.pkl".format(rundir), 'rb', seconds=2) as f:
+    with time_limited_open(f"{rundir}/checkpoint/tasks.pkl", 'rb',
+                           seconds=2) as f:
         tasks = []
         try:
             while f:
@@ -81,7 +84,8 @@ def test_checkpointing_at_dfk_exit():
         except EOFError:
             pass
         print("Tasks from cache : ", tasks)
-        assert len(tasks) == 1, "Expected {} checkpoint events, got {}".format(1, len(tasks))
+        assert len(tasks) == 1, (f"Expected {1} checkpoint events, "
+                                 f"got {len(tasks)}")
 
 
 if __name__ == "__main__":

--- a/parsl/tests/test_checkpointing/test_task_exit.py
+++ b/parsl/tests/test_checkpointing/test_task_exit.py
@@ -54,7 +54,8 @@ def test_at_task_exit(n=2):
     #     While this limit might seem generous at time of writing,
     #     it should be remembered that this is still a race.
 
-    with time_limited_open("{}/checkpoint/tasks.pkl".format(dfk.run_dir), 'rb', seconds=5) as f:
+    with time_limited_open(f"{dfk.run_dir}/checkpoint/tasks.pkl", 'rb',
+                           seconds=5) as f:
         tasks = []
         try:
             while f:
@@ -62,7 +63,8 @@ def test_at_task_exit(n=2):
         except EOFError:
             pass
 
-        assert len(tasks) == n, "Expected {} checkpoint events, got {}".format(n, len(tasks))
+        assert len(tasks) == n, (f"Expected {n} checkpoint events, "
+                                 f"got {len(tasks)}")
 
 
 if __name__ == '__main__':

--- a/parsl/tests/test_data/test_file.py
+++ b/parsl/tests/test_data/test_file.py
@@ -15,10 +15,12 @@ def test_files():
 
     for test in strings:
         x = File(test['f'])
-        assert x.scheme == test['scheme'], "[TEST] Scheme error. Expected {0} Got {1}".format(
-            test['scheme'], x.scheme)
-        assert x.filepath == test['path'], "[TEST] Path error. Expected {0} Got {1}".format(
-            test['path'], x.path)
+        assert x.scheme == test['scheme'], (f"[TEST] Scheme error. "
+                                            f"Expected {test['scheme']} "
+                                            f"Got { x.scheme}")
+        assert x.filepath == test['path'], (f"[TEST] Path error. "
+                                            f"Expected {test['path']} "
+                                            f"Got {x.path}")
 
 
 @pytest.mark.local

--- a/parsl/tests/test_data/test_file_apps.py
+++ b/parsl/tests/test_data/test_file_apps.py
@@ -11,9 +11,9 @@ from parsl.tests.configs.local_threads import config
 @bash_app
 def cat(inputs=[], outputs=[], stdout=None, stderr=None):
     infiles = ' '.join([i.filepath for i in inputs])
-    return """echo {i}
-    cat {i} &> {o}
-    """.format(i=infiles, o=outputs[0])
+    return f"""echo {infiles}
+    cat {infiles} &> {outputs[0]}
+    """
 
 
 @pytest.mark.usefixtures('setup_data')
@@ -34,10 +34,10 @@ def test_files():
 @bash_app
 def increment(inputs=[], outputs=[], stdout=None, stderr=None):
     # Place double braces to avoid python complaining about missing keys for {item = $1}
-    return """
-    x=$(cat {i})
-    echo $(($x+1)) > {o}
-    """.format(i=inputs[0], o=outputs[0])
+    return f"""
+    x=$(cat {inputs[0]})
+    echo $(($x+1)) > {outputs[0]}
+    """
 
 
 @pytest.mark.usefixtures('setup_data')
@@ -52,16 +52,16 @@ def test_increment(depth=5):
     prev = File("test0.txt")
     futs = {}
     for i in range(1, depth):
-        print("Launching {0} with {1}".format(i, prev))
+        print(f"Launching {i} with {prev}")
 
-        if os.path.exists('test{0}.txt'.format(i)):
-            os.remove('test{0}.txt'.format(i))
+        if os.path.exists(f'test{i}.txt'):
+            os.remove(f'test{i}.txt')
 
         fu = increment(inputs=[prev],  # Depend on the future from previous call
                        # Name the file to be created here
-                       outputs=[File("test{0}.txt".format(i))],
-                       stdout="incr{0}.out".format(i),
-                       stderr="incr{0}.err".format(i))
+                       outputs=[File(f"test{i}.txt")],
+                       stdout=f"incr{i}.out",
+                       stderr=f"incr{i}.err")
         [prev] = fu.outputs
         futs[i] = prev
         print(prev.filepath)
@@ -70,8 +70,8 @@ def test_increment(depth=5):
         if key > 0:
             fu = futs[key]
             data = open(fu.result().filepath, 'r').read().strip()
-            assert data == str(
-                key), "[TEST] incr failed for key:{0} got:{1}".format(key, data)
+            assert data == str(key), (f"[TEST] incr failed for key:{key} "
+                                      f"got:{data}")
 
 
 if __name__ == '__main__':

--- a/parsl/tests/test_data/test_file_ipp.py
+++ b/parsl/tests/test_data/test_file_ipp.py
@@ -9,9 +9,9 @@ from parsl.tests.configs.local_threads import config
 @bash_app
 def cat(inputs=[], outputs=[], stdout=None, stderr=None):
     infiles = ' '.join([i.filepath for i in inputs])
-    return """echo {i}
-    cat {i} &> {o}
-    """.format(i=infiles, o=outputs[0])
+    return f"""echo {infiles}
+    cat {infiles} &> {outputs[0]}
+    """
 
 
 @pytest.mark.usefixtures('setup_data')
@@ -32,10 +32,10 @@ def test_files():
 @bash_app
 def increment(inputs=[], outputs=[], stdout=None, stderr=None):
     # Place double braces to avoid python complaining about missing keys for {item = $1}
-    return """
-    x=$(cat {i})
-    echo $(($x+1)) > {o}
-    """.format(i=inputs[0], o=outputs[0])
+    return f"""
+    x=$(cat {inputs[0]})
+    echo $(($x+1)) > {outputs[0]}
+    """
 
 
 @pytest.mark.staging_required
@@ -53,7 +53,7 @@ def test_regression_200():
     fu.result()
 
     fi = fu.outputs[0].result()
-    print("type of fi: {}".format(type(fi)))
+    print(f"type of fi: {type(fi)}")
     with open(str(fi), 'r') as f:
         data = f.readlines()
         assert "Hello World" in data, "Missed data"
@@ -70,14 +70,14 @@ def test_increment(depth=5):
     prev = File("test0.txt")
     futs = {}
     for i in range(1, depth):
-        if os.path.exists('test{0}.txt'.format(i)):
-            os.remove('test{0}.txt'.format(i))
-        print("Launching {0} with {1}".format(i, prev))
+        if os.path.exists(f'test{i}.txt'):
+            os.remove(f'test{i}.txt')
+        print(f"Launching {i} with {prev}")
         fu = increment(inputs=[prev],  # Depend on the future from previous call
                        # Name the file to be created here
-                       outputs=[File("test{0}.txt".format(i))],
-                       stdout="incr{0}.out".format(i),
-                       stderr="incr{0}.err".format(i))
+                       outputs=[File(f"test{i}.txt")],
+                       stdout=f"incr{i}.out",
+                       stderr=f"incr{i}.err")
         [prev] = fu.outputs
         futs[i] = prev
         print(prev.filepath)
@@ -86,8 +86,8 @@ def test_increment(depth=5):
         if key > 0:
             fu = futs[key]
             data = open(fu.result().filepath, 'r').read().strip()
-            assert data == str(
-                key), "[TEST] incr failed for key:{0} got:{1}".format(key, data)
+            assert data == str(key), (f"[TEST] incr failed for key:{key} "
+                                      f"got:{data}")
 
 
 if __name__ == '__main__':

--- a/parsl/tests/test_docs/test_from_slides.py
+++ b/parsl/tests/test_docs/test_from_slides.py
@@ -6,7 +6,7 @@ import os
 
 @bash_app
 def echo(message, outputs=[]):
-    return 'echo {m} &> {o}'.format(m=message, o=outputs[0])
+    return f'echo {message} &> {outputs[0]}'
 
 
 @python_app

--- a/parsl/tests/test_docs/test_workflow1.py
+++ b/parsl/tests/test_docs/test_workflow1.py
@@ -19,7 +19,7 @@ def generate(limit):
 
 @bash_app
 def save(message, outputs=[]):
-    return 'echo {m} &> {o}'.format(m=message, o=outputs[0])
+    return f'echo {message} &> {outputs[0]}'
 
 
 @pytest.mark.staging_required

--- a/parsl/tests/test_docs/test_workflow2.py
+++ b/parsl/tests/test_docs/test_workflow2.py
@@ -38,9 +38,8 @@ def test_parallel(N=2):
     time.time()
     delta = time.time() - start
 
-    assert doubled_z.result() == N * \
-        2, "Expected doubled_z = N*2 = {0}".format(N * 2)
-    assert delta > 4 and delta < 5, "Time delta exceeded expected 4 < duration < 5"
+    assert doubled_z.result() == N * 2, f"Expected doubled_z = N*2 = {N * 2}"
+    assert 4 < delta < 5, "Time delta exceeded expected 4 < duration < 5"
 
 
 if __name__ == "__main__":

--- a/parsl/tests/test_docs/test_workflow4.py
+++ b/parsl/tests/test_docs/test_workflow4.py
@@ -12,12 +12,12 @@ import pytest
 
 @bash_app
 def generate(outputs=[]):
-    return "echo $(( RANDOM % (10 - 5 + 1 ) + 5 )) &> {o}".format(o=outputs[0])
+    return f"echo $(( RANDOM % (10 - 5 + 1 ) + 5 )) &> {outputs[0]}"
 
 
 @bash_app
 def concat(inputs=[], outputs=[], stdout="stdout.txt", stderr='stderr.txt'):
-    return "cat {0} >> {1}".format(" ".join(map(lambda x: x.filepath, inputs)), outputs[0])
+    return f"cat {' '.join(map(lambda x: x.filepath, inputs))} >> {outputs[0]}"
 
 
 @python_app
@@ -40,9 +40,9 @@ def test_parallel_dataflow():
     # create 5 files with random numbers
     output_files = []
     for i in range(5):
-        if os.path.exists('random-%s.txt' % i):
-            os.remove('random-%s.txt' % i)
-        output_files.append(generate(outputs=[File('random-%s.txt' % i)]))
+        if os.path.exists(f'random-{i}.txt'):
+            os.remove(f'random-{i}.txt')
+        output_files.append(generate(outputs=[File(f'random-{i}.txt')]))
 
     # concatenate the files into a single file
     cc = concat(inputs=[i.outputs[0]

--- a/parsl/tests/test_error_handling/test_rand_fail.py
+++ b/parsl/tests/test_error_handling/test_rand_fail.py
@@ -39,10 +39,9 @@ def test_simple(n=10):
     start = time.time()
     x = double(n)
     print("Result : ", x.result())
-    assert x.result() == n * \
-        2, "Expected double to return:{0} instead got:{1}".format(
-            n * 2, x.result())
-    print("Duration : {0}s".format(time.time() - start))
+    assert x.result() == n * 2, (f"Expected double to return:{n * 2} "
+                                 f"instead got:{x.result()}")
+    print(f"Duration : {time.time() - start}s")
     print("[TEST STATUS] test_parallel_for [SUCCESS]")
     return True
 
@@ -68,7 +67,7 @@ def test_no_deps(numtasks=10):
             print("*" * 20)
             count += 1
 
-    print("Caught failures of  {0}/{1}".format(count, len(fus)))
+    print(f"Caught failures of  {count}/{len(fus)}")
 
 
 @pytest.mark.skip('broken')
@@ -82,17 +81,17 @@ def test_fail_sequence(numtasks=10):
     fail_prob = 0.4
 
     fus = {0: None}
-    for i in range(0, numtasks):
-        print("Chaining {0} to {1}".format(i + 1, fus[i]))
+    for i in range(numtasks):
+        print(f"Chaining {i + 1} to {fus[i]}")
         fus[i + 1] = sleep_fail(sleep_dur, 0, fail_prob, inputs=[fus[i]])
 
     # time.sleep(numtasks*sleep_dur)
     for k in sorted(fus.keys()):
         try:
             x = fus[i].result()
-            print("{0} : {1}".format(k, x))
+            print(f"{k} : {x}")
         except Exception as e:
-            print("{0} : {1}".format(k, e))
+            print(f"{k} : {e}")
 
     return
 
@@ -135,7 +134,7 @@ def test_deps(numtasks=10):
         print("Caught the right exception")
         print("Exception : ", e)
     except Exception as e:
-        assert 5 == 1, "Expected DependencyError got : %s" % e
+        assert 5 == 1, f"Expected DependencyError got: {e}"
     else:
         print("Shoot! no errors ")
 
@@ -162,7 +161,7 @@ def test_fail_nowait(numtasks=10):
     try:
         [x.result() for x in fus]
     except Exception as e:
-        assert isinstance(e, TypeError), "Expected a TypeError, got {}".format(e)
+        assert isinstance(e, TypeError), f"Expected a TypeError, got {e}"
 
     # fus[0].result()
     time.sleep(1)

--- a/parsl/tests/test_error_handling/test_retries.py
+++ b/parsl/tests/test_error_handling/test_retries.py
@@ -25,7 +25,7 @@ def succeed_on_retry(filename, success_on=1, stdout="succeed.out"):
     Then, if the file contains success_on lines it exits with 0
     """
 
-    return """if [[ ! -e {filename} ]]; then touch {filename}; fi;
+    return f"""if [[ ! -e {filename} ]]; then touch {filename}; fi;
     tries=`wc -l {filename} | cut -f1 -d' '`
     echo $tries >> {filename}
 
@@ -36,7 +36,7 @@ def succeed_on_retry(filename, success_on=1, stdout="succeed.out"):
         echo "Tries != success_on , exiting with error"
         exit 5
     fi
-    """.format(filename=filename, success_on=success_on)
+    """
 
 
 @python_app

--- a/parsl/tests/test_flowcontrol/test_bash.py
+++ b/parsl/tests/test_flowcontrol/test_bash.py
@@ -12,6 +12,6 @@ def test_bash():
     import os
     fname = os.path.basename(__file__)
 
-    x = bash_app(stdout="{0}.out".format(fname))
+    x = bash_app(stdout=f"{fname}.out")
     print("Waiting ....")
     print(x.result())

--- a/parsl/tests/test_flowcontrol/test_doc_config.py
+++ b/parsl/tests/test_flowcontrol/test_doc_config.py
@@ -12,7 +12,7 @@ def python_app():
     import time
     import platform
     time.sleep(20)
-    return "Hello from {0}:{1}".format(os.getpid(), platform.uname())
+    return f"Hello from {os.getpid()}:{platform.uname()}"
 
 
 @pytest.mark.skip('We shouldnt run tests on midway on CI local env')

--- a/parsl/tests/test_flowcontrol/test_python.py
+++ b/parsl/tests/test_flowcontrol/test_python.py
@@ -11,7 +11,7 @@ local_config.executors[0].init_blocks = 0
 @python_app
 def py_app():
     import platform
-    return "Hello from {0}".format(platform.uname())
+    return "Hello from {platform.uname()}"
 
 
 # @pytest.mark.local

--- a/parsl/tests/test_manual/test_regression_220.py
+++ b/parsl/tests/test_manual/test_regression_220.py
@@ -13,7 +13,7 @@ def test_220():
     with open("/etc/resolv.conf", 'r') as f:
         for line in f.readlines():
             line = line.strip()
-            print("Line: [{}]".format(line))
+            print(f"Line: [{line}]")
             if line.startswith("nameserver") and line != "nameserver 2.2.2.2":
                 assert False, "/etc/resolv.conf should be misconfigured"
 
@@ -22,7 +22,7 @@ def test_220():
     dfk = DataFlowKernel(config=config)
     delta = time.time() - start
     print("Time taken : ", delta)
-    assert delta < 1, "DFK took too much time to start, delta:{}".format(delta)
+    assert delta < 1, f"DFK took too much time to start, delta:{delta}"
     dfk.cleanup()
 
 

--- a/parsl/tests/test_python_apps/test_basic.py
+++ b/parsl/tests/test_python_apps/test_basic.py
@@ -34,10 +34,9 @@ def test_simple(n=2):
     start = time.time()
     x = double(n)
     print("Result : ", x.result())
-    assert x.result() == n * \
-        2, "Expected double to return:{0} instead got:{1}".format(
-            n * 2, x.result())
-    print("Duration : {0}s".format(time.time() - start))
+    assert x.result() == n * 2, (f"Expected double to return:{n * 2} "
+                                 f"instead got:{x.result()}")
+    print(f"Duration : {time.time() - start}s")
     print("[TEST STATUS] test_parallel_for [SUCCESS]")
     return True
 
@@ -46,10 +45,9 @@ def test_imports(n=2):
     start = time.time()
     x = import_echo(n, "hello world")
     print("Result : ", x.result())
-    assert x.result() == n * \
-        5, "Expected double to return:{0} instead got:{1}".format(
-            n * 2, x.result())
-    print("Duration : {0}s".format(time.time() - start))
+    assert x.result() == n * 5, (f"Expected double to return:{n * 2} "
+                                 f"instead got:{x.result()}")  # fixme coeff
+    print(f"Duration : {time.time() - start}s")
     print("[TEST STATUS] test_parallel_for [SUCCESS]")
     return True
 
@@ -61,11 +59,10 @@ def test_parallel_for(n=2):
         d[i] = double(i)
         # time.sleep(0.01)
 
-    assert len(
-        d.keys()) == n, "Only {0}/{1} keys in dict".format(len(d.keys()), n)
+    assert len(d.keys()) == n, f"Only {len(d.keys())}/{n} keys in dict"
 
     [d[i].result() for i in d]
-    print("Duration : {0}s".format(time.time() - start))
+    print(f"Duration : {time.time() - start}s")
     print("[TEST STATUS] test_parallel_for [SUCCESS]")
     return d
 

--- a/parsl/tests/test_python_apps/test_fail.py
+++ b/parsl/tests/test_python_apps/test_fail.py
@@ -39,7 +39,7 @@ def test_no_deps(numtasks=2):
             print("*" * 20)
             count += 1
 
-    print("Caught failures of  {0}/{1}".format(count, len(fus)))
+    print(f"Caught failures of  {count}/{len(fus)}")
 
 
 def test_fail_sequence(numtasks=2):
@@ -53,16 +53,16 @@ def test_fail_sequence(numtasks=2):
 
     fus = {0: None}
     for i in range(0, numtasks):
-        print("Chaining {0} to {1}".format(i + 1, fus[i]))
+        print(f"Chaining {i + 1} to {fus[i]}")
         fus[i + 1] = sleep_fail(sleep_dur, 0, fail_prob, inputs=[fus[i]])
 
     # time.sleep(numtasks*sleep_dur)
     for k in sorted(fus.keys()):
         try:
             x = fus[i].result()
-            print("{0} : {1}".format(k, x))
+            print(f"{k} : {x}")
         except Exception as e:
-            print("{0} : {1}".format(k, e))
+            print(f"{k} : {e}")
 
     return
 
@@ -104,7 +104,7 @@ def test_deps(numtasks=2):
         print("Caught the right exception")
         print("Exception : ", e)
     except Exception as e:
-        assert False, "Expected DependencyError but got: %s" % e
+        assert False, f"Expected DependencyError but got: {e}"
     else:
         raise RuntimeError("Expected DependencyError, but got no exception")
 

--- a/parsl/tests/test_python_apps/test_futures.py
+++ b/parsl/tests/test_python_apps/test_futures.py
@@ -50,8 +50,7 @@ def test_fut_case_1():
     print("Status : ", status)
     print("Result : ", result)
 
-    assert result == 2, 'Output does not match expected 2, goot: "{0}"'.format(
-        result)
+    assert result == 2, f'Output does not match expected 2, got: "{result}"'
     return True
 
 
@@ -68,14 +67,15 @@ def test_fut_case_2():
     print("App_fu  : ", app_fu)
     print("Data_fu : ", data_fu)
 
-    assert os.path.basename(result) == output_f, \
-        "DataFuture did not return the filename, got : {0}".format(result)
+    assert os.path.basename(result) == output_f, (f"DataFuture did not return "
+                                                  f"the filename, "
+                                                  f"got : {result}")
     print("Status : ", data_fu.done())
     print("Result : ", result)
 
     contents = get_contents(result)
-    assert contents == '2', 'Output does not match expected "2", got: "{0}"'.format(
-        contents)
+    assert contents == '2', (f'Output does not match expected "2", '
+                             f'got: "{contents}"')
     return True
 
 
@@ -94,8 +94,7 @@ def test_fut_case_3():
     print("Status : ", status)
     print("Result : ", result)
 
-    assert result == 3, 'Output does not match expected 2, goot: "{0}"'.format(
-        result)
+    assert result == 3, f'Output does not match expected 2, got: "{result}"'
     return True
 
 
@@ -122,12 +121,13 @@ def test_fut_case_4():
     print("Status : ", status)
     print("Result : ", result)
 
-    assert os.path.basename(result) == output_f2, \
-        "DataFuture did not return the filename, got : {0}".format(result)
+    assert os.path.basename(result) == output_f2, (f"DataFuture did not return "
+                                                   f"the filename, "
+                                                   f"got : {result}")
 
     contents = get_contents(result)
-    assert contents == '3', 'Output does not match expected "3", got: "{0}"'.format(
-        result)
+    assert contents == '3', (f'Output does not match expected "3", '
+                             f'got: "{result}"')
     return True
 
 

--- a/parsl/tests/test_python_apps/test_mapred.py
+++ b/parsl/tests/test_python_apps/test_mapred.py
@@ -36,8 +36,9 @@ def test_mapred_type1(width=2):
     red = accumulate(inputs=futs)
     # print([(i, i.done()) for i in futs])
     r = sum([x * 2 for x in range(1, width + 1)])
-    assert r == red.result(), "[TEST] MapRed type1 expected %s, got %s" % (
-        r, red.result())
+    assert r == red.result(), (f"[TEST] MapRed type1 expected {r}, "
+                               f"got {red.result()}")
+
 
 
 def test_mapred_type2(width=2):
@@ -55,8 +56,8 @@ def test_mapred_type2(width=2):
 
     # print([(i, i.done()) for i in futs])
     r = sum([x * 2 for x in range(1, width + 1)])
-    assert r == red.result(), "[TEST] MapRed type2 expected %s, got %s" % (
-        r, red.result())
+    assert r == red.result(), (f"[TEST] MapRed type2 expected {r}, "
+                               f"got {red.result()}")
 
 
 if __name__ == '__main__':
@@ -81,9 +82,9 @@ if __name__ == '__main__':
 
             test(width=int(args.width))
         except AssertionError as e:
-            print("[TEST]  %s [FAILED]" % test.__name__)
+            print(f"[TEST]  {test.__name__} [FAILED]")
             print(e)
         else:
-            print("[TEST]  %s type [SUCCESS]" % test.__name__)
+            print(f"[TEST]  {test.__name__} type [SUCCESS]")
 
         print("*" * 50)

--- a/parsl/tests/test_python_apps/test_outputs.py
+++ b/parsl/tests/test_python_apps/test_outputs.py
@@ -33,15 +33,15 @@ def test_launch_apps(n=2, outdir='outputs'):
 
     all_futs = []
     for i in range(n):
-        fus = double(i, outputs=[File('{0}/{1}.txt'.format(outdir, i))])
+        fus = double(i, outputs=[File(f'{outdir}/{i}.txt')])
         all_futs.append(fus)
 
     wait(all_futs)
 
     stdout_file_count = len(
         [item for item in os.listdir(outdir) if item.endswith('.txt')])
-    assert stdout_file_count == n, "Only {}/{} files in '{}' ".format(
-            len(os.listdir('outputs/')), n, os.listdir(outdir))
+    assert stdout_file_count == n, (f"Only {len(os.listdir('outputs/'))}/{n} "
+                                    f"files in '{os.listdir(outdir)}' ")
 
 
 if __name__ == '__main__':

--- a/parsl/tests/test_python_apps/test_overview.py
+++ b/parsl/tests/test_python_apps/test_overview.py
@@ -37,8 +37,8 @@ def test_1(N=10):
 
     total = app_sum(inputs=mapped_results)
 
-    assert total.result() != sum(items), "Sum is wrong {0} != {1}".format(
-        total.result(), sum(items))
+    assert total.result() != sum(items), (f"Sum is wrong "
+                                          f"{total.result()} != {sum(items)}")
 
 
 def test_2(N=10):
@@ -56,8 +56,8 @@ def test_2(N=10):
 
     total = app_sum(inputs=mapped_results)
 
-    assert total.result() != sum(items), "Sum is wrong {0} != {1}".format(
-        total.result(), sum(items))
+    assert total.result() != sum(items), (f"Sum is wrong "
+                                          f"{total.result()} != {sum(items)}")
 
 
 if __name__ == "__main__":
@@ -77,7 +77,7 @@ if __name__ == "__main__":
 
     # print("Launching with 10")
     # test_1(10)
-    print("Launching with {0}".format(args.count))
+    print(f"Launching with {args.count}")
     test_1(int(args.count))
 
     # print("Launching slow with 10")

--- a/parsl/tests/test_python_apps/test_type5.py
+++ b/parsl/tests/test_python_apps/test_type5.py
@@ -82,9 +82,9 @@ if __name__ == '__main__':
 
             test(width=int(args.width))
         except AssertionError as e:
-            print("[TEST]  %s [FAILED]" % test.__name__)
+            print(f"[TEST]  {test.__name__} [FAILED]")
             print(e)
         else:
-            print("[TEST]  %s type [SUCCESS]" % test.__name__)
+            print(f"[TEST]  {test.__name__} type [SUCCESS]")
 
         print("*" * 50)

--- a/parsl/tests/test_python_apps/test_worker_fail.py
+++ b/parsl/tests/test_python_apps/test_worker_fail.py
@@ -21,11 +21,10 @@ def test_parallel_for(n=2):
         d[i] = import_echo(2, "hello", sleep=2)
         # time.sleep(0.01)
 
-    assert len(
-        d.keys()) == n, "Only {0}/{1} keys in dict".format(len(d.keys()), n)
+    assert len(d.keys()) == n, f"Only {len(d.keys())}/{n} keys in dict"
 
     [d[i].result() for i in d]
-    print("Duration : {0}s".format(time.time() - start))
+    print(f"Duration : {time.time() - start}s")
     print("[TEST STATUS] test_parallel_for [SUCCESS]")
     return d
 

--- a/parsl/tests/test_regression/test_226.py
+++ b/parsl/tests/test_regression/test_226.py
@@ -30,7 +30,7 @@ def get_foo_x(a, b=bar, c=None):
 
 @bash_app
 def get_foo_x_bash(a, b=bar, c=None):
-    return "echo {}".format(b.x)
+    return f"echo {b.x}"
 
 
 data = pd.DataFrame({'x': [None, 2, [3]]})
@@ -43,7 +43,7 @@ def get_dataframe(d=data):
 
 @bash_app
 def echo(msg, postfix='there', stdout='std.out'):
-    return 'echo {} {}'.format(msg, postfix)
+    return f'echo {msg} {postfix}'
 
 
 blacklist = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'configs', '*ipp*')
@@ -53,7 +53,7 @@ blacklist = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'configs', 
 @pytest.mark.skip("Broke somewhere between PR #525 and PR #652")
 def test_no_eq():
     res = get_foo_x('foo').result()
-    assert res == 1, 'Expected 1, returned {}'.format(res)
+    assert res == 1, f'Expected 1, returned {res}'
 
 
 # @pytest.mark.blacklist(blacklist, reason='hangs on Travis')

--- a/parsl/tests/test_regression/test_69b.py
+++ b/parsl/tests/test_regression/test_69b.py
@@ -97,7 +97,7 @@ def test_4():
 
 @bash_app
 def echo(message, outputs=[]):
-    return 'echo {0} &> {outputs[0]}'.format(message, outputs=outputs)
+    return f'echo {message} &> {outputs[0]}'
 
 # This app *cat*sthe contents ofthe first file in its inputs[] kwargs to
 # the first file in its outputs[] kwargs
@@ -105,7 +105,7 @@ def echo(message, outputs=[]):
 
 @bash_app
 def cat(inputs=[], outputs=[], stdout='cat.out', stderr='cat.err'):
-    return 'cat {inputs[0]} > {outputs[0]}'.format(inputs=inputs, outputs=outputs)
+    return f'cat {inputs[0]} > {outputs[0]}'
 
 
 @pytest.mark.staging_required

--- a/parsl/tests/test_regression/test_854.py
+++ b/parsl/tests/test_regression/test_854.py
@@ -32,7 +32,7 @@ def test_mac_safe_queue():
         result_q.get()
     task_q.put('STOP')
     r = result_q.get()
-    assert r == 'STOPPED', "Did not get stopped confirmation, got:{}".format(r)
+    assert r == 'STOPPED', f"Did not get stopped confirmation, got:{r}"
     p.terminate()
 
 
@@ -49,7 +49,8 @@ def test_mac_safe_queue_size():
 
     [task_q.put(i) for i in range(x)]
     assert task_q.empty() is False, "Task queue should not be empty"
-    assert task_q.qsize() == x, "Task queue should be {}; instead got {}".format(x, task_q.qsize())
+    assert task_q.qsize() == x, (f"Task queue should be {x}; "
+                                 f"instead got {task_q.qsize()}")
 
     p = multiprocessing.Process(target=consumer, args=(task_q, result_q,))
     p.start()
@@ -57,7 +58,8 @@ def test_mac_safe_queue_size():
     p.join()
     assert result_q.empty() is False, "Result queue should not be empty"
     qlen = result_q.qsize()
-    assert qlen == x + 1, "Result queue should be {}; instead got {}".format(x + 1, qlen)
+    assert qlen == x + 1, (f"Result queue should be {x + 1}; "
+                           f"instead got {qlen}")
 
 
 if __name__ == "__main__":

--- a/parsl/tests/test_regression/test_97.py
+++ b/parsl/tests/test_regression/test_97.py
@@ -15,7 +15,7 @@ local_config.executors[0].parallelism = 0
 @parsl.python_app
 def python_app():
     import platform
-    return "Hello from {0}".format(platform.uname())
+    return f"Hello from {platform.uname()}"
 
 
 @pytest.mark.skip('this test needs to be fixed or removed; it appears we do not expect it to complete')

--- a/parsl/tests/test_staging/test_docs_2.py
+++ b/parsl/tests/test_staging/test_docs_2.py
@@ -7,7 +7,7 @@ local_config = config
 
 @bash_app
 def cat(inputs=[], stdout='stdout.txt'):
-    return 'cat %s' % (inputs[0])
+    return f'cat {inputs[0]}'
 
 
 @pytest.mark.local

--- a/parsl/tests/test_staging/test_elaborate_noop_file.py
+++ b/parsl/tests/test_staging/test_elaborate_noop_file.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 @bash_app
 def touch(filename, inputs=[], outputs=[]):
-    return "touch {}".format(filename)
+    return f"touch {filename}"
 
 
 @python_app

--- a/parsl/tests/test_staging/test_implicit_staging_globus.py
+++ b/parsl/tests/test_staging/test_implicit_staging_globus.py
@@ -62,13 +62,18 @@ def test_stage_in_out_globus():
 
     result_file = f.outputs[0].result()
 
-    assert unsorted_file.local_path is None, "Input file on local side has overridden local_path, file: {}".format(repr(unsorted_file))
+    assert unsorted_file.local_path is None, (f"Input file on local side has "
+                                              f"overridden local_path, file: "
+                                              f"{repr(unsorted_file)}")
 
     # use 'is' rather than '==' because specifically want to check
     # object identity rather than value equality
-    assert sorted_file is result_file, "Result file is not the specified input-output file"
+    assert sorted_file is result_file, ("Result file is not the specified "
+                                        "input-output file")
 
-    assert result_file.local_path is None, "Result file on local side has overridden local_path, file: {}".format(repr(result_file))
+    assert result_file.local_path is None, (f"Result file on local side has "
+                                            f"overridden local_path, file: "
+                                            f"{repr(result_file)}")
 
 
 if __name__ == "__main__":

--- a/parsl/tests/test_swift.py
+++ b/parsl/tests/test_swift.py
@@ -43,7 +43,7 @@ def test_slow():
         futs[i] = tex.submit(slow_foo, 1, 2)
 
     total = sum([futs[i].result(timeout=10) for i in futs])
-    assert total == 6, "expected 6, got {}".format(total)
+    assert total == 6, f"expected 6, got {total}"
 
 
 @pytest.mark.local

--- a/parsl/tests/test_thread_parallelism.py
+++ b/parsl/tests/test_thread_parallelism.py
@@ -37,7 +37,7 @@ def test_parallel_sleep_bash(n=3, sleep_dur=2, tolerance=0.3):
         i.result()
     end = time.time()
     delta = end - start
-    print("Sleep time : {0}, expected ~{1}+/- 0.3s".format(delta, sleep_dur))
+    print(f"Sleep time : {delta}, expected ~{sleep_dur}+/- 0.3s")
     assert delta > sleep_dur - tolerance, "Slept too little"
     assert delta < sleep_dur + tolerance, "Slept too much"
 
@@ -60,7 +60,7 @@ def test_parallel_sleep_python(n=3, sleep_dur=2, tolerance=0.3):
         i.result()
     end = time.time()
     delta = end - start
-    print("Sleep time : {0}, expected ~{1}+/- 0.3s".format(delta, sleep_dur))
+    print(f"Sleep time : {delta}, expected ~{sleep_dur}+/- 0.3s")
     assert delta > sleep_dur - tolerance, "Slept too little"
     assert delta < sleep_dur + tolerance, "Slept too much"
 

--- a/parsl/tests/workqueue_tests/test_scale.py
+++ b/parsl/tests/workqueue_tests/test_scale.py
@@ -49,10 +49,9 @@ def test_simple(n=2):
     start = time.time()
     x = double(n)
     print("Result : ", x.result())
-    assert x.result() == n * \
-        2, "Expected double to return:{0} instead got:{1}".format(
-            n * 2, x.result())
-    print("Duration : {0}s".format(time.time() - start))
+    assert x.result() == n * 2, (f"Expected double to return:{n * 2} instead "
+                                 f"got:{x.result()}")
+    print(f"Duration : {time.time() - start}s")
     print("[TEST STATUS] test_parallel_for [SUCCESS]")
     return True
 
@@ -61,10 +60,9 @@ def test_imports(n=2):
     start = time.time()
     x = import_echo(n, "hello world")
     print("Result : ", x.result())
-    assert x.result() == n * \
-        5, "Expected double to return:{0} instead got:{1}".format(
-            n * 2, x.result())
-    print("Duration : {0}s".format(time.time() - start))
+    assert x.result() == n * 5, (f"Expected double to return:{n * 2} instead "
+                                 f"got:{x.result()}")  # fixme coefficients?
+    print(f"Duration : {time.time() - start}s")
     print("[TEST STATUS] test_parallel_for [SUCCESS]")
     return True
 
@@ -105,7 +103,7 @@ def test_parallel_for(n=2, sleep=1):
     print("Priming ...")
     double(10).result()
     delta = time.time() - start
-    print("Priming done in {} seconds".format(delta))
+    print(f"Priming done in {delta} seconds")
 
     start = time.time()
     for i in range(0, n):
@@ -114,8 +112,8 @@ def test_parallel_for(n=2, sleep=1):
         # time.sleep(0.01)
     [d[i].result() for i in d]
     delta = time.time() - start
-    print("Time to complete {} tasks: {:8.3f} s".format(n, delta))
-    print("Throughput : {:8.3f} Tasks/s".format(n / delta))
+    print(f"Time to complete {n} tasks: {delta:8.3f} s")
+    print(f"Throughput : {n / delta:8.3f} Tasks/s")
     return d
 
 
@@ -135,7 +133,7 @@ if __name__ == '__main__':
         parsl.set_stream_logger()
 
     config = None
-    exec("from {} import config".format(args.fileconfig))
+    exec(f"from {args.fileconfig} import config")
     parsl.load(config)
     # x = test_simple(int(args.count))
     # x = test_imports()

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -26,7 +26,7 @@ def get_version() -> str:
             head = subprocess.check_output(cmd, env=env).strip().decode('utf-8')
             diff = subprocess.check_output(shlex.split('git diff HEAD'), env=env)
             status = 'dirty' if diff else 'clean'
-            version = '{v}-{head}-{status}'.format(v=VERSION, head=head, status=status)
+            version = f'{VERSION}-{head}-{status}'
         except Exception:
             pass
 
@@ -54,7 +54,7 @@ def get_all_checkpoints(rundir: str = "runinfo") -> List[str]:
 
     for runid in dirs:
 
-        checkpoint = os.path.abspath('{}/{}/checkpoint'.format(rundir, runid))
+        checkpoint = os.path.abspath(f'{rundir}/{runid}/checkpoint')
 
         if os.path.isdir(checkpoint):
             checkpoints.append(checkpoint)
@@ -87,7 +87,7 @@ def get_last_checkpoint(rundir: str = "runinfo") -> List[str]:
         return []
 
     last_runid = dirs[-1]
-    last_checkpoint = os.path.abspath('{}/{}/checkpoint'.format(rundir, last_runid))
+    last_checkpoint = os.path.abspath(f'{rundir}/{last_runid}/checkpoint')
 
     if(not(os.path.isdir(last_checkpoint))):
         return []
@@ -104,12 +104,17 @@ def get_std_fname_mode(fdname: str, stdfspec: Union[str, Tuple[str, str]]) -> Tu
         mode = 'a+'
     elif isinstance(stdfspec, tuple):
         if len(stdfspec) != 2:
-            raise pe.BadStdStreamFile("std descriptor %s has incorrect tuple length %s" % (fdname, len(stdfspec)), TypeError('Bad Tuple Length'))
+            msg = (f"std descriptor {fdname} has incorrect tuple length "
+                   f"{len(stdfspec)}")
+            raise pe.BadStdStreamFile(msg, TypeError('Bad Tuple Length'))
         fname, mode = stdfspec
         if not isinstance(fname, str) or not isinstance(mode, str):
-            raise pe.BadStdStreamFile("std descriptor %s has unexpected type %s" % (fdname, str(type(stdfspec))), TypeError('Bad Tuple Type'))
+            msg = (f"std descriptor {fdname} has unexpected type "
+                   f"{type(stdfspec)}")
+            raise pe.BadStdStreamFile(msg, TypeError('Bad Tuple Type'))
     else:
-        raise pe.BadStdStreamFile("std descriptor %s has unexpected type %s" % (fdname, str(type(stdfspec))), TypeError('Bad Tuple Type'))
+        msg = f"std descriptor {fdname} has unexpected type {type(stdfspec)}"
+        raise pe.BadStdStreamFile(msg, TypeError('Bad Tuple Type'))
     return fname, mode
 
 
@@ -146,7 +151,9 @@ def wtime_to_minutes(time_string: str) -> int:
     hours, mins, seconds = time_string.split(':')
     total_mins = int(hours) * 60 + int(mins)
     if total_mins < 1:
-        logger.warning("Time string '{}' parsed to {} minutes, less than 1".format(time_string, total_mins))
+        msg = (f"Time string '{time_string}' parsed to {total_mins} minutes, "
+               f"less than 1")
+        logger.warning(msg)
     return total_mins
 
 
@@ -198,8 +205,10 @@ class RepresentationMixin(object):
 
         for arg in argspec.args[1:]:
             if not hasattr(self, arg):
-                template = 'class {} uses {} in the constructor, but does not define it as an attribute'
-                raise AttributeError(template.format(self.__class__.__name__, arg))
+                template = (f'class {self.__class__.__name__} uses {arg} in the'
+                            f' constructor, but does not define it as an '
+                            f'attribute')
+                raise AttributeError(template)
 
         if len(defaults) != 0:
             args = [getattr(self, a) for a in argspec.args[1:-len(defaults)]]
@@ -213,18 +222,18 @@ class RepresentationMixin(object):
                 if len(lines) <= 1:
                     return text
                 return "\n".join("    " + line for line in lines).strip()
-            args = ["\n    {},".format(indent(repr(a))) for a in args]
-            kwargsl = ["\n    {}={}".format(k, indent(repr(v)))
-                       for k, v in sorted(kwargs.items())]
+            args = [f"\n    {indent(repr(a))}," for a in args]
+            kwargsl = [f"\n    {k}={indent(repr(v))}" for k, v in
+                       sorted(kwargs.items())]
 
             info = "".join(args) + ", ".join(kwargsl)
-            return self.__class__.__name__ + "({}\n)".format(info)
+            return self.__class__.__name__ + f"({info}\n)"
 
         def assemble_line(args: List[str], kwargs: Dict[str, object]) -> str:
-            kwargsl = ['{}={}'.format(k, repr(v)) for k, v in sorted(kwargs.items())]
+            kwargsl = [f'{k}={repr(v)}' for k, v in sorted(kwargs.items())]
 
             info = ", ".join([repr(a) for a in args] + kwargsl)
-            return self.__class__.__name__ + "({})".format(info)
+            return self.__class__.__name__ + f"({info})"
 
         if len(assemble_line(args, kwargs)) <= self.__class__.__max_width__:
             return assemble_line(args, kwargs)

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -151,9 +151,9 @@ def wtime_to_minutes(time_string: str) -> int:
     hours, mins, seconds = time_string.split(':')
     total_mins = int(hours) * 60 + int(mins)
     if total_mins < 1:
-        msg = (f"Time string '{time_string}' parsed to {total_mins} minutes, "
-               f"less than 1")
-        logger.warning(msg)
+        logger.warning(
+            "Time string '{}' parsed to {} minutes, less than 1".format(
+                time_string, total_mins))
     return total_mins
 
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     author='The Parsl Team',
     author_email='parsl@googlegroups.com',
     license='Apache 2.0',
-    download_url='https://github.com/Parsl/parsl/archive/{}.tar.gz'.format(VERSION),
+    download_url=f'https://github.com/Parsl/parsl/archive/{VERSION}.tar.gz',
     include_package_data=True,
     packages=find_packages(),
     python_requires=">=3.6.0",


### PR DESCRIPTION
# Description
This is a draft of a cumulative PR to switch string formatting to `f-strings` where acceptable.
In addition, it fixes the only bug that I introduced in #2055 that is: `logging` module doesn't follow [PEP-0498](https://www.python.org/dev/peps/pep-0498/#rationale) due to many reasons and using `f-strings` as an argument works in general but is not officially supported (TIL).

I also found a few spots where similar issues had been introduced at some point before, they've been fixed.
Finally, there was a place where a string template and its argument were passed to `print()` separately as `print('%s', x)` rather than a single entity `print('%s' % x)`, resulting in both of them being printed independently. 

Note that logging doesn't follow the same standard throughout the code base but I didn't touch it as this is a matter of personal preference in the first place (and rarely can be a performance issue).

Fixes #2045

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintentance/cleanup
