### PR TITLE
Add python 3.10, drop python 3.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
   main-test-suite:
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     runs-on: ubuntu-20.04
     timeout-minutes: 30
 

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ The latest Parsl version available on PyPi is v1.1.0.
 QuickStart
 ==========
 
-Parsl is now available on PyPI, but first make sure you have Python3.6+ ::
+Parsl is now available on PyPI, but first make sure you have Python3.7+ ::
 
     $ python3 --version
 
@@ -93,7 +93,7 @@ For Developers
 Requirements
 ============
 
-Parsl is supported in Python 3.6+. Requirements can be found `here <requirements.txt>`_. Requirements for running tests can be found `here <test-requirements.txt>`_.
+Parsl is supported in Python 3.7+. Requirements can be found `here <requirements.txt>`_. Requirements for running tests can be found `here <test-requirements.txt>`_.
 
 Code of Conduct
 ============

--- a/codemeta.json
+++ b/codemeta.json
@@ -191,8 +191,8 @@
         "name": "The Python Package Index",
         "url": "https://pypi.org"
     },
-    "runtimePlatform": "Python 3.6.4",
+    "runtimePlatform": "Python 3.7",
     "url": "https://github.com/Parsl/parsl",
     "developmentStatus": "3 - Alpha",
-    "programmingLanguage": "Python :: 3.6"
+    "programmingLanguage": "Python :: 3.7"
 }

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -31,8 +31,8 @@ Installation using Conda
 
 1. Create and activate a new conda environment::
 
-     $ conda create --name parsl_py36 python=3.6
-     $ source activate parsl_py36
+     $ conda create --name parsl_py37 python=3.7
+     $ source activate parsl_py37
 
 2. Install Parsl::
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     download_url='https://github.com/Parsl/parsl/archive/{}.tar.gz'.format(VERSION),
     include_package_data=True,
     packages=find_packages(),
-    python_requires=">=3.6.0",
+    python_requires=">=3.7.0",
     install_requires=install_requires,
     scripts = ['parsl/executors/high_throughput/process_worker_pool.py',
                'parsl/executors/extreme_scale/mpi_worker_pool.py',
@@ -60,7 +60,7 @@ setup(
         # Licence, must match with licence above
         'License :: OSI Approved :: Apache Software License',
         # Python versions supported
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
# Description
Python 3.10 was released 2021-10-04  (see https://www.python.org/dev/peps/pep-0619/)
Python 3.6 was end-of-lifed 2021-12-23 (see https://www.python.org/dev/peps/pep-0494/#lifespan)

## Type of change

- Code maintentance/cleanup
