### PR TITLE
Introduce separate None and manual checkpoint modes

### DIFF
--- a/docs/userguide/checkpoints.rst
+++ b/docs/userguide/checkpoints.rst
@@ -182,8 +182,9 @@ Parsl provides four checkpointing modes:
    from parsl.configs.local_threads import config
    config.checkpoint_mode = 'dfk_exit'
 
-4. Manual: in addition to these automated checkpointing modes, it is also possible to manually initiate a checkpoint
-   by calling ``DataFlowKernel.checkpoint()`` in the Parsl program code.
+4. ``manual``: in addition to these automated checkpointing modes, it is also possible
+   to manually initiate a checkpoint by calling ``DataFlowKernel.checkpoint()`` in the
+   Parsl program code.
 
 
    import parsl

--- a/parsl/config.py
+++ b/parsl/config.py
@@ -29,8 +29,8 @@ class Config(RepresentationMixin):
         List of paths to checkpoint files. See :func:`parsl.utils.get_all_checkpoints` and
         :func:`parsl.utils.get_last_checkpoint` for helpers. Default is None.
     checkpoint_mode : str, optional
-        Checkpoint mode to use, can be ``'dfk_exit'``, ``'task_exit'``, or ``'periodic'``. If set to
-        `None`, checkpointing will be disabled. Default is None.
+        Checkpoint mode to use, can be ``'dfk_exit'``, ``'task_exit'``, ``'periodic'`` or ``'manual'``.
+        If set to `None`, checkpointing will be disabled. Default is None.
     checkpoint_period : str, optional
         Time interval (in "HH:MM:SS") at which to checkpoint completed tasks. Only has an effect if
         ``checkpoint_mode='periodic'``.
@@ -77,7 +77,8 @@ class Config(RepresentationMixin):
                  checkpoint_mode: Union[None,
                                         Literal['task_exit'],
                                         Literal['periodic'],
-                                        Literal['dfk_exit']] = None,
+                                        Literal['dfk_exit'],
+                                        Literal['manual']] = None,
                  checkpoint_period: Optional[str] = None,
                  garbage_collect: bool = True,
                  internal_tasks_max_threads: int = 10,

--- a/parsl/tests/test_checkpointing/test_python_checkpoint_1.py
+++ b/parsl/tests/test_checkpointing/test_python_checkpoint_1.py
@@ -4,7 +4,7 @@ import pytest
 
 import parsl
 from parsl import python_app
-from parsl.tests.configs.local_threads import config
+from parsl.tests.configs.local_threads import fresh_config
 
 
 @python_app(cache=True)
@@ -28,6 +28,8 @@ def launch_n_random(n=2):
 def test_initial_checkpoint_write(n=2):
     """1. Launch a few apps and write the checkpoint once a few have completed
     """
+    config = fresh_config()
+    config.checkpoint_mode = 'manual'
     parsl.load(config)
     results = launch_n_random(n)
 


### PR DESCRIPTION
initially these did not need to be different, but
since #1512 introduced garbage collection, there is
now a distinction:

* with no checkpointing, tasks can be garbage collected
immediately.

* with manual checkpointing, tasks should not be garbage
collected until they are checkpointed.


## Type of change

- Bug fix (non-breaking change that fixes an issue)
