### PR TITLE
Change pbs qstat to use json format

### DIFF
--- a/parsl/providers/pbspro/pbspro.py
+++ b/parsl/providers/pbspro/pbspro.py
@@ -8,6 +8,8 @@ from parsl.providers.pbspro.template import template_string
 from parsl.providers import TorqueProvider
 from parsl.providers.provider_base import JobState, JobStatus
 
+from parsl.providers.torque.torque import translate_table
+
 logger = logging.getLogger(__name__)
 
 
@@ -86,6 +88,42 @@ class PBSProProvider(TorqueProvider):
         self._label = 'pbspro'
         self.cpus_per_node = cpus_per_node
         self.select_options = select_options
+
+
+    def _status(self):
+        ''' Internal: Do not call. Returns the status list for a list of job_ids
+
+        Args:
+              self
+
+        Returns:
+              [status...] : Status list of all jobs
+        '''
+
+        job_ids = list(self.resources.keys())
+        job_id_list = ' '.join(self.resources.keys())
+
+        jobs_missing = list(self.resources.keys())
+
+        retcode, stdout, stderr = self.execute_wait("qstat -f -F json {0}".format(job_id_list))
+
+        for job_id, job in retcode['Jobs'].items():
+            for long_job_id in job_ids:
+                if long_job_id.startswith(job_id):
+                    logger.debug('coerced job_id %s -> %s', job_id, long_job_id)
+                    job_id = long_job_id
+                    break
+
+            job_state = job.get('job_state', JobState.UNKNOWN)
+            state = translate_table.get(job_state, JobState.UNKNOWN)
+            self.resources[job_id]['status'] = JobStatus(state)
+            jobs_missing.remove(job_id)
+
+        # squeue does not report on jobs that are not running. So we are filling in the
+        # blanks for missing jobs, we might lose some information about why the jobs failed.
+        for missing_job in jobs_missing:
+            self.resources[missing_job]['status'] = JobStatus(JobState.COMPLETED)
+
 
     def submit(self, command, tasks_per_node, job_name="parsl"):
         """Submits the command job.

--- a/parsl/providers/pbspro/pbspro.py
+++ b/parsl/providers/pbspro/pbspro.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import time
+import json
 
 from parsl.channels import LocalChannel
 from parsl.launchers import SingleNodeLauncher
@@ -107,7 +108,9 @@ class PBSProProvider(TorqueProvider):
 
         retcode, stdout, stderr = self.execute_wait("qstat -f -F json {0}".format(job_id_list))
 
-        for job_id, job in retcode['Jobs'].items():
+        job_statuses = json.loads(stdout)
+
+        for job_id, job in job_statuses['Jobs'].items():
             for long_job_id in job_ids:
                 if long_job_id.startswith(job_id):
                     logger.debug('coerced job_id %s -> %s', job_id, long_job_id)


### PR DESCRIPTION
# Description

PBSPro defaults to using the Torque qstat command which is limited in the number of characters used to represent a job id. This is a problem on the ALCF Polaris machine which has long job names (id.polaris.alcf....) which are shortened in qstat (e.g., 123.polaris.al*). These shorthand job ids do not resolve in the dictionary of resources, causing the provider to fail when scaling.

This PR provides a customized PBSPro status() function that uses `qstat -f -F json` to retrieve the full job description as json and then extracts the long job id from the dictionary of jobs.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
