### PR TITLE
Remove histogram of mean CPU time

### DIFF
--- a/parsl/monitoring/visualization/templates/resource_usage.html
+++ b/parsl/monitoring/visualization/templates/resource_usage.html
@@ -37,9 +37,6 @@
 <div class="container">
   <div class="row">
     <div class="col-6" style="height: 300px;">
-{{ user_time_distribution_avg_plot|safe }}
-    </div>
-    <div class="col-6" style="height: 300px;">
 {{ user_time_distribution_max_plot|safe }}
     </div>
   </div>

--- a/parsl/monitoring/visualization/views.py
+++ b/parsl/monitoring/visualization/views.py
@@ -172,8 +172,6 @@ def workflow_resources(workflow_id):
         "SELECT * FROM node WHERE run_id='%s'" % (workflow_id), db.engine)
 
     return render_template('resource_usage.html', workflow_details=workflow_details,
-                           user_time_distribution_avg_plot=resource_distribution_plot(
-                               df_resources, df_task, type='psutil_process_time_user', label='CPU Time Distribution', option='avg'),
                            user_time_distribution_max_plot=resource_distribution_plot(
                                df_resources, df_task, type='psutil_process_time_user', label='CPU Time Distribution', option='max'),
                            memory_usage_distribution_avg_plot=resource_distribution_plot(


### PR DESCRIPTION
This removed plot measures the mean CPU time across all resource readings for each task, and then makes a histogram of how many tasks fall into each bucket.

However, the mean cumulative CPU time across all resource readings (for a given task) doesn't really have a lot of meaning. The maximum value plot, which makes more sense, is retained by this PR.

# Description

- Code maintentance/cleanup
