### PR TITLE
Allow Work Queue per-task files to be placed outside rundir

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -14,6 +14,7 @@ import hashlib
 import subprocess
 import os
 import socket
+import time
 import pickle
 import queue
 import inspect
@@ -196,6 +197,12 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
             when the worker needs to be wrapped inside some other command
             (for example, to run the worker inside a container). Default is
             'work_queue_worker'.
+
+        function_dir: str
+            The directory where serialized function invocations are placed
+            to be sent to workers. If undefined, this defaults to a directory
+            under runinfo/. If shared_filesystem=True, then this directory
+            must be visible from both the submitting side and workers.
     """
 
     radio_mode = "filesystem"
@@ -224,7 +231,8 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
                  init_command: str = "",
                  worker_options: str = "",
                  full_debug: bool = True,
-                 worker_executable: str = 'work_queue_worker'):
+                 worker_executable: str = 'work_queue_worker',
+                 function_dir: Optional[str] = None):
         BlockProviderExecutor.__init__(self, provider=provider,
                                        block_error_handler=True)
         self._scaling_enabled = True
@@ -261,6 +269,7 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         self.cached_envs = {}  # type: Dict[int, str]
         self.worker_options = worker_options
         self.worker_executable = worker_executable
+        self.function_dir = function_dir
 
         if not self.address:
             self.address = socket.gethostname()
@@ -290,7 +299,13 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         self.tasks_lock = threading.Lock()
 
         # Create directories for data and results
-        self.function_data_dir = os.path.join(self.run_dir, "function_data")
+        if not self.function_dir:
+            self.function_data_dir = os.path.join(self.run_dir, "function_data")
+        else:
+            tp = str(time.time())
+            tx = os.path.join(self.function_dir, tp)
+            os.mkdir(tx)
+            self.function_data_dir = os.path.join(self.function_dir, tp, "function_data")
         self.package_dir = os.path.join(self.run_dir, "package_data")
         self.wq_log_dir = os.path.join(self.run_dir, self.label)
         logger.debug("function data directory: {}\nlog directory: {}".format(self.function_data_dir, self.wq_log_dir))


### PR DESCRIPTION
# Description

This allows these files to be placed on a local filesystem while the rest of the rundir lives on a shared filesystem, which can significiantly reduce the load on the shared filesystem and give significant task speedups.

## Type of change

- New feature (non-breaking change that adds functionality)
