### PR TITLE
Don't deserialize during serialization

### DIFF
--- a/parsl/serialize/facade.py
+++ b/parsl/serialize/facade.py
@@ -71,8 +71,6 @@ def serialize(obj, buffer_threshold=1e6):
         for method in methods_for_code.values():
             try:
                 serialized = method.serialize(obj)
-                # We attempt a deserialization to make sure both work.
-                method.deserialize(serialized)
             except Exception as e:
                 last_exception = e
                 continue


### PR DESCRIPTION
It is unlikely that this will detect any problems serialization problems, and it is expensive under heavy loads - roughly doubling the cost of serializing complex objects, if they are not already in the cache.

## Type of change

- Code maintentance/cleanup
