### PR TITLE
Log process, thread, function metadata in parsl.log

### DIFF
--- a/parsl/log_utils.py
+++ b/parsl/log_utils.py
@@ -17,6 +17,13 @@ import typeguard
 from typing import Optional
 
 
+DEFAULT_FORMAT = (
+    "%(created)f %(asctime)s %(processName)s-%(process)d "
+    "%(threadName)s-%(thread)d %(name)s:%(lineno)d %(funcName)s %(levelname)s: "
+    "%(message)s"
+)
+
+
 @typeguard.typechecked
 def set_stream_logger(name: str = 'parsl', level: int = logging.DEBUG, format_string: Optional[str] = None, stream: Optional[io.TextIOWrapper] = None):
     """Add a stream log handler.
@@ -64,7 +71,7 @@ def set_file_logger(filename: str, name: str = 'parsl', level: int = logging.DEB
        -  None
     """
     if format_string is None:
-        format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+        format_string = DEFAULT_FORMAT
 
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)

--- a/parsl/tests/test_checkpointing/test_periodic.py
+++ b/parsl/tests/test_checkpointing/test_periodic.py
@@ -1,9 +1,7 @@
 import argparse
-import datetime
 import time
 
 import pytest
-from dateutil.parser import parse
 
 import parsl
 from parsl.app.app import python_app
@@ -30,10 +28,8 @@ def slow_double(x, sleep_dur=1):
 
 def tstamp_to_seconds(line):
     print("Parsing line: ", line)
-    parsed = parse(line[0:23], fuzzy=True)
-    epoch = datetime.datetime.utcfromtimestamp(0)
-    f = (parsed - epoch).total_seconds()
-    return f
+    f = line.partition(" ")[0]
+    return float(f)
 
 
 @pytest.mark.local
@@ -60,8 +56,8 @@ def test_periodic(n=4):
 
     with open("{}/parsl.log".format(dfk.run_dir), 'r') as f:
         log_lines = f.readlines()
-        expected_msg = "]  Done checkpointing"
-        expected_msg2 = "]  No tasks checkpointed in this pass"
+        expected_msg = " Done checkpointing"
+        expected_msg2 = " No tasks checkpointed in this pass"
 
         lines = [line for line in log_lines if expected_msg in line or expected_msg2 in line]
         assert len(lines) >= 3, "Insufficient checkpoint lines in logfile"


### PR DESCRIPTION
This is useful when trying to understand which components are writing which logs, when their logging overlaps in time.

It should replace the less accurate manual style of annotating some log messages with [TOPIC] prefixes

This PR also adds a unix timestamp, which is accurate to microsecond resolution, which is also useful when trying to correlate between components.

## Type of change

- New feature (non-breaking change that adds functionality)
