### PR TITLE
Force keyword only mode for block provider

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -201,7 +201,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
 
         logger.debug("Initializing HighThroughputExecutor")
 
-        BlockProviderExecutor.__init__(self, provider)
+        BlockProviderExecutor.__init__(self, provider=provider)
         self.label = label
         self.launch_cmd = launch_cmd
         self.worker_debug = worker_debug

--- a/parsl/executors/low_latency/executor.py
+++ b/parsl/executors/low_latency/executor.py
@@ -40,7 +40,7 @@ class LowLatencyExecutor(BlockProviderExecutor, RepresentationMixin):
                  ):
         logger.debug("Initializing LowLatencyExecutor")
 
-        BlockProviderExecutor.__init__(self, provider)
+        BlockProviderExecutor.__init__(self, provider=provider)
         self.label = label
         self.launch_cmd = launch_cmd
         self.provider = provider

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -40,7 +40,7 @@ class BlockProviderExecutor(ParslExecutor):
     any init_blocks parameter. Subclasses must implement that behaviour
     themselves.
     """
-    def __init__(self, provider: ExecutionProvider):
+    def __init__(self, *, provider: ExecutionProvider):
         super().__init__()
         self._provider = provider
         # errors can happen during the submit call to the provider; this is used

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -225,7 +225,7 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
                  worker_options: str = "",
                  full_debug: bool = True,
                  worker_executable: str = 'work_queue_worker'):
-        BlockProviderExecutor.__init__(self, provider)
+        BlockProviderExecutor.__init__(self, provider=provider)
         self._scaling_enabled = True
 
         if not _work_queue_enabled:


### PR DESCRIPTION
This is because block provider will get more parameters in future PRs
and this will force the usage of each parameter to be named for
clarity.

## Type of change

- Code maintentance/cleanup
