### PR TITLE
Make manager phrasing consistent in log messages.

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -487,7 +487,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
             Worker id to be put on hold
         """
         c = self.command_client.run("HOLD_WORKER;{}".format(worker_id))
-        logger.debug("Sent hold request to worker: {}".format(worker_id))
+        logger.debug("Sent hold request to manager: {}".format(worker_id))
         return c
 
     @property


### PR DESCRIPTION
The before message referred to manager; the after
message referred to worker.

This patch makes them the same - using manager

## Type of change

- Documentation update
- Code maintentance/cleanup
