### PR TITLE
Update LSF provider to make it more friendly for different LSF-based computers

### DIFF
--- a/docs/userguide/checkpoints.rst
+++ b/docs/userguide/checkpoints.rst
@@ -49,7 +49,7 @@ during development. Using app caching will ensure that only modified apps are re
 App equivalence 
 ^^^^^^^^^^^^^^^
 
-Parsl determines app equivalence by storing the a hash
+Parsl determines app equivalence by storing the hash
 of the app function. Thus, any changes to the app code (e.g., 
 its signature, its body, or even the docstring within the body)
 will invalidate cached values. 

--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -253,9 +253,10 @@ class MpiRunLauncher(Launcher):
     - mpirun is installed and can be located in $PATH
     - The provider makes available the $PBS_NODEFILE environment variable
     """
-    def __init__(self, debug: bool = True, bash_location: str = '/bin/bash'):
+    def __init__(self, debug: bool = True, bash_location: str = '/bin/bash', overrides: str = ''):
         super().__init__(debug=debug)
         self.bash_location = bash_location
+        self.overrides = overrides
 
     def __call__(self, command, tasks_per_node, nodes_per_block):
         """
@@ -277,11 +278,12 @@ cat << MPIRUN_EOF > cmd_$JOBNAME.sh
 MPIRUN_EOF
 chmod u+x cmd_$JOBNAME.sh
 
-mpirun -np $WORKERCOUNT {bash_location} cmd_$JOBNAME.sh
+mpirun -np $WORKERCOUNT {overrides} {bash_location} cmd_$JOBNAME.sh
 
 [[ "{debug}" == "1" ]] && echo "All workers done"
 '''.format(command=command,
            task_blocks=task_blocks,
+           overrides=self.overrides,
            bash_location=self.bash_location,
            debug=debug_num)
         return x

--- a/parsl/providers/lsf/lsf.py
+++ b/parsl/providers/lsf/lsf.py
@@ -75,7 +75,7 @@ class LSFProvider(ClusterProvider, RepresentationMixin):
     bsub_redirection: Bool
         Should a redirection symbol "<" be included when submitting jobs, i.e., Bsub < job_script.
     request_by_nodes: Bool
-        Request by nodes or request by cores per block. 
+        Request by nodes or request by cores per block.
         When this is set to false, nodes_per_block is computed by cores_per_block / cores_per_node.
         Default is True.
     """

--- a/parsl/providers/lsf/lsf.py
+++ b/parsl/providers/lsf/lsf.py
@@ -56,6 +56,8 @@ class LSFProvider(ClusterProvider, RepresentationMixin):
         Walltime requested per block in HH:MM:SS.
     project : str
         Project to which the resources must be charged
+    queue : str
+        Queue to which to submit the job request
     scheduler_options : str
         String to prepend to the #SBATCH blocks in the submit script to the scheduler.
     worker_init : str

--- a/parsl/providers/lsf/lsf.py
+++ b/parsl/providers/lsf/lsf.py
@@ -69,7 +69,7 @@ class LSFProvider(ClusterProvider, RepresentationMixin):
         :class:`~parsl.launchers.AprunLauncher`
     move_files : Optional[Bool]: should files be moved? by default, Parsl will try to move files.
     bsub_redirection: Bool
-        Should a redirection symbol `<` be included when submitting jobs, i.e., Bsub < job_script.
+        Should a redirection symbol "<" be included when submitting jobs, i.e., Bsub < job_script.
     request_by_nodes: Bool
         Request by nodes or request by cores per block. Default is True.
     """

--- a/parsl/providers/lsf/lsf.py
+++ b/parsl/providers/lsf/lsf.py
@@ -118,14 +118,14 @@ class LSFProvider(ClusterProvider, RepresentationMixin):
         if project:
             self.scheduler_options += "#BSUB -P {}\n".format(project)
         if queue:
-            self.scheduler_options += "#BSUB -q {}\n".format(queue) 
+            self.scheduler_options += "#BSUB -q {}\n".format(queue)
         if request_by_nodes:
             self.scheduler_options += "#BSUB -nnodes {}\n".format(nodes_per_block)
         if cores_per_block and not request_by_nodes:
             self.scheduler_options += "#BSUB -n {}\n".format(cores_per_block)
         if cores_per_block and not request_by_nodes:
             self.scheduler_options += '#BSUB -R "span[ptile={}]"\n'.format(cores_per_node)
-        
+
         self.worker_init = worker_init
 
     def _status(self):
@@ -212,7 +212,7 @@ class LSFProvider(ClusterProvider, RepresentationMixin):
         if self.bsub_redirection:
             cmd = "bsub < {0}".format(channel_script_path)
         else:
-            cmd = "bsub {0}".format(channel_script_path)        
+            cmd = "bsub {0}".format(channel_script_path)
         retcode, stdout, stderr = super().execute_wait(cmd)
 
         job_id = None

--- a/parsl/providers/lsf/lsf.py
+++ b/parsl/providers/lsf/lsf.py
@@ -127,9 +127,16 @@ class LSFProvider(ClusterProvider, RepresentationMixin):
             self.scheduler_options += "#BSUB -q {}\n".format(queue)
         if request_by_nodes:
             self.scheduler_options += "#BSUB -nnodes {}\n".format(nodes_per_block)
-        if not request_by_nodes and cores_per_block and cores_per_node:
+        else:
+            assert cores_per_block is not None and cores_per_node is not None, \
+                       "Requesting resources by the number of cores. " \
+                       "Need to specify cores_per_block and cores_per_node in the LSF provider."
+
             self.scheduler_options += "#BSUB -n {}\n".format(cores_per_block)
             self.scheduler_options += '#BSUB -R "span[ptile={}]"\n'.format(cores_per_node)
+
+            # Set nodes_per_block manually for Parsl strategy
+            assert cores_per_node != 0, "Need to specify a non-zero cores_per_node."
             self.nodes_per_block = int(math.ceil(cores_per_block / cores_per_node))
 
         self.worker_init = worker_init

--- a/parsl/providers/lsf/lsf.py
+++ b/parsl/providers/lsf/lsf.py
@@ -38,6 +38,10 @@ class LSFProvider(ClusterProvider, RepresentationMixin):
         :class:`~parsl.channels.SSHInteractiveLoginChannel`.
     nodes_per_block : int
         Nodes to provision per block.
+    cores_per_block : int
+        Cores to provision per block. Enabled only when request_by_nodes is False.
+    cores_per_node: int
+        Cores to provision per node. Enabled only when request_by_nodes is False.
     init_blocks : int
         Number of blocks to request at the start of the run.
     min_blocks : int
@@ -64,6 +68,10 @@ class LSFProvider(ClusterProvider, RepresentationMixin):
         :class:`~parsl.launchers.SrunLauncher`, or
         :class:`~parsl.launchers.AprunLauncher`
     move_files : Optional[Bool]: should files be moved? by default, Parsl will try to move files.
+    bsub_redirection: Bool
+        Should a redirection symbol `<` be included when submitting jobs, i.e., Bsub < job_script.
+    request_by_nodes: Bool
+        Request by nodes or request by cores per block. Default is True.
     """
 
     def __init__(self,

--- a/parsl/providers/lsf/template.py
+++ b/parsl/providers/lsf/template.py
@@ -1,8 +1,6 @@
 template_string = '''#!/bin/bash
 
-#BSUB -P ${project}
 #BSUB -W ${walltime}
-#BSUB -nnodes ${nodes}
 #BSUB -J ${jobname}
 #BSUB -o ${submit_script_dir}/${jobname}.submit.stdout
 #BSUB -e ${submit_script_dir}/${jobname}.submit.stderr


### PR DESCRIPTION
# Description

The current LSF provider is used only on Summit, but can't be used on some other computers that use a slightly different LSF.

For example, the SUSTech LSF-based HPC cluster differs in the following aspects.

(1) It requests resources based on `the number of cores`, rather than the number of nodes `#BSUB -nnodes ${nodes}` on Summit. 
```
#BSUB -n 80 ##number of total cores
#BSUB -R "span[ptile=40]" ##40 cores per node
```

(2) The job submission requires to specify the queue `#BSUB -q short ##queue name`.

(3) It does not have a project specification `#BSUB -P project`.

(4) `Bsub` command requires a redirection symbol `<`, i.e., `bsub < job_script`.

This PR updates the LSF provider to make it more friendly to general LSF providers.
The PR also adds an override option to mpirun launcher to allow binding a manager to each node.

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
