### PR TITLE
Rework resource monitoring termination

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -137,6 +137,16 @@ ignore_missing_imports = True
 [mypy-flask.*]
 ignore_missing_imports = True
 
+# this is an internal undocumentated package
+# of multiprocessing - trying to get Event
+# to typecheck in monitoring, but it's not
+# a top level class as far as mypy is concerned.
+# but... when commented out seems ok?
+# so lets see when happens when I try to merge
+# in clean CI
+#[mypy-multiprocessing.synchronization.*]
+#ignore_missing_imports = True
+
 [mypy-plotly.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
Instead of killing the monitor process using terminate,
use a multiprocessing event, as process terminate can
sometimes corrupt shared queues, according to documentation.

Send the final resource message after resource monitoring
has completed - otherwise, the "last" message is not
necessarily before the final resource monitoring message.

## Type of change

- New feature (non-breaking change that adds functionality)
