### PR TITLE
Support using spawn instead of fork for HTEx

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -154,10 +154,10 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         What method to use to start new worker processes.
         HTEx supports "spawn," "fork," and "thread" workers.
         "Spawn" and "fork" workers are launched in separate processes using different mechanisms,
-         which are described in `Python's multiprocessing documentation.
+        which are described in `Python's multiprocessing documentation.
         <https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_.
         "Thread" workers are separate threads of the ``process_worker_pool``, which saves on memory but is
-        only recommended for workloads that involving launching other processes (e.g., ``bash_app``s).
+        only recommended for workloads that involving launching other processes (e.g., ``bash_app`` s).
         Default: fork
 
     prefetch_capacity : int

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -10,6 +10,7 @@ import pickle
 import time
 import queue
 import uuid
+from threading import Thread
 from typing import Sequence, Optional
 
 import zmq
@@ -124,10 +125,7 @@ class Manager(object):
             List of accelerators available to the workers. Default: Empty list
 
         start_method: str
-            What method to use to start new worker processes.
-            HTEx supports either "spawn" or "fork", which are described in the
-            `Python's multiprocessing documentation.
-            <https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_.
+            What method to use to start new worker processes. Choices are fork, spawn, and thread.
             Default: fork
 
         """
@@ -194,6 +192,8 @@ class Manager(object):
             self.mpProcess = mpForkProcess
         elif start_method == "spawn":
             self.mpProcess = mpSpawnProcess
+        elif start_method == "thread":
+            self.mpProcess = Thread
         else:
             raise ValueError(f'HTEx does not support start method: "{start_method}"')
 
@@ -674,7 +674,7 @@ if __name__ == "__main__":
                         help="Whether/how workers should control CPU affinity.")
     parser.add_argument("--available-accelerators", type=str, nargs="*",
                         help="Names of available accelerators")
-    parser.add_argument("--start-method", type=str, choices=["fork", "spawn"], default="fork",
+    parser.add_argument("--start-method", type=str, choices=["fork", "spawn", "thread"], default="fork",
                         help="Method used to start new worker processes")
 
     args = parser.parse_args()

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -24,7 +24,8 @@ from parsl.version import VERSION as PARSL_VERSION
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.executors.high_throughput.errors import WorkerLost
 from parsl.executors.high_throughput.probe import probe_addresses
-from parsl.multiprocessing import ForkProcess as mpProcess
+from parsl.multiprocessing import ForkProcess as mpForkProcess
+from parsl.multiprocessing import SpawnProcess as mpSpawnProcess
 
 from parsl.multiprocessing import SizedQueue as mpQueue
 
@@ -64,7 +65,8 @@ class Manager(object):
                  heartbeat_period=30,
                  poll_period=10,
                  cpu_affinity=False,
-                 available_accelerators: Sequence[str] = ()):
+                 available_accelerators: Sequence[str] = (),
+                 start_method: str = 'fork'):
         """
         Parameters
         ----------
@@ -120,6 +122,14 @@ class Manager(object):
 
         available_accelerators: list of str
             List of accelerators available to the workers. Default: Empty list
+
+        start_method: str
+            What method to use to start new worker processes.
+            HTEx supports either "spawn" or "fork", which are described in the
+            `Python's multiprocessing documentation.
+            <https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_.
+            Default: fork
+
         """
 
         logger.info("Manager started")
@@ -177,6 +187,15 @@ class Manager(object):
         self.worker_count = min(max_workers,
                                 mem_slots,
                                 math.floor(cores_on_node / cores_per_worker))
+
+        # Determine which start method to use
+        start_method = start_method.lower()
+        if start_method == "fork":
+            self.mpProcess = mpForkProcess
+        elif start_method == "spawn":
+            self.mpProcess = mpSpawnProcess
+        else:
+            raise ValueError(f'HTEx does not support start method: "{start_method}"')
 
         self.pending_task_queue = mpQueue()
         self.pending_result_queue = mpQueue()
@@ -384,15 +403,15 @@ class Manager(object):
                     except KeyError:
                         logger.info("Worker {} was not busy when it died".format(worker_id))
 
-                    p = mpProcess(target=worker, args=(worker_id,
-                                                       self.uid,
-                                                       self.worker_count,
-                                                       self.pending_task_queue,
-                                                       self.pending_result_queue,
-                                                       self.ready_worker_queue,
-                                                       self._tasks_in_progress,
-                                                       self.cpu_affinity
-                                                 ), name="HTEX-Worker-{}".format(worker_id))
+                    p = self.mpProcess(target=worker, args=(worker_id,
+                                                            self.uid,
+                                                            self.worker_count,
+                                                            self.pending_task_queue,
+                                                            self.pending_result_queue,
+                                                            self.ready_worker_queue,
+                                                            self._tasks_in_progress,
+                                                            self.cpu_affinity),
+                                       name="HTEX-Worker-{}".format(worker_id))
                     self.procs[worker_id] = p
                     logger.info("Worker {} has been restarted".format(worker_id))
                 time.sleep(self.heartbeat_period)
@@ -410,16 +429,17 @@ class Manager(object):
 
         self.procs = {}
         for worker_id in range(self.worker_count):
-            p = mpProcess(target=worker, args=(worker_id,
-                                               self.uid,
-                                               self.worker_count,
-                                               self.pending_task_queue,
-                                               self.pending_result_queue,
-                                               self.ready_worker_queue,
-                                               self._tasks_in_progress,
-                                               self.cpu_affinity,
-                                               self.available_accelerators[worker_id] if self.accelerators_available else None),
-                          name="HTEX-Worker-{}".format(worker_id))
+            p = self.mpProcess(target=worker,
+                               args=(worker_id,
+                                     self.uid,
+                                     self.worker_count,
+                                     self.pending_task_queue,
+                                     self.pending_result_queue,
+                                     self.ready_worker_queue,
+                                     self._tasks_in_progress,
+                                     self.cpu_affinity,
+                                     self.available_accelerators[worker_id] if self.accelerators_available else None),
+                               name="HTEX-Worker-{}".format(worker_id))
             p.start()
             self.procs[worker_id] = p
 
@@ -654,6 +674,8 @@ if __name__ == "__main__":
                         help="Whether/how workers should control CPU affinity.")
     parser.add_argument("--available-accelerators", type=str, nargs="*",
                         help="Names of available accelerators")
+    parser.add_argument("--start-method", type=str, choices=["fork", "spawn"], default="fork",
+                        help="Method used to start new worker processes")
 
     args = parser.parse_args()
 
@@ -682,6 +704,7 @@ if __name__ == "__main__":
         logger.info("Heartbeat period: {}".format(args.hb_period))
         logger.info("CPU affinity: {}".format(args.cpu_affinity))
         logger.info("Accelerators: {}".format(" ".join(args.available_accelerators)))
+        logger.info("Start method: {}".format(args.start_method))
 
         manager = Manager(task_port=args.task_port,
                           result_port=args.result_port,

--- a/parsl/multiprocessing.py
+++ b/parsl/multiprocessing.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 # maybe ForkProcess should be: Callable[..., Process] so as to make
 # it clear that it returns a Process always to the type checker?
 ForkProcess: Type = multiprocessing.get_context('fork').Process
+SpawnProcess: Type = multiprocessing.get_context('spawn').Process
 
 
 class MacSafeQueue(multiprocessing.queues.Queue):

--- a/parsl/tests/sites/test_mpi/mpi_hello
+++ b/parsl/tests/sites/test_mpi/mpi_hello
@@ -1,0 +1,1 @@
+mpi_test/mpi_hello

--- a/parsl/tests/sites/test_mpi/mpi_hello
+++ b/parsl/tests/sites/test_mpi/mpi_hello
@@ -1,1 +1,0 @@
-mpi_test/mpi_hello

--- a/parsl/tests/sites/test_start_method.py
+++ b/parsl/tests/sites/test_start_method.py
@@ -1,0 +1,42 @@
+import os
+
+from pytest import mark
+
+import parsl
+from parsl.providers import LocalProvider
+from parsl.channels import LocalChannel
+from parsl.config import Config
+from parsl.executors import HighThroughputExecutor
+from parsl import python_app
+
+
+@python_app()
+def test_function():
+    return os.getpid()
+
+
+@mark.local
+def test_spawn_method():
+    local_config = Config(
+        executors=[
+            HighThroughputExecutor(
+                label="fork",
+                worker_debug=True,
+                max_workers=2,
+                provider=LocalProvider(
+                    channel=LocalChannel(),
+                    init_blocks=1,
+                    max_blocks=1,
+                ),
+                start_method="spawn"
+            )
+        ],
+        strategy=None,
+    )
+
+    parsl.load(local_config)
+
+    # Get the PID for the child function as a way of making sure it launches
+    future = test_function()
+    remote_pid = future.result()
+    assert remote_pid != os.getpid()


### PR DESCRIPTION
# Description

Polaris, in particular, has an interaction between MPI and fork which makes HTEx worker pools fail to function when used with an MPILauncher. This PR adds the ability for HTEx to launch workers by spawning a new process rather than forking.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
- Documentation update
