### PR TITLE
Increase htex address probe timeout to 2 minutes.

### DIFF
--- a/parsl/executors/high_throughput/probe.py
+++ b/parsl/executors/high_throughput/probe.py
@@ -9,7 +9,7 @@ from zmq.utils.monitor import recv_monitor_message
 logger = logging.getLogger(__name__)
 
 
-def probe_addresses(addresses, task_port, timeout=2):
+def probe_addresses(addresses, task_port, timeout=120):
     """
     Parameters
     ----------


### PR DESCRIPTION
On loaded systems, the previous 2 second timeout
was too short, and workers were failing without
discovering any addresses.

The increased time makes this more reliable.

This change means that when a worker is launched which
cannot connect through any of the supplied addresses,
that worker will take two minutes to fail, rather
than two seconds.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
