### PR TITLE
Move total tasks to back of plot so that doesn't override tasks

### DIFF
--- a/parsl/monitoring/visualization/plots/default/workflow_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_plots.py
@@ -105,13 +105,14 @@ def task_per_app_plot(task, status, time_completed):
                 all_tasks[j - start] += 1
         fig = go.Figure(
             data=[go.Scatter(x=list(range(0, end - start + 1)),
-                             y=tasks_per_app[app],
-                             name=app,
-                             ) for app in tasks_per_app] +
-                 [go.Scatter(x=list(range(0, end - start + 1)),
                              y=all_tasks,
                              name='All',
-                             )],
+                             )] +
+                 [go.Scatter(x=list(range(0, end - start + 1)),
+                             y=tasks_per_app[app],
+                             name=app,
+                             ) for app in tasks_per_app],
+
             layout=go.Layout(xaxis=dict(autorange=True,
                                         title='Time (seconds)'),
                              yaxis=dict(title='Number of tasks'),


### PR DESCRIPTION
When all tasks are the same app, the total task line was plotting over the top of the per-app tasks.

I think it is better to see the per-app tasks rather than the total tasks.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
