### PR TITLE
Clarify log messages when SlurmProvider gets unknown statuses

### DIFF
--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -155,6 +155,8 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
             if parts and parts[0] != 'JOBID':
                 job_id = parts[0]
                 slurm_state = parts[4]
+                if slurm_state not in translate_table:
+                    logger.warning(f"Slurm status {slurm_state} is not known")
                 status = translate_table.get(slurm_state, JobState.UNKNOWN)
                 logger.debug("Updating job {} with slurm status {} to parsl state {!s}".format(job_id, slurm_state, status))
                 self.resources[job_id]['status'] = JobStatus(status)

--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -154,8 +154,9 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
             parts = line.split()
             if parts and parts[0] != 'JOBID':
                 job_id = parts[0]
-                status = translate_table.get(parts[4], JobState.UNKNOWN)
-                logger.debug("Updating job {} with slurm status {} to parsl state {!s}".format(job_id, parts[4], status))
+                slurm_state = parts[4]
+                status = translate_table.get(slurm_state, JobState.UNKNOWN)
+                logger.debug("Updating job {} with slurm status {} to parsl state {!s}".format(job_id, slurm_state, status))
                 self.resources[job_id]['status'] = JobStatus(status)
                 jobs_missing.remove(job_id)
 

--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -155,7 +155,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
             if parts and parts[0] != 'JOBID':
                 job_id = parts[0]
                 status = translate_table.get(parts[4], JobState.UNKNOWN)
-                logger.debug("Updating job {} with slurm status {} to parsl status {}".format(job_id, parts[4], status))
+                logger.debug("Updating job {} with slurm status {} to parsl state {!s}".format(job_id, parts[4], status))
                 self.resources[job_id]['status'] = JobStatus(status)
                 jobs_missing.remove(job_id)
 


### PR DESCRIPTION
# Description

This PR tries to make logging clearer when SlurmProvider receives unknown statuses. Most immediately this is driven by #2255.

JobState enums are now output using `str()` which renders their symbolic name, instead of numerical state value.

old:
2022-05-11 03:30:24.572 parsl.providers.slurm.slurm:158 [DEBUG]  Updating job 58928398 with slurm status R to parsl status 2

vs

new:
2022-05-11 03:37:51.814 parsl.providers.slurm.slurm:158 [DEBUG]  Updating job 58928492 with slurm status R to parsl state JobState.RUNNING

If a state does not exist in the translation table, a warning is logged:

2022-05-11 04:05:21.818 parsl.providers.slurm.slurm:159 [WARNING]  Slurm status XXX is not known

## Type of change

- Code maintentance/cleanup
