### PR TITLE
Improve support for Windows

### DIFF
--- a/parsl/addresses.py
+++ b/parsl/addresses.py
@@ -10,7 +10,10 @@ import logging
 import platform
 import requests
 import socket
-import fcntl
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
 import struct
 import typeguard
 import psutil
@@ -85,6 +88,7 @@ def address_by_interface(ifname: str) -> str:
         Name of the interface whose address is to be returned. Required.
 
     """
+    assert fcntl is not None, "This function is not supported on your OS."
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     return socket.inet_ntoa(fcntl.ioctl(
         s.fileno(),

--- a/parsl/addresses.py
+++ b/parsl/addresses.py
@@ -13,7 +13,7 @@ import socket
 try:
     import fcntl
 except ImportError:
-    fcntl = None
+    fcntl = None  # type: ignore
 import struct
 import typeguard
 import psutil


### PR DESCRIPTION
# Description

Changes made in my efforts to get Parsl working minimally on Windows.

- Do not crash when fcntl is not found.

Addresses #1878, though I would not claim I will fix it completely.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
