### PR TITLE
Remove a TODO about runid configuration

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -110,7 +110,6 @@ class DataFlowKernel(object):
         self.time_began = datetime.datetime.now()
         self.time_completed = None
 
-        # TODO: make configurable
         logger.info("Run id is: " + self.run_id)
 
         self.workflow_name = None


### PR DESCRIPTION
# Description

This value is a surrogate key generated by parsl. Reuse of runids will break lots of assumptions about runid uniqueness. It shouldn't be user configurable.

There are other  fields for identifying run identity according to the users identity rules (workflow name and version), as well as the ability to use the generated runid as a key into a different user-controlled data structure.

## Type of change

- Code maintentance/cleanup
