### PR TITLE
Make monitoring hub exit condition more explicit

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1103,7 +1103,8 @@ class DataFlowKernel(object):
                                   'tasks_completed_count': self.tasks_completed_count,
                                   "time_began": self.time_began,
                                   'time_completed': self.time_completed,
-                                  'run_id': self.run_id, 'rundir': self.run_dir})
+                                  'run_id': self.run_id, 'rundir': self.run_dir,
+                                  'exit_now': True})
 
             self.monitoring.close()
 

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -460,7 +460,7 @@ class MonitoringRouter:
                         block_msgs.put((msg, 0))
                     else:
                         priority_msgs.put((msg, 0))
-                    if msg[0] == MessageType.WORKFLOW_INFO and 'python_version' not in msg[1]:
+                    if msg[0] == MessageType.WORKFLOW_INFO and 'exit_now' in msg[1] and msg[1]['exit_now']:
                         break
                 except zmq.Again:
                     pass


### PR DESCRIPTION
Prior to this PR, the monitoring hub decided it was time to exit
by relying on the absence of a python version string in WORKFLOW_INFO
messages that it was sent.

This PR replaces that with an explicit exit field, which makes
the shutdown logic easier to read. It should not change any other
behaviour.

This is part of an ongoing sequence of PRs attempting to simplify monitoring message flow.

## Type of change

- Code maintentance/cleanup
