### PR TITLE
broaden error message text for htex zmq pipe errors

### DIFF
--- a/parsl/executors/high_throughput/zmq_pipes.py
+++ b/parsl/executors/high_throughput/zmq_pipes.py
@@ -121,7 +121,7 @@ class TasksOutgoing(object):
                 return
             else:
                 timeout_ms += 1
-                logger.debug("Not sending due to full zmq pipe, timeout: {} ms".format(timeout_ms))
+                logger.debug("Not sending due to non-ready zmq pipe, timeout: {} ms".format(timeout_ms))
 
     def close(self):
         self.zmq_socket.close()


### PR DESCRIPTION
this warning is not due to a full pipe, but due to an unresponsive pipe - eg if the interchange has gone away.

rephrasing to make less confusing.

- Documentation update
