### PR TITLE
Reparent executor errors which do not contain an executor context

### DIFF
--- a/parsl/executors/errors.py
+++ b/parsl/executors/errors.py
@@ -49,7 +49,7 @@ class ScalingFailed(ExecutorError):
         self.reason = reason
 
 
-class DeserializationError(ExecutorError):
+class DeserializationError(ParslError):
     """ Failure at the Deserialization of results/exceptions from remote workers
     """
 
@@ -60,7 +60,7 @@ class DeserializationError(ExecutorError):
         return "Failed to deserialize return objects. Reason:{}".format(self.reason)
 
 
-class SerializationError(ExecutorError):
+class SerializationError(ParslError):
     """ Failure to serialize data arguments for the tasks
     """
 
@@ -73,7 +73,7 @@ class SerializationError(ExecutorError):
                                                                            self.troubleshooting)
 
 
-class BadMessage(ExecutorError):
+class BadMessage(ParslError):
     """ Mangled/Poorly formatted/Unsupported message received
     """
 


### PR DESCRIPTION
This tries to split the dual role of the executor base exception: is it for exceptions coming from executors, or is it with errors with an executor context?

## Type of change

- Tidy