### PR TITLE
remove object/init boilerplate

### DIFF
--- a/parsl/dataflow/job_error_handler.py
+++ b/parsl/dataflow/job_error_handler.py
@@ -5,10 +5,7 @@ from parsl.executors.base import ParslExecutor
 from parsl.providers.provider_base import JobStatus, JobState
 
 
-class JobErrorHandler(object):
-    def __init__(self):
-        pass
-
+class JobErrorHandler:
     def run(self, status: List[ExecutorStatus]):
         for es in status:
             self._check_irrecoverable_executor(es)


### PR DESCRIPTION
This is unused -- it would affect how __init__ is called in the presence of subclasses, but this class is not designed for subclassing/multiple inheritence

## Type of change

- Code maintentance/cleanup
