### PR TITLE
Fix type ambiguity between executor object and executor label in scaling failed, along with TODOs

### DIFF
--- a/parsl/executors/errors.py
+++ b/parsl/executors/errors.py
@@ -1,16 +1,15 @@
 """Exceptions raise by Executors."""
 from parsl.app.errors import ParslError
-
-from typing import Optional
+from parsl.executors.base import ParslExecutor
 
 
 class ExecutorError(ParslError):
-    """Base class for all exceptions.
+    """Base class for executor related exceptions.
 
     Only to be invoked when only a more specific error is not available.
     """
 
-    def __init__(self, executor, reason):
+    def __init__(self, executor: ParslExecutor, reason: str):
         self.executor = executor
         self.reason = reason
 
@@ -44,9 +43,8 @@ Please checkout {} for this feature".format(self.feature,
 class ScalingFailed(ExecutorError):
     """Scaling failed due to error in Execution provider."""
 
-    def __init__(self, executor: Optional[str], reason: str):
-        self.executor = executor
-        self.reason = reason
+    def __str__(self):
+        return f"Executor {self.executor.label} failed to scale due to: {self.reason}"
 
 
 class DeserializationError(ExecutorError):

--- a/parsl/executors/flux/executor.py
+++ b/parsl/executors/flux/executor.py
@@ -221,6 +221,7 @@ class FluxExecutor(NoStatusHandlingExecutor, RepresentationMixin):
                 self.working_dir,
                 self.flux_executor_kwargs,
                 self.provider,
+                self,
                 self.flux_path,
                 self.launch_cmd,
             ),
@@ -343,6 +344,7 @@ def _submit_flux_jobs(
     working_dir: str,
     flux_executor_kwargs: Mapping,
     provider: ExecutionProvider,
+    executor: FluxExecutor,
     flux_path: str,
     launch_cmd: str,
 ):
@@ -364,7 +366,7 @@ def _submit_flux_jobs(
     )
     if not job_id:
         raise ScalingFailed(
-            provider.label, "Attempt to provision nodes via provider has failed",
+            executor, "Attempt to provision nodes via provider has failed",
         )
     # wait for the flux package path to be sent
     _check_provider_job(socket, provider, job_id)

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -680,7 +680,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
 
     def _get_launch_command(self, block_id: str) -> str:
         if self.launch_cmd is None:
-            raise ScalingFailed(self.provider.label, "No launch command")
+            raise ScalingFailed(self, "No launch command")
         launch_cmd = self.launch_cmd.format(block_id=block_id)
         return launch_cmd
 

--- a/parsl/executors/low_latency/executor.py
+++ b/parsl/executors/low_latency/executor.py
@@ -100,7 +100,7 @@ class LowLatencyExecutor(BlockProviderExecutor, RepresentationMixin):
                             self.launch_cmd, self.workers_per_node)
                         logger.debug("Launched block {}:{}".format(i, block))
                         if not block:
-                            raise(ScalingFailed(self.provider.label,
+                            raise(ScalingFailed(self,
                                                 "Attempts to provision nodes via provider has failed"))
                         self.blocks.extend([block])
 

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -161,7 +161,7 @@ class BlockProviderExecutor(ParslExecutor):
         """Scales out the number of blocks by "blocks"
         """
         if not self.provider:
-            raise (ScalingFailed(None, "No execution provider available"))
+            raise ScalingFailed(self, "No execution provider available")
         block_ids = []
         logger.info(f"Scaling out by {blocks} blocks")
         for i in range(blocks):
@@ -182,8 +182,8 @@ class BlockProviderExecutor(ParslExecutor):
         job_id = self.provider.submit(launch_cmd, 1)
         logger.debug("Launched block {}->{}".format(block_id, job_id))
         if not job_id:
-            raise(ScalingFailed(self.provider.label,
-                                "Attempts to provision nodes via provider has failed"))
+            raise ScalingFailed(self,
+                                "Attempt to provision nodes did not return a job ID")
         return job_id
 
     @abstractmethod


### PR DESCRIPTION
I've seen the ambiguity that lead to this in the wild with LSST - naming a provider when an executor should have been named, in a ScalingFailed error.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
