### PR TITLE
Make parsl wait for ThreadPoolExecutor tasks to complete during shutdown

### DIFF
--- a/parsl/executors/threads.py
+++ b/parsl/executors/threads.py
@@ -90,13 +90,19 @@ class ThreadPoolExecutor(NoStatusHandlingExecutor, RepresentationMixin):
 
         raise NotImplementedError
 
-    def shutdown(self, block=False):
-        """Shutdown the ThreadPool.
+    def shutdown(self, block=True):
+        """Shutdown the ThreadPool. The underlying concurrent.futures thread pool
+        implementation will not terminate tasks that are being executed, because it
+        does not provide a mechanism to do that. With block set to false, this will
+        return immediately and it will appear as if the DFK is shut down, but
+        the python process will not be able to exit until the thread pool has
+        emptied out by task completions. In either case, this can be a very long wait.
 
         Kwargs:
             - block (Bool): To block for confirmations or not
 
         """
+        logger.debug("Shutting down executor, which involves waiting for running tasks to complete")
         x = self.executor.shutdown(wait=block)
         logger.debug("Done with executor shutdown")
         return x


### PR DESCRIPTION
When parsl shuts down at the end of a python process, previously it would
not wait for thread pool tasks to complete.

However, the underlying thread pool executor (from the concurrent.* library)
would then cause the python process exit to stall until thread-local tasks
are complete.

This PR makes parsl also wait, so that it is clearer when debugging slow
or hanging shutdown that thread-local tasks are involved.

In the case of shutting down a DFK at process exit, this should not
significantly delay shutdown any futher.

In the case of shutting down a DFK in the middle of a process, this will
cause longer delay, but in the absence of the ability to cancel tasks
in the thread local executor, this maybe the best thing to do (rather than
claiming that shutdown has actually completed when tasks are still
running)

## Type of change

- New feature (non-breaking change that adds functionality)
