### PR TITLE
More accurately record worker usage in efficiency plot

### DIFF
--- a/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_resource_plots.py
@@ -97,16 +97,18 @@ def resource_time_series(tasks, type='psutil_process_time_user', label='CPU user
 def worker_efficiency(task, node):
     try:
         node['epoch_time'] = (pd.to_datetime(
-            node['timestamp']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
+            node['timestamp']) - pd.Timestamp("1970-01-01")) / pd.Timedelta('1s')
         task['epoch_time_start'] = (pd.to_datetime(
-            task['task_try_time_launched']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
+            task['task_try_time_launched']) - pd.Timestamp("1970-01-01")) / pd.Timedelta('1s')
         task['epoch_time_running'] = (pd.to_datetime(
-            task['task_try_time_running']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
+            task['task_try_time_running']) - pd.Timestamp("1970-01-01")) / pd.Timedelta('1s')
         task['epoch_time_returned'] = (pd.to_datetime(
-            task['task_try_time_returned']) - pd.Timestamp("1970-01-01")) // pd.Timedelta('1s')
+            task['task_try_time_returned']) - pd.Timestamp("1970-01-01")) / pd.Timedelta('1s')
         start = int(min(task['epoch_time_start'].min(), node['epoch_time'].min()))
         end = int(task['epoch_time_returned'].max())
 
+        # worker_plot will be used to make a histogram of worker usage, one bucket per
+        # second
         worker_plot = [0] * (end - start + 1)
         total_workers = node['worker_count'].sum()
 
@@ -118,9 +120,35 @@ def worker_efficiency(task, node):
                 # there is no end time for this, so we should assume the "end" time
                 etr = end
             else:
-                etr = int(row['epoch_time_returned'])
-            for j in range(int(row['epoch_time_running']), etr + 1):
-                worker_plot[j - start] += 1
+                etr = row['epoch_time_returned']
+
+            # there's a two cases here:
+            # The task starts and ends in same one-second bucket:
+            #   populate one bucket with the fraction of second between
+            #   the start and end
+            #
+            # or
+            #
+            # The task starts in one bucket and ends in another:
+            #   populate middle buckets with 1, and start/end buckets with fraction
+
+            start_bucket = int(row['epoch_time_running']) - start
+            end_bucket = int(etr) - start
+
+            if start_bucket == end_bucket:
+                fraction = etr - row['epoch_time_running']
+                worker_plot[start_bucket] += fraction
+
+            else:
+                fraction_before = row['epoch_time_running'] - int(row['epoch_time_running'])
+                worker_plot[start_bucket] += (1 - fraction_before)
+
+                for j in range(start_bucket + 1, end_bucket):
+                    worker_plot[j] += 1
+
+                fraction_after = etr - int(etr)
+                worker_plot[end_bucket] += fraction_after
+
         fig = go.Figure(
             data=[go.Scatter(x=list(range(0, end - start + 1)),
                              y=worker_plot,


### PR DESCRIPTION
Prior to this PR, the plot was generated by computing a histogram of one-second buckets, and each task contributed 1 second to each bucket that it overlapped, even when the task was only running for part of that second (the first and last seconds).

After this PR, a task only contributes a fraction of a second to the start and end buckets, based on the fractional part of the start/end timestamp.

For a workflow with many short running tasks, this will show a large decrease in worker usage: for example, the pytest test suite running with --config htex_local_alternate.py on my laptop goes from a peak of 50 workers in use (more workers than actually exist!) to a peak of 3.

See issue #2474 for more discussion and example plots.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
