### PR TITLE
Make work queue executor pop tasks so failure handler does not see them

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -721,7 +721,7 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
 
                 # Obtain the future from the tasks dictionary
                 with self.tasks_lock:
-                    future = self.tasks[task_report.id]
+                    future = self.tasks.pop(task_report.id)
 
                 logger.debug("Updating Future for Parsl Task {}".format(task_report.id))
                 if task_report.result_received:


### PR DESCRIPTION
This is part of a fix for task #2473, but not all of it.

Prior to this PR, when Parsl decides that a work queue executor is permanently failed, it will attempt to set an exeception on all task futures, even tasks which already have received a result.

This results in an incorrect state exception, which then stops the rest of executor permanent failure handling.

This change to use .pop makes the Work Queue Executor behave more like the High Throughput Executor: completed task futures will not be stored in the list of tasks, and so (race conditions aside) will not get an exception set on them.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
