### PR TITLE
Use fresh_config() in pytest if config is not available

### DIFF
--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -111,7 +111,12 @@ def load_dfk_session(request, pytestconfig):
         if DataFlowKernelLoader._dfk is not None:
             raise RuntimeError("DFK didn't start as None - there was a DFK from somewhere already")
 
-        dfk = parsl.load(module.config)
+        if hasattr(module, 'config'):
+            dfk = parsl.load(module.config)
+        elif hasattr(module, 'fresh_config'):
+            dfk = parsl.load(module.fresh_config())
+        else:
+            raise RuntimeError("Config module does not define config or fresh_config")
 
         yield
 


### PR DESCRIPTION
In general when re-using config files in the test suite,
fresh_config() is a cleaner choice than using config, as
it generates a whole new structure each time.

Individual configs can't, in general, be loaded using
parsl.load() more than once due to mutability of the
component objects (although in many cases this might work).

Generating a config at import time is also sometimes
expensive - for example, it often requires a network lookup
to determine IP address. Using fresh_config() defers
that activity until a particular config is actually
needed.

## Type of change

- New feature (non-breaking change that adds functionality)
- Code maintentance/cleanup
