### PR TITLE
Adding an update_version option to tag_and_release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,11 @@ package: ## package up a distribution.
 deploy: ## deploy the distribution
 	./tag_and_release.sh release
 
+# THIS IS MEANT TO BE INVOKED BY GITHUB ACTIONS **ONLY**
+.PHONY: update_version
+update_version: ## Update version
+    ./tag_and_release.sh update_version
+
 .PHONY: release
 release: deps tag package deploy   ## create a release. To run, do a 'make VERSION="version string"  release'
 

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ deploy: ## deploy the distribution
 # THIS IS MEANT TO BE INVOKED BY GITHUB ACTIONS **ONLY**
 .PHONY: update_version
 update_version: ## Update version
-    ./tag_and_release.sh update_version
+	./tag_and_release.sh update_version
 
 .PHONY: release
 release: deps tag package deploy   ## create a release. To run, do a 'make VERSION="version string"  release'

--- a/tag_and_release.sh
+++ b/tag_and_release.sh
@@ -51,4 +51,26 @@ release () {
     twine upload dist/*
 }
 
+update_version () {
+    latest=$(pip index versions parsl | grep LATEST | awk '{print $2}')
+    echo "Latest version = $latest"
+    target_version=$(date +%Y.%m.%d)
+    echo "Target version = $target_version"
+    if [[ $latest == $target_version ]]
+    then
+       echo "Conflict detected. Target version already is uploaded on Pypi"
+       exit -1
+    else
+        cat << EOF > parsl/version.py
+"""Set module version.
+
+<Major>.<Minor>.<maintenance>[alpha/beta/..]
+Alphas will be numbered like this -> 0.4.0a0
+"""
+VERSION = '$target_version'
+EOF
+    fi
+
+}
+
 "$@"


### PR DESCRIPTION
# Description

This PR adds a new option to `tag_and_release.sh` script to help with weekly releases.
The steps to doing the weekly release would go like this:

1. Run tests and confirm all green
2. Run the github action here -> `https://github.com/Parsl/parsl/pull/2441` 
    * This action will run `version_update` on master bumping the version to "YYYY.MM.DD"
    * The action will do `python -m build` instead of our current `setup.py` calls
    * Action will deploy now to testpypi, and later to pypi.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
