### PR TITLE
Export type annotations using PEP561 convention

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     license='Apache 2.0',
     download_url='https://github.com/Parsl/parsl/archive/{}.tar.gz'.format(VERSION),
     include_package_data=True,
+    package_data={'parsl': ['py.typed']},
     packages=find_packages(),
     python_requires=">=3.6.0",
     install_requires=install_requires,


### PR DESCRIPTION
This allows source code which uses Parsl to take advantage of the
currently very limited type annotations that are present on Parsl
code if/when they are checked with mypy.

Prior to this, those type annotations were used for:
 - internal self consistency with mypy
 - runtime checking with typeguard

I've been seeing increasing use of type annotations on user code
recently so I think it makes sense to export our declarations for
use by downstream users.

This work is driven most immediately by integration with exaworks,
where the psij code is heavily type checked and I would like the
interface code to be as type-checked as possible given what exists
already.

## Type of change

- New feature (non-breaking change that adds functionality)
