### PR TITLE
Update slack join links to currently unexpired link

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -7,7 +7,7 @@ Please be aware of `Parsl's Code of Conduct <https://github.com/Parsl/parsl/blob
 
 If you are not familiar with GitHub pull requests, the main mechanism to contribute changes to our code, there is `documentation available  <https://opensource.com/article/19/7/create-pull-request-github>`_.
 
-If you have questions, please ask in our Slack's `#parsl-help channel <https://parsl-project.slack.com/archives/C4KBVPJG0>`_. If needed, `join it here <https://join.slack.com/t/parsl-project/shared_invite/enQtMzg2MDAwNjg2ODY1LTUyYmViOTY1ZTU2ZDUwZTVmOWQ1M2IzZTE5MTM3YWZlM2RhM2IyZjk4ODgwNGRhOGE1MzJlNTYyYjNkYzIzZW>`_ first.
+If you have questions, please ask in our Slack's `#parsl-help channel <https://parsl-project.slack.com/archives/C4KBVPJG0>`_. If needed, `join it here <https://join.slack.com/t/parsl-project/shared_invite/zt-4xbquc5t-Ur65ZeVtUOX51Ts~GRN6_g>`_ first.
 
 
 Coding conventions
@@ -158,4 +158,4 @@ Discussion and Support
 
 The best way to discuss development activities is via Git issues.
 
-To get involved in community discussion please `join <https://join.slack.com/t/parsl-project/shared_invite/enQtMzg2MDAwNjg2ODY1LTk0ZmYyZWE2NDMwYzVjZThmNTUxOWE0MzNkN2JmYjMyY2QzYzg0YTM3MDEzYjc2ZjcxZGZhMGQ1MzBmOWRiOTM>`_ the Parsl Slack channel.
+To get involved in community discussion please `join <https://join.slack.com/t/parsl-project/shared_invite/zt-4xbquc5t-Ur65ZeVtUOX51Ts~GRN6_g>`_ the Parsl Slack channel.


### PR DESCRIPTION
I tested this using anonymous mode in my browser: the old links tell me they are expired. The new one invites me to sign up.

Fixes #2145

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Documentation update
