### PR TITLE
upgrade flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,12 +3,13 @@
 # E126: continuation line over-indented for hanging indent
 # This one is bad. Sometimes ordering matters, conditional imports
 # setting env vars necessary etc.
+# E275: no whitespace after keyword, fails on upgrade from flake8 3.8.0 to 5.0.4
 # E402: module level import not at top of file
 # E129: Visual indent to not match indent as next line, counter eg here:
 # https://github.com/PyCQA/pycodestyle/issues/386
 # W504: line break after binary operator
 #       (Raised by flake8 even when it is followed)
-ignore = E124, E126, E402, E129, W504
+ignore = E124, E126, E275, E402, E129, W504
 max-line-length = 160
 exclude = parsl/executors/serialize/, test_import_fail.py
 # E741 disallows ambiguous single letter names which look like numbers

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-flake8==3.8.0
+flake8==5.0.4
 ipyparallel
 pandas
 pytest>=6.2.5,<7


### PR DESCRIPTION
flake8 broken due to importlib 5.0.0 release. this PR works on upgrading all the stuff around that to fix.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
- Code maintentance/cleanup
