### PR TITLE
Add a filesystem based monitoring radio

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -196,6 +196,8 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
             'work_queue_worker'.
     """
 
+    radio_mode = "filesystem"
+
     @typeguard.typechecked
     def __init__(self,
                  label: str = "WorkQueueExecutor",


### PR DESCRIPTION
This is intended to replace UDP based monitoring for work queue when a shared file system is available.

## Type of change

- New feature (non-breaking change that adds functionality)
