### PR TITLE
Reorder debug message so it happens when the message is received

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -442,8 +442,8 @@ class MonitoringRouter:
                 try:
                     data, addr = self.sock.recvfrom(2048)
                     msg = pickle.loads(data)
-                    resource_msgs.put((msg, addr))
                     self.logger.debug("Got UDP Message from {}: {}".format(addr, msg))
+                    resource_msgs.put((msg, addr))
                 except socket.timeout:
                     pass
 


### PR DESCRIPTION
Previously, this message wouldn't be logged until after the message was
sent to the resource_msgs queue; if that queue blocked, the message would
not be logged at the right time.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintentance/cleanup
