### PR TITLE
Remove unused fields from RESOURCE_INFO protocol messages

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -579,8 +579,7 @@ class DatabaseManager:
             self.pending_priority_queue.put(cast(Any, x))
         elif x[0] == MessageType.RESOURCE_INFO:
             body = x[1]
-            assert len(body) == 3
-            self.pending_resource_queue.put(body[-1])
+            self.pending_resource_queue.put(body)
         elif x[0] == MessageType.NODE_INFO:
             assert len(x) == 2, "expected NODE_INFO tuple to have exactly two elements"
 

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -120,9 +120,7 @@ class FilesystemRadio(MonitoringRadio):
 
         tmp_filename = f"{self.tmp_path}/{unique_id}"
         new_filename = f"{self.new_path}/{unique_id}"
-        buffer = ((MessageType.RESOURCE_INFO, (self.source_id,   # Identifier for manager
-                   int(time.time()),  # epoch timestamp
-                   message)), "NA")
+        buffer = ((MessageType.RESOURCE_INFO, message), "NA")
 
         # this will write the message out then atomically
         # move it into new/, so that a partially written
@@ -165,9 +163,7 @@ class HTEXRadio(MonitoringRadio):
         import parsl.executors.high_throughput.monitoring_info
 
         try:
-            buffer = (MessageType.RESOURCE_INFO, (self.source_id,   # Identifier for manager
-                      int(time.time()),  # epoch timestamp
-                      message))
+            buffer = (MessageType.RESOURCE_INFO, message)
         except Exception:
             logging.exception("Exception during pickling", exc_info=True)
             return
@@ -235,9 +231,7 @@ class UDPRadio(MonitoringRadio):
             None
         """
         try:
-            buffer = pickle.dumps((self.source_id,   # Identifier for manager
-                                   int(time.time()),  # epoch timestamp
-                                   message))
+            buffer = pickle.dumps(message)
         except Exception:
             logging.exception("Exception during pickling", exc_info=True)
             return


### PR DESCRIPTION
This means instead of a tuple of one useful field and two unused
fields, the tuple can be dropped and only the one useful field,
the message, sent.

## Type of change

- Code maintentance/cleanup
