### PR TITLE
Use __name__ for conftest.py logging so logs appear under its own name

### DIFF
--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -14,7 +14,7 @@ import _pytest.runner as runner
 import parsl
 from parsl.dataflow.dflow import DataFlowKernelLoader
 
-logger = logging.getLogger('parsl')
+logger = logging.getLogger(__name__)
 
 
 def dumpstacks(sig, frame):


### PR DESCRIPTION
## Type of change

- Code maintentance/cleanup
