### PR TITLE
Disambiguate which executor blocks are launched on

### DIFF
--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -177,7 +177,7 @@ class BlockProviderExecutor(ParslExecutor):
         launch_cmd = self._get_launch_command(block_id)
         job_id = self.provider.submit(launch_cmd, 1)
         if job_id:
-            logger.debug("Launched block {}->{}".format(block_id, job_id))
+            logger.debug(f"Launched block {block_id} on executor {self.label} with job ID {job_id}")
         else:
             raise ScalingFailed(self,
                                 "Attempt to provision nodes did not return a job ID")


### PR DESCRIPTION
Elaborate on x->y notation to be clear what the
x and y values are in the log message

## Type of change

- Documentation update
- Code maintentance/cleanup
