### PR TITLE
only query active slurm jobs

### DIFF
--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -138,15 +138,21 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         Returns:
               [status...] : Status list of all jobs
         '''
-        job_id_list = ','.join(self.resources.keys())
+        job_id_list = ','.join(
+            [jid for jid, job in self.resources.keys() if not job['status'].terminal]
+        )
+        if not job_id_list:
+            logger.debug('No active jobs, skipping status update')
+            return
+
         cmd = "squeue --job {0}".format(job_id_list)
-        logger.debug("Executing sqeueue")
+        logger.debug("Executing %s", cmd)
         retcode, stdout, stderr = self.execute_wait(cmd)
-        logger.debug("sqeueue returned")
+        logger.debug("sqeueue returned %s %s", stdout, stderr)
 
         # Execute_wait failed. Do no update
         if retcode != 0:
-            logger.warning("squeue failed with non-zero exit code {} - see https://github.com/Parsl/parsl/issues/1588".format(retcode))
+            logger.warning("squeue failed with non-zero exit code {}".format(retcode))
             return
 
         jobs_missing = list(self.resources.keys())


### PR DESCRIPTION
# Description

When squeue is called with at least one job ID which is active, it returns successfully. If it is called with only jobs that have already completed, it returns an error. This situation happens if no blocks are currently running.

The same logic (checking if the existing status is terminal) is used in the [local](https://github.com/Parsl/parsl/blob/master/parsl/providers/local/local.py#L77) and [kubernetes](https://github.com/Parsl/parsl/blob/master/parsl/providers/kubernetes/kube.py#L208) providers.

Fixes #1588

## Type of change

- Bug fix (non-breaking change that fixes an issue)
