### PR TITLE
Make scale in of htex_auto_scale more effective

### DIFF
--- a/parsl/dataflow/strategy.py
+++ b/parsl/dataflow/strategy.py
@@ -262,7 +262,10 @@ class Strategy(object):
                     logger.debug("More slots than tasks")
                     if isinstance(executor, HighThroughputExecutor):
                         if active_blocks > min_blocks:
-                            exec_status.scale_in(1, force=False, max_idletime=self.max_idletime)
+                            exec_status.scale_in(
+                                active_blocks - active_tasks // tasks_per_node // nodes_per_block,
+                                force=False, max_idletime=self.max_idletime
+                            )
 
                 elif strategy_type == 'simple':
                     # skip for simple strategy

--- a/parsl/dataflow/strategy.py
+++ b/parsl/dataflow/strategy.py
@@ -242,8 +242,8 @@ class Strategy(object):
                 # Case 2b
                 else:
                     # logger.debug("Strategy: Case.2b")
-                    excess = math.ceil((active_tasks * parallelism) - active_slots)
-                    excess_blocks = math.ceil(float(excess) / (tasks_per_node * nodes_per_block))
+                    excess_slots = math.ceil((active_tasks * parallelism) - active_slots)
+                    excess_blocks = math.ceil(float(excess_slots) / (tasks_per_node * nodes_per_block))
                     excess_blocks = min(excess_blocks, max_blocks - active_blocks)
                     logger.debug("Requesting {} more blocks".format(excess_blocks))
                     exec_status.scale_out(excess_blocks)
@@ -262,8 +262,8 @@ class Strategy(object):
                     logger.debug("More slots than tasks")
                     if isinstance(executor, HighThroughputExecutor):
                         if active_blocks > min_blocks:
-                            excess = math.ceil(active_slots - (active_tasks * parallelism))
-                            excess_blocks = math.ceil(float(excess) / (tasks_per_node * nodes_per_block))
+                            excess_slots = math.ceil(active_slots - (active_tasks * parallelism))
+                            excess_blocks = math.ceil(float(excess_slots) / (tasks_per_node * nodes_per_block))
                             excess_blocks = min(excess_blocks, active_blocks - min_blocks)
                             exec_status.scale_in(excess_blocks, force=False, max_idletime=self.max_idletime)
 

--- a/parsl/dataflow/strategy.py
+++ b/parsl/dataflow/strategy.py
@@ -262,10 +262,10 @@ class Strategy(object):
                     logger.debug("More slots than tasks")
                     if isinstance(executor, HighThroughputExecutor):
                         if active_blocks > min_blocks:
-                            exec_status.scale_in(
-                                active_blocks - active_tasks // tasks_per_node // nodes_per_block,
-                                force=False, max_idletime=self.max_idletime
-                            )
+                            excess = math.ceil(active_slots - (active_tasks * parallelism))
+                            excess_blocks = math.ceil(float(excess) / (tasks_per_node * nodes_per_block))
+                            excess_blocks = min(excess_blocks, active_blocks - min_blocks)
+                            exec_status.scale_in(excess_blocks, force=False, max_idletime=self.max_idletime)
 
                 elif strategy_type == 'simple':
                     # skip for simple strategy


### PR DESCRIPTION
# Description

For htex_auto_scale instead of removing only 1 block at most in case there are more slots than tasks, remove try to remove many blocks so that the number of slots matches the number of tasks. This is of course still limited by how many blocks have reached the configured max_idletime.

Fixes #2195

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
