### PR TITLE
Add ipython3 version constraints to cope with newly release ipython 8.7.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,3 +120,4 @@ For more information, please visit `the informational
 page <https://sustainable-open-science-and-software.github.io/>`__ or
 download the `participant information
 sheet <https://sustainable-open-science-and-software.github.io/assets/PIS_sustainable_software.pdf>`__.
+test

--- a/README.rst
+++ b/README.rst
@@ -120,4 +120,3 @@ For more information, please visit `the informational
 page <https://sustainable-open-science-and-software.github.io/>`__ or
 download the `participant information
 sheet <https://sustainable-open-science-and-software.github.io/assets/PIS_sustainable_software.pdf>`__.
-test

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extras_require = {
     'kubernetes' : ['kubernetes'],
     'oauth_ssh' : ['oauth-ssh>=0.9'],
     'extreme_scale' : ['mpi4py'],
-    'docs' : ['nbsphinx', 'sphinx_rtd_theme', 'ipython'],
+    'docs' : ['nbsphinx', 'sphinx_rtd_theme', 'ipython==8.6.0'],
     'google_cloud' : ['google-auth', 'google-api-python-client'],
     'gssapi' : ['python-gssapi'],
     'azure' : ['azure<=4', 'msrestazure'],

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extras_require = {
     'kubernetes' : ['kubernetes'],
     'oauth_ssh' : ['oauth-ssh>=0.9'],
     'extreme_scale' : ['mpi4py'],
-    'docs' : ['nbsphinx', 'sphinx_rtd_theme', 'ipython==8.6.0'],
+    'docs' : ['nbsphinx', 'sphinx_rtd_theme', 'ipython<=8.6.0'],
     'google_cloud' : ['google-auth', 'google-api-python-client'],
     'gssapi' : ['python-gssapi'],
     'azure' : ['azure<=4', 'msrestazure'],


### PR DESCRIPTION
# Description

doc build is failing with

```


Warning, treated as error:
/home/runner/work/parsl/parsl/docs/1-parsl-introduction.ipynb::Pygments lexer name 'ipython3' is not known
make: *** [Makefile:52: html] Error 2
```

## Type of change

- Bug fix (non-breaking change that fixes an issue)
