### PR TITLE
Fix type error when job status output is large

### DIFF
--- a/parsl/providers/provider_base.py
+++ b/parsl/providers/provider_base.py
@@ -84,9 +84,10 @@ class JobStatus(object):
                 size = f.tell()
                 f.seek(0, os.SEEK_SET)
                 if size > JobStatus.SUMMARY_TRUNCATION_THRESHOLD:
-                    head = f.read(JobStatus.SUMMARY_TRUNCATION_THRESHOLD / 2)
-                    f.seek(size - JobStatus.SUMMARY_TRUNCATION_THRESHOLD / 2, os.SEEK_SET)
-                    tail = f.read(JobStatus.SUMMARY_TRUNCATION_THRESHOLD / 2)
+                    half_threshold = int(JobStatus.SUMMARY_TRUNCATION_THRESHOLD / 2)
+                    head = f.read(half_threshold)
+                    f.seek(size - half_threshold, os.SEEK_SET)
+                    tail = f.read(half_threshold)
                     return head + '\n...\n' + tail
                 else:
                     f.seek(0, os.SEEK_SET)


### PR DESCRIPTION
When job status output is large, parsl tries to create an abbreviated
summary.

Before this PR, when that code path runs, this error happens:

    head = f.read(JobStatus.SUMMARY_TRUNCATION_THRESHOLD / 2)
TypeError: argument should be integer or None, not 'float'

There is a cross-python behaviour change here: in python 2,
/ 2 returns an int, but in python3 it returns a float.

python 2: 1/2 gives 0
>>> type(1/2)
<type 'int'>

python 3:  1/2 gives 0.5
>>> type(1/2)
<class 'float'>

This PR makes the code round-down to an int.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
