### PR TITLE
Remove documentation references to user-extensible flow control

### DIFF
--- a/docs/userguide/execution.rst
+++ b/docs/userguide/execution.rst
@@ -199,18 +199,15 @@ tasks with a thin workload.
 To address dynamic workload requirements, 
 Parsl implements a cloud-like elasticity model in which resource
 blocks are provisioned/deprovisioned in response to workload pressure. 
-Parsl provides an extensible strategy interface by which users
-can implement their own elasticity logic. 
 Given the general nature of the implementation, 
 Parsl can provide elastic execution on clouds, clusters,
 and supercomputers. Of course, in an HPC setting, elasticity may
 be complicated by queue delays.
 
-Parsl's elasticity model includes an extensible flow control system
+Parsl's elasticity model includes a flow control system
 that monitors outstanding tasks and available compute capacity.
-This flow control monitor, which can be extended or implemented by users,
-determines when to trigger scaling (in or out) events to match
-workload needs.
+This flow control monitor determines when to trigger scaling (in or out)
+events to match workload needs.
 
 The animated diagram below shows how blocks are elastically
 managed within an executor. The Parsl configuration for an executor


### PR DESCRIPTION
Flow control / scaling strategy choices are hard coded into the parsl source code in self.strategies in Strategy.__init__ and require patching the parsl source code to add more.

## Type of change

- Documentation update
- Code maintentance/cleanup
