### PR TITLE
Fix htex scale down breakage due to overly aggressive result heartbeat

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -534,7 +534,7 @@ class Interchange(object):
 
                     self.results_outgoing.send_multipart(b_messages)
                     logger.debug("[MAIN] Current tasks: {}".format(self._ready_manager_queue[manager]['tasks']))
-                    if len(self._ready_manager_queue[manager]['tasks']) == 0:
+                    if len(self._ready_manager_queue[manager]['tasks']) == 0 and self._ready_manager_queue[manager]['idle_since'] is None:
                         self._ready_manager_queue[manager]['idle_since'] = time.time()
                 logger.debug("[MAIN] leaving results_incoming section")
 


### PR DESCRIPTION
PR #2104 introduced a result channel heartbeat. However, this heartbeat
resulted in the idle time of managers being updated on each heartbeat.

Because of this, no manager ever appears to be idling for very long.

And because of this, the scale down code will not select any manager
for scaling down.

This PR makes result channel messages not update the idle time if
a manager already has an idle time: a result channel message (either
a result or a heartbeat) now means:
"I am (still) idle", rather than "I am idle starting from now".

There is no CI test for this (before or after). See issue #1885 

## Type of change

- Bug fix (non-breaking change that fixes an issue)
