### PR TITLE
Do not propagate logs for components with own log files

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -126,6 +126,7 @@ class Interchange(object):
         os.makedirs(self.logdir, exist_ok=True)
 
         start_file_logger("{}/interchange.log".format(self.logdir), level=logging_level)
+        logger.propagate = False
         logger.debug("Initializing Interchange process")
 
         self.client_address = client_address

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -262,6 +262,8 @@ class DatabaseManager:
         self.logdir = logdir
         os.makedirs(self.logdir, exist_ok=True)
 
+        logger.propagate = False
+
         set_file_logger("{}/database_manager.log".format(self.logdir), level=logging_level,
                         format_string="%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s] [%(threadName)s %(thread)d] %(message)s",
                         name="database_manager")

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -62,6 +62,7 @@ def start_file_logger(filename: str, name: str = 'monitoring', level: int = logg
 
     logger = logging.getLogger(name)
     logger.setLevel(level)
+    logger.propagate = False
     handler = logging.FileHandler(filename)
     handler.setLevel(level)
     formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
Components such as the interchange and monitoring router
log to their own files.

However, log messages from those components are also passed
up to the root logger. In more complicated environments,
that root logger may also log those messages, which is
undesirable.

This commit turns off upwards propagation of log messages
from those separate components to the root logger.

## Type of change

- New feature (non-breaking change that adds functionality)
