### PR TITLE
Do not log full monitoring message

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -415,7 +415,7 @@ class MonitoringHub(RepresentationMixin):
 
     # TODO: tighten the Any message format
     def send(self, mtype: MessageType, message: Any) -> None:
-        self.logger.debug("Sending message {}, {}".format(mtype, message))
+        self.logger.debug("Sending message type {}".format(mtype))
         try:
             self._dfk_channel.send_pyobj((mtype, message))
         except zmq.Again:


### PR DESCRIPTION
In the presence of large numbers of blocks, these messages
could be extremely large

## Type of change

- Code maintentance/cleanup
