### PR TITLE
Use proper subclass of Exception when executor is in a bad state.

### DIFF
--- a/parsl/executors/errors.py
+++ b/parsl/executors/errors.py
@@ -18,6 +18,14 @@ class ExecutorError(ParslError):
         return "Executor {0} failed due to: {1}".format(self.executor, self.reason)
 
 
+class BadStateException(ExecutorError):
+    """Error returned by task Futures when an executor is in a bad state.
+    """
+
+    def __init__(self, executor, exception):
+        super().init(executor, str(exception))
+
+
 class UnsupportedFeatureError(ExecutorError):
     """Error raised when attemping to use unsupported feature in an Executor"""
 

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -7,7 +7,7 @@ from typing import List, Any, Dict, Optional, Tuple, Union
 
 import parsl  # noqa F401
 from parsl.executors.base import ParslExecutor
-from parsl.executors.errors import ScalingFailed
+from parsl.executors.errors import BadStateException, ScalingFailed
 from parsl.providers.provider_base import JobStatus, ExecutionProvider, JobState
 
 
@@ -115,7 +115,7 @@ class BlockProviderExecutor(ParslExecutor):
         # We set all current tasks to this exception to make sure that
         # this is raised in the main context.
         for task in self._tasks:
-            self._tasks[task].set_exception(Exception(str(self._executor_exception)))
+            self._tasks[task].set_exception(BadStateException(self, self._executor_exception))
 
     @property
     def bad_state_is_set(self):


### PR DESCRIPTION
This follows the general Parsl style, which defines different
exception classes for different errors.

## Type of change

- Code maintentance/cleanup
