### PR TITLE
Remove a commented out line of dead code in htex

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -390,7 +390,6 @@ class Interchange(object):
         self._command_thread.start()
 
         poller = zmq.Poller()
-        # poller.register(self.task_incoming, zmq.POLLIN)
         poller.register(self.task_outgoing, zmq.POLLIN)
         poller.register(self.results_incoming, zmq.POLLIN)
 


### PR DESCRIPTION
Poller registration for task_incoming happens in
migrate_tasks_to_internal

## Type of change

- Code maintentance/cleanup
