### PR TITLE
Improve docs and defaults for slurm partition and account parameters.

### DIFF
--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -42,9 +42,9 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
     Parameters
     ----------
     partition : str
-        Slurm partition to request blocks from. If none, no partition slurm directive will be specified.
+        Slurm partition to request blocks from. If unspecified or ``None``, no partition slurm directive will be specified.
     account : str
-        Slurm account to which to charge resources used by the job. If none, the job will use the
+        Slurm account to which to charge resources used by the job. If unspecified or ``None``, the job will use the
         user's default account.
     channel : Channel
         Channel for accessing this provider. Possible channels include
@@ -85,7 +85,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
 
     @typeguard.typechecked
     def __init__(self,
-                 partition: Optional[str],
+                 partition: Optional[str] = None,
                  account: Optional[str] = None,
                  channel: Channel = LocalChannel(),
                  nodes_per_block: int = 1,


### PR DESCRIPTION
This adds a default to the partition parameter of None, to make it
behave like the account parameter.

The documentation for partition and account parameters is made a
bit more verbose to distinguish between omitting a parameter and
specifying a python None value.

See issue #2125 

## Type of change

- Documentation update
- Code maintentance/cleanup
