### PR TITLE
Regularise NODE_INFO message format

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -266,9 +266,12 @@ class Interchange(object):
     def _send_monitoring_info(self, hub_channel, manager):
         if hub_channel:
             logger.info("Sending message {} to hub".format(self._ready_manager_queue[manager]))
-            hub_channel.send_pyobj((MessageType.NODE_INFO,
-                                    datetime.datetime.now(),
-                                    self._ready_manager_queue[manager]))
+
+            d = self._ready_manager_queue[manager].copy()
+            d['timestamp'] = datetime.datetime.now()
+            d['last_heartbeat'] = datetime.datetime.fromtimestamp(d['last_heartbeat'])
+
+            hub_channel.send_pyobj((MessageType.NODE_INFO, d))
 
     @wrap_with_logs(target="interchange")
     def _command_server(self, kill_event):


### PR DESCRIPTION
Prior to this, the monitoring router reformatted NODE_INFO messages.
This PR regularises the format of NODE_INFO messages at the point
that they are initially sent, so that the router does not have to
reformat them.

The router still adds a run_id field to the NODE_INFO message, as
before, as this information is not available in the interchange where
the messages are generated

This moves around these non-routing behaviours in MonitoringRouter:

* reformatting an htex last_heartbeat time into a more suitable type
* putting the message timestamp into the message dictionary

## Type of change

- Code maintentance/cleanup
