### PR TITLE
Relabel worker efficiency plot to show that total workers is constant

### DIFF
--- a/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
@@ -128,7 +128,7 @@ def worker_efficiency(task, node):
                              ),
                   go.Scatter(x=list(range(0, end - start + 1)),
                              y=[total_workers] * (end - start + 1),
-                             name='Total online workers',
+                             name='Total of workers in whole run',
                              )
                  ],
             layout=go.Layout(xaxis=dict(autorange=True,


### PR DESCRIPTION
The previous label, "total online workers", suggests that this line might vary over time as workers come online and go offline. This is not the case.

See issue #2474 

## Type of change

- Documentation update