### PR TITLE
Move monitoring radios into their own module

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -9,7 +9,6 @@ import zmq
 from functools import wraps
 
 import queue
-from abc import ABCMeta, abstractmethod
 from parsl.multiprocessing import ForkProcess, SizedQueue
 from multiprocessing import Event, Process, Queue
 from parsl.utils import RepresentationMixin
@@ -19,10 +18,9 @@ from parsl.utils import setproctitle
 from parsl.serialize import deserialize
 
 from parsl.monitoring.message_type import MessageType
+from parsl.monitoring.radios import MonitoringRadio, UDPRadio, HTEXRadio, FilesystemRadio
 from parsl.monitoring.types import AddressedMonitoringMessage, TaggedMonitoringMessage
 from typing import cast, Any, Callable, Dict, List, Optional, Union
-
-from parsl.serialize import serialize
 
 _db_manager_excepts: Optional[Exception]
 
@@ -71,174 +69,6 @@ def start_file_logger(filename: str, name: str = 'monitoring', level: int = logg
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     return logger
-
-
-class MonitoringRadio(metaclass=ABCMeta):
-    @abstractmethod
-    def send(self, message: object) -> None:
-        pass
-
-
-class FilesystemRadio(MonitoringRadio):
-    """A MonitoringRadio that sends messages over a shared filesystem.
-
-    The messsage directory structure is based on maildir,
-    https://en.wikipedia.org/wiki/Maildir
-
-    The writer creates a message in tmp/ and then when it is fully
-    written, moves it atomically into new/
-
-    The reader ignores tmp/ and only reads and deletes messages from
-    new/
-
-    This avoids a race condition of reading partially written messages.
-
-    This radio is likely to give higher shared filesystem load compared to
-    the UDPRadio, but should be much more reliable.
-    """
-
-    def __init__(self, *, monitoring_url: str, source_id: int, timeout: int = 10, run_dir: str):
-        logger.info("filesystem based monitoring channel initializing")
-        self.source_id = source_id
-        self.id_counter = 0
-        self.radio_uid = f"host-{socket.gethostname()}-pid-{os.getpid()}-radio-{id(self)}"
-        self.base_path = f"{run_dir}/monitor-fs-radio/"
-        self.tmp_path = f"{self.base_path}/tmp"
-        self.new_path = f"{self.base_path}/new"
-
-        os.makedirs(self.tmp_path, exist_ok=True)
-        os.makedirs(self.new_path, exist_ok=True)
-
-    def send(self, message: object) -> None:
-        logger.info("Sending a monitoring message via filesystem")
-
-        # this should be randomised by things like worker ID, process ID, whatever
-        # because there will in general be many FilesystemRadio objects sharing the
-        # same space (even from the same process). id(self) used here will
-        # disambiguate in one process at one instant, but not between
-        # other things: eg different hosts, different processes, same process different non-overlapping instantiations
-        unique_id = f"msg-{self.radio_uid}-{self.id_counter}"
-
-        self.id_counter = self.id_counter + 1
-
-        tmp_filename = f"{self.tmp_path}/{unique_id}"
-        new_filename = f"{self.new_path}/{unique_id}"
-        buffer = (message, "NA")
-
-        # this will write the message out then atomically
-        # move it into new/, so that a partially written
-        # file will never be observed in new/
-        with open(tmp_filename, "wb") as f:
-            f.write(serialize(buffer))
-        os.rename(tmp_filename, new_filename)
-
-
-class HTEXRadio(MonitoringRadio):
-
-    def __init__(self, monitoring_url: str, source_id: int, timeout: int = 10):
-        """
-        Parameters
-        ----------
-
-        monitoring_url : str
-            URL of the form <scheme>://<IP>:<PORT>
-        source_id : str
-            String identifier of the source
-        timeout : int
-            timeout, default=10s
-        """
-        self.source_id = source_id
-        logger.info("htex-based monitoring channel initialising")
-
-    def send(self, message: object) -> None:
-        """ Sends a message to the UDP receiver
-
-        Parameter
-        ---------
-
-        message: object
-            Arbitrary pickle-able object that is to be sent
-
-        Returns:
-            None
-        """
-
-        import parsl.executors.high_throughput.monitoring_info
-
-        result_queue = parsl.executors.high_throughput.monitoring_info.result_queue
-
-        # this message needs to go in the result queue tagged so that it is treated
-        # i) as a monitoring message by the interchange, and then further more treated
-        # as a RESOURCE_INFO message when received by monitoring (rather than a NODE_INFO
-        # which is the implicit default for messages from the interchange)
-
-        # for the interchange, the outer wrapper, this needs to be a dict:
-
-        interchange_msg = {
-            'type': 'monitoring',
-            'payload': message
-        }
-
-        if result_queue:
-            result_queue.put(pickle.dumps(interchange_msg))
-        else:
-            logger.error("result_queue is uninitialized - cannot put monitoring message")
-
-        return
-
-
-class UDPRadio(MonitoringRadio):
-
-    def __init__(self, monitoring_url: str, source_id: int, timeout: int = 10):
-        """
-        Parameters
-        ----------
-
-        monitoring_url : str
-            URL of the form <scheme>://<IP>:<PORT>
-        source_id : str
-            String identifier of the source
-        timeout : int
-            timeout, default=10s
-        """
-        self.monitoring_url = monitoring_url
-        self.sock_timeout = timeout
-        self.source_id = source_id
-        try:
-            self.scheme, self.ip, port = (x.strip('/') for x in monitoring_url.split(':'))
-            self.port = int(port)
-        except Exception:
-            raise Exception("Failed to parse monitoring url: {}".format(monitoring_url))
-
-        self.sock = socket.socket(socket.AF_INET,
-                                  socket.SOCK_DGRAM,
-                                  socket.IPPROTO_UDP)  # UDP
-        self.sock.settimeout(self.sock_timeout)
-
-    def send(self, message: object) -> None:
-        """ Sends a message to the UDP receiver
-
-        Parameter
-        ---------
-
-        message: object
-            Arbitrary pickle-able object that is to be sent
-
-        Returns:
-            None
-        """
-        try:
-            buffer = pickle.dumps(message)
-        except Exception:
-            logging.exception("Exception during pickling", exc_info=True)
-            return
-
-        try:
-            self.sock.sendto(buffer, (self.ip, self.port))
-        except socket.timeout:
-            logging.error("Could not send message within timeout limit")
-            return
-        return
 
 
 @typeguard.typechecked

--- a/parsl/monitoring/radios.py
+++ b/parsl/monitoring/radios.py
@@ -1,0 +1,183 @@
+import os
+import socket
+import pickle
+import logging
+
+from abc import ABCMeta, abstractmethod
+
+from typing import Optional
+
+from parsl.serialize import serialize
+
+_db_manager_excepts: Optional[Exception]
+
+
+logger = logging.getLogger(__name__)
+
+
+class MonitoringRadio(metaclass=ABCMeta):
+    @abstractmethod
+    def send(self, message: object) -> None:
+        pass
+
+
+class FilesystemRadio(MonitoringRadio):
+    """A MonitoringRadio that sends messages over a shared filesystem.
+
+    The messsage directory structure is based on maildir,
+    https://en.wikipedia.org/wiki/Maildir
+
+    The writer creates a message in tmp/ and then when it is fully
+    written, moves it atomically into new/
+
+    The reader ignores tmp/ and only reads and deletes messages from
+    new/
+
+    This avoids a race condition of reading partially written messages.
+
+    This radio is likely to give higher shared filesystem load compared to
+    the UDPRadio, but should be much more reliable.
+    """
+
+    def __init__(self, *, monitoring_url: str, source_id: int, timeout: int = 10, run_dir: str):
+        logger.info("filesystem based monitoring channel initializing")
+        self.source_id = source_id
+        self.id_counter = 0
+        self.radio_uid = f"host-{socket.gethostname()}-pid-{os.getpid()}-radio-{id(self)}"
+        self.base_path = f"{run_dir}/monitor-fs-radio/"
+        self.tmp_path = f"{self.base_path}/tmp"
+        self.new_path = f"{self.base_path}/new"
+
+        os.makedirs(self.tmp_path, exist_ok=True)
+        os.makedirs(self.new_path, exist_ok=True)
+
+    def send(self, message: object) -> None:
+        logger.info("Sending a monitoring message via filesystem")
+
+        # this should be randomised by things like worker ID, process ID, whatever
+        # because there will in general be many FilesystemRadio objects sharing the
+        # same space (even from the same process). id(self) used here will
+        # disambiguate in one process at one instant, but not between
+        # other things: eg different hosts, different processes, same process different non-overlapping instantiations
+        unique_id = f"msg-{self.radio_uid}-{self.id_counter}"
+
+        self.id_counter = self.id_counter + 1
+
+        tmp_filename = f"{self.tmp_path}/{unique_id}"
+        new_filename = f"{self.new_path}/{unique_id}"
+        buffer = (message, "NA")
+
+        # this will write the message out then atomically
+        # move it into new/, so that a partially written
+        # file will never be observed in new/
+        with open(tmp_filename, "wb") as f:
+            f.write(serialize(buffer))
+        os.rename(tmp_filename, new_filename)
+
+
+class HTEXRadio(MonitoringRadio):
+
+    def __init__(self, monitoring_url: str, source_id: int, timeout: int = 10):
+        """
+        Parameters
+        ----------
+
+        monitoring_url : str
+            URL of the form <scheme>://<IP>:<PORT>
+        source_id : str
+            String identifier of the source
+        timeout : int
+            timeout, default=10s
+        """
+        self.source_id = source_id
+        logger.info("htex-based monitoring channel initialising")
+
+    def send(self, message: object) -> None:
+        """ Sends a message to the UDP receiver
+
+        Parameter
+        ---------
+
+        message: object
+            Arbitrary pickle-able object that is to be sent
+
+        Returns:
+            None
+        """
+
+        import parsl.executors.high_throughput.monitoring_info
+
+        result_queue = parsl.executors.high_throughput.monitoring_info.result_queue
+
+        # this message needs to go in the result queue tagged so that it is treated
+        # i) as a monitoring message by the interchange, and then further more treated
+        # as a RESOURCE_INFO message when received by monitoring (rather than a NODE_INFO
+        # which is the implicit default for messages from the interchange)
+
+        # for the interchange, the outer wrapper, this needs to be a dict:
+
+        interchange_msg = {
+            'type': 'monitoring',
+            'payload': message
+        }
+
+        if result_queue:
+            result_queue.put(pickle.dumps(interchange_msg))
+        else:
+            logger.error("result_queue is uninitialized - cannot put monitoring message")
+
+        return
+
+
+class UDPRadio(MonitoringRadio):
+
+    def __init__(self, monitoring_url: str, source_id: int, timeout: int = 10):
+        """
+        Parameters
+        ----------
+
+        monitoring_url : str
+            URL of the form <scheme>://<IP>:<PORT>
+        source_id : str
+            String identifier of the source
+        timeout : int
+            timeout, default=10s
+        """
+        self.monitoring_url = monitoring_url
+        self.sock_timeout = timeout
+        self.source_id = source_id
+        try:
+            self.scheme, self.ip, port = (x.strip('/') for x in monitoring_url.split(':'))
+            self.port = int(port)
+        except Exception:
+            raise Exception("Failed to parse monitoring url: {}".format(monitoring_url))
+
+        self.sock = socket.socket(socket.AF_INET,
+                                  socket.SOCK_DGRAM,
+                                  socket.IPPROTO_UDP)  # UDP
+        self.sock.settimeout(self.sock_timeout)
+
+    def send(self, message: object) -> None:
+        """ Sends a message to the UDP receiver
+
+        Parameter
+        ---------
+
+        message: object
+            Arbitrary pickle-able object that is to be sent
+
+        Returns:
+            None
+        """
+        try:
+            buffer = pickle.dumps(message)
+        except Exception:
+            logging.exception("Exception during pickling", exc_info=True)
+            return
+
+        try:
+            self.sock.sendto(buffer, (self.ip, self.port))
+        except socket.timeout:
+            logging.error("Could not send message within timeout limit")
+            return
+        return


### PR DESCRIPTION
This is part of splitting up the large parsl.monitoring.monitoring module (933 lines). Radios need to live somewhere they can be accessed by a soon-to-be moved remote monitoring wrapper, without importing the full monitoring module.

## Type of change

- Code maintentance/cleanup
