### PR TITLE
Remove unused interchange SHUTDOWN codepath

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -331,11 +331,6 @@ class Interchange(object):
                     else:
                         reply = False
 
-                elif command_req == "SHUTDOWN":
-                    logger.info("Received SHUTDOWN command")
-                    kill_event.set()
-                    reply = True
-
                 else:
                     reply = None
 


### PR DESCRIPTION
This is never used - or at least, there is no other
SHUTDOWN literal in the parsl codebase.

## Type of change

- Code maintentance/cleanup
