### PR TITLE
Correct misleading docstring on confusing hub port vs hub port range

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -143,10 +143,17 @@ class MonitoringHub(RepresentationMixin):
         hub_address : str
              The ip address at which the workers will be able to reach the Hub.
         hub_port : int
-             The specific port at which workers will be able to reach the Hub via UDP. Default: None
+             The UDP port to which workers will be able to deliver messages to
+             the monitoring router.
+             Note that despite the similar name, this is not related to
+             hub_port_range.
+             Default: None
         hub_port_range : tuple(int, int)
-             The MonitoringHub picks ports at random from the range which will be used by Hub.
-             This is overridden when the hub_port option is set. Default: (55050, 56000)
+             The port range for a ZMQ channel from an executor process
+             (for example, the interchange in the High Throughput Executor)
+             to deliver monitoring messages to the monitoring router.
+             Note that despite the similar name, this is not related to hub_port.
+             Default: (55050, 56000)
         client_address : str
              The ip address at which the dfk will be able to reach Hub. Default: "127.0.0.1"
         client_port_range : tuple(int, int)


### PR DESCRIPTION
Although the naming and previous docstring suggest that the two parameters
work together to define a single port which either is specified explicitly
or comes from the supplied range, this is not true.

Two listening ports are used:

* one for the UDP receiver for message from workers

and

* one for ZMQ queue from from the htex interchange (or any other executor
  that wants it)

The UDP port is either `hub_port` or an arbitrary system-allocated port,
ignoring hub_port_range.

The ZMQ queue port is always chosen from `hub_port_range`, which has a
default value so a user is not required to specify it. `hub_port` is never used
for this port.

## Type of change

- Documentation update
