### PR TITLE
Tighten exception catching in bash error code test, because e.exitcode is not defined for arbitrary exceptions

### DIFF
--- a/parsl/tests/test_bash_apps/test_error_codes.py
+++ b/parsl/tests/test_bash_apps/test_error_codes.py
@@ -8,6 +8,8 @@ from parsl.app.app import bash_app
 import parsl.app.errors as pe
 
 
+from parsl.app.errors import BashExitFailure
+
 from parsl.tests.configs.local_threads import config
 
 
@@ -67,7 +69,7 @@ def test_div_0(test_fn=div_0):
     f = test_fn()
     try:
         f.result()
-    except Exception as e:
+    except BashExitFailure as e:
         print("Caught exception", e)
         assert e.exitcode == err_code, "{0} expected err_code:{1} but got {2}".format(test_fn.__name__,
                                                                                       err_code,
@@ -116,7 +118,7 @@ def test_not_executable(test_fn=not_executable):
     f = test_fn()
     try:
         f.result()
-    except Exception as e:
+    except BashExitFailure as e:
         print("Caught exception", e)
         assert e.exitcode == err_code, "{0} expected err_code:{1} but got {2}".format(test_fn.__name__,
                                                                                       err_code,
@@ -131,7 +133,7 @@ def run_app(test_fn, err_code):
     print(f)
     try:
         f.result()
-    except Exception as e:
+    except BashExitFailure as e:
         print("Caught exception", e)
         assert e.exitcode == err_code, "{0} expected err_code:{1} but got {2}".format(test_fn.__name__,
                                                                                       err_code,


### PR DESCRIPTION
## Type of change

- Code maintentance/cleanup
