### PR TITLE
Re-enabled scale down test

### DIFF
--- a/parsl/tests/test_scaling/test_scale_down.py
+++ b/parsl/tests/test_scaling/test_scale_down.py
@@ -43,7 +43,9 @@ def sleeper(t):
     return random.randint(0, 10000)
 
 
-@pytest.mark.skip('fails 50% of time in CI - see issue #1885')
+# see issue #1885 for details of failures of this test.
+# at the time of issue #1885 this test was failing frequently
+# in CI.
 @pytest.mark.local
 def test_scale_out():
     dfk = parsl.dfk()


### PR DESCRIPTION
This was disabled due to frequent failure (see issue #1885) but this test
has been re-enabled in the `desc` branch for a while and has not caused
trouble, so this commit should re-enabled it in master.

Issue #1885 also notes the utility of this test in discovering scaling-in
breakage - which gives some pressure to re-enable this test.

## Type of change

- Code maintentance/cleanup
