### PR TITLE
Bump version to 1.3.0a0

### DIFF
--- a/parsl/version.py
+++ b/parsl/version.py
@@ -3,4 +3,4 @@
 <Major>.<Minor>.<maintenance>[alpha/beta/..]
 Alphas will be numbered like this -> 0.4.0a0
 """
-VERSION = '1.3.0-dev'
+VERSION = '1.3.0a0'


### PR DESCRIPTION
# Description

Only change here is a version bump to `1.3.0a0` for putting an alpha out on Pypi to unblock `funcx`
