### PR TITLE
Update hook advice in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -140,8 +140,7 @@ Developers may find it useful to setup a pre-commit git hook to automatically li
     $ cat ~/parsl/.git/hooks/pre-commit
     #!/bin/sh
 
-    flake8 parsl
-    nosetests -vx parsl/tests/test_threads parsl/tests/test_data parsl/tests/test_checkpointing
+    make lint flake8 mypy local_thread_test
 
 Project documentation
 ---------------------


### PR DESCRIPTION
This takes into account that additional cheap linting is available
with mypy and the __init__ directory checker script, and that tests
are no longer invoked with nose.

## Type of change

- Documentation update
