### PR TITLE
Add constraints for networkx for parsl-visualize

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,3 +125,4 @@ sheet <https://sustainable-open-science-and-software.github.io/assets/PIS_sustai
 
 
 
+test

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require = {
         'sqlalchemy>=1.3.0,!=1.3.4,<1.4',
         'sqlalchemy_utils',
         'pydot',
-        'networkx',
+        'networkx>=2.5,<2.6',
         'Flask>=1.0.2',
         'flask_sqlalchemy',
         'pandas<1.4',


### PR DESCRIPTION
A recent networkx release, 2.8.4, does not work with parsl-visualize. The previously working version was 2.5.x, and this PR adds a constraint for that.


Fixed errors look like this:

```
  File "/home/benc/parsl/src/parsl/parsl/monitoring/visualization/plots/default/workflow_plots.py", line 251, in workflow_dag_plot
    name = dic['task_status_name'][node]
KeyError: '0'
```