### PR TITLE
Allow bad block based permanent failure to be disabled

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -197,11 +197,12 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
                  poll_period: int = 10,
                  address_probe_timeout: Optional[int] = None,
                  managed: bool = True,
-                 worker_logdir_root: Optional[str] = None):
+                 worker_logdir_root: Optional[str] = None,
+                 block_error_handler: bool = True):
 
         logger.debug("Initializing HighThroughputExecutor")
 
-        BlockProviderExecutor.__init__(self, provider=provider)
+        BlockProviderExecutor.__init__(self, provider=provider, block_error_handler=block_error_handler)
         self.label = label
         self.launch_cmd = launch_cmd
         self.worker_debug = worker_debug

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -39,10 +39,16 @@ class BlockProviderExecutor(ParslExecutor):
     invoking scale_out, but it will not initialize the blocks requested by
     any init_blocks parameter. Subclasses must implement that behaviour
     themselves.
+
+    BENC: TODO: block error handling: maybe I want this more user pluggable?
+    I'm not sure of use cases for switchability at the moment beyond "yes or no"
     """
-    def __init__(self, *, provider: ExecutionProvider):
+    def __init__(self, *,
+                 provider: ExecutionProvider,
+                 block_error_handler: bool):
         super().__init__()
         self._provider = provider
+        self.block_error_handler = block_error_handler
         # errors can happen during the submit call to the provider; this is used
         # to keep track of such errors so that they can be handled in one place
         # together with errors reported by status()
@@ -127,10 +133,12 @@ class BlockProviderExecutor(ParslExecutor):
 
     @property
     def error_management_enabled(self):
-        return True
+        return self.block_error_handler
 
     def handle_errors(self, error_handler: "parsl.dataflow.job_error_handler.JobErrorHandler",
                       status: Dict[str, JobStatus]) -> None:
+        if not self.block_error_handler:
+            return
         init_blocks = 3
         if hasattr(self.provider, 'init_blocks'):
             init_blocks = self.provider.init_blocks  # type: ignore

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -225,7 +225,8 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
                  worker_options: str = "",
                  full_debug: bool = True,
                  worker_executable: str = 'work_queue_worker'):
-        BlockProviderExecutor.__init__(self, provider=provider)
+        BlockProviderExecutor.__init__(self, provider=provider,
+                                       block_error_handler=True)
         self._scaling_enabled = True
 
         if not _work_queue_enabled:

--- a/parsl/tests/configs/htex_local_alternate.py
+++ b/parsl/tests/configs/htex_local_alternate.py
@@ -54,6 +54,7 @@ def fresh_config():
                     max_blocks=5,
                     launcher=SingleNodeLauncher(),
                 ),
+                block_error_handler=False
             )
         ],
         strategy='simple',


### PR DESCRIPTION
This is motivated by two use cases:

* at in2p3 with htex submitting large numbers of blocks into
many queues results in expected block failure. Because this
failure is expected, it should not result in permanent executor
failure.

* the psi/j slurm provider reports failures differently (more
accurately?) which seems to trigger this behaviour

## Type of change

- New feature (non-breaking change that adds functionality)
