### PR TITLE
Remove awkward Actions column from viz workflow summary

### DIFF
--- a/parsl/monitoring/visualization/templates/workflows_summary.html
+++ b/parsl/monitoring/visualization/templates/workflows_summary.html
@@ -14,7 +14,6 @@
         <th>Status</th>
         <th>Runtime (s)</th>
         <th>Tasks</th>
-        <th>Actions</th>
       </tr>
     </thead>
     <tbody>
@@ -29,9 +28,6 @@
              <span class="task task-complete">{{ w['tasks_completed_count'] }}</span>
              <span class="task task-failed">{{ w['tasks_failed_count'] }}</span>
 
-        </td>
-        <td>
-          <a href="workflow/{{ w['run_id'] }}/resource_usage"><span class="fas fa-chart-bar"></span></a>
         </td>
       </tr>
     {% endfor %}


### PR DESCRIPTION
This previously contained only a link to the resource summary page,
which is also linked from individual workflow summaries.

The workflow summaries page also has links to other interesting info - the
DAGs view.

It is inconsistent having only the resources report linked from the Actions
column; and this link is not an Action.

Remove Action entirely and leave everything linked from per-workflow info.

## Type of change

- Code maintentance/cleanup
