### PR TITLE
Make log about queue management duplicate thread be an error

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -499,7 +499,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
             logger.debug("Started queue management thread")
 
         else:
-            logger.debug("Management thread already exists, returning")
+            logger.error("Management thread already exists, returning")
 
     def hold_worker(self, worker_id):
         """Puts a worker on hold, preventing scheduling of additional tasks to it.


### PR DESCRIPTION
If this case is firing, then something is wrong.

## Type of change

- Documentation update
- Code maintentance/cleanup
