### PR TITLE
Remove DuplicateTaskError

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -147,7 +147,6 @@ Exceptions
     parsl.executors.errors.BadMessage
     parsl.dataflow.error.DataFlowException
     parsl.dataflow.error.ConfigurationError
-    parsl.dataflow.error.DuplicateTaskError
     parsl.dataflow.error.BadCheckpoint
     parsl.dataflow.error.DependencyError
     parsl.launchers.error.BadLauncher

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -23,7 +23,7 @@ from parsl.app.futures import DataFuture
 from parsl.config import Config
 from parsl.data_provider.data_manager import DataManager
 from parsl.data_provider.files import File
-from parsl.dataflow.error import BadCheckpoint, ConfigurationError, DependencyError, DuplicateTaskError
+from parsl.dataflow.error import BadCheckpoint, ConfigurationError, DependencyError
 from parsl.dataflow.flow_control import FlowControl, Timer
 from parsl.dataflow.futures import AppFuture
 from parsl.dataflow.memoization import Memoizer
@@ -886,11 +886,9 @@ class DataFlowKernel(object):
                     'kwargs': app_kwargs,
                     'app_fu': app_fu})
 
-        if task_id in self.tasks:
-            raise DuplicateTaskError(
-                "internal consistency error: Task {0} already exists in task list".format(task_id))
-        else:
-            self.tasks[task_id] = task_def
+        assert task_id not in self.tasks
+
+        self.tasks[task_id] = task_def
 
         # Get the list of dependencies for the task
         depends = self._gather_all_deps(app_args, app_kwargs)

--- a/parsl/dataflow/error.py
+++ b/parsl/dataflow/error.py
@@ -11,11 +11,6 @@ class ConfigurationError(DataFlowException):
     """
 
 
-class DuplicateTaskError(DataFlowException):
-    """Raised by the DataFlowKernel when it finds that a job with the same task-id has been launched before.
-    """
-
-
 class BadCheckpoint(DataFlowException):
     """Error raised at the end of app execution due to missing output files.
 


### PR DESCRIPTION
This is not an error that should be happening ever, and is better detected by an assert rather than a user exposed specific error type.

I guess the test comes from race-condition prone code a long time ago.

## Type of change

- Code maintentance/cleanup
