### PR TITLE
Rephrase optional module missing error

### DIFF
--- a/parsl/errors.py
+++ b/parsl/errors.py
@@ -12,6 +12,6 @@ class OptionalModuleMissing(ParslError):
         self.reason = reason
 
     def __str__(self) -> str:
-        return "The functionality requested requires missing optional modules {0}, because: {1}".format(
+        return "The functionality requested requires optional modules {0} which could not be imported, because: {1}".format(
             self.module_names, self.reason
         )


### PR DESCRIPTION
This error can be raised when an optional module failed to import
for any reason, not just because the optional module is missing.

A recent example is that sqlalchemy released a new incompatible
version which parsl's requirements spec was not protecting against.
This was fixed in PR #1994.

## Type of change

- Documentation update
