### PR TITLE
Separate accumulation and sending of resource info

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -853,69 +853,76 @@ def monitor(pid: int,
     children_user_time = {}  # type: Dict[int, float]
     children_system_time = {}  # type: Dict[int, float]
 
+    def accumulate_and_prepare() -> Dict[str, Any]:
+        d = {"psutil_process_" + str(k): v for k, v in pm.as_dict().items() if k in simple}
+        d["run_id"] = run_id
+        d["task_id"] = task_id
+        d["try_id"] = try_id
+        d['resource_monitoring_interval'] = sleep_dur
+        d['hostname'] = platform.node()
+        d['first_msg'] = False
+        d['last_msg'] = False
+        d['timestamp'] = datetime.datetime.now()
+
+        logging.debug("getting children")
+        children = pm.children(recursive=True)
+        logging.debug("got children")
+
+        d["psutil_cpu_count"] = psutil.cpu_count()
+        d['psutil_process_memory_virtual'] = pm.memory_info().vms
+        d['psutil_process_memory_resident'] = pm.memory_info().rss
+        d['psutil_process_time_user'] = pm.cpu_times().user
+        d['psutil_process_time_system'] = pm.cpu_times().system
+        d['psutil_process_children_count'] = len(children)
+        try:
+            d['psutil_process_disk_write'] = pm.io_counters().write_bytes
+            d['psutil_process_disk_read'] = pm.io_counters().read_bytes
+        except Exception:
+            # occasionally pid temp files that hold this information are unvailable to be read so set to zero
+            logging.exception("Exception reading IO counters for main process. Recorded IO usage may be incomplete", exc_info=True)
+            d['psutil_process_disk_write'] = 0
+            d['psutil_process_disk_read'] = 0
+        for child in children:
+            for k, v in child.as_dict(attrs=summable_values).items():
+                d['psutil_process_' + str(k)] += v
+            child_user_time = child.cpu_times().user
+            child_system_time = child.cpu_times().system
+            children_user_time[child.pid] = child_user_time
+            children_system_time[child.pid] = child_system_time
+            d['psutil_process_memory_virtual'] += child.memory_info().vms
+            d['psutil_process_memory_resident'] += child.memory_info().rss
+            try:
+                d['psutil_process_disk_write'] += child.io_counters().write_bytes
+                d['psutil_process_disk_read'] += child.io_counters().read_bytes
+            except Exception:
+                # occassionally pid temp files that hold this information are unvailable to be read so add zero
+                logging.exception("Exception reading IO counters for child {k}. Recorded IO usage may be incomplete".format(k=k), exc_info=True)
+                d['psutil_process_disk_write'] += 0
+                d['psutil_process_disk_read'] += 0
+        total_children_user_time = 0.0
+        for child_pid in children_user_time:
+            total_children_user_time += children_user_time[child_pid]
+        total_children_system_time = 0.0
+        for child_pid in children_system_time:
+            total_children_system_time += children_system_time[child_pid]
+        d['psutil_process_time_user'] += total_children_user_time
+        d['psutil_process_time_system'] += total_children_system_time
+        logging.debug("sending message")
+        return d
+
     while not terminate_event.is_set():
         logging.debug("start of monitoring loop")
-
         try:
-            d = {"psutil_process_" + str(k): v for k, v in pm.as_dict().items() if k in simple}
-            d["run_id"] = run_id
-            d["task_id"] = task_id
-            d["try_id"] = try_id
-            d['resource_monitoring_interval'] = sleep_dur
-            d['hostname'] = platform.node()
-            d['first_msg'] = False
-            d['last_msg'] = False
-            d['timestamp'] = datetime.datetime.now()
-
-            logging.debug("getting children")
-            children = pm.children(recursive=True)
-            logging.debug("got children")
-
-            d["psutil_cpu_count"] = psutil.cpu_count()
-            d['psutil_process_memory_virtual'] = pm.memory_info().vms
-            d['psutil_process_memory_resident'] = pm.memory_info().rss
-            d['psutil_process_time_user'] = pm.cpu_times().user
-            d['psutil_process_time_system'] = pm.cpu_times().system
-            d['psutil_process_children_count'] = len(children)
-            try:
-                d['psutil_process_disk_write'] = pm.io_counters().write_bytes
-                d['psutil_process_disk_read'] = pm.io_counters().read_bytes
-            except Exception:
-                # occasionally pid temp files that hold this information are unvailable to be read so set to zero
-                logging.exception("Exception reading IO counters for main process. Recorded IO usage may be incomplete", exc_info=True)
-                d['psutil_process_disk_write'] = 0
-                d['psutil_process_disk_read'] = 0
-            for child in children:
-                for k, v in child.as_dict(attrs=summable_values).items():
-                    d['psutil_process_' + str(k)] += v
-                child_user_time = child.cpu_times().user
-                child_system_time = child.cpu_times().system
-                children_user_time[child.pid] = child_user_time
-                children_system_time[child.pid] = child_system_time
-                d['psutil_process_memory_virtual'] += child.memory_info().vms
-                d['psutil_process_memory_resident'] += child.memory_info().rss
-                try:
-                    d['psutil_process_disk_write'] += child.io_counters().write_bytes
-                    d['psutil_process_disk_read'] += child.io_counters().read_bytes
-                except Exception:
-                    # occassionally pid temp files that hold this information are unvailable to be read so add zero
-                    logging.exception("Exception reading IO counters for child {k}. Recorded IO usage may be incomplete".format(k=k), exc_info=True)
-                    d['psutil_process_disk_write'] += 0
-                    d['psutil_process_disk_read'] += 0
-            total_children_user_time = 0.0
-            for child_pid in children_user_time:
-                total_children_user_time += children_user_time[child_pid]
-            total_children_system_time = 0.0
-            for child_pid in children_system_time:
-                total_children_system_time += children_system_time[child_pid]
-            d['psutil_process_time_user'] += total_children_user_time
-            d['psutil_process_time_system'] += total_children_system_time
-            logging.debug("sending message")
+            d = accumulate_and_prepare()
             radio.send((MessageType.RESOURCE_INFO, d))
         except Exception:
             logging.exception("Exception getting the resource usage. Not sending usage to Hub", exc_info=True)
-
         logging.debug("sleeping")
         terminate_event.wait(timeout=sleep_dur)
 
+    try:
+        d = accumulate_and_prepare()
+        radio.send((MessageType.RESOURCE_INFO, d))
+    except Exception:
+        logging.exception("Exception getting the resource usage. Not sending final usage to Hub", exc_info=True)
     logging.debug("End of monitoring helper")


### PR DESCRIPTION
This allows accumulation to run more frequently, to
give more accuracy, without generating monitoring
message traffic load.

This PR also adds a final send when the monitoring
loop terminates, to capture the final resource usage
which in the DESC case was especially interesting.

## Type of change

- New feature (non-breaking change that adds functionality)
