### PR TITLE
Index task_hashsum to give cross-run query speedup

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -131,7 +131,7 @@ class Database:
         task_depends = Column('task_depends', Text, nullable=True)
         task_func_name = Column('task_func_name', Text, nullable=False)
         task_memoize = Column('task_memoize', Text, nullable=False)
-        task_hashsum = Column('task_hashsum', Text, nullable=True)
+        task_hashsum = Column('task_hashsum', Text, nullable=True, index=True)
         task_inputs = Column('task_inputs', Text, nullable=True)
         task_outputs = Column('task_outputs', Text, nullable=True)
         task_stdin = Column('task_stdin', Text, nullable=True)


### PR DESCRIPTION
Practical experience with wstat has shown this index
to give great speedup when making queries which match
up tasks between runs based on their checkpointing
hashsum.

## Type of change

- New feature (non-breaking change that adds functionality)
