### PR TITLE
Put default job error handling in one place

### DIFF
--- a/parsl/dataflow/job_error_handler.py
+++ b/parsl/dataflow/job_error_handler.py
@@ -13,9 +13,7 @@ class JobErrorHandler:
     def _check_irrecoverable_executor(self, es: ExecutorStatus):
         if not es.executor.error_management_enabled:
             return
-        custom_handling = es.executor.handle_errors(self, es.status)
-        if not custom_handling:
-            self.simple_error_handler(es.executor, es.status, 3)
+        es.executor.handle_errors(self, es.status)
 
     def simple_error_handler(self, executor: ParslExecutor, status: Dict[str, JobStatus], threshold: int):
         (total_jobs, failed_jobs) = self.count_jobs(status)

--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -180,7 +180,7 @@ class ParslExecutor(metaclass=ABCMeta):
 
     @abstractmethod
     def handle_errors(self, error_handler: "parsl.dataflow.job_error_handler.JobErrorHandler",
-                      status: Dict[str, JobStatus]) -> bool:
+                      status: Dict[str, JobStatus]) -> None:
         """This method is called by the error management infrastructure after a status poll. The
         executor implementing this method is then responsible for detecting abnormal conditions
         based on the status of submitted jobs. If the executor does not implement any special
@@ -188,7 +188,6 @@ class ParslExecutor(metaclass=ABCMeta):
         scheme will be used.
         :param error_handler: a reference to the generic error handler calling this method
         :param status: status of all jobs launched by this executor
-        :return: True if this executor implements custom error handling, or False otherwise
         """
         pass
 

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -130,14 +130,13 @@ class BlockProviderExecutor(ParslExecutor):
         return True
 
     def handle_errors(self, error_handler: "parsl.dataflow.job_error_handler.JobErrorHandler",
-                      status: Dict[str, JobStatus]) -> bool:
+                      status: Dict[str, JobStatus]) -> None:
         init_blocks = 3
         if hasattr(self.provider, 'init_blocks'):
             init_blocks = self.provider.init_blocks  # type: ignore
         if init_blocks < 1:
             init_blocks = 1
         error_handler.simple_error_handler(self, status, init_blocks)
-        return True
 
     @property
     def tasks(self) -> Dict[object, Future]:
@@ -230,8 +229,8 @@ class NoStatusHandlingExecutor(ParslExecutor):
         return {}
 
     def handle_errors(self, error_handler: "parsl.dataflow.job_error_handler.JobErrorHandler",
-                      status: Dict[str, JobStatus]) -> bool:
-        return False
+                      status: Dict[str, JobStatus]) -> None:
+        pass
 
     @property
     def tasks(self) -> Dict[object, Future]:


### PR DESCRIPTION
Prior to this commit, job error handling failures
were dealt with in two places - a "default" with 3 retries,
and for all status handling executors, in handle errors,
with an "init blocks" limit which overrode that.

This removes the default handling -- 3 is an unconfigured
arbitrary value at the moment, and in practice this code
path isn't used because our error handling executors are
all status handling executors.

Handling errors at the executor level is now mandatory,
but can still be delegated to simple_error_handler.

This is part of an ongoing move towards BlockProviderExecutor
holding the relevant code (which can then be overridden
if desired) rather than having a second non-inheritence-based
default path.

## Type of change

- Code maintentance/cleanup
