### PR TITLE
Remove periodic timeout in interchange task pull loop

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -141,7 +141,6 @@ class Interchange(object):
         self.context = zmq.Context()
         self.task_incoming = self.context.socket(zmq.DEALER)
         self.task_incoming.set_hwm(0)
-        self.task_incoming.RCVTIMEO = 10  # in milliseconds
         self.task_incoming.connect("tcp://{}:{}".format(client_address, client_ports[0]))
         self.results_outgoing = self.context.socket(zmq.DEALER)
         self.results_outgoing.set_hwm(0)


### PR DESCRIPTION
This loop was to check the kill event, which is
no longer used by this thread (see PR #2423), so there
is no need to loop repeatedly in the absence of
messages.

## Type of change

- Code maintentance/cleanup
