### PR TITLE
Remove never-used interchange.start poll_period arg

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -340,15 +340,14 @@ class Interchange(object):
                 continue
 
     @wrap_with_logs
-    def start(self, poll_period=None):
+    def start(self):
         """ Start the interchange
         """
         logger.info("Incoming ports bound")
 
         hub_channel = self._create_monitoring_channel()
 
-        if poll_period is None:
-            poll_period = self.poll_period
+        poll_period = self.poll_period
 
         start = time.time()
         count = 0


### PR DESCRIPTION
This poll period is specified as an argument to the
Interchange() constructor, and doesn't also need to
be settable by start()

## Type of change

- Code maintentance/cleanup
