### PR TITLE
Set forked process names for debugging memory/cpu usage

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -151,3 +151,6 @@ ignore_missing_imports = True
 
 [mypy-flux.*]
 ignore_missing_imports = True
+
+[mypy-setproctitle.*]
+ignore_missing_imports = True

--- a/parsl/dataflow/usage_tracking/usage.py
+++ b/parsl/dataflow/usage_tracking/usage.py
@@ -9,6 +9,7 @@ import socket
 import sys
 import platform
 
+from parsl.utils import setproctitle
 from parsl.multiprocessing import ForkProcess
 from parsl.dataflow.states import States
 from parsl.version import VERSION as PARSL_VERSION
@@ -43,6 +44,8 @@ def udp_messenger(domain_name, UDP_IP, UDP_PORT, sock_timeout, message):
           - sock_timeout (int) : Socket timeout
           - to_send (multiprocessing.Queue) : Queue of outgoing messages to internet
     """
+    setproctitle("parsl: Usage tracking")
+
     try:
         if message is None:
             raise ValueError("message was none")

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -13,6 +13,7 @@ import queue
 import threading
 import json
 
+from parsl.utils import setproctitle
 from parsl.version import VERSION as PARSL_VERSION
 from parsl.serialize import ParslSerializer
 serialize_object = ParslSerializer().serialize
@@ -592,6 +593,7 @@ def starter(comm_q, *args, **kwargs):
 
     The executor is expected to call this function. The args, kwargs match that of the Interchange.__init__
     """
+    setproctitle("parsl: HTEX interchange")
     # logger = multiprocessing.get_logger()
     ic = Interchange(*args, **kwargs)
     comm_q.put((ic.worker_task_port,

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -29,6 +29,7 @@ from parsl.executors.status_handling import BlockProviderExecutor
 from parsl.providers.provider_base import ExecutionProvider
 from parsl.providers import LocalProvider, CondorProvider
 from parsl.executors.workqueue import exec_parsl_function
+from parsl.utils import setproctitle
 
 import typeguard
 from typing import Dict, List, Optional, Set, Union
@@ -740,6 +741,7 @@ def _work_queue_submit_wait(task_queue=multiprocessing.Queue(),
     module capabilities, rather than shared memory.
     """
     logger.debug("Starting WorkQueue Submit/Wait Process")
+    setproctitle("parsl: Work Queue submit/wait")
 
     # Enable debugging flags and create logging file
     wq_debug_log = None

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -12,6 +12,7 @@ from parsl.dataflow.states import States
 from parsl.errors import OptionalModuleMissing
 from parsl.monitoring.message_type import MessageType
 from parsl.process_loggers import wrap_with_logs
+from parsl.utils import setproctitle
 
 logger = logging.getLogger("database_manager")
 
@@ -674,6 +675,8 @@ def dbm_starter(exception_q: "queue.Queue[Tuple[str, str]]",
     The DFK should start this function. The args, kwargs match that of the monitoring config
 
     """
+    setproctitle("parsl: monitoring database")
+
     try:
         dbm = DatabaseManager(db_url=db_url,
                               logdir=logdir,

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -14,6 +14,7 @@ from parsl.multiprocessing import ForkProcess, SizedQueue
 from multiprocessing import Process, Queue
 from parsl.utils import RepresentationMixin
 from parsl.process_loggers import wrap_with_logs
+from parsl.utils import setproctitle
 
 from parsl.serialize import deserialize
 
@@ -519,7 +520,9 @@ def filesystem_receiver(logdir: str, q: "queue.Queue[Tuple[Tuple[MessageType, Di
     logger = start_file_logger("{}/monitoring_filesystem_radio.log".format(logdir),
                                name="monitoring_filesystem_radio",
                                level=logging.DEBUG)
+
     logger.info("Starting filesystem radio receiver")
+    setproctitle("parsl: monitoring filesystem receiver")
     base_path = f"{run_dir}/monitor-fs-radio/"
     tmp_dir = f"{base_path}/tmp/"
     new_dir = f"{base_path}/new/"
@@ -722,7 +725,7 @@ def router_starter(comm_q: "queue.Queue[Union[Tuple[int, int], str]]",
                    logdir: str,
                    logging_level: int,
                    run_id: str) -> None:
-
+    setproctitle("parsl: monitoring router")
     try:
         router = MonitoringRouter(hub_address=hub_address,
                                   hub_port=hub_port,

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -12,6 +12,15 @@ from typing import List, Tuple, Union, Generator, IO, AnyStr, Dict
 import parsl
 from parsl.version import VERSION
 
+
+try:
+    import setproctitle as setproctitle_module
+except ImportError:
+    _setproctitle_enabled = False
+else:
+    _setproctitle_enabled = True
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -255,3 +264,10 @@ class AtomicIDCounter:
             new_id = self.count
             self.count += 1
             return new_id
+
+
+def setproctitle(title: str) -> None:
+    if _setproctitle_enabled:
+        setproctitle_module.setproctitle(title)
+    else:
+        logger.warn(f"setproctitle not enabled for process {title}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tblib
 requests
 paramiko
 psutil>=5.5.1
+setproctitle


### PR DESCRIPTION
Previously, in `ps`, all processes appeared with the same commandline,
that of the process which which was used to launch parsl (for example,
python3 ..., or pytest ..., or bps ... in one LSST project).

This commit gives more interesting names.

Perhaps the process name should include some kind of workflow identifier so as to
disambiguate? That's an issue for users running multiple workflows, most likely spread
across time when leftover processes are left behind. Although the regular process
three would show relationships.

This patch deals with processes forked with multiprocessing, in:
 * monitoring
 * high throughput executor
 * work queue executor


## Type of change

- New feature (non-breaking change that adds functionality)
