### PR TITLE
Move monitoring.db to runinfo

### DIFF
--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -64,7 +64,7 @@ the ``parsl-visualize`` utility::
    $ parsl-visualize
 
 By default, this command expects that the default ``monitoring.db`` database is used
-in the current working directory. Other databases can be loaded by passing
+in the runinfo directory. Other databases can be loaded by passing
 the database URI on the command line.  For example, if the full path
 to the database is ``/tmp/my_monitoring.db``, run::
 

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -57,7 +57,7 @@ class Database:
     Base = declarative_base()
 
     def __init__(self,
-                 url: str = 'sqlite:///monitoring.db',
+                 url: str = 'sqlite:///runinfomonitoring.db',
                  ):
 
         self.eng = sa.create_engine(url)
@@ -251,7 +251,7 @@ class Database:
 
 class DatabaseManager:
     def __init__(self,
-                 db_url: str = 'sqlite:///monitoring.db',
+                 db_url: str = 'sqlite:///runinfo/monitoring.db',
                  logdir: str = '.',
                  logging_level: int = logging.INFO,
                  batching_interval: float = 1,

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -132,7 +132,7 @@ class MonitoringHub(RepresentationMixin):
 
                  workflow_name: Optional[str] = None,
                  workflow_version: Optional[str] = None,
-                 logging_endpoint: str = 'sqlite:///monitoring.db',
+                 logging_endpoint: str = 'sqlite:///runinfo/monitoring.db',
                  logdir: Optional[str] = None,
                  monitoring_debug: bool = False,
                  resource_monitoring_enabled: bool = True,

--- a/parsl/monitoring/visualization/app.py
+++ b/parsl/monitoring/visualization/app.py
@@ -8,7 +8,7 @@ def cli_run():
     """ Instantiates the Monitoring viz server
     """
     parser = argparse.ArgumentParser(description='Parsl visualization tool')
-    parser.add_argument('db_path', type=str, default="sqlite:///{cwd}/monitoring.db".format(cwd=os.getcwd()),
+    parser.add_argument('db_path', type=str, default="sqlite:///{cwd}/runinfo/monitoring.db".format(cwd=os.getcwd()),
                         nargs="?", help='Database path in the format sqlite:///<absolute_path_to_db>')
     parser.add_argument('-p', '--port', type=int, default=8080,
                         help='Port at which the monitoring Viz Server is hosted. Default: 8080')

--- a/parsl/tests/test-viz.sh
+++ b/parsl/tests/test-viz.sh
@@ -7,7 +7,7 @@
 killall --wait parsl-visualize || echo No previous parsl-visualize to kill
 
 if  [ -n "$1" ]; then
-  rm -f monitoring.db
+  rm -f runinfo/monitoring.db
   pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/htex_local_alternate.py --cov=parsl --cov-append --cov-report= --random-order
 fi
 

--- a/parsl/tests/test_monitoring/test_basic.py
+++ b/parsl/tests/test_monitoring/test_basic.py
@@ -27,9 +27,9 @@ def test_row_counts():
     import sqlalchemy
     from parsl.tests.configs.htex_local_alternate import fresh_config
 
-    if os.path.exists("monitoring.db"):
+    if os.path.exists("runinfo/monitoring.db"):
         logger.info("Monitoring database already exists - deleting")
-        os.remove("monitoring.db")
+        os.remove("runinfo/monitoring.db")
 
     logger.info("loading parsl")
     parsl.load(fresh_config())

--- a/parsl/tests/test_monitoring/test_basic.py
+++ b/parsl/tests/test_monitoring/test_basic.py
@@ -44,7 +44,7 @@ def test_row_counts():
     # at this point, we should find one row in the monitoring database.
 
     logger.info("checking database content")
-    engine = sqlalchemy.create_engine("sqlite:///monitoring.db")
+    engine = sqlalchemy.create_engine("sqlite:///runinfo/monitoring.db")
     with engine.begin() as connection:
 
         result = connection.execute("SELECT COUNT(*) FROM workflow")

--- a/parsl/tests/test_monitoring/test_db_locks.py
+++ b/parsl/tests/test_monitoring/test_db_locks.py
@@ -16,9 +16,9 @@ def this_app():
 def test_row_counts():
     from parsl.tests.configs.htex_local_alternate import fresh_config
     import sqlalchemy
-    if os.path.exists("monitoring.db"):
+    if os.path.exists("runinfo/monitoring.db"):
         logger.info("Monitoring database already exists - deleting")
-        os.remove("monitoring.db")
+        os.remove("runinfo/monitoring.db")
 
     engine = sqlalchemy.create_engine("sqlite:///runinfo/monitoring.db")
 

--- a/parsl/tests/test_monitoring/test_db_locks.py
+++ b/parsl/tests/test_monitoring/test_db_locks.py
@@ -20,7 +20,7 @@ def test_row_counts():
         logger.info("Monitoring database already exists - deleting")
         os.remove("monitoring.db")
 
-    engine = sqlalchemy.create_engine("sqlite:///monitoring.db")
+    engine = sqlalchemy.create_engine("sqlite:///runinfo/monitoring.db")
 
     logger.info("loading parsl")
     parsl.load(fresh_config())

--- a/parsl/tests/test_monitoring/test_fuzz_zmq.py
+++ b/parsl/tests/test_monitoring/test_fuzz_zmq.py
@@ -18,9 +18,9 @@ def test_row_counts():
     from parsl.tests.configs.htex_local_alternate import fresh_config
     import sqlalchemy
 
-    if os.path.exists("monitoring.db"):
+    if os.path.exists("runinfo/monitoring.db"):
         logger.info("Monitoring database already exists - deleting")
-        os.remove("monitoring.db")
+        os.remove("runinfo/monitoring.db")
 
     logger.info("loading parsl")
     parsl.load(fresh_config())

--- a/parsl/tests/test_monitoring/test_fuzz_zmq.py
+++ b/parsl/tests/test_monitoring/test_fuzz_zmq.py
@@ -78,7 +78,7 @@ def test_row_counts():
     # at this point, we should find one row in the monitoring database.
 
     logger.info("checking database content")
-    engine = sqlalchemy.create_engine("sqlite:///monitoring.db")
+    engine = sqlalchemy.create_engine("sqlite:///runinfo/monitoring.db")
     with engine.begin() as connection:
 
         result = connection.execute("SELECT COUNT(*) FROM workflow")

--- a/parsl/tests/test_monitoring/test_memoization_representation.py
+++ b/parsl/tests/test_monitoring/test_memoization_representation.py
@@ -17,9 +17,9 @@ def test_hashsum():
     import sqlalchemy
     from parsl.tests.configs.htex_local_alternate import fresh_config
 
-    if os.path.exists("monitoring.db"):
+    if os.path.exists("runinfo/monitoring.db"):
         logger.info("Monitoring database already exists - deleting")
-        os.remove("monitoring.db")
+        os.remove("runinfo/monitoring.db")
 
     logger.info("loading parsl")
     parsl.load(fresh_config())

--- a/parsl/tests/test_monitoring/test_memoization_representation.py
+++ b/parsl/tests/test_monitoring/test_memoization_representation.py
@@ -51,7 +51,7 @@ def test_hashsum():
     # at this point, we should find one row in the monitoring database.
 
     logger.info("checking database content")
-    engine = sqlalchemy.create_engine("sqlite:///monitoring.db")
+    engine = sqlalchemy.create_engine("sqlite:///runinfo/monitoring.db")
     with engine.begin() as connection:
 
         # we should have three tasks, but with only two tries, because the


### PR DESCRIPTION
# Description

This change was made to keep all parsl files in runinfo and to maintain a sense of tidiness.

Fixes #2136

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

