### PR TITLE
Make retry tests wait for all launched tasks before finishing

### DIFF
--- a/parsl/tests/test_error_handling/test_retries.py
+++ b/parsl/tests/test_error_handling/test_retries.py
@@ -55,14 +55,15 @@ def test_fail_nowait(numtasks=10):
         fu = sleep_then_fail(sleep_dur=0.1)
         fus.extend([fu])
 
+    # wait for all tasks to complete before ending this test
+    [x.exception() for x in fus]
+
     try:
         [x.result() for x in fus]
     except Exception as e:
         assert isinstance(
             e, TypeError), "Expected a TypeError, got {}".format(e)
 
-    # wait for all tasks to complete before ending this test
-    [x.exception() for x in fus]
     print("Done")
 
 
@@ -80,14 +81,15 @@ def test_fail_delayed(numtasks=10):
         fu = sleep_then_fail(inputs=[x], sleep_dur=0.5)
         fus.extend([fu])
 
+    # wait for all tasks to complete before ending this test
+    [x.exception() for x in fus]
+
     try:
         [x.result() for x in fus]
     except Exception as e:
         assert isinstance(
             e, TypeError), "Expected a TypeError, got {}".format(e)
 
-    # wait for all tasks to complete before ending this test
-    [x.exception() for x in fus]
     print("Done")
 
 

--- a/parsl/tests/test_error_handling/test_retries.py
+++ b/parsl/tests/test_error_handling/test_retries.py
@@ -61,6 +61,8 @@ def test_fail_nowait(numtasks=10):
         assert isinstance(
             e, TypeError), "Expected a TypeError, got {}".format(e)
 
+    # wait for all tasks to complete before ending this test
+    [x.exception() for x in fus]
     print("Done")
 
 
@@ -84,6 +86,8 @@ def test_fail_delayed(numtasks=10):
         assert isinstance(
             e, TypeError), "Expected a TypeError, got {}".format(e)
 
+    # wait for all tasks to complete before ending this test
+    [x.exception() for x in fus]
     print("Done")
 
 


### PR DESCRIPTION
Without this, the tasks continue to run while subsequent local
tests happen. This is at the least confusing in logs - I haven't
checked if it introduces any actual testing problems.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
