### PR TITLE
docs: add Flux/LLNL TOSS3 configuration

### DIFF
--- a/docs/userguide/configuring.rst
+++ b/docs/userguide/configuring.rst
@@ -514,6 +514,19 @@ using the `CobaltProvider`. This configuration assumes that the script is being 
 .. literalinclude:: ../../parsl/configs/theta.py
 
 
+TOSS3 (LLNL)
+------------
+
+.. image:: https://hpc.llnl.gov/sites/default/files/Magma--2020-LLNL.jpg
+
+The following snippet shows an example configuration for executing on one of LLNL's **TOSS3**
+machines, such as Quartz, Ruby, Topaz, Jade, or Magma. This example uses the `FluxExecutor`
+and connects to Slurm using the `SlurmProvider`. This configuration assumes that the script
+is being executed on the login nodes of one of the machines.
+
+.. literalinclude:: ../../parsl/configs/toss3_llnl.py
+
+
 Further help
 ------------
 

--- a/parsl/configs/toss3_llnl.py
+++ b/parsl/configs/toss3_llnl.py
@@ -1,0 +1,29 @@
+from parsl.config import Config
+from parsl.executors import FluxExecutor
+from parsl.providers import SlurmProvider
+from parsl.launchers import SrunLauncher
+
+
+config = Config(
+    executors=[
+        FluxExecutor(
+            provider=SlurmProvider(
+                partition="YOUR_PARTITION",  # e.g. "pbatch", "pdebug"
+                account="YOUR_ACCOUNT",
+                launcher=SrunLauncher(overrides="--mpibind=off"),
+                nodes_per_block=1,
+                init_blocks=1,
+                min_blocks=1,
+                max_blocks=1,
+                walltime="00:30:00",
+                # string to prepend to #SBATCH blocks in the submit
+                # script to the scheduler, e.g.: '#SBATCH -t 50'
+                scheduler_options='',
+                # Command to be run before starting a worker, such as:
+                # 'module load Anaconda; source activate parsl_env'.
+                worker_init='',
+                cmd_timeout=120,
+            ),
+        )
+    ]
+)


### PR DESCRIPTION
# Description

Updates the documentation to add a config for LLNL TOSS3 machines. TOSS3 machines are commodity machines with no GPUs (with one or two exceptions). They all run Slurm.

Fixes # (issue)

## Type of change

- Documentation update
