### PR TITLE
Fix lsf_provider's error status caused by incomplete line

### DIFF
--- a/parsl/providers/lsf/lsf.py
+++ b/parsl/providers/lsf/lsf.py
@@ -165,9 +165,11 @@ class LSFProvider(ClusterProvider, RepresentationMixin):
             parts = line.split()
             if parts and parts[0] != 'JOBID':
                 job_id = parts[0]
-                state = translate_table.get(parts[2], JobState.UNKNOWN)
-                self.resources[job_id]['status'] = JobStatus(state)
-                jobs_missing.remove(job_id)
+                # the line can be uncompleted. len > 2 ensures safe indexing.
+                if len(parts) > 2:
+                    state = translate_table.get(parts[2], JobState.UNKNOWN)
+                    self.resources[job_id]['status'] = JobStatus(state)
+                    jobs_missing.remove(job_id)
 
         # squeue does not report on jobs that are not running. So we are filling in the
         # blanks for missing jobs, we might lose some information about why the jobs failed.


### PR DESCRIPTION
# Description
For parsl's lsf provider, the list indexing error (out of bounds) appears in the `_status` function when the `bjobs` stdout is incomplete.
Take a real case at SUSTech's Taiyi Cluser ( LSF managed cluster) as an example.

`JOBID      USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME`
`3909009    cse-liy RUN   debug      login01     40*r13n44   *0.8569713 Jul 15 11:14`
`                                                                             40*r13n45                                           `
`3909010    cse-liy PEND  debug      login01                 *80.888154 Jul 15 11:14`
One job can be executed by two hosts. There will be a newline which only contains the id of exec_host.
The original code my occurs list indexing error. Because the length of `parts` is 1, but there is a indexing of `parts[2]`.

# How to Fix
I only add a line to check if the length of `parts` list is greater than 2.

**What about check `len(parts) == len(Attributes at the first row)`?**
The length of the attributes at the first row is not equal to the length of the `parts`. Because the `SUBMIT_TIME` contains multiple blankSpaces.


## Type of change


Bug fix (non-breaking change that fixes an issue)
