### PR TITLE
Put block ID into try table with WQ executor via PARSL_WORKER_BLOCK_ID env var

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -279,7 +279,7 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
     def _get_launch_command(self, block_id):
         # this executor uses different terminology for worker/launch
         # commands than in htex
-        return self.worker_command
+        return f"PARSL_WORKER_BLOCK_ID={block_id} {self.worker_command}"
 
     def start(self):
         """Create submit process and collector thread to create, send, and


### PR DESCRIPTION
This allows the block ID to be reported for tasks in monitoring

## Type of change

- New feature (non-breaking change that adds functionality)
