### PR TITLE
Add log and API that binds executor IDs to task try IDs.

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -593,9 +593,10 @@ class DataFlowKernel(object):
             logger.exception("Task {} requested invalid executor {}: config is\n{}".format(task_id, executor_label, self._config))
             raise ValueError("Task {} requested invalid executor {}".format(task_id, executor_label))
 
+        try_id = task_record['fail_count']
+
         if self.monitoring is not None and self.monitoring.resource_monitoring_enabled:
             wrapper_logging_level = logging.DEBUG if self.monitoring.monitoring_debug else logging.INFO
-            try_id = task_record['fail_count']
             executable = self.monitoring.monitor_wrapper(executable, try_id, task_id,
                                                          self.monitoring.monitoring_hub_url,
                                                          self.run_id,
@@ -611,7 +612,10 @@ class DataFlowKernel(object):
 
         self._send_task_log_info(task_record)
 
-        logger.info("Task {} launched on executor {}".format(task_id, executor.label))
+        if hasattr(exec_fu, "parsl_executor_task_id"):
+            logger.info(f"Parsl task {task_id} try {try_id} launched on executor {executor.label} with executor id {exec_fu.parsl_executor_task_id}")
+        else:
+            logger.info(f"Parsl task {task_id} try {try_id} launched on executor {executor.label}")
 
         self._log_std_streams(task_record)
 

--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -64,6 +64,11 @@ class ParslExecutor(metaclass=ABCMeta):
     @abstractmethod
     def submit(self, func: Callable, resource_specification: Dict[str, Any], *args: Any, **kwargs: Any) -> Future:
         """Submit.
+
+        The executor can optionally set a parsl_executor_task_id attribute on
+        the Future that it returns, and in that case, parsl will log a
+        relationship between the executor's task ID and parsl level try/task
+        IDs.
         """
         pass
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -584,6 +584,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         logger.debug("Pushing function {} to queue with args {}".format(func, args_to_print))
 
         fut = Future()
+        fut.parsl_executor_task_id = task_id
         self.tasks[task_id] = fut
 
         try:

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -433,6 +433,7 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
 
         # Create a Future object and have it be mapped from the task ID in the tasks dictionary
         fu = Future()
+        fu.parsl_executor_task_id = task_id
         with self.tasks_lock:
             self.tasks[str(task_id)] = fu
 


### PR DESCRIPTION
If an executor's returned executor future contains a property
'parsl_executor_task_id' then a log message will be emitted
binding that to the parsl DFK level task and try IDs.

This has been useful when correlating logs across multiple
layers in LSST.

## Type of change

- New feature (non-breaking change that adds functionality)
