### PR TITLE
Upgrade mypy to address bug in mypy 0.961 vs python 3.10.7

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,7 +8,7 @@ pytest-random-order
 mock>=1.0.0
 nbsphinx
 sphinx_rtd_theme
-mypy==0.961
+mypy==0.981
 types-python-dateutil
 types-requests
 types-six


### PR DESCRIPTION
See issue https://github.com/python/mypy/issues/13627

CI builds were failing due to this incompatibility which is fixed in mypy 0.981

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintentance/cleanup
