### PR TITLE
Eliminate pytest nose and upgrade pytest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
-nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/

--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -232,9 +232,8 @@ def pytest_make_collect_report(collector):
     if not call.excinfo:
         outcome = "passed"
     else:
-        from _pytest import nose
         from _pytest.outcomes import Skipped
-        skip_exceptions = (Skipped,) + nose.get_skip_exceptions()
+        skip_exceptions = (Skipped,)
         if call.excinfo.errisinstance(KeyError):
             outcome = "skipped"
             r = collector._repr_failure_py(call.excinfo, "line").reprcrash

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
 flake8==3.8.0
 ipyparallel
 pandas
-pytest>=4.6,<5
+pytest>=6.2.5,<7
 pytest-cov
 pytest-xdist==1.26.1
 pytest-random-order


### PR DESCRIPTION
# Description

Older pytest was causing problems in a couple of places: python 3.10 support, exaworks development

Newer pytest changes/removes how it deals with `nose` test compatibility; but parsl stopped doing nose tests in #272 in 2018, so this PR removes those vestiges.

## Type of change

- Code maintentance/cleanup
