### PR TITLE
Include hashsum in app cache update logs, remove function name

### DIFF
--- a/parsl/dataflow/memoization.py
+++ b/parsl/dataflow/memoization.py
@@ -276,8 +276,7 @@ class Memoizer(object):
             return
 
         if task['hashsum'] in self.memo_lookup_table:
-            logger.info('Updating app cache entry with latest %s:%s call' %
-                        (task['func_name'], task_id))
-            self.memo_lookup_table[task['hashsum']] = r
+            logger.info(f"Replacing app cache entry {task['hashsum']} with result from task {task_id}")
         else:
-            self.memo_lookup_table[task['hashsum']] = r
+            logger.debug(f"Storing app cache entry {task['hashsum']} with result from task {task_id}")
+        self.memo_lookup_table[task['hashsum']] = r


### PR DESCRIPTION
Being clear about which entry is being replaced (identified by
hash sum) is important.

function name is not so relevant when debugging - that info is
available via task id - so is removed from message

## Type of change

- Code maintentance/cleanup
