### PR TITLE
Dispatch monitoring messages on tag type, instead of queue name

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -14,7 +14,7 @@ from parsl.utils import RepresentationMixin
 from parsl.process_loggers import wrap_with_logs
 
 from parsl.monitoring.message_type import MessageType
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import cast, Any, Callable, Dict, List, Optional, Union
 
 _db_manager_excepts: Optional[Exception]
 
@@ -474,12 +474,10 @@ class MonitoringRouter:
                 try:
                     msg = self.ic_channel.recv_pyobj()
                     self.logger.debug("Got ZMQ Message from interchange: {}".format(msg))
-
-                    assert msg[0] == MessageType.NODE_INFO \
-                        or msg[0] == MessageType.BLOCK_INFO, \
-                        "IC Channel expects only NODE_INFO or BLOCK_INFO and cannot dispatch other message types"
-
+                    assert isinstance(msg, tuple), "IC Channel expects only tuples, got {}".format(msg)
+                    assert len(msg) >= 1, "IC Channel expects tuples of length at least 1, got {}".format(msg)
                     if msg[0] == MessageType.NODE_INFO:
+                        assert len(msg) >= 1, "IC Channel expects NODE_INFO tuples of length at least 3, got {}".format(msg)
                         msg[2]['last_heartbeat'] = datetime.datetime.fromtimestamp(msg[2]['last_heartbeat'])
                         msg[2]['run_id'] = self.run_id
                         msg[2]['timestamp'] = msg[1]
@@ -487,8 +485,10 @@ class MonitoringRouter:
                         # ((tag, dict), addr)
                         node_msg = ((msg[0], msg[2]), 0)
                         node_msgs.put(node_msg)
+                    elif msg[0] == MessageType.RESOURCE_INFO:
+                       resource_msgs.put(cast(Any, msg))
                     elif msg[0] == MessageType.BLOCK_INFO:
-                        block_msgs.put((msg, 0))
+                        block_msgs.put(cast(Any, (msg, 0)))
                     else:
                         self.logger.error(f"Discarding message from interchange with unknown type {msg[0].value}")
                 except zmq.Again:

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -486,7 +486,7 @@ class MonitoringRouter:
                         node_msg = ((msg[0], msg[2]), 0)
                         node_msgs.put(node_msg)
                     elif msg[0] == MessageType.RESOURCE_INFO:
-                       resource_msgs.put(cast(Any, msg))
+                        resource_msgs.put(cast(Any, msg))
                     elif msg[0] == MessageType.BLOCK_INFO:
                         block_msgs.put(cast(Any, (msg, 0)))
                     else:


### PR DESCRIPTION
This means monitoring messages are handled based on their
declared tag type, rather than how they are received by the
database manager.

Specifically, RESOURCE_INFO messages are now handled more
like other messages.

This is groundwork for future PRs which will, for example,
allow remote tasks to deliver their resource messages over
htex's existing channels, rather than via UDP.

## Type of change

- Code maintentance/cleanup
