### PR TITLE
Remove task_id param from memo functions, as whole task record is available

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -404,7 +404,7 @@ class DataFlowKernel(object):
         if not task_record['app_fu'] == future:
             logger.error("Internal consistency error: callback future is not the app_fu in task structure, for task {}".format(task_id))
 
-        self.memoizer.update_memo(task_id, task_record, future)
+        self.memoizer.update_memo(task_record, future)
 
         if self.checkpoint_mode == 'task_exit':
             self.checkpoint(tasks=[task_id])
@@ -549,7 +549,7 @@ class DataFlowKernel(object):
         task_id = task_record['id']
         task_record['try_time_launched'] = datetime.datetime.now()
 
-        memo_fu = self.memoizer.check_memo(task_id, task_record)
+        memo_fu = self.memoizer.check_memo(task_record)
         if memo_fu:
             logger.info("Reusing cached result for task {}".format(task_id))
             task_record['from_memo'] = True

--- a/parsl/dataflow/memoization.py
+++ b/parsl/dataflow/memoization.py
@@ -206,7 +206,7 @@ class Memoizer(object):
         hashedsum = hashlib.md5(x).hexdigest()
         return hashedsum
 
-    def check_memo(self, task_id, task):
+    def check_memo(self, task):
         """Create a hash of the task and its inputs and check the lookup table for this hash.
 
         If present, the results are returned. The result is a tuple indicating whether a memo
@@ -221,6 +221,9 @@ class Memoizer(object):
 
         This call will also set task['hashsum'] to the unique hashsum for the func+inputs.
         """
+
+        task_id = task['id']
+
         if not self.memoize or not task['memoize']:
             task['hashsum'] = None
             logger.debug("Task {} will not be memoized".format(task_id))
@@ -254,11 +257,10 @@ class Memoizer(object):
         """
         return self.memo_lookup_table[hashsum]
 
-    def update_memo(self, task_id, task, r):
+    def update_memo(self, task, r):
         """Updates the memoization lookup table with the result from a task.
 
         Args:
-             - task_id (int): Integer task id
              - task (dict) : A task dict from dfk.tasks
              - r (Result future): Result future
 
@@ -267,6 +269,9 @@ class Memoizer(object):
         """
         # TODO: could use typeguard
         assert isinstance(r, Future)
+
+        task_id = task['id']
+
         if not self.memoize or not task['memoize'] or 'hashsum' not in task:
             return
 


### PR DESCRIPTION
When these functions need the task id, they can extract it from
the task record.
see #2014 

## Type of change

- Code maintentance/cleanup
