### PR TITLE
Remove AppFuture.__repr__, because superclass Future repr is sufficient

### DIFF
--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -113,8 +113,3 @@ class AppFuture(Future):
     @property
     def outputs(self):
         return self._outputs
-
-    def __repr__(self):
-        return '<%s super=%s>' % (
-            self.__class__.__name__,
-            super().__repr__())


### PR DESCRIPTION
A long time ago there was a lot of complexity in AppFuture. This has
basically all been moved elsewhere, so there is nothing AppFuture
specific that is being represented any more.

This PR removes the almost-empty AppFuture repr, in favour of the superclass
repr.

This makes repr of AppFuture change from this:

<AppFuture super=<AppFuture at 0x7f4bfe06a730 state=finished returned int>>

to this:

<AppFuture at 0x7f2ce1aa6f70 state=finished returned int>

## Type of change

- Documentation update
- Code maintentance/cleanup
