### PR TITLE
Fix race condition between WorkQueue task submission and scaling

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -623,9 +623,10 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         implemented and probably could be replaced with a counter.
         """
         outstanding = 0
-        for fut in self.tasks.values():
-            if not fut.done():
-                outstanding += 1
+        with self.tasks_lock:
+            for fut in self.tasks.values():
+                if not fut.done():
+                    outstanding += 1
         logger.debug(f"Counted {outstanding} outstanding tasks")
         return outstanding
 


### PR DESCRIPTION
WorkQueueExecutor status reporting did not properly lock the task status
dictionary. This commit adds that lock.

When task submission happens at the same time as flow control, for example
when a very large number of tasks are submitted, this exception can occur:

    2022-02-23 14:42:14 parsl.dataflow.flow_control:114 MainProcess(112424) FlowControl-Thread [ERROR]  Flow control callback threw an exception - logging and proceeding anyway
    Traceback (most recent call last):
      File "/home/ir-shir1/rds/rds-iris-ip005/ras81/wq_env/lib/python3.8/site-packages/parsl/dataflow/flow_control.py", line 112, in make_callback
        self.callback(tasks=self._event_buffer, kind=kind)
      File "/home/ir-shir1/rds/rds-iris-ip005/ras81/wq_env/lib/python3.8/site-packages/parsl/dataflow/task_status_poller.py", line 104, in poll
        self._strategy.strategize(self._poll_items, tasks)
      File "/home/ir-shir1/rds/rds-iris-ip005/ras81/wq_env/lib/python3.8/site-packages/parsl/dataflow/strategy.py", line 140, in _strategy_simple
        self._general_strategy(status_list, tasks, strategy_type='simple')
      File "/home/ir-shir1/rds/rds-iris-ip005/ras81/wq_env/lib/python3.8/site-packages/parsl/dataflow/strategy.py", line 174, in _general_strategy
        active_tasks = executor.outstanding
      File "/home/ir-shir1/rds/rds-iris-ip005/ras81/wq_env/lib/python3.8/site-packages/parsl/executors/workqueue/executor.py", line 633, in outstanding
        for fut in self.tasks.values():
    RuntimeError: dictionary changed size during iteration

Several LSST DESC users have encountered this.

Fixes #2230

# Description

Please include a summary of the change and (optionally) which issue is fixed. Please also include
relevant motivation and context.

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
- Code maintentance/cleanup
