### PR TITLE
Regularise monitoring RESOURCE_INFO messages

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -541,8 +541,10 @@ class DatabaseManager:
                         "_migrate_logs_to_internal can only migrate WORKFLOW_,TASK_INFO message from priority queue, got x[0] == {}".format(x[0])
                     self.pending_priority_queue.put(cast(Any, x))
                 elif queue_tag == 'resource':
-                    assert len(x) == 3
-                    self.pending_resource_queue.put(x[-1])
+                    assert x[0] == MessageType.RESOURCE_INFO, "_migrate_logs_to_internal can only migrate RESOURCE_INFO message from resource queue"
+                    body = x[1]
+                    assert len(body) == 3
+                    self.pending_resource_queue.put(body[-1])
                 elif queue_tag == 'node':
                     assert len(x) == 2, "expected message tuple to have exactly two elements"
                     assert x[0] == MessageType.NODE_INFO, "_migrate_logs_to_internal can only migrate NODE_INFO messages from node queue"

--- a/parsl/monitoring/message_type.py
+++ b/parsl/monitoring/message_type.py
@@ -6,6 +6,9 @@ class MessageType(Enum):
     # Reports any task related info such as launch, completion etc.
     TASK_INFO = 0
 
+    # Reports of resource utilization on a per-task basis
+    RESOURCE_INFO = 1
+
     # Top level workflow information
     WORKFLOW_INFO = 2
 

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -222,7 +222,7 @@ class MonitoringHub(RepresentationMixin):
         comm_q = SizedQueue(maxsize=10)  # type: Queue[Union[Tuple[int, int], str]]
         self.exception_q = SizedQueue(maxsize=10)  # type: Queue[Tuple[str, str]]
         self.priority_msgs = SizedQueue()  # type: Queue[Tuple[Any, int]]
-        self.resource_msgs = SizedQueue()  # type: Queue[Tuple[Dict[str, Any], Any]]
+        self.resource_msgs = SizedQueue()  # type: Queue[Tuple[Tuple[MessageType, Dict[str, Any]], Any]]
         self.node_msgs = SizedQueue()  # type: Queue[Tuple[Tuple[MessageType, Dict[str, Any]], int]]
         self.block_msgs = SizedQueue()  # type:  Queue[Tuple[Tuple[MessageType, Dict[str, Any]], Any]]
 
@@ -442,14 +442,14 @@ class MonitoringRouter:
               priority_msgs: "queue.Queue[Tuple[Tuple[MessageType, Dict[str, Any]], int]]",
               node_msgs: "queue.Queue[Tuple[Tuple[MessageType, Dict[str, Any]], int]]",
               block_msgs: "queue.Queue[Tuple[Tuple[MessageType, Dict[str, Any]], int]]",
-              resource_msgs: "queue.Queue[Tuple[Dict[str, Any], Any]]") -> None:
+              resource_msgs: "queue.Queue[Tuple[Tuple[MessageType, Dict[str, Any]], Any]]") -> None:
         try:
             while True:
                 try:
                     data, addr = self.sock.recvfrom(2048)
                     msg = pickle.loads(data)
                     self.logger.debug("Got UDP Message from {}: {}".format(addr, msg))
-                    resource_msgs.put((msg, addr))
+                    resource_msgs.put(((MessageType.RESOURCE_INFO, msg), addr))
                 except socket.timeout:
                     pass
 
@@ -517,7 +517,7 @@ def router_starter(comm_q: "queue.Queue[Union[Tuple[int, int], str]]",
                    priority_msgs: "queue.Queue[Tuple[Tuple[MessageType, Dict[str, Any]], int]]",
                    node_msgs: "queue.Queue[Tuple[Tuple[MessageType, Dict[str, Any]], int]]",
                    block_msgs: "queue.Queue[Tuple[Tuple[MessageType, Dict[str, Any]], int]]",
-                   resource_msgs: "queue.Queue[Tuple[Dict[str, Any], str]]",
+                   resource_msgs: "queue.Queue[Tuple[Tuple[MessageType, Dict[str, Any]], str]]",
 
                    hub_address: str,
                    hub_port: Optional[int],


### PR DESCRIPTION
This PR makes RESOURCE_INFO messages be in the same format as other
monitoring messages:  ( ( tag, message ), address)

This is part of ongoing rationalisation of monitoring messaging that
will allow any kind of message to be sent over any monitoring channel,
from any location.

## Type of change

- Code maintentance/cleanup
