### PR TITLE
Add option to specify stream for stream logger

### DIFF
--- a/parsl/executors/extreme_scale/mpi_worker_pool.py
+++ b/parsl/executors/extreme_scale/mpi_worker_pool.py
@@ -439,13 +439,15 @@ def start_file_logger(filename, rank, name='parsl', level=logging.DEBUG, format_
     logger.addHandler(handler)
 
 
-def set_stream_logger(name='parsl', level=logging.DEBUG, format_string=None):
+def set_stream_logger(name='parsl', level=logging.DEBUG, format_string=None, stream=None):
     """Add a stream log handler.
 
     Args:
          - name (string) : Set the logger name.
          - level (logging.LEVEL) : Set to logging.DEBUG by default.
          - format_string (sting) : Set to None by default.
+         - stream (io.TextIOWrapper) : Specify sys.stdout or sys.stderr for stream.
+            If not specified, the default stream for logging.StreamHandler is used.
 
     Returns:
          - None
@@ -457,7 +459,7 @@ def set_stream_logger(name='parsl', level=logging.DEBUG, format_string=None):
     global logger
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)
-    handler = logging.StreamHandler()
+    handler = logging.StreamHandler(stream)
     handler.setLevel(level)
     formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
     handler.setFormatter(formatter)

--- a/parsl/log_utils.py
+++ b/parsl/log_utils.py
@@ -10,6 +10,7 @@ However the following helper functions are provided for logging:
     This sets the logging to a file. This is ideal for reporting issues to the dev team.
 
 """
+import io
 import logging
 import typeguard
 
@@ -17,13 +18,15 @@ from typing import Optional
 
 
 @typeguard.typechecked
-def set_stream_logger(name: str = 'parsl', level: int = logging.DEBUG, format_string: Optional[str] = None):
+def set_stream_logger(name: str = 'parsl', level: int = logging.DEBUG, format_string: Optional[str] = None, stream: Optional[io.TextIOWrapper] = None):
     """Add a stream log handler.
 
     Args:
          - name (string) : Set the logger name.
          - level (logging.LEVEL) : Set to logging.DEBUG by default.
          - format_string (string) : Set to None by default.
+         - stream (io.TextIOWrapper) : Specify sys.stdout or sys.stderr for stream.
+            If not specified, the default stream for logging.StreamHandler is used.
 
     Returns:
          - None
@@ -34,7 +37,7 @@ def set_stream_logger(name: str = 'parsl', level: int = logging.DEBUG, format_st
 
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)
-    handler = logging.StreamHandler()
+    handler = logging.StreamHandler(stream)
     handler.setLevel(level)
     formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
     handler.setFormatter(formatter)


### PR DESCRIPTION
# Description

Adds a `stream` keyword argument to `set_stream_logger` function so that the user can specify whether the `StreamHandler` directs to `sys.stderr` or `sys.stdout`.
For my work on a TACC Frontera project, I want this stream to be directed to `sys.stdout` instead of the default `sys.stderr` for the instantiated `StreamHandler`.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
