### PR TITLE
Add missing seconds units on idle duration log

### DIFF
--- a/parsl/dataflow/strategy.py
+++ b/parsl/dataflow/strategy.py
@@ -235,7 +235,7 @@ class Strategy(object):
                         exec_status.scale_in(active_blocks - min_blocks)
 
                     else:
-                        logger.debug(f"Idle time {idle_duration} is less than max_idletime {self.max_idletime}s for executor {label}; not scaling in")
+                        logger.debug(f"Idle time {idle_duration}s is less than max_idletime {self.max_idletime}s for executor {label}; not scaling in")
 
             # Case 2
             # More tasks than the available slots.


### PR DESCRIPTION
This is consistent with other durations logged in the strategy module

## Type of change

- Code maintentance/cleanup
