### PR TITLE
Add support for pinning workers to an accelerator

### DIFF
--- a/docs/userguide/configuring.rst
+++ b/docs/userguide/configuring.rst
@@ -291,6 +291,61 @@ and Work Queue does not require Python to run.
    The automatic packaging feature only supports packages installed via ``pip`` or ``conda``.
    Importing from other locations (e.g. via ``$PYTHONPATH``) or importing other modules in the same directory is not supported.
 
+
+Accelerators
+------------
+
+Many modern clusters provide multiple accelerators per compute note, yet many applications are best suited to using a single accelerator per task.
+Parsl supports pinning each worker to difference accelerators using ``available_accelerators`` option of the :class:`~parsl.executors.HighThroughputExecutor`.
+Provide either the number of executors (Parsl will assume they are named in integers starting from zero) or a list of the names of the accelerators available on the node.
+
+.. code-block:: python
+
+    local_config = Config(
+        executors=[
+            HighThroughputExecutor(
+                label="htex_Local",
+                worker_debug=True,
+                available_accelerators=2,
+                provider=LocalProvider(
+                    channel=LocalChannel(),
+                    init_blocks=1,
+                    max_blocks=1,
+                ),
+            )
+        ],
+        strategy=None,
+    )
+
+
+Multi-Threaded Applications
+---------------------------
+
+Workflows which launch multiple workers on a single node which perform multi-threaded tasks (e.g., NumPy, Tensorflow operations) may run into thread contention issues.
+Each worker may try to use the same hardware threads, which leads to performance penalties.
+Use the ``cpu_affinity`` feature of the :class:`~parsl.executors.HighThroughputExecutor` to assign workers to specific cores.
+Parsl provides a 'block' or 'alternate' option on how cores are pinned to each worker (ex: 4 cores are grouped (0, 1) and (2, 3) for block,
+(0, 2) and (1, 3) for alternate).
+Select the best blocking strategy for processor's cache hierarchy (choose 'alternate' if in doubt) to ensure workers to not compete for cores.
+
+.. code-block:: python
+
+    local_config = Config(
+        executors=[
+            HighThroughputExecutor(
+                label="htex_Local",
+                worker_debug=True,
+                cpu_affinity='alternate',
+                provider=LocalProvider(
+                    channel=LocalChannel(),
+                    init_blocks=1,
+                    max_blocks=1,
+                ),
+            )
+        ],
+        strategy=None,
+    )
+
 Ad-Hoc Clusters
 ---------------
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -6,7 +6,7 @@ import queue
 import datetime
 import pickle
 from multiprocessing import Queue
-from typing import Dict  # noqa F401 (used in type annotation)
+from typing import Dict, Sequence  # noqa F401 (used in type annotation)
 from typing import List, Optional, Tuple, Union
 import math
 
@@ -139,6 +139,15 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         "alternating" to assign cores to workers in round-robin
         (ex: assign 0,2 to worker 0, 1,3 to worker 1).
 
+    available_accelerators: int | list | None
+        Accelerators available for workers to use. Each worker will be pinned to exactly one of the provided
+        accelerators, and no more workers will be launched than the number of accelerators.
+
+        Either provide the list of accelerator names or the number available. If a number is provided,
+        Parsl will create names as integers starting with 0.
+
+        default: empty list
+
     prefetch_capacity : int
         Number of tasks that could be prefetched over available worker capacity.
         When there are a few tasks (<100) or when tasks are long running, this option should
@@ -181,6 +190,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
                  mem_per_worker: Optional[float] = None,
                  max_workers: Union[int, float] = float('inf'),
                  cpu_affinity: str = 'none',
+                 available_accelerators: Union[int, Sequence[str]] = (),
                  prefetch_capacity: int = 0,
                  heartbeat_threshold: int = 120,
                  heartbeat_period: int = 30,
@@ -220,7 +230,16 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
                 self.provider.cores_per_node is not None:
             cpu_slots = math.floor(self.provider.cores_per_node / cores_per_worker)
 
+        # Set the list of available accelerators
+        if isinstance(available_accelerators, int):
+            # If the user provide an integer, create some names for them
+            available_accelerators = list(map(str, range(available_accelerators)))
+        self.available_accelerators = available_accelerators.copy()
+
+        # Determine the number of workers per node
         self._workers_per_node = min(max_workers, mem_slots, cpu_slots)
+        if len(self.available_accelerators) > 0:
+            self._workers_per_node = min(self._workers_per_node, len(available_accelerators))
         if self._workers_per_node == float('inf'):
             self._workers_per_node = 1  # our best guess-- we do not have any provider hints
 
@@ -252,7 +271,8 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
                                "--hb_period={heartbeat_period} "
                                "{address_probe_timeout_string} "
                                "--hb_threshold={heartbeat_threshold} "
-                               "--cpu-affinity {cpu_affinity} ")
+                               "--cpu-affinity {cpu_affinity} "
+                               "--available-accelerators {accelerators}")
 
     def initialize_scaling(self):
         """ Compose the launch command and call the scale_out
@@ -284,7 +304,8 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
                                        heartbeat_threshold=self.heartbeat_threshold,
                                        poll_period=self.poll_period,
                                        logdir=worker_logdir,
-                                       cpu_affinity=self.cpu_affinity)
+                                       cpu_affinity=self.cpu_affinity,
+                                       accelerators=" ".join(self.available_accelerators))
         self.launch_cmd = l_cmd
         logger.debug("Launch command: {}".format(self.launch_cmd))
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -139,7 +139,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         "alternating" to assign cores to workers in round-robin
         (ex: assign 0,2 to worker 0, 1,3 to worker 1).
 
-    available_accelerators: int | list | None
+    available_accelerators: int | list
         Accelerators available for workers to use. Each worker will be pinned to exactly one of the provided
         accelerators, and no more workers will be launched than the number of accelerators.
 
@@ -234,7 +234,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         if isinstance(available_accelerators, int):
             # If the user provide an integer, create some names for them
             available_accelerators = list(map(str, range(available_accelerators)))
-        self.available_accelerators = available_accelerators.copy()
+        self.available_accelerators = list(available_accelerators)
 
         # Determine the number of workers per node
         self._workers_per_node = min(max_workers, mem_slots, cpu_slots)

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -176,7 +176,6 @@ class Manager(object):
         self.worker_count = min(max_workers,
                                 mem_slots,
                                 math.floor(cores_on_node / cores_per_worker))
-        logger.info("Manager will spawn {} workers".format(self.worker_count))
 
         self.pending_task_queue = mpQueue()
         self.pending_result_queue = mpQueue()
@@ -190,10 +189,13 @@ class Manager(object):
         self.heartbeat_threshold = heartbeat_threshold
         self.poll_period = poll_period
         self.cpu_affinity = cpu_affinity
+
+        # Define accelerator available, adjust worker count accordingly
         self.available_accelerators = available_accelerators
         self.accelerators_available = len(available_accelerators) > 0
         if self.accelerators_available:
-            assert max_workers <= len(self.available_accelerators), "More workers available than accelerators"
+            self.worker_count = min(len(self.available_accelerators), self.worker_count)
+        logger.info("Manager will spawn {} workers".format(self.worker_count))
 
     def create_reg_message(self):
         """ Creates a registration message to identify the worker to the interchange

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -10,6 +10,8 @@ import pickle
 import time
 import queue
 import uuid
+from typing import Sequence, Optional
+
 import zmq
 import math
 import json
@@ -61,7 +63,8 @@ class Manager(object):
                  heartbeat_threshold=120,
                  heartbeat_period=30,
                  poll_period=10,
-                 cpu_affinity=False):
+                 cpu_affinity=False,
+                 available_accelerators: Sequence[str] = ()):
         """
         Parameters
         ----------
@@ -113,6 +116,9 @@ class Manager(object):
 
         cpu_affinity : str
              Whether each worker should force its affinity to different CPUs
+
+        available_accelerators: list of str
+            List of accelerators available to the workers. Default: Empty list
         """
 
         logger.info("Manager started")
@@ -184,6 +190,10 @@ class Manager(object):
         self.heartbeat_threshold = heartbeat_threshold
         self.poll_period = poll_period
         self.cpu_affinity = cpu_affinity
+        self.available_accelerators = available_accelerators
+        self.accelerators_available = len(available_accelerators) > 0
+        if self.accelerators_available:
+            assert max_workers <= len(self.available_accelerators), "More workers available than accelerators"
 
     def create_reg_message(self):
         """ Creates a registration message to identify the worker to the interchange
@@ -398,8 +408,9 @@ class Manager(object):
                                                self.pending_result_queue,
                                                self.ready_worker_queue,
                                                self._tasks_in_progress,
-                                               self.cpu_affinity
-                                         ), name="HTEX-Worker-{}".format(worker_id))
+                                               self.cpu_affinity,
+                                               self.available_accelerators[worker_id] if self.accelerators_available else None),
+                          name="HTEX-Worker-{}".format(worker_id))
             p.start()
             self.procs[worker_id] = p
 
@@ -473,7 +484,7 @@ def execute_task(bufs):
 
 
 @wrap_with_logs(target="worker_log")
-def worker(worker_id, pool_id, pool_size, task_queue, result_queue, worker_queue, tasks_in_progress, cpu_affinity):
+def worker(worker_id, pool_id, pool_size, task_queue, result_queue, worker_queue, tasks_in_progress, cpu_affinity, accelerator: Optional[str]):
     """
 
     Put request token into queue
@@ -519,6 +530,13 @@ def worker(worker_id, pool_id, pool_size, task_queue, result_queue, worker_queue
         # Set the affinity for this worker
         os.sched_setaffinity(0, my_cores)
         logger.info("Set worker CPU affinity to {}".format(my_cores))
+
+    # If desired, pin to accelerator
+    if accelerator is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = accelerator
+        os.environ["ROCR_VISIBLE_DEVICES"] = accelerator
+        os.environ["SYCL_DEVICE_FILTER"] = f"*:*:{accelerator}"
+        logger.info(f'Pinned worker to accelerator: {accelerator}')
 
     while True:
         worker_queue.put(worker_id)
@@ -618,6 +636,8 @@ if __name__ == "__main__":
                         help="REQUIRED: Result port for posting results to the interchange")
     parser.add_argument("--cpu-affinity", type=str, choices=["none", "block", "alternating"],
                         help="Whether/how workers should control CPU affinity.")
+    parser.add_argument("--available-accelerators", type=str, nargs="*",
+                        help="Names of available accelerators")
 
     args = parser.parse_args()
 
@@ -645,6 +665,7 @@ if __name__ == "__main__":
         logger.info("Heartbeat threshold: {}".format(args.hb_threshold))
         logger.info("Heartbeat period: {}".format(args.hb_period))
         logger.info("CPU affinity: {}".format(args.cpu_affinity))
+        logger.info("Accelerators: {}".format(" ".join(args.available_accelerators)))
 
         manager = Manager(task_port=args.task_port,
                           result_port=args.result_port,
@@ -659,7 +680,8 @@ if __name__ == "__main__":
                           heartbeat_threshold=int(args.hb_threshold),
                           heartbeat_period=int(args.hb_period),
                           poll_period=int(args.poll),
-                          cpu_affinity=args.cpu_affinity)
+                          cpu_affinity=args.cpu_affinity,
+                          available_accelerators=args.available_accelerators)
         manager.start()
 
     except Exception:


### PR DESCRIPTION
# Description

Adds an option to HTEx for pinning each worker to a different GPU. Needed for systems that include multiple GPUs per node when tasks do not scale to >1 GPU and there is no mechanism in the scheduler for partitioning GPUs.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
- Documentation update
