### PR TITLE
BUG fixed bug in condor provider for unknown pilot jobs

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -58,7 +58,7 @@
             "givenName": "Ian",
             "familyName": "Foster",
             "email": "foster@anl.gov"
-        }, 
+        },
         {
             "@id":"http://orcid.org/0000-0002-0762-2684",
             "@type": "Person",
@@ -72,6 +72,14 @@
             "givenName": "Kelly L.",
             "familyName": "Rowland",
             "email": "kellyrowland@lbl.gov"
+        },
+        {
+            "@id":"https://orcid.org/0000-0001-7774-2246",
+            "@type": "Person",
+            "givenName": "Matthew R.",
+            "familyName": "Becker",
+            "email": "becker.mr@gmail.com"
+        }
     ],
     "softwareRequirements": [
         {

--- a/parsl/providers/condor/condor.py
+++ b/parsl/providers/condor/condor.py
@@ -303,12 +303,12 @@ class CondorProvider(RepresentationMixin, ClusterProvider):
             logger.debug("Attempting removal of jobs : {0}".format(cmd))
             retcode, stdout, stderr = self.execute_wait(cmd)
             if retcode == 0:
-                for jid in job_ids:
+                for jid in job_id_chunk:
                     if jid in self.resources:
                         self.resources[jid]['status'] = JobStatus(JobState.CANCELLED)
-                rets.extend([True for i in job_ids])
+                rets.extend([True for i in job_id_chunk])
             else:
-                rets.extend([False for i in job_ids])
+                rets.extend([False for i in job_id_chunk])
 
         return rets
 


### PR DESCRIPTION
# Description

This commit ensures the condor provider doesn't throw an error for
pilot jobs it doesn't know about. It also adds the ability to make
calls to the scheduler in chunks of pilot jobs to help them timeout
less.


Fixes #2160 
Fixes #2159 

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
