### PR TITLE
Add type annotations for provider_base.py and fix some bugs there

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,17 @@ plugins = sqlmypy
 [mypy-non_existent.*]
 ignore_missing_imports = True
 
+[mypy-parsl.providers.provider_base.*]
+no_implicit_optional = True
+strict_equality = True
+disallow_untyped_decorators = True
+warn_unused_ignores = True
+check_untyped_defs = True
+no_implicit_reexport = True
+disallow_subclassing_any = True
+warn_unreachable = True
+disallow_untyped_defs = True
+
 [mypy-parsl.monitoring.*]
 no_implicit_optional = True
 strict_equality = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,11 @@ plugins = sqlmypy
 [mypy-non_existent.*]
 ignore_missing_imports = True
 
+# some subpackages in parsl are fully typed and should be checked with much
+# stricter type checking options - a longer term goal might be for all of
+# parsl to be checked that way, so these options could be default instead of
+# listed per package; but unless/until that happens, the more-strictly-checked
+# code should be listed here:
 [mypy-parsl.providers.provider_base.*]
 no_implicit_optional = True
 strict_equality = True

--- a/parsl/providers/provider_base.py
+++ b/parsl/providers/provider_base.py
@@ -29,8 +29,8 @@ class JobStatus(object):
     """Encapsulates a job state together with other details, presently a (error) message"""
     SUMMARY_TRUNCATION_THRESHOLD = 2048
 
-    def __init__(self, state: JobState, message: str = None, exit_code: Optional[int] = None,
-                 stdout_path: str = None, stderr_path: str = None):
+    def __init__(self, state: JobState, message: Optional[str] = None, exit_code: Optional[int] = None,
+                 stdout_path: Optional[str] = None, stderr_path: Optional[str] = None):
         self.state = state
         self.message = message
         self.exit_code = exit_code
@@ -38,28 +38,30 @@ class JobStatus(object):
         self.stderr_path = stderr_path
 
     @property
-    def terminal(self):
+    def terminal(self) -> bool:
         return self.state.terminal
 
     @property
-    def status_name(self):
+    def status_name(self) -> str:
         return self.state.status_name
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.message is not None:
             return "{} ({})".format(self.state, self.message)
         else:
             return "{}".format(self.state)
 
     @property
-    def stdout(self):
+    def stdout(self) -> Optional[str]:
         return self._read_file(self.stdout_path)
 
     @property
-    def stderr(self):
+    def stderr(self) -> Optional[str]:
         return self._read_file(self.stderr_path)
 
-    def _read_file(self, path):
+    def _read_file(self, path: Optional[str]) -> Optional[str]:
+        if path is None:
+            return None
         try:
             with open(path, 'r') as f:
                 return f.read()
@@ -67,14 +69,14 @@ class JobStatus(object):
             return None
 
     @property
-    def stdout_summary(self):
+    def stdout_summary(self) -> Optional[str]:
         return self._read_summary(self.stdout_path)
 
     @property
-    def stderr_summary(self):
+    def stderr_summary(self) -> Optional[str]:
         return self._read_summary(self.stderr_path)
 
-    def _read_summary(self, path):
+    def _read_summary(self, path: Optional[str]) -> Optional[str]:
         if not path:
             # can happen for synthetic job failures
             return None

--- a/parsl/providers/provider_base.py
+++ b/parsl/providers/provider_base.py
@@ -7,13 +7,16 @@ from typing import Any, List, Optional
 class JobState(bytes, Enum):
     """Defines a set of states that a job can be in"""
 
-    def __new__(cls, value, terminal, status_name):
-        # noinspection PyArgumentList
+    def __new__(cls, value: int, terminal: bool, status_name: str) -> "JobState":
         obj = bytes.__new__(cls, [value])
         obj._value_ = value
         obj.terminal = terminal
         obj.status_name = status_name
         return obj
+
+    value: int
+    terminal: bool
+    status_name: str
 
     UNKNOWN = (0, False, "UNKNOWN")
     PENDING = (1, False, "PENDING")


### PR DESCRIPTION
# Description

Most of these annotations have been brewing in the `benc-mypy` branch for a while. My recent work on exaworks psij, which has much stronger type-checking, has pushed me to want these annotations in mainstream parsl while implementing a parsl provider which interfaces with psij.

Implementing this interface with psij and using these type annotations has revealed a bug when a job status is created with a `None` stdout or stderr: a default None stdout or stderr path causes an exception when accessing the `stdout` or `stderr` property. This is fixed to return `None` in that case.

~~This PR uses some python >=3.7 syntax, so probably can't be merged unless Python 3.6 support is dropped - see PR #2208 - keeping this PR as draft until then~~

## Type of change

- Bugfix
- New feature (non-breaking change that adds functionality)
