### PR TITLE
Ignore kill event in interchange command server

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -265,7 +265,7 @@ class Interchange(object):
             hub_channel.send_pyobj((MessageType.NODE_INFO, d))
 
     @wrap_with_logs(target="interchange")
-    def _command_server(self, kill_event):
+    def _command_server(self):
         """ Command server to run async command to the interchange
         """
         logger.debug("Command Server Starting")
@@ -275,7 +275,7 @@ class Interchange(object):
 
         reply: Any  # the type of reply depends on the command_req received (aka this needs dependent types...)
 
-        while not kill_event.is_set():
+        while True:
             try:
                 command_req = self.command_channel.recv_pyobj()
                 logger.debug("Received command request: {}".format(command_req))
@@ -349,7 +349,6 @@ class Interchange(object):
         self._task_puller_thread.start()
 
         self._command_thread = threading.Thread(target=self._command_server,
-                                                args=(self._kill_event,),
                                                 name="Interchange-Command")
         self._command_thread.start()
 


### PR DESCRIPTION
The interchange is shut down by process termination, so
this code path is not needed.

## Type of change

- Code maintentance/cleanup
