### PR TITLE
Send only log manager failure report once per manager

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -548,7 +548,7 @@ class Interchange(object):
                         result_package = {'type': 'result', 'task_id': tid, 'exception': serialize_object(RemoteExceptionWrapper(*sys.exc_info()))}
                         pkl_package = pickle.dumps(result_package)
                         self.results_outgoing.send(pkl_package)
-                        logger.warning("Sent failure reports, unregistering manager")
+                logger.warning("Sent failure reports, unregistering manager")
                 self._ready_manager_queue.pop(manager, 'None')
                 if manager in interesting_managers:
                     interesting_managers.remove(manager)


### PR DESCRIPTION
Prior to this, it was logged for each outstanding task.

## Type of change

- Code maintentance/cleanup
