### PR TITLE
Remove logger.warn (replace with warning) - this is causing pytest warnings that .warn is deprecated

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1085,7 +1085,7 @@ class DataFlowKernel(object):
                 logger.info(f"Shutting down executor {executor.label}")
                 executor.shutdown()
             elif executor.managed and executor.bad_state_is_set:  # and bad_state_is_set
-                logger.warn(f"Not shutting down executor {executor.label} because it is in bad state")
+                logger.warning(f"Not shutting down executor {executor.label} because it is in bad state")
             else:
                 logger.info(f"Not shutting down executor {executor.label} because it is unmanaged")
 


### PR DESCRIPTION
## Type of change

- Code maintentance/cleanup
