### PR TITLE
WIP remove extra lock around the AppFuture state

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -312,8 +312,7 @@ class DataFlowKernel(object):
             if task_record['status'] == States.dep_fail:
                 logger.info("Task {} failed due to dependency failure so skipping retries".format(task_id))
                 task_record['time_returned'] = datetime.datetime.now()
-                with task_record['app_fu']._update_lock:
-                    task_record['app_fu'].set_exception(e)
+                task_record['app_fu'].set_exception(e)
 
             elif task_record['fail_cost'] <= self._config.retries:
 
@@ -336,8 +335,7 @@ class DataFlowKernel(object):
                 task_record['status'] = States.failed
                 self.tasks_failed_count += 1
                 task_record['time_returned'] = datetime.datetime.now()
-                with task_record['app_fu']._update_lock:
-                    task_record['app_fu'].set_exception(e)
+                task_record['app_fu'].set_exception(e)
 
         else:
             if task_record['from_memo']:
@@ -365,8 +363,9 @@ class DataFlowKernel(object):
                         task_record['status'] = States.failed
                         self.tasks_failed_count += 1
                         task_record['time_returned'] = datetime.datetime.now()
-                        with task_record['app_fu']._update_lock:
-                            task_record['app_fu'].set_exception(TypeError(f"join_app body must return a Future, got {type(inner_future)}"))
+                        task_record['app_fu'].set_exception(
+                            TypeError(f"join_app body must return a Future, got {type(inner_future)}")
+                        )
 
         self._log_std_streams(task_record)
 
@@ -401,8 +400,7 @@ class DataFlowKernel(object):
             task_record['status'] = States.failed
             self.tasks_failed_count += 1
             task_record['time_returned'] = datetime.datetime.now()
-            with task_record['app_fu']._update_lock:
-                task_record['app_fu'].set_exception(e)
+            task_record['app_fu'].set_exception(e)
 
         else:
             res = inner_app_future.result()
@@ -461,8 +459,7 @@ class DataFlowKernel(object):
         logger.info(f"Task {task_record['id']} completed ({old_state.name} -> {new_state.name})")
         task_record['time_returned'] = datetime.datetime.now()
 
-        with task_record['app_fu']._update_lock:
-            task_record['app_fu'].set_result(result)
+        task_record['app_fu'].set_result(result)
 
     @staticmethod
     def _unwrap_remote_exception_wrapper(future: Future) -> Any:

--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -65,7 +65,6 @@ class AppFuture(Future):
                    by this future.
         """
         super().__init__()
-        self._update_lock = threading.Lock()
         self._outputs = []
         self.task_def = task_def
 

--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -8,7 +8,6 @@ We have two basic types of futures:
 
 from concurrent.futures import Future
 import logging
-import threading
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Description

There appears to be a threading lock used to control access to the state of the AppFuture. However, internally, python Future objects use their own lock around the state of the future. See here for example (https://github.com/python/cpython/blob/3.10/Lib/concurrent/futures/_base.py#L531). Thus I suspect the external lock is not needed and may negatively impact performance since an update of a Future requires holding two locks.

I think this change needs a good look from a dev who knows the code-base better however. There might be other race conditions I am unaware of that this lock was used to solve. I cannot think of a way the external lock would help when the internal one wouldn't.

This change does not appear to help #2162 but it might be worth it anyhow. 

## Type of change

- Bug fix (non-breaking change that fixes an issue)
