### PR TITLE
Allow monitoring radio mode to be chosen by executors

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -598,6 +598,7 @@ class DataFlowKernel(object):
                                                          self.run_id,
                                                          wrapper_logging_level,
                                                          self.monitoring.resource_monitoring_interval,
+                                                         executor.radio_mode,
                                                          executor.monitor_resources())
 
         with self.submitter_lock:

--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -23,6 +23,11 @@ class ParslExecutor(metaclass=ABCMeta):
        label: str - a human readable label for the executor, unique
               with respect to other executors.
 
+    Per-executor monitoring behaviour can be influenced by exposing:
+
+       radio_mode: str - a string describing which radio mode should be used to
+              send task resource data back to the submit side.
+
     An executor may optionally expose:
 
        storage_access: List[parsl.data_provider.staging.Staging] - a list of staging
@@ -39,6 +44,7 @@ class ParslExecutor(metaclass=ABCMeta):
     """
 
     label: str = "undefined"
+    radio_mode: str = "udp"
 
     def __enter__(self):
         return self


### PR DESCRIPTION
This patch introduces code to make that choice available
to the monitoring wrapper, but does not add any further
modes.

## Type of change

- New feature (non-breaking change that adds functionality)
