### PR TITLE
Add wrapper renaming to python app walltime. Fixes #2449

### DIFF
--- a/parsl/app/python.py
+++ b/parsl/app/python.py
@@ -3,6 +3,8 @@ import logging
 import tblib.pickling_support
 tblib.pickling_support.install()
 
+from functools import wraps
+
 from parsl.app.app import AppBase
 from parsl.app.errors import wrap_error
 from parsl.dataflow.dflow import DataFlowKernelLoader
@@ -12,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def timeout(f, seconds):
+    @wraps(f)
     def wrapper(*args, **kwargs):
         import threading
         import ctypes

--- a/parsl/tests/test_error_handling/test_python_walltime.py
+++ b/parsl/tests/test_error_handling/test_python_walltime.py
@@ -5,21 +5,28 @@ from parsl.app.errors import AppTimeout
 
 
 @parsl.python_app
-def my_app(walltime=1):
+def my_app(t, walltime=1):
     import time
-    time.sleep(1.2)
-    return True
+    time.sleep(t)
+    return 7
 
 
 def test_python_walltime():
-    f = my_app()
+    f = my_app(2)
     with pytest.raises(AppTimeout):
         f.result()
 
 
 def test_python_longer_walltime_at_invocation():
-    f = my_app(walltime=6)
-    f.result()
+    f = my_app(1, walltime=6)
+    assert f.result() == 7
+
+
+def test_python_walltime_wrapped_names():
+    f = my_app(1, walltime=6)
+    assert f.result() == 7
+    assert f.task_def['func'].__name__ == "my_app"
+    assert f.task_def['func_name'] == "my_app"
 
 
 def test_python_bad_decorator_args():


### PR DESCRIPTION
# Description

python_app walltime is implemented as a wrapper. That wrapper did not use `@wraps`, unlike many other parsl function wrappers.

This resulted in the app name being "wrapped", the name of the wrapper.

This PR adds `@wraps` so that the app name is preserved.

This PR also adds a test that fails before this change, and passes afterwards.

Fixes #2449

## Type of change

- Bug fix (non-breaking change that fixes an issue)
