### PR TITLE
Upgrade Sphinx to latest

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,6 +13,6 @@ types-python-dateutil
 types-requests
 types-six
 sqlalchemy-stubs
-Sphinx==3.4.1
+Sphinx==4.5.0
 twine
 wheel


### PR DESCRIPTION
This is motivated by a failure in CI with the previous version,
vs Jinja2.

See: https://github.com/sphinx-doc/sphinx/issues/10291

## Type of change

- Code maintentance/cleanup
