### PR TITLE
Fix bad message logging on interchange deserialization failure

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -392,7 +392,7 @@ class Interchange(object):
                     except Exception:
                         logger.warning("[MAIN] Got Exception reading registration message from manager: {}".format(
                             manager), exc_info=True)
-                        logger.debug("[MAIN] Message :\n{}\n".format(message[0]))
+                        logger.debug("[MAIN] Message: \n{}\n".format(message[1]))
                     else:
                         # We set up an entry only if registration works correctly
                         self._ready_manager_queue[manager] = {'last_heartbeat': time.time(),


### PR DESCRIPTION
Previously, the manager field was logged, even though the log
claimed it was the (JSON) message. This PR corrects that.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
