### PR TITLE
Add more debugging messages around router/dbm termination

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -444,7 +444,11 @@ class MonitoringHub(RepresentationMixin):
             self.router_proc.join()
             self.logger.debug("Finished waiting for router termination")
             if len(exception_msgs) == 0:
+                self.logger.debug("Sending STOP to DBM")
                 self.priority_msgs.put(("STOP", 0))
+            else:
+                self.logger.debug("Not sending STOP to DBM, because there were DBM exceptions")
+            self.logger.debug("Waiting for DB termination")
             self.dbm_proc.join()
             self.logger.debug("Finished waiting for DBM termination")
 


### PR DESCRIPTION
This is to get more information about one place I have
seen shutdown hang in CI.

## Type of change

- Code maintentance/cleanup
