### PR TITLE
Make WorkqueueExecutor show itself with RepresentationMixin

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -74,7 +74,7 @@ WqTaskToParsl = namedtuple('WqTaskToParsl', 'id result_received result reason st
 ParslFileToWq = namedtuple('ParslFileToWq', 'parsl_name stage cache')
 
 
-class WorkQueueExecutor(NoStatusHandlingExecutor):
+class WorkQueueExecutor(NoStatusHandlingExecutor, putils.RepresentationMixin):
     """Executor to use Work Queue batch system
 
     The WorkQueueExecutor system utilizes the Work Queue framework to
@@ -235,7 +235,7 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
         self.use_cache = use_cache
         self.working_dir = working_dir
         self.registered_files = set()  # type: Set[str]
-        self.full = full_debug
+        self.full_debug = full_debug
         self.source = True if pack else source
         self.pack = pack
         self.extra_pkgs = extra_pkgs or []
@@ -285,7 +285,7 @@ class WorkQueueExecutor(NoStatusHandlingExecutor):
                                  "launch_cmd": self.launch_cmd,
                                  "data_dir": self.function_data_dir,
                                  "collector_queue": self.collector_queue,
-                                 "full": self.full,
+                                 "full": self.full_debug,
                                  "shared_fs": self.shared_fs,
                                  "autolabel": self.autolabel,
                                  "autolabel_window": self.autolabel_window,


### PR DESCRIPTION
Prior to this PR, config dumps using the WorkqueueExecutor would show only the class name and object id:

```
    executors=[<parsl.executors.workqueue.executor.WorkQueueExecutor object at 0x7f29216f7400>
], 
```

 Now they show a more elaborate representation of the configuration in line with the rest of parsl.

```
WorkQueueExecutor(
        address='parsl-dev-3-7-257', 
        autocategory=True, 
        autolabel=False, 
        autolabel_window=1, 
        env=None, 
        extra_pkgs=[], 
        full_debug=True, 
        init_command='', 
        label='WorkQueueExecutor', 
        managed=True, 
        max_retries=1, 
        pack=False, 
        port=9000, 
        project_name=None, 
        project_password_file=None, 
        provider=LocalProvider(
            channel=LocalChannel(envs={}, script_dir=None, userhome='/home/benc/parsl/src/parsl'), 
            cmd_timeout=30, 
            init_blocks=1, 
            launcher=SingleNodeLauncher(debug=True, fail_on_any=False), 
            max_blocks=1, 
            min_blocks=0, 
            move_files=None, 
            nodes_per_block=1, 
            parallelism=1, 
            worker_init=''
        ), 
        shared_fs=False, 
        source=False, 
        storage_access=[FTPInTaskStaging(), HTTPInTaskStaging(), NoOpFileStaging()], 
        use_cache=False, 
        worker_executable='work_queue_worker', 
        worker_options='', 
        working_dir='.'
    )], 
```

Fixes #2007 

## Type of change

- Bug fix (non-breaking change that fixes an issue)
