### PR TITLE
Fix CI broken by dependency package changes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+concurrency=multiprocessing,thread
+parallel=True

--- a/README.rst
+++ b/README.rst
@@ -120,3 +120,4 @@ For more information, please visit `the informational
 page <https://sustainable-open-science-and-software.github.io/>`__ or
 download the `participant information
 sheet <https://sustainable-open-science-and-software.github.io/assets/PIS_sustainable_software.pdf>`__.
+

--- a/README.rst
+++ b/README.rst
@@ -120,4 +120,3 @@ For more information, please visit `the informational
 page <https://sustainable-open-science-and-software.github.io/>`__ or
 download the `participant information
 sheet <https://sustainable-open-science-and-software.github.io/assets/PIS_sustainable_software.pdf>`__.
-

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,6 @@ pytest>=4.6,<5
 pytest-cov
 pytest-xdist==1.26.1
 pytest-random-order
-coverage==4.5.4
 mock>=1.0.0
 nbsphinx
 sphinx_rtd_theme


### PR DESCRIPTION
Recently (since the PR #2078) something has changed in dependency packages which made `pip` unable to find a valid set of package versions to install.

The version pin on `coverage` that is removed by this PR was conflicting with
pytest-cov > 2.10. Previously pip was able to easily find a solution
to that by using an earlier pytest-cov, but as of some recent
ecosystem change, it was unable to find a solution.

When manually trying to install pytest-cov 2.11.0 on my laptop
with a working parsl dependency stack already installed:

```
The conflict is caused by:
    The user requested coverage==4.5.4
    pytest-cov 2.11.0 depends on coverage>=5.2.1
```

When building in CI, this resulted in pip spending "forever" (i.e. longer
than the test timeout) trying to find a solution.

This PR removes that pin of `coverage` -- coverage is only used by pytest-cov so we should trust it to require the correct version.

The consequent version change in the `coverage` package broke coverage checking with `--config local`, and so this PR introduces a `.coveragerc` that appears to fix that problem.
