### PR TITLE
Make the interactive fibonacci test wait for all of its tasks

### DIFF
--- a/parsl/tests/test_python_apps/test_fibonacci_iterative.py
+++ b/parsl/tests/test_python_apps/test_fibonacci_iterative.py
@@ -11,18 +11,13 @@ def get_num(first, second):
 
 
 def test_fibonacci(num=3):
-    x1 = 0
-    x2 = 1
     counter = 0
     results = []
     results.append(0)
     results.append(1)
     while counter < num - 2:
         counter += 1
-        results.append(get_num(x1, x2))
-        temp = x2
-        x2 = get_num(x1, x2)
-        x1 = temp
+        results.append(get_num(results[counter - 1], results[counter]))
     for i in range(len(results)):
         if isinstance(results[i], int):
             print(results[i])


### PR DESCRIPTION
Previously, some tasks were not waited for, which make debugging
in the test suite hard as they would run over into the next test
run.

This PR removes some intermediate value complexity from the test
and uses previous values/futures from results[]

Specifically, every launched app now goes into results[] which
means each will now be waited for by the end of the test.
The potentially-unrecorded second call to get_num in the loop is
removed.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
