### PR TITLE
Fix Task class in models.py, adding task_time_invoked column (ref #2266)

### DIFF
--- a/parsl/monitoring/visualization/models.py
+++ b/parsl/monitoring/visualization/models.py
@@ -58,6 +58,8 @@ class Task(db.Model):
     run_id = db.Column('run_id', db.Text, nullable=False)
     task_func_name = db.Column('task_func_name', db.Text, nullable=False)
     task_depends = db.Column('task_depends', db.Text, nullable=True)
+    task_time_invoked = db.Column(
+        'task_time_invoked', db.DateTime, nullable=True)
     task_time_returned = db.Column(
         'task_time_returned', db.DateTime, nullable=True)
     task_memoize = db.Column('task_memoize', db.Text, nullable=False)


### PR DESCRIPTION
# Description

I addressed the issue described in https://github.com/Parsl/parsl/issues/2266#issuecomment-1142077440 and https://github.com/Parsl/parsl/issues/2266#issuecomment-1150712877, by adding the missing entry `task_time_invoked` to the `Task` class in `parsl/monitoring/visualization/models.py`. Unless I'm missing something, this should close the corresponding issue.

Fixes #2266 

## Type of change

- Bug fix (non-breaking change that fixes an issue)