### PR TITLE
Fix and test wrong type handling for joinapp returns

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -337,8 +337,8 @@ class DataFlowKernel(object):
 
                     inner_future = future.result()
 
-                    # this assert should actually be a test that causes the
-                    # current app to fail cleanly if it is not a Future
+                    # Fail with a TypeError if the joinapp python body returned
+                    # something we can't join on.
                     if isinstance(inner_future, Future):
                         task_record['status'] = States.joining
                         task_record['joins'] = inner_future

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -336,10 +336,20 @@ class DataFlowKernel(object):
                     # listener to that inner future.
 
                     inner_future = future.result()
-                    assert isinstance(inner_future, Future)
-                    task_record['status'] = States.joining
-                    task_record['joins'] = inner_future
-                    inner_future.add_done_callback(partial(self.handle_join_update, task_record))
+
+                    # this assert should actually be a test that causes the
+                    # current app to fail cleanly if it is not a Future
+                    if isinstance(inner_future, Future):
+                        task_record['status'] = States.joining
+                        task_record['joins'] = inner_future
+                        inner_future.add_done_callback(partial(self.handle_join_update, task_record))
+                    else:
+                        task_record['time_returned'] = datetime.datetime.now()
+                        task_record['status'] = States.failed
+                        self.tasks_failed_count += 1
+                        task_record['time_returned'] = datetime.datetime.now()
+                        with task_record['app_fu']._update_lock:
+                            task_record['app_fu'].set_exception(TypeError(f"join_app body must return a Future, got {type(inner_future)}"))
 
         self._log_std_streams(task_record)
 

--- a/parsl/tests/test_python_apps/test_join.py
+++ b/parsl/tests/test_python_apps/test_join.py
@@ -1,3 +1,4 @@
+import pytest
 import time
 
 from parsl import join_app, python_app
@@ -44,6 +45,20 @@ def test_result_flow():
     f = outer_app()
     res = f.result()
     assert res == RESULT_CONSTANT
+
+
+@join_app
+def join_wrong_type_app():
+    return 3
+
+
+def test_wrong_type():
+    # at present, wrong time raises an assert that does not propagate to user level
+    # so the DFK hangs. What should happen is that the app raises an exception via
+    # its app future.
+    f = join_wrong_type_app()
+    with pytest.raises(TypeError):
+        f.result()
 
 
 def test_dependency_on_joined():

--- a/parsl/tests/test_python_apps/test_join.py
+++ b/parsl/tests/test_python_apps/test_join.py
@@ -53,9 +53,6 @@ def join_wrong_type_app():
 
 
 def test_wrong_type():
-    # at present, wrong time raises an assert that does not propagate to user level
-    # so the DFK hangs. What should happen is that the app raises an exception via
-    # its app future.
     f = join_wrong_type_app()
     with pytest.raises(TypeError):
         f.result()


### PR DESCRIPTION
prior to this, returning the wrong type was resulting in a
hang.

after this, returning the wrong type gives a TypeError - for
example:

TypeError: join_app body must return a Future, got <class 'list'>

## Type of change

- Bug fix (non-breaking change that fixes an issue)
