### PR TITLE
Increase CI concurrency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
 
     - name: make ${{ matrix.makefile-target }}
       run: |
-        make test
+        make ${{ matrix.makefile-target }}
 
     - name: Checking parsl-visualize
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
                            # "local_thread_test",
                            # "htex_local_test",
                            # "htex_local_alternate_test",
-                          "clean_coverage lint flake8 mypy local_thread_test htex_local_test workqueue_ex_test" ]
+                          "htex_local_alternate_test workqueue_ex_test" ]
                            # "config_local_test"]
     runs-on: ubuntu-20.04
     timeout-minutes: 30

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,12 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        makefile-target: ["test"]
+        makefile-target: ["lint flake8 mypy",
+                          "local_thread_test",
+                          "htex_local_test",
+                          "htex_local_alternate_test",
+                          "workqueue_ex_test",
+                          "config_local_test"]
     runs-on: ubuntu-20.04
     timeout-minutes: 30
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,7 @@ jobs:
         parsl/tests/test-viz.sh
 
     - name: Check monitoring did not report errors
+      run: |
         # assert that none of the runs in this test have put an ERROR message into a
         # database manager log file or monitoring router log file. It would be better if
         # the tests themselves failed immediately when there was a monitoring error, but

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,20 +50,20 @@ jobs:
       run: |
         make ${{ matrix.makefile-target }}
 
-    - name: Checking parsl-visualize
-      run: |
-        sudo apt-get install -y graphviz
-        pip install .[monitoring]
-        parsl/tests/test-viz.sh
+    # - name: Checking parsl-visualize
+    #  run: |
+    #    sudo apt-get install -y graphviz
+    #    pip install .[monitoring]
+    #    parsl/tests/test-viz.sh
 
-    - name: Check monitoring did not report errors
-      run: |
-        # assert that none of the runs in this test have put an ERROR message into a
-        # database manager log file or monitoring router log file. It would be better if
-        # the tests themselves failed immediately when there was a monitoring error, but
-        # in the absence of that, this is a dirty way to check.
-        bash -c '! grep ERROR runinfo*/*/database_manager.log'
-        bash -c '! grep ERROR runinfo*/*/monitoring_router.log'
+    # - name: Check monitoring did not report errors
+    #  run: |
+    #    # assert that none of the runs in this test have put an ERROR message into a
+    #    # database manager log file or monitoring router log file. It would be better if
+    #    # the tests themselves failed immediately when there was a monitoring error, but
+    #    # in the absence of that, this is a dirty way to check.
+    #    bash -c '! grep ERROR runinfo*/*/database_manager.log'
+    #    bash -c '! grep ERROR runinfo*/*/monitoring_router.log'
 
 
     - name: make coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+        makefile-target: ["test"]
     runs-on: ubuntu-20.04
     timeout-minutes: 30
 
@@ -39,9 +40,43 @@ jobs:
         make deps
         make clean_coverage
 
-    - name: make test
+    - name: make ${{ matrix.makefile-target }}
       run: |
         make test
+
+    - name: Checking parsl-visualize
+      run: |
+        sudo apt-get install -y graphviz
+        pip install .[monitoring]
+        parsl/tests/test-viz.sh
+
+    - name: Check monitoring did not report errors
+        # assert that none of the runs in this test have put an ERROR message into a
+        # database manager log file or monitoring router log file. It would be better if
+        # the tests themselves failed immediately when there was a monitoring error, but
+        # in the absence of that, this is a dirty way to check.
+        bash -c '! grep ERROR runinfo*/*/database_manager.log'
+        bash -c '! grep ERROR runinfo*/*/monitoring_router.log'
+
+
+    - name: make coverage
+      run: |
+        make coverage
+
+    - name: Archive runinfo logs
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: runinfo-${{ matrix.python-version }}
+        path: runinfo/
+
+  documentation:
+    - uses: actions/checkout@master
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.10
 
     - name: Documentation checks
       run: |
@@ -55,27 +90,3 @@ jobs:
         make SPHINXOPTS=-W html
 
         cd ..
-
-        # assert that none of the runs in this test have put an ERROR message into a
-        # database manager log file or monitoring router log file. It would be better if
-        # the tests themselves failed immediately when there was a monitoring error, but
-        # in the absence of that, this is a dirty way to check.
-        bash -c '! grep ERROR runinfo*/*/database_manager.log'
-        bash -c '! grep ERROR runinfo*/*/monitoring_router.log'
-
-    - name: Checking parsl-visualize
-      run: |
-        sudo apt-get install -y graphviz
-        pip install .[monitoring]
-        parsl/tests/test-viz.sh
-
-    - name: make coverage
-      run: |
-        make coverage
-
-    - name: Archive runinfo logs
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v2
-      with:
-        name: runinfo-${{ matrix.python-version }}
-        path: runinfo/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,8 +74,19 @@ jobs:
   documentation:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
-
     steps:
+    - name: copy of arbitrary installs from above
+      run: |
+        sudo apt-get update -q
+        python -m pip install Cython
+        python -m pip install numpy
+        python --version
+        python -m cython --version
+        python -c "import numpy;print(numpy.__version__)"
+
+        # this is to make the workqueue binary installer happy
+        sudo apt-get install -y libpython3.5
+
     - uses: actions/checkout@master
 
     - name: Set up Python 3.10

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
                            # "local_thread_test",
                            # "htex_local_test",
                            # "htex_local_alternate_test",
-                          "clean_coverage lint flake8 mypy local_thread_test htex_local_test htex_local_alternate_test workqueue_ex_test workqueue_ex_test" ]
+                          "clean_coverage lint flake8 mypy local_thread_test htex_local_test workqueue_ex_test" ]
                            # "config_local_test"]
     runs-on: ubuntu-20.04
     timeout-minutes: 30

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,10 @@ jobs:
         path: runinfo/
 
   documentation:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+
+    steps:
     - uses: actions/checkout@master
 
     - name: Set up Python 3.10

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,7 @@ jobs:
 
     - name: Documentation checks
       run: |
+        make deps
         pip install .[docs]
         sudo apt-get install -y pandoc
         cd docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,9 +94,12 @@ jobs:
       with:
         python-version: "3.10"
 
-    - name: Documentation checks
+    - name: Make deps
       run: |
         make deps
+
+    - name: Documentation checks
+      run: |
         pip install .[docs]
         sudo apt-get install -y pandoc
         cd docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
                           "local_thread_test",
                           "htex_local_test",
                           "htex_local_alternate_test",
-                          "workqueue_ex_test",
+                          "clean_coverage lint flake8 mypy local_thread_test htex_local_test htex_local_alternate_test workqueue_ex_test workqueue_ex_test",
                           "config_local_test"]
     runs-on: ubuntu-20.04
     timeout-minutes: 30

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,20 +51,19 @@ jobs:
       run: |
         make ${{ matrix.makefile-target }}
 
-    # - name: Checking parsl-visualize
-    #  run: |
-    #    sudo apt-get install -y graphviz
-    #    pip install .[monitoring]
-    #    parsl/tests/test-viz.sh
-
-    # - name: Check monitoring did not report errors
-    #  run: |
-    #    # assert that none of the runs in this test have put an ERROR message into a
-    #    # database manager log file or monitoring router log file. It would be better if
-    #    # the tests themselves failed immediately when there was a monitoring error, but
-    #    # in the absence of that, this is a dirty way to check.
-    #    bash -c '! grep ERROR runinfo*/*/database_manager.log'
-    #    bash -c '! grep ERROR runinfo*/*/monitoring_router.log'
+    - name: Checking parsl-visualize and monitoring output
+      run: |
+         if [ -d runinfo ] && [ -f runinfo/monitoring.db ]; then
+           sudo apt-get install -y graphviz
+           pip install .[monitoring]
+           parsl/tests/test-viz.sh
+           # assert that none of the runs in this test have put an ERROR message into a
+           # database manager log file or monitoring router log file. It would be better if
+           # the tests themselves failed immediately when there was a monitoring error, but
+           # in the absence of that, this is a dirty way to check.
+           bash -c '! grep ERROR runinfo*/*/database_manager.log'
+           bash -c '! grep ERROR runinfo*/*/monitoring_router.log'
+         fi
 
 
     - name: make coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,8 @@ jobs:
                           "htex_local_test",
                           # "htex_local_alternate_test",
                           # wq fails unless htex_local_alternate_test runs in the same session
-                          "htex_local_alternate_test workqueue_ex_test",
+                          "htex_local_alternate_test",
+                          "workqueue_ex_test",
                           "config_local_test"]
     runs-on: ubuntu-20.04
     timeout-minutes: 30

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
                            # "local_thread_test",
                            # "htex_local_test",
                            # "htex_local_alternate_test",
-                          "clean_coverage lint flake8 mypy local_thread_test htex_local_test htex_local_alternate_test workqueue_ex_test workqueue_ex_test",
+                          "clean_coverage lint flake8 mypy local_thread_test htex_local_test htex_local_alternate_test workqueue_ex_test workqueue_ex_test" ]
                            # "config_local_test"]
     runs-on: ubuntu-20.04
     timeout-minutes: 30

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,13 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        makefile-target: [ # "lint flake8 mypy",
-                           # "local_thread_test",
-                           # "htex_local_test",
-                           # "htex_local_alternate_test",
-                          "htex_local_alternate_test workqueue_ex_test" ]
-                           # "config_local_test"]
+        makefile-target: ["lint flake8 mypy",
+                          "local_thread_test",
+                          "htex_local_test",
+                          # "htex_local_alternate_test",
+                          # wq fails unless htex_local_alternate_test runs in the same session
+                          "htex_local_alternate_test workqueue_ex_test",
+                          "config_local_test"]
     runs-on: ubuntu-20.04
     timeout-minutes: 30
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        makefile-target: ["lint flake8 mypy",
-                          "local_thread_test",
-                          "htex_local_test",
-                          "htex_local_alternate_test",
+        makefile-target: [ # "lint flake8 mypy",
+                           # "local_thread_test",
+                           # "htex_local_test",
+                           # "htex_local_alternate_test",
                           "clean_coverage lint flake8 mypy local_thread_test htex_local_test htex_local_alternate_test workqueue_ex_test workqueue_ex_test",
-                          "config_local_test"]
+                           # "config_local_test"]
     runs-on: ubuntu-20.04
     timeout-minutes: 30
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Documentation checks
       run: |

--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,9 @@ $(WORKQUEUE_INSTALL):
 
 .PHONY: workqueue_ex_test
 workqueue_ex_test: $(WORKQUEUE_INSTALL)  ## run all tests with workqueue_ex config
-        pwd
-        ls
-        ls parsl/
+	pwd
+	ls
+	ls parsl/
 	PYTHONPATH=.:/tmp/cctools/lib/python3.8/site-packages  pytest parsl/tests/ -k "not cleannet and not issue363" --config parsl/tests/configs/workqueue_ex.py --random-order
 
 .PHONY: config_local_test

--- a/Makefile
+++ b/Makefile
@@ -73,11 +73,7 @@ $(WORKQUEUE_INSTALL):
 
 .PHONY: workqueue_ex_test
 workqueue_ex_test: $(WORKQUEUE_INSTALL)  ## run all tests with workqueue_ex config
-	pwd
-	ls
-	ls parsl/
-	python -c "import parsl; print(parsl.__file__); print(parsl.__version__)"
-	PYTHONPATH=.:/tmp/cctools/lib/python3.8/site-packages  python -c "import parsl; print(parsl.__file__); print(parsl.__version__)"
+        pip3 install .
 	PYTHONPATH=.:/tmp/cctools/lib/python3.8/site-packages  pytest parsl/tests/ -k "not cleannet and not issue363" --config parsl/tests/configs/workqueue_ex.py --random-order
 
 .PHONY: config_local_test

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,10 @@ mypy: ## run mypy checks
 	MYPYPATH=$(CWD)/mypy-stubs mypy parsl/tests/configs/
 	MYPYPATH=$(CWD)/mypy-stubs mypy parsl/tests/test*/
 	MYPYPATH=$(CWD)/mypy-stubs mypy parsl/tests/sites/
-        # only the top level of monitoring is checked here because the visualization code does not type check
+	# only the top level of monitoring is checked here because the visualization code does not type check
 	MYPYPATH=$(CWD)/mypy-stubs mypy parsl/app/ parsl/channels/ parsl/dataflow/ parsl/data_provider/ parsl/launchers parsl/providers/ parsl/monitoring/*py
-        # process worker pool is explicitly listed to check, because it is not
-        # imported from anywhere in core parsl python code.
+	# process worker pool is explicitly listed to check, because it is not
+	# imported from anywhere in core parsl python code.
 	MYPYPATH=$(CWD)/mypy-stubs mypy parsl/executors/high_throughput/process_worker_pool.py
 
 .PHONY: local_thread_test
@@ -73,7 +73,7 @@ $(WORKQUEUE_INSTALL):
 
 .PHONY: workqueue_ex_test
 workqueue_ex_test: $(WORKQUEUE_INSTALL)  ## run all tests with workqueue_ex config
-        pip3 install .
+	pip3 install .
 	PYTHONPATH=.:/tmp/cctools/lib/python3.8/site-packages  pytest parsl/tests/ -k "not cleannet and not issue363" --config parsl/tests/configs/workqueue_ex.py --random-order
 
 .PHONY: config_local_test

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,8 @@ workqueue_ex_test: $(WORKQUEUE_INSTALL)  ## run all tests with workqueue_ex conf
 	pwd
 	ls
 	ls parsl/
+	python -c "import parsl; print(parsl.__file__); print(parsl.__version__)"
+	PYTHONPATH=.:/tmp/cctools/lib/python3.8/site-packages  python -c "import parsl; print(parsl.__file__); print(parsl.__version__)"
 	PYTHONPATH=.:/tmp/cctools/lib/python3.8/site-packages  pytest parsl/tests/ -k "not cleannet and not issue363" --config parsl/tests/configs/workqueue_ex.py --random-order
 
 .PHONY: config_local_test

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ $(WORKQUEUE_INSTALL):
 
 .PHONY: workqueue_ex_test
 workqueue_ex_test: $(WORKQUEUE_INSTALL)  ## run all tests with workqueue_ex config
+        pwd
+        ls
+        ls parsl/
 	PYTHONPATH=.:/tmp/cctools/lib/python3.8/site-packages  pytest parsl/tests/ -k "not cleannet and not issue363" --config parsl/tests/configs/workqueue_ex.py --random-order
 
 .PHONY: config_local_test


### PR DESCRIPTION
# Description

This is to decrease walltime for a single CI run.

This ends up needing a bunch of target dependency work, as the existing makefile+workflow assumes a particular linear ordering not expressed in makefile targets.

## Type of change

- Code maintentance/cleanup
