### PR TITLE
Allocate block ids uniquely

### DIFF
--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shlex
 import subprocess
+import threading
 import time
 import typeguard
 from contextlib import contextmanager
@@ -239,3 +240,18 @@ class RepresentationMixin(object):
             return assemble_line(args, kwargs)
         else:
             return assemble_multiline(args, kwargs)
+
+
+class AtomicIDCounter:
+    """A class to allocate counter-style IDs, in a thread-safe way.
+    """
+
+    def __init__(self):
+        self.count = 0
+        self.lock = threading.Lock()
+
+    def get_id(self):
+        with self.lock:
+            new_id = self.count
+            self.count += 1
+            return new_id


### PR DESCRIPTION
Previously the code around block ID allocation was a bit fuzzy and
it looks like it could sometimes allocate the same block ID several
times in the presence of failure.

This is at least causing confusion in debugging frequent hangs in
CI.

A second ID allocator was used when a block ID had not already been
allocated, for simulating failures. This ID allocation code is changed
in this PR to use the same sequence counter.

Fixes #2181 

## Type of change

- Bug fix (non-breaking change that fixes an issue)
