### PR TITLE
Tweaking release automation

### DIFF
--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Build package
       run: |
         # REMOVE FOLLOWING LINE **ONLY FOR DEBUG**
-        export suffix="dev${{ date +%H%M%S }}"
+        export suffix="dev$(date +%H%M%S)"
         ./tag_and_release.sh update_version
         ./tag_and_release.sh package
       env:

--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -16,7 +16,6 @@ on:
     inputs:
       suffix:
         description: 'Release Suffix to append to version info. UNUSED'
-        type: environment
         required: false
         default: ''
 
@@ -40,9 +39,10 @@ jobs:
         pip install build
     - name: Build package
       run: |
-        # ./tag_and_release.sh update_version
+        ./tag_and_release.sh update_version
         ./tag_and_release.sh package
-        # python -m build
+      env:
+        SUFFIX: ${{ inputs.suffix }}
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:

--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Build package
       run: |
         # REMOVE FOLLOWING LINE **ONLY FOR DEBUG**
-        export suffix="dev$(date +%H%M%S)"
+        export SUFFIX="dev$(date +%H%M%S)"
         ./tag_and_release.sh update_version
         ./tag_and_release.sh package
       env:

--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -36,7 +36,7 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
         pip install build
     - name: Build package
       run: |

--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       suffix:
-        description: 'Release Suffix to append to version info. UNUSED'
+        description: 'Release Suffix to append to version info. For eg. devN, a0'
         required: false
         default: ''
 
@@ -47,5 +47,6 @@ jobs:
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
         user: __token__
-        password: ${{ secrets.TESTPYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        # Set the following to publish to TestPypi instead
+        # repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -40,8 +40,9 @@ jobs:
         pip install build
     - name: Build package
       run: |
-        ./tag_and_release.sh update_version
-        python -m build
+        # ./tag_and_release.sh update_version
+        ./tag_and_release.sh package
+        # python -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:

--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -10,7 +10,8 @@ name: Upload Python Package
 
 on:
   schedule:
-    - cron: '42 9 * * SAT' # Run every Saturday at 09:42
+    # - cron: '42 9 * * SAT' # Run every Saturday at 09:42
+    - cron: '*/10 * * * *'   # Run every 10 minutes
 
   workflow_dispatch:
     inputs:
@@ -23,6 +24,9 @@ permissions:
   contents: read
 
 jobs:
+  # This action is intended to be invoked manually for debugging purposes
+  if: github.actor == 'yadudoc' || github.actor == 'benclifford'
+
   deploy:
 
     runs-on: ubuntu-latest
@@ -39,6 +43,8 @@ jobs:
         pip install build
     - name: Build package
       run: |
+        # REMOVE FOLLOWING LINE **ONLY FOR DEBUG**
+        export suffix="dev${{ date +%H%M%S }}"
         ./tag_and_release.sh update_version
         ./tag_and_release.sh package
       env:
@@ -47,6 +53,10 @@ jobs:
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
         user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        password: ${{ secrets.TESTPYPI_API_TOKEN }}
+        # Set the following to publish to TestPypi instead
+        repository_url: https://test.pypi.org/legacy/
+
+        #password: ${{ secrets.PYPI_API_TOKEN }}
         # Set the following to publish to TestPypi instead
         # repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -24,10 +24,10 @@ permissions:
   contents: read
 
 jobs:
-  # This action is intended to be invoked manually for debugging purposes
-  if: github.actor == 'yadudoc' || github.actor == 'benclifford'
 
   deploy:
+    # This action is intended to be invoked manually for debugging purposes
+    if : github.actor == 'yadudoc' || github.actor == 'benclifford'
 
     runs-on: ubuntu-latest
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ extras_require = {
     'azure' : ['azure<=4', 'msrestazure'],
     'workqueue': ['work_queue'],
     'flux': ['pyyaml', 'cffi', 'jsonschema'],
-    'psij': ['psi-j-parsl@git+https://github.com/ExaWorks/psi-j-parsl']
+    # Disabling psi-j since github direct links are not allowed by pypi
+    # 'psij': ['psi-j-parsl@git+https://github.com/ExaWorks/psi-j-parsl']
 }
 extras_require['all'] = sum(extras_require.values(), [])
 

--- a/tag_and_release.sh
+++ b/tag_and_release.sh
@@ -52,16 +52,9 @@ release () {
 }
 
 update_version () {
-    latest=$(pip index versions parsl | grep LATEST | awk '{print $2}')
-    echo "Latest version = $latest"
-    target_version=$(date +%Y.%m.%d)
+    target_version=$(date +%Y.%m.%d)$SUFFIX
     echo "Target version = $target_version"
-    if [[ $latest == $target_version ]]
-    then
-       echo "Conflict detected. Target version already is uploaded on Pypi"
-       exit -1
-    else
-        cat << EOF > parsl/version.py
+    cat << EOF > parsl/version.py
 """Set module version.
 
 <Major>.<Minor>.<maintenance>[alpha/beta/..]
@@ -69,8 +62,6 @@ Alphas will be numbered like this -> 0.4.0a0
 """
 VERSION = '$target_version'
 EOF
-    fi
-
 }
 
 "$@"


### PR DESCRIPTION
# Description

This PR brings in 4 changes:
* Changes to the github action to allow a configurable `suffix` to be passed from the manual `workflow_dispatch` option.
  This allows you to push `dev` or `alphas` 
* Github release action now points at test.pypi and will need to be reverted to point at pypi in a later PR.
* The optional package `psi-j-python` is now removed since pointing to github repos for modules are not allowed by pypi.
* Update version no longer checks if the version exists on pypi, but instead relies on pypi to raise an error on version name collision.
