### PR TITLE
Allow use of WorkQueue running_time_min resource constraint

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -59,7 +59,8 @@ logger = logging.getLogger(__name__)
 
 
 # Support structure to communicate parsl tasks to the work queue submit thread.
-ParslTaskToWq = namedtuple('ParslTaskToWq', 'id category cores memory disk gpus priority env_pkg map_file function_file result_file input_files output_files')
+ParslTaskToWq = namedtuple('ParslTaskToWq',
+                           'id category cores memory disk gpus priority running_time_min env_pkg map_file function_file result_file input_files output_files')
 
 # Support structure to communicate final status of work queue tasks to parsl
 # result is only valid if result_received is True
@@ -358,11 +359,12 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         disk = None
         gpus = None
         priority = None
+        running_time_min = None
         if resource_specification and isinstance(resource_specification, dict):
             logger.debug("Got resource specification: {}".format(resource_specification))
 
             required_resource_types = set(['cores', 'memory', 'disk'])
-            acceptable_resource_types = set(['cores', 'memory', 'disk', 'gpus', 'priority'])
+            acceptable_resource_types = set(['cores', 'memory', 'disk', 'gpus', 'priority', 'running_time_min'])
             keys = set(resource_specification.keys())
 
             if not keys.issubset(acceptable_resource_types):
@@ -395,6 +397,8 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
                     gpus = resource_specification[k]
                 elif k == 'priority':
                     priority = resource_specification[k]
+                elif k == 'running_time_min':
+                    running_time_min = resource_specification[k]
 
         self.task_counter += 1
         task_id = self.task_counter
@@ -459,6 +463,7 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
                                                  disk,
                                                  gpus,
                                                  priority,
+                                                 running_time_min,
                                                  env_pkg,
                                                  map_file,
                                                  function_file,
@@ -826,6 +831,8 @@ def _work_queue_submit_wait(task_queue=multiprocessing.Queue(),
                 t.specify_gpus(task.gpus)
             if task.priority is not None:
                 t.specify_priority(task.priority)
+            if task.running_time_min is not None:
+                t.specify_running_time_min(task.running_time_min)
 
             if max_retries is not None:
                 logger.debug(f"Specifying max_retries {max_retries}")


### PR DESCRIPTION
# Description

WQ recently introduced an additional resource constraint: workers can be aware of their remaining wall time, and tasks can be constrained to only go to workers with sufficient remaining time.

This has been used with success on the `desc` parsl branch for a few months.

cc. @dthain 

## Type of change

- New feature (non-breaking change that adds functionality)