### PR TITLE
Configure sphinx to put in full documentation for each method

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -366,3 +366,8 @@ texinfo_documents = [
 # texinfo_no_detailmenu = False
 
 autosummary_generate = True
+
+autodoc_default_options = {
+    'members': True,
+    'undoc-members': True
+}

--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -100,7 +100,7 @@ class DataManager(object):
         """Transport the input from the input source to the executor, if it is file-like,
         returning a DataFuture that wraps the stage-in operation.
 
-        If no staging in is required - because the `file` parameter is not file-like,
+        If no staging in is required - because the ``file`` parameter is not file-like,
         then return that parameter unaltered.
 
         Args:

--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -138,7 +138,7 @@ class ParslExecutor(metaclass=ABCMeta):
         and this method is a delegate to the corresponding method in the provider.
 
         :return: the number of seconds to wait between calls to status() or zero if no polling
-        should be done
+                 should be done
         """
         pass
 
@@ -147,10 +147,8 @@ class ParslExecutor(metaclass=ABCMeta):
     def error_management_enabled(self) -> bool:
         """Indicates whether worker error management is supported by this executor. Worker error
         management is done externally to the executor. However, the executor must implement
-        certain methods that allow this to function. These methods are:
+        certain status handling methods that allow this to function. These methods are:
 
-        Status Handling Methods
-        -----------------------
         :method:handle_errors
         :method:set_bad_state_and_fail_all
 

--- a/parsl/executors/flux/executor.py
+++ b/parsl/executors/flux/executor.py
@@ -261,24 +261,22 @@ class FluxExecutor(NoStatusHandlingExecutor, RepresentationMixin):
     ):
         """Wrap a callable in a Flux job and submit it to Flux.
 
-        Parameters
-        ----------
-        func: callable
-            The callable to submit as a job to Flux
-        resource_specification: collections.abc.Mapping
-            A mapping defining the resources to allocate to the Flux job.
+        :param func: The callable to submit as a job to Flux
+
+        :param resource_specification: A mapping defining the resources to allocate to the Flux job.
+
             Only the following keys are checked for:
-            * num_tasks: the number of tasks to launch (MPI ranks for an MPI job),
-              default 1
-            * cores_per_task: cores per task, default 1
-            * gpus_per_task: gpus per task, default 1
-            * num_nodes: if > 0, evenly distribute the allocated cores/gpus
-              across the given number of nodes. Does *not* give the job exclusive
-              access to those nodes; this option only affects distribution.
-        *args:
-            positional arguments for the callable
-        **kwargs:
-            keyword arguments for the callable
+
+            -  num_tasks: the number of tasks to launch (MPI ranks for an MPI job), default 1
+            -  cores_per_task: cores per task, default 1
+            -  gpus_per_task: gpus per task, default 1
+            -  num_nodes: if > 0, evenly distribute the allocated cores/gpus
+               across the given number of nodes. Does *not* give the job exclusive
+               access to those nodes; this option only affects distribution.
+
+        :param args: positional arguments for the callable
+
+        :param kwargs: keyword arguments for the callable
         """
         # protect self._task_id_counter and shutdown/submit race
         with self._submission_lock:

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -529,10 +529,10 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
 
         Args:
             - func (callable) : Callable function
-            - *args (list) : List of arbitrary positional arguments.
+            - args (list) : List of arbitrary positional arguments.
 
         Kwargs:
-            - **kwargs (dict) : A dictionary of arbitrary keyword args for func.
+            - kwargs (dict) : A dictionary of arbitrary keyword args for func.
 
         Returns:
               Future
@@ -639,8 +639,8 @@ class HighThroughputExecutor(StatusHandlingExecutor, RepresentationMixin):
              Used along with blocks to indicate whether blocks should be terminated by force.
              When force = True, we will kill blocks regardless of the blocks being busy
              When force = False, Only idle blocks will be terminated.
-             If the # of `idle_blocks` < `blocks`, the list of jobs marked for termination
-             will be in the range: 0 -`blocks`.
+             If the # of ``idle_blocks`` < ``blocks``, the list of jobs marked for termination
+             will be in the range: 0 - ``blocks``.
 
         max_idletime: float
              A time to indicate how long a block can be idle.

--- a/parsl/executors/swift_t.py
+++ b/parsl/executors/swift_t.py
@@ -307,10 +307,10 @@ class TurbineExecutor(NoStatusHandlingExecutor):
 
         Args:
             - func (callable) : Callable function
-            - *args (list) : List of arbitrary positional arguments.
+            - args (list) : List of arbitrary positional arguments.
 
         Kwargs:
-            - **kwargs (dict) : A dictionary of arbitrary keyword args for func.
+            - kwargs (dict) : A dictionary of arbitrary keyword args for func.
 
         Returns:
               Future

--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -138,6 +138,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
 
         Kwargs:
              - job_name (String): Name for job, must be unique
+
         Returns:
              - None: At capacity, cannot provision more
              - job_id: (string) Identifier for the job

--- a/parsl/providers/provider_base.py
+++ b/parsl/providers/provider_base.py
@@ -143,7 +143,7 @@ class ExecutionProvider(metaclass=ABCMeta):
         Returns:
              - A job identifier, this could be an integer, string etc
                or None or any other object that evaluates to boolean false
-                  if submission failed but an exception isn't thrown.
+               if submission failed but an exception isn't thrown.
 
         Raises:
              - ExecutionProviderException or its subclasses


### PR DESCRIPTION
Before this, only a small table of summary information was given for each
class, and per-method docstrings were not presented.

This PR also fixes several errors in docstring text that were previously
not a problem, because those pieces of docstring were not used.

Attached are before/after screenshots showing the extra information:

![pre](https://user-images.githubusercontent.com/280107/123082402-80c5a800-d40e-11eb-9096-353cca548fda.png)
![post](https://user-images.githubusercontent.com/280107/123082404-815e3e80-d40e-11eb-8049-610f4e72181f.png)


## Type of change

- New feature (non-breaking change that adds functionality)
- Documentation update
