### PR TITLE
adds wraps to monitoring so functions have their names back

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -6,6 +6,7 @@ import time
 import typeguard
 import datetime
 import zmq
+from functools import wraps
 
 import queue
 from parsl.multiprocessing import ForkProcess, SizedQueue
@@ -324,6 +325,7 @@ class MonitoringHub(RepresentationMixin):
         """ Internal
         Wrap the Parsl app with a function that will call the monitor function and point it at the correct pid when the task begins.
         """
+        @wraps(f)
         def wrapped(*args: List[Any], **kwargs: Dict[str, Any]) -> Any:
             # Send first message to monitoring router
             send_first_message(try_id,


### PR DESCRIPTION
# Description

Callables lose their name attributes when monitoring is turned on as the wrapper function for monitoring doesn't wrap callables correctly. More details can be found in this [issue](https://github.com/cooperative-computing-lab/cctools/issues/2813). Issue is now fixed using wrap decorator from functools module.

## Type of change

Choose which options apply, and delete the ones which do not apply.
- Breaking change (fix or feature that would cause existing functionality to not work as expected)