### PR TITLE
Correct docstring: a parsl config is not a dict

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -260,7 +260,7 @@ class DataFlowKernel(object):
         """Returns the fully initialized config that the DFK is actively using.
 
         Returns:
-             - config (dict)
+             - Config object
         """
         return self._config
 


### PR DESCRIPTION
## Type of change

- Documentation update
