### PR TITLE
Fix broken PR #2192 task state counting

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -459,7 +459,7 @@ class DataFlowKernel(object):
         """
 
         with self.task_state_counts_lock:
-            if hasattr(task_record, 'status'):
+            if 'status' in task_record:
                 self.task_state_counts[task_record['status']] -= 1
             self.task_state_counts[new_state] += 1
             task_record['status'] = new_state


### PR DESCRIPTION
task_record stores data as dictionary entries, not as attributes,
and PR #2192 used the wrong membership test for that.

Because of that, old task states were not being decremented ever.

Prior to this commit:

2022-02-17 15:51:50.231 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.unsched: 298
2022-02-17 15:51:50.231 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.pending: 298
2022-02-17 15:51:50.231 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.running: 0
2022-02-17 15:51:50.231 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.exec_done: 238
2022-02-17 15:51:50.232 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.failed: 36
2022-02-17 15:51:50.232 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.dep_fail: 11
2022-02-17 15:51:50.232 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.launched: 268
2022-02-17 15:51:50.232 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.fail_retryable: 0
2022-02-17 15:51:50.232 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.memo_done: 13
2022-02-17 15:51:50.232 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.joining: 41

With this commit:

2022-02-17 15:55:26.279 parsl.dataflow.dflow:952 [INFO]  Summary of tasks in DFK:
2022-02-17 15:55:26.279 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.unsched: 0
2022-02-17 15:55:26.279 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.pending: 0
2022-02-17 15:55:26.279 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.running: 0
2022-02-17 15:55:26.279 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.exec_done: 238
2022-02-17 15:55:26.279 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.failed: 36
2022-02-17 15:55:26.279 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.dep_fail: 11
2022-02-17 15:55:26.279 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.launched: 0
2022-02-17 15:55:26.279 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.fail_retryable: 0
2022-02-17 15:55:26.279 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.memo_done: 13
2022-02-17 15:55:26.279 parsl.dataflow.dflow:956 [INFO]  Tasks in state States.joining: 0


## Type of change


- Bug fix (non-breaking change that fixes an issue)
