### PR TITLE
Add wrap_with_logs around cleanup calls

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -31,6 +31,7 @@ from parsl.dataflow.rundirs import make_rundir
 from parsl.dataflow.states import States, FINAL_STATES, FINAL_FAILURE_STATES
 from parsl.dataflow.usage_tracking.usage import UsageTracker
 from parsl.executors.threads import ThreadPoolExecutor
+from parsl.process_loggers import wrap_with_logs
 from parsl.providers.provider_base import JobStatus, JobState
 from parsl.utils import get_version, get_std_fname_mode, get_all_checkpoints
 
@@ -1040,6 +1041,7 @@ class DataFlowKernel(object):
 
         logger.info("All remaining tasks completed")
 
+    @wrap_with_logs
     def cleanup(self):
         """DataFlowKernel cleanup.
 


### PR DESCRIPTION
This is part of ungoing debugging of parsl shutdown,
especially tied to cleanup running inside a python
process that has a lot of other stuff going on,
eg BPS in lsst/desc

## Type of change

- Code maintentance/cleanup
