### PR TITLE
Do not log None return of heartbeat send

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -222,8 +222,8 @@ class Manager(object):
         """ Send heartbeat to the incoming task queue
         """
         heartbeat = (HEARTBEAT_CODE).to_bytes(4, "little")
-        r = self.task_incoming.send(heartbeat)
-        logger.debug("Return from heartbeat: {}".format(r))
+        self.task_incoming.send(heartbeat)
+        logger.debug("Sent heartbeat")
 
     @wrap_with_logs
     def pull_tasks(self, kill_event):


### PR DESCRIPTION
The return code of the send is always None - errors are
indicated by exceptions.

This message has confused me for years.

## Type of change

- Code maintentance/cleanup
