### PR TITLE
Document WorkqueueExecutor project_name remote reporting better

### DIFF
--- a/parsl/configs/wqex_local.py
+++ b/parsl/configs/wqex_local.py
@@ -1,7 +1,7 @@
 from parsl.config import Config
 from parsl.executors import WorkQueueExecutor
 
-import uuid;
+import uuid
 
 config = Config(
     executors=[
@@ -13,7 +13,7 @@ config = Config(
             # which can be viewed here:  http://ccl.cse.nd.edu/software/workqueue/status
 
             # To disable status reporting, comment out the project_name.
-            project_name="parsl-wq-"+str(uuid.uuid4()),
+            project_name="parsl-wq-" + str(uuid.uuid4()),
 
             # The port number that Work Queue will listen on for connecting workers.
             port=9123,

--- a/parsl/configs/wqex_local.py
+++ b/parsl/configs/wqex_local.py
@@ -1,12 +1,24 @@
 from parsl.config import Config
 from parsl.executors import WorkQueueExecutor
 
+import uuid;
+
 config = Config(
     executors=[
         WorkQueueExecutor(
-            label="parsl_wq_example",
+            label="parsl-wq-example",
+
+            # If a project_name is given, then Work Queue will periodically
+            # report its status and performance back to the global WQ catalog,
+            # which can be viewed here:  http://ccl.cse.nd.edu/software/workqueue/status
+
+            # To disable status reporting, comment out the project_name.
+            project_name="parsl-wq-"+str(uuid.uuid4()),
+
+            # The port number that Work Queue will listen on for connecting workers.
             port=9123,
-            project_name="parsl_wq_example",
+
+            # A shared filesystem is not needed when using Work Queue.
             shared_fs=False
         )
     ]

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -102,8 +102,10 @@ class WorkQueueExecutor(NoStatusHandlingExecutor, putils.RepresentationMixin):
             Default is True (managed by DFK).
 
         project_name: str
-            If given, Work Queue master process name. Default is None.
-            Overrides address.
+            If a project_name is given, then Work Queue will periodically
+            report its status and performance back to the global WQ catalog,
+            which can be viewed here:  http://ccl.cse.nd.edu/software/workqueue/status
+            Default is None.  Overrides address.
 
         project_password_file: str
             Optional password file for the work queue project. Default is None.


### PR DESCRIPTION
# Description

This PR causes the WQ executor to use a project name of "parsl-wq-{UUID}" by default, unless the user picks another one.  This allow the standard WQ reporting infrastructure to uniquely identify each worklfow separately.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
