### PR TITLE
Use only symbolic log level, not number constant, in interchange docstring

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -119,7 +119,7 @@ class Interchange(object):
              Parsl log directory paths. Logs and temp files go here. Default: '.'
 
         logging_level : int
-             Logging level as defined in the logging module. Default: logging.INFO (20)
+             Logging level as defined in the logging module. Default: logging.INFO
 
         poll_period : int
              The main thread polling period, in milliseconds. Default: 10ms


### PR DESCRIPTION
## Type of change

- Documentation update
- Code maintentance/cleanup
