### PR TITLE
Add monitoring dependency to local tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ workqueue_ex_test: $(WORKQUEUE_INSTALL)  ## run all tests with workqueue_ex conf
 config_local_test: ## run all tests with workqueue_ex config
 	echo "$(MPI)"
 	parsl/executors/extreme_scale/install-mpi.sh $(MPI)
-	pip3 install ".[extreme_scale]"
+	pip3 install ".[extreme_scale,monitoring]"
 	PYTHONPATH=. pytest parsl/tests/ -k "not cleannet" --config local --cov=parsl --cov-append --cov-report= --random-order
 
 .PHONY: site_test


### PR DESCRIPTION
In CI this was not revealed because of the order in which tests are run there.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
