### PR TITLE
Add debugging around strategy failures

### DIFF
--- a/parsl/dataflow/strategy.py
+++ b/parsl/dataflow/strategy.py
@@ -163,7 +163,7 @@ class Strategy(object):
 
     @wrap_with_logs
     def _general_strategy(self, status_list, tasks, *, strategy_type):
-        logger.debug(f"general strategy starting with strategy_type {strategy_type}")
+        logger.debug(f"general strategy starting with strategy_type {strategy_type} for {len(status_list)} executors")
 
         for exec_status in status_list:
             executor = exec_status.executor


### PR DESCRIPTION
In one particular test in CI, no blocks were started and the logs look like
this, as if after one execution attempt, the executor is not strategised over
any more.

```
1652440511.041642 2022-05-13 11:15:11 INFO MainProcess-9443 MainThread-139718497531712 parsl.dataflow.dflow:685 launch_task Parsl task 0 try 0 launched on executor htex_Local with executor id 1
1652440511.301012 2022-05-13 11:15:11 DEBUG MainProcess-9443 FlowControl-Thread-139713557300992 parsl.dataflow.strategy:163 _general_strategy general strategy starting
1652440511.942638 2022-05-13 11:15:11 DEBUG MainProcess-9443 FlowControl-Thread-139713372706560 parsl.dataflow.task_status_poller:52 send_monitoring_info Sending message [] to hub from task status poller
1652440511.944299 2022-05-13 11:15:11 DEBUG MainProcess-9443 FlowControl-Thread-139713372706560 parsl.dataflow.strategy:163 _general_strategy general strategy starting
1652440511.945580 2022-05-13 11:15:11 DEBUG MainProcess-9443 FlowControl-Thread-139713372706560 parsl.dataflow.strategy:171 _general_strategy strategy_simple: strategizing for executor htex_Local
1652440516.301130 2022-05-13 11:15:16 DEBUG MainProcess-9443 FlowControl-Thread-139713557300992 parsl.dataflow.strategy:163 _general_strategy general strategy starting
1652440521.301223 2022-05-13 11:15:21 DEBUG MainProcess-9443 FlowControl-Thread-139713557300992 parsl.dataflow.strategy:163 _general_strategy general strategy starting
1652440526.301344 2022-05-13 11:15:26 DEBUG MainProcess-9443 FlowControl-Thread-139713557300992 parsl.dataflow.strategy:163 _general_strategy general strategy starting
1652440531.301553 2022-05-13 11:15:31 DEBUG MainProcess-9443 FlowControl-Thread-139713557300992 parsl.dataflow.strategy:163 _general_strategy general strategy starting
1652440536.301758 2022-05-13 11:15:36 DEBUG MainProcess-9443 FlowControl-Thread-139713557300992 parsl.dataflow.strategy:163 _general_strategy general strategy starting
1652440541.301929 2022-05-13 11:15:41 DEBUG MainProcess-9443 FlowControl-Thread-139713557300992 parsl.dataflow.strategy:163 _general_strategy general strategy starting
1652440546.302123 2022-05-13 11:15:46 DEBUG MainProcess-9443 FlowControl-Thread-139713557300992 parsl.dataflow.strategy:163 _general_strategy general strategy starting
1652440551.302215 2022-05-13 11:15:51 DEBUG MainProcess-9443 FlowControl-Thread-139713557300992 parsl.dataflow.strategy:163 _general_strategy general strategy starting
1652440556.302412 2022-05-13 11:15:56 DEBUG MainProcess-9443 FlowControl-Thread-139713557300992 parsl.dataflow.strategy:163 _general_strategy general strategy starting
1652440561.302607 2022-05-13 11:16:01 DEBUG MainProcess-9443 FlowControl-Thread-139713557300992 parsl.dataflow.strategy:163 _general_strategy general strategy starting
1652440566.302742 2022-05-13 11:16:06 DEBUG MainProcess-9443 FlowControl-Thread-139713557300992 parsl.dataflow.strategy:163 _general_strategy general strategy starting
```


## Type of change

- Code maintentance/cleanup
