### PR TITLE
Fix a race condition in the local channel

### DIFF
--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -68,9 +68,7 @@ class LocalChannel(Channel, RepresentationMixin):
                 shell=True,
                 preexec_fn=os.setpgrp
             )
-            proc.wait(timeout=walltime)
-            stdout = proc.stdout.read()
-            stderr = proc.stderr.read()
+            (stdout, stderr) = proc.communicate(timeout=walltime)
             retcode = proc.returncode
 
         except Exception as e:


### PR DESCRIPTION
This was showing up as a hang when the qstat command launched by
the grid_engine provider returned a very large output: the process
would not exit until stdout had been read enough to empty buffers,
but stdout would not be read until the process had been exited.

Python provides `communicate` to deal with exactly this sort of
complexity, so this PR switches to using that.

Found by Quentin Le Boulc'h

Fixes #2102 

## Type of change

- Bug fix (non-breaking change that fixes an issue)
