### PR TITLE
Remove references to cloudpickle, sometimes replacing with dill

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -315,9 +315,9 @@ Addressing SerializationError
 As of v1.0.0, Parsl will raise a `SerializationError` when it encounters an object that Parsl cannot serialize.
 This applies to objects passed as arguments to an app, as well as objects returned from the app.
 
-Parsl uses `cloudpickle <https://github.com/cloudpipe/cloudpickle>`_ and pickle to serialize Python objects
+Parsl uses dill and pickle to serialize Python objects
 to/from functions. Therefore, Python apps can only use input and output objects that can be serialized by
-cloudpickle or pickle. For example the following data types are known to have issues with serializability :
+dill or pickle. For example the following data types are known to have issues with serializability :
 
 * Closures
 * Objects of complex classes with no ``__dict__`` or ``__getstate__`` methods defined

--- a/docs/userguide/apps.rst
+++ b/docs/userguide/apps.rst
@@ -113,7 +113,7 @@ There are some limitations on the Python functions that can be converted to apps
 
 1. Functions should act only on defined input arguments. That is, they should not use script-level or global variables.
 2. Functions must explicitly import any required modules.
-3. Parsl uses `cloudpickle <https://github.com/cloudpipe/cloudpickle>`_ and pickle to serialize Python objects to/from apps. Therefore, Parsl require that all input and output objects can be serialized by cloudpickle or pickle. See :ref:`label_serialization_error`.
+3. Parsl uses dill and pickle to serialize Python objects to/from apps. Therefore, Parsl require that all input and output objects can be serialized by dill or pickle. See :ref:`label_serialization_error`.
 4. STDOUT and STDERR produced by Python apps remotely are not captured.
 
 

--- a/docs/userguide/data.rst
+++ b/docs/userguide/data.rst
@@ -16,7 +16,7 @@ can be passed to, and returned from, a Parsl app.
     r = example('bob')
     print(r.result())
 
-Parsl uses the cloudpickle and pickle libraries to serialize Python objects 
+Parsl uses the dill and pickle libraries to serialize Python objects 
 into a sequence of bytes that can be passed over a network from the submitting
 machine to executing workers.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -79,9 +79,6 @@ ignore_missing_imports = True
 [mypy-cPickle.*]
 ignore_missing_imports = True
 
-[mypy-cloudpickle.*]
-ignore_missing_imports = True
-
 [mypy-copy_reg.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
## Type of change

- Documentation update
- Code maintentance/cleanup
