### PR TITLE
Rename task_status_poller because it polls jobs not tasks

### DIFF
--- a/parsl/dataflow/flow_control.py
+++ b/parsl/dataflow/flow_control.py
@@ -5,7 +5,7 @@ import time
 from typing import Sequence
 
 from parsl.executors.base import ParslExecutor
-from parsl.dataflow.task_status_poller import TaskStatusPoller
+from parsl.dataflow.job_status_poller import JobStatusPoller
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ class FlowControl(object):
         self.threshold = threshold
         self.interval = interval
         self.cb_args = args
-        self.task_status_poller = TaskStatusPoller(dfk)
+        self.task_status_poller = JobStatusPoller(dfk)
         self.callback = self.task_status_poller.poll
         self._handle = None
         self._event_count = 0

--- a/parsl/dataflow/job_error_handler.py
+++ b/parsl/dataflow/job_error_handler.py
@@ -1,6 +1,6 @@
 from typing import List, Dict
 
-from parsl.dataflow.task_status_poller import ExecutorStatus
+from parsl.dataflow.job_status_poller import ExecutorStatus
 from parsl.executors.base import ParslExecutor
 from parsl.providers.provider_base import JobStatus, JobState
 

--- a/parsl/dataflow/job_status_poller.py
+++ b/parsl/dataflow/job_status_poller.py
@@ -99,7 +99,7 @@ class PollItem(ExecutorStatus):
         return self._status.__repr__()
 
 
-class TaskStatusPoller(object):
+class JobStatusPoller(object):
     def __init__(self, dfk: "parsl.dataflow.dflow.DataFlowKernel"):
         self._poll_items = []  # type: List[PollItem]
         self.dfk = dfk


### PR DESCRIPTION
This aligns with the JobStatus and JobState classes.

## Type of change

- Code maintentance/cleanup
