### PR TITLE
CI fixing megablast

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9"]
     runs-on: ubuntu-20.04
-    timeout-minutes: 60
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@master

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ release: deps tag package deploy   ## create a release. To run, do a 'make VERSI
 .PHONY: coverage
 coverage: ## show the coverage report
 	# coverage report
-        echo no-op coverage report
+	echo no-op coverage report
 
 .PHONY: clean
 clean: ## clean up the environment by deleting the .venv, dist, eggs, mypy caches, coverage info, etc

--- a/Makefile
+++ b/Makefile
@@ -57,34 +57,34 @@ mypy: ## run mypy checks
 
 .PHONY: local_thread_test
 local_thread_test: ## run all tests with local_thread config
-	pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/local_threads.py --cov=parsl --cov-append --cov-report= --random-order
+	pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/local_threads.py --random-order
 
 .PHONY: htex_local_test
 htex_local_test: ## run all tests with htex_local config
-	PYTHONPATH=.  pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/htex_local.py --cov=parsl --cov-append --cov-report= --random-order
+	PYTHONPATH=.  pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/htex_local.py --random-order
 
 .PHONY: htex_local_alternate_test
 htex_local_alternate_test: ## run all tests with htex_local config
 	pip3 install ".[monitoring]"
-	PYTHONPATH=.  pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/htex_local_alternate.py --cov=parsl --cov-append --cov-report= --random-order
+	PYTHONPATH=.  pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/htex_local_alternate.py --random-order
 
 $(WORKQUEUE_INSTALL):
 	parsl/executors/workqueue/install-workqueue.sh
 
 .PHONY: workqueue_ex_test
 workqueue_ex_test: $(WORKQUEUE_INSTALL)  ## run all tests with workqueue_ex config
-	PYTHONPATH=.:/tmp/cctools/lib/python3.8/site-packages  pytest parsl/tests/ -k "not cleannet and not issue363" --config parsl/tests/configs/workqueue_ex.py --cov=parsl --cov-append --cov-report= --random-order
+	PYTHONPATH=.:/tmp/cctools/lib/python3.8/site-packages  pytest parsl/tests/ -k "not cleannet and not issue363" --config parsl/tests/configs/workqueue_ex.py --random-order
 
 .PHONY: config_local_test
 config_local_test: ## run all tests with workqueue_ex config
 	echo "$(MPI)"
 	parsl/executors/extreme_scale/install-mpi.sh $(MPI)
 	pip3 install ".[extreme_scale,monitoring]"
-	PYTHONPATH=. pytest parsl/tests/ -k "not cleannet" --config local --cov=parsl --cov-append --cov-report= --random-order
+	PYTHONPATH=. pytest parsl/tests/ -k "not cleannet" --config local --random-order
 
 .PHONY: site_test
 site_test:
-	pytest parsl/tests/ -k "not cleannet" ${SHARED_FS_OPTIONS} --config parsl/tests/site_tests/site_config_selector.py --cov=parsl --cov-append --cov-report= --random-order
+	pytest parsl/tests/ -k "not cleannet" ${SHARED_FS_OPTIONS} --config parsl/tests/site_tests/site_config_selector.py --random-order
 	pytest parsl/tests/site_tests/ ${SHARED_FS_OPTIONS} --config local
 
 .PHONY: test ## run all tests with all config types
@@ -107,7 +107,8 @@ release: deps tag package deploy   ## create a release. To run, do a 'make VERSI
 
 .PHONY: coverage
 coverage: ## show the coverage report
-	coverage report
+	# coverage report
+        echo no-op coverage report
 
 .PHONY: clean
 clean: ## clean up the environment by deleting the .venv, dist, eggs, mypy caches, coverage info, etc

--- a/README.rst
+++ b/README.rst
@@ -124,3 +124,4 @@ sheet <https://sustainable-open-science-and-software.github.io/assets/PIS_sustai
 
 
 
+

--- a/README.rst
+++ b/README.rst
@@ -121,3 +121,4 @@ page <https://sustainable-open-science-and-software.github.io/>`__ or
 download the `participant information
 sheet <https://sustainable-open-science-and-software.github.io/assets/PIS_sustainable_software.pdf>`__.
 
+

--- a/README.rst
+++ b/README.rst
@@ -120,3 +120,4 @@ For more information, please visit `the informational
 page <https://sustainable-open-science-and-software.github.io/>`__ or
 download the `participant information
 sheet <https://sustainable-open-science-and-software.github.io/assets/PIS_sustainable_software.pdf>`__.
+

--- a/README.rst
+++ b/README.rst
@@ -123,3 +123,4 @@ sheet <https://sustainable-open-science-and-software.github.io/assets/PIS_sustai
 
 
 
+

--- a/README.rst
+++ b/README.rst
@@ -122,3 +122,4 @@ download the `participant information
 sheet <https://sustainable-open-science-and-software.github.io/assets/PIS_sustainable_software.pdf>`__.
 
 
+

--- a/README.rst
+++ b/README.rst
@@ -120,4 +120,3 @@ For more information, please visit `the informational
 page <https://sustainable-open-science-and-software.github.io/>`__ or
 download the `participant information
 sheet <https://sustainable-open-science-and-software.github.io/assets/PIS_sustainable_software.pdf>`__.
-

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1078,12 +1078,15 @@ class DataFlowKernel(object):
         self.usage_tracker.send_message()
         self.usage_tracker.close()
 
-        logger.info("Terminating flow_control and strategy threads")
+        logger.info("Closing flowcontrol")
         self.flowcontrol.close()
+
+        logger.info("Scaling in and shutting down executors")
 
         for executor in self.executors.values():
             if executor.managed and not executor.bad_state_is_set:
                 if executor.scaling_enabled:
+                    logger.info(f"Scaling in executor {executor.label}")
                     job_ids = executor.provider.resources.keys()
                     block_ids = executor.scale_in(len(job_ids))
                     if self.monitoring and block_ids:
@@ -1093,7 +1096,12 @@ class DataFlowKernel(object):
                         msg = executor.create_monitoring_info(new_status)
                         logger.debug("Sending message {} to hub from DFK".format(msg))
                         self.monitoring.send(MessageType.BLOCK_INFO, msg)
+                logger.info(f"Shutting down executor {executor.label}")
                 executor.shutdown()
+            elif executor.managed and executor.bad_state_is_set:  # and bad_state_is_set
+                logger.warn(f"Not shutting down executor {executor.label} because it is in bad state")
+            else:
+                logger.info(f"Not shutting down executor {executor.label} because it is unmanaged")
 
         self.time_completed = datetime.datetime.now()
 

--- a/parsl/executors/errors.py
+++ b/parsl/executors/errors.py
@@ -15,7 +15,7 @@ class ExecutorError(ParslError):
         self.reason = reason
 
     def __str__(self):
-        return "Executor {0} failed due to: {1}".format(self.executor, self.reason)
+        return "Executor {0} failed due to: {1}".format(self.executor.label, self.reason)
 
 
 class BadStateException(ExecutorError):

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -684,18 +684,10 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         launch_cmd = self.launch_cmd.format(block_id=block_id)
         return launch_cmd
 
-    def shutdown(self, hub=True, targets='all', block=False):
+    def shutdown(self):
         """Shutdown the executor, including all workers and controllers.
-
-        This is not implemented.
-
-        Kwargs:
-            - hub (Bool): Whether the hub should be shutdown, Default: True,
-            - targets (list of ints| 'all'): List of block id's to kill, Default: 'all'
-            - block (Bool): To block for confirmations or not
         """
 
         logger.info("Attempting HighThroughputExecutor shutdown")
         self.queue_proc.terminate()
         logger.info("Finished HighThroughputExecutor shutdown attempt")
-        return True

--- a/parsl/tests/site_tests/test_provider.py
+++ b/parsl/tests/site_tests/test_provider.py
@@ -61,8 +61,8 @@ def test_provider():
     # A new PR will handle removing blocks from self.block
     # this includes failed/completed/canceled blocks
     assert len(current_jobs) == 1, "Expected current_jobs == 1"
+    dfk.cleanup()
     parsl.clear()
-    del dfk
     logger.info("Ended test_provider")
     return True
 

--- a/parsl/tests/site_tests/test_site.py
+++ b/parsl/tests/site_tests/test_site.py
@@ -45,8 +45,8 @@ def test_platform(n=2, sleep_dur=10):
 
     print("Test passed")
 
+    dfk.cleanup()
     parsl.clear()
-    del dfk
     return True
 
 

--- a/parsl/tests/sites/test_dynamic_executor.py
+++ b/parsl/tests/sites/test_dynamic_executor.py
@@ -72,6 +72,8 @@ def test_dynamic_executor():
     print("Successfully added htex executor and ran with it. The results are", results)
 
     print("Done testing")
+
+    dfk.cleanup()
     parsl.clear()
 
 

--- a/parsl/tests/test-viz.sh
+++ b/parsl/tests/test-viz.sh
@@ -11,7 +11,7 @@ if  [ -n "$1" ]; then
   pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/htex_local_alternate.py --cov=parsl --cov-append --cov-report= --random-order
 fi
 
-parsl-visualize &
+parsl-visualize --debug &
 
 mkdir -p test-parsl-visualize.tmp
 cd test-parsl-visualize.tmp

--- a/parsl/tests/test_checkpointing/test_python_checkpoint_1.py
+++ b/parsl/tests/test_checkpointing/test_python_checkpoint_1.py
@@ -44,6 +44,8 @@ def test_initial_checkpoint_write(n=2):
         cptpath), "Tasks checkpoint missing: {0}".format(cptpath)
 
     run_dir = parsl.dfk().run_dir
+
+    parsl.dfk().cleanup()
     parsl.clear()
 
     return run_dir, results

--- a/parsl/tests/test_checkpointing/test_python_checkpoint_2.py
+++ b/parsl/tests/test_checkpointing/test_python_checkpoint_2.py
@@ -41,6 +41,7 @@ def test_loading_checkpoint(n=2):
 
     for i in range(n):
         assert relaunched[i] == results[i], "Expected relaunched to contain cached results from first run"
+    parsl.dfk().cleanup()
     parsl.clear()
 
 

--- a/parsl/tests/test_checkpointing/test_python_checkpoint_3.py
+++ b/parsl/tests/test_checkpointing/test_python_checkpoint_3.py
@@ -13,6 +13,7 @@ def local_setup():
 
 
 def local_teardown():
+    parsl.dfk().cleanup()
     parsl.clear()
 
 

--- a/parsl/tests/test_checkpointing/test_task_exit.py
+++ b/parsl/tests/test_checkpointing/test_task_exit.py
@@ -15,6 +15,7 @@ def local_setup():
 
 
 def local_teardown():
+    parsl.dfk().cleanup
     parsl.clear()
 
 

--- a/parsl/tests/test_error_handling/test_htex_basic.py
+++ b/parsl/tests/test_error_handling/test_htex_basic.py
@@ -13,6 +13,7 @@ def local_setup():
 
 
 def local_teardown():
+    parsl.dfk().cleanup()
     parsl.clear()
 
 

--- a/parsl/tests/test_error_handling/test_htex_missing_worker.py
+++ b/parsl/tests/test_error_handling/test_htex_missing_worker.py
@@ -14,6 +14,7 @@ def local_setup():
 
 
 def local_teardown():
+
     parsl.dfk().cleanup()
     parsl.clear()
 
@@ -34,3 +35,9 @@ def test_that_it_fails():
         failed = True
     if not failed:
         raise Exception("The app somehow ran without a valid worker")
+
+    assert parsl.dfk().config.executors[0]._executor_bad_state.is_set()
+
+    # htex needs shutting down explicitly because dfk.cleanup() will not
+    # do that, as it is in bad state
+    parsl.dfk().config.executors[0].shutdown()

--- a/parsl/tests/test_error_handling/test_htex_worker_failure.py
+++ b/parsl/tests/test_error_handling/test_htex_worker_failure.py
@@ -15,6 +15,7 @@ def local_setup():
 
 
 def local_teardown():
+    parsl.dfk().cleanup()
     parsl.clear()
 
 

--- a/parsl/tests/test_error_handling/test_retries.py
+++ b/parsl/tests/test_error_handling/test_retries.py
@@ -61,6 +61,8 @@ def test_fail_nowait(numtasks=10):
         assert isinstance(
             e, TypeError), "Expected a TypeError, got {}".format(e)
 
+    # wait for all tasks to complete before ending this test
+    [x.exception() for x in fus]
     print("Done")
 
 
@@ -84,6 +86,8 @@ def test_fail_delayed(numtasks=10):
         assert isinstance(
             e, TypeError), "Expected a TypeError, got {}".format(e)
 
+    # wait for all tasks to complete before ending this test
+    [x.exception() for x in fus]
     print("Done")
 
 

--- a/parsl/tests/test_flowcontrol/test_one_block.py
+++ b/parsl/tests/test_flowcontrol/test_one_block.py
@@ -61,6 +61,7 @@ def test_one_block():
 
     f = app()
     f.result()
+    parsl.dfk().cleanup()
     parsl.clear()
 
     assert oneshot_provider.recorded_submits == 1

--- a/parsl/tests/test_flowcontrol/test_python_diamond.py
+++ b/parsl/tests/test_flowcontrol/test_python_diamond.py
@@ -17,6 +17,7 @@ def local_setup():
 
 
 def local_teardown():
+    parsl.dfk().cleanup()
     parsl.clear()
 
 

--- a/parsl/tests/test_staging/test_1316.py
+++ b/parsl/tests/test_staging/test_1316.py
@@ -59,6 +59,7 @@ def test_1316_local_path_on_execution_side_sp2():
 
     assert not file.local_path, "The local_path on the submit side should not be set"
 
+    parsl.dfk().cleanup()
     parsl.clear()
 
 
@@ -81,4 +82,5 @@ def test_1316_local_path_setting_preserves_dependency_sp2():
 
     assert not file.local_path, "The local_path on the submit side should not be set"
 
+    parsl.dfk().cleanup()
     parsl.clear()

--- a/parsl/tests/test_threads/test_lazy_errors.py
+++ b/parsl/tests/test_threads/test_lazy_errors.py
@@ -23,6 +23,7 @@ def test_lazy_behavior():
         assert isinstance(f.exception(), ZeroDivisionError)
         assert f.done()
 
+    parsl.dfk().cleanup()
     parsl.clear()
     return
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_require = {
         'networkx',
         'Flask>=1.0.2',
         'flask_sqlalchemy',
-        'pandas',
+        'pandas<1.4',
         'plotly',
         'python-daemon'
     ],


### PR DESCRIPTION
CI was down to less than 50% of builds passing, and then to 100% failure with a new release of pandas.

This PR contains a number of distinct changes which I have tried for fixing and debugging CI, none on which were in themselves completely reliable.

This PR has passed 6 times in a row with no code changes, so the reliability looks like it is massively increased. I still think there is some broken behaviour, as the reason that 6 is only 6 is because the 7th to last test hung, and all that's changed since then is addition of some logging around the suspicious area.