### PR TITLE
Remove breaking .[all] install target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,10 +75,6 @@ script:
     - wget http://127.0.0.1:8080/ --recursive --no-verbose --page-requisites --level=inf -e robots=off
     - killall --wait parsl-visualize
 
-    # check that 'all' install target works, even though we aren't doing any further
-    # testing of what is installed
-    - pip install .[all]
-
     # run simple worker test. this is unlikely to scale due to
     # a stdout/stderr buffering bug in present master.
     # - coverage run --append --source=parsl parsl/tests/manual_tests/test_worker_count.py -c 1000


### PR DESCRIPTION
This was introduced in PR 1391 to test that all targets could be installed.

That target has never really installed properly though - different parts of
parsl optional dependencies conflict with each other and this test has
previously only passed because pip didn't actually error out when dependencies
conflicted.

More recently this has become a problem where pip is not trying hard to
resolve a dependency that quite likely is not resolveable, and appears
to get stuck trying to install msazure and jeepney.

INFO: pip is looking at multiple versions of jeepney to determine which version is compatible with other requirements. This could take a while.
Collecting jeepney>=0.4.2
Downloading jeepney-0.5.0-py3-none-any.whl (45 kB)
Downloading jeepney-0.4.3-py3-none-any.whl (21 kB)
Downloading jeepney-0.4.2-py3-none-any.whl (21 kB)


## Type of change

- Bug fix (non-breaking change that fixes an issue)
