### PR TITLE
Make executor bad state exception log use the exception

### DIFF
--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -108,7 +108,7 @@ class BlockProviderExecutor(ParslExecutor):
         return status
 
     def set_bad_state_and_fail_all(self, exception: Exception):
-        logger.exception("Exception: {}".format(exception))
+        logger.exception("Setting bad state due to exception", exc_info=exception)
         self._executor_exception = exception
         # Set bad state to prevent new tasks from being submitted
         self._executor_bad_state.set()


### PR DESCRIPTION
# Description

Prior to this, the error message would be reported with no
in-context exception, and so would emit a line like this:

```
2021-11-26 18:21:10.761 parsl.executors.status_handling:111 [ERROR]  Exception:         STDOUT: /home/benc/parsl/src/parsl/runinfo/018/submit_scripts/parsl.localprovider.1637950869.7853742.sh: line 3: executable_that_hopefully_does_not_exist_1030509.py: command not found

NoneType: None
```

The NoneType: None happens there because no exception is in
scope at the moment.

After this change, the log reports:

```
2021-11-26 18:09:51.235 parsl.executors.status_handling:111 [ERROR]  Setting bad state due to exception
Exception:      STDOUT: /home/benc/parsl/src/parsl/runinfo/008/submit_scripts/parsl.localprovider.1637950190.2711153.sh: line 3: executable_that_hopefully_does_not_exist_1030509.py: command not found
```

If the supplied exception object has a stack trace, then that will also be
logged at this point now.


## Type of change

- Code maintentance/cleanup
