### PR TITLE
Make missing worker test cleanup DFK at end

### DIFF
--- a/parsl/tests/test_error_handling/test_htex_missing_worker.py
+++ b/parsl/tests/test_error_handling/test_htex_missing_worker.py
@@ -14,6 +14,7 @@ def local_setup():
 
 
 def local_teardown():
+    parsl.dfk().cleanup()
     parsl.clear()
 
 


### PR DESCRIPTION
Without this, that DFK continues to exist and emit logs while other tests are happening.

## Type of change

- Code maintentance/cleanup
