### PR TITLE
Remove unused try block around assignment

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -165,12 +165,6 @@ class HTEXRadio(MonitoringRadio):
 
         import parsl.executors.high_throughput.monitoring_info
 
-        try:
-            buffer = message
-        except Exception:
-            logging.exception("Exception during pickling", exc_info=True)
-            return
-
         result_queue = parsl.executors.high_throughput.monitoring_info.result_queue
 
         # this message needs to go in the result queue tagged so that it is treated
@@ -182,7 +176,7 @@ class HTEXRadio(MonitoringRadio):
 
         interchange_msg = {
             'type': 'monitoring',
-            'payload': buffer
+            'payload': message
         }
 
         if result_queue:


### PR DESCRIPTION
This is inherited from copy-paste of a different radio implementation
where serialisation happened at this point. In the HTEX radio case,
serialisation happens inside the htext implementation so doesn't
happen here.

## Type of change

- Code maintentance/cleanup
