### PR TITLE
Move tests to use lazily constructed configurations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,4 +19,9 @@ per-file-ignores = parsl/monitoring/visualization/*:E741,
   # needed because this deliberately has undefined names in it
   parsl/tests/test_swift.py:F821,
   # test_ssh_errors.py really is broken
-  parsl/tests/integration/test_channels/test_ssh_errors.py:F821
+  parsl/tests/integration/test_channels/test_ssh_errors.py:F821,
+
+  # tests often import fresh_config into their namespace as local_config
+  # but then do not use it directly, because tests/conftests.py
+  # looks for it instead.
+  parsl/tests/**:F401

--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,14 @@ workqueue_ex_test: $(WORKQUEUE_INSTALL)  ## run all tests with workqueue_ex conf
 .PHONY: config_local_test
 config_local_test: ## run all tests with workqueue_ex config
 	echo "$(MPI)"
+	sudo apt-get install -y strace
 	parsl/executors/extreme_scale/install-mpi.sh $(MPI)
 	pip3 install ".[extreme_scale,monitoring]"
-	PYTHONPATH=. pytest parsl/tests/ -k "not cleannet" --config local --random-order
+	echo "List of currently running processes"
+	ps -ax
+	uptime
+	echo starting strace:
+	PYTHONPATH=. strace pytest parsl/tests/ -k "not cleannet" --config local --random-order
 
 .PHONY: site_test
 site_test:

--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,6 @@ config_local_test: ## run all tests with workqueue_ex config
 	echo "$(MPI)"
 	parsl/executors/extreme_scale/install-mpi.sh $(MPI)
 	pip3 install ".[extreme_scale,monitoring]"
-	echo "List of currently running processes"
-	ps -ax
-	uptime
 	PYTHONPATH=. pytest parsl/tests/ -k "not cleannet" --config local --random-order
 
 .PHONY: site_test

--- a/Makefile
+++ b/Makefile
@@ -78,14 +78,12 @@ workqueue_ex_test: $(WORKQUEUE_INSTALL)  ## run all tests with workqueue_ex conf
 .PHONY: config_local_test
 config_local_test: ## run all tests with workqueue_ex config
 	echo "$(MPI)"
-	sudo apt-get install -y strace
 	parsl/executors/extreme_scale/install-mpi.sh $(MPI)
 	pip3 install ".[extreme_scale,monitoring]"
 	echo "List of currently running processes"
 	ps -ax
 	uptime
-	echo starting strace:
-	PYTHONPATH=. strace pytest parsl/tests/ -k "not cleannet" --config local --random-order
+	PYTHONPATH=. pytest parsl/tests/ -k "not cleannet" --config local --random-order
 
 .PHONY: site_test
 site_test:

--- a/README.rst
+++ b/README.rst
@@ -104,4 +104,3 @@ Contributing
 ============
 
 We welcome contributions from the community. Please see our `contributing guide <https://github.com/Parsl/parsl/blob/master/CONTRIBUTING.rst>`_.
-

--- a/README.rst
+++ b/README.rst
@@ -104,3 +104,4 @@ Contributing
 ============
 
 We welcome contributions from the community. Please see our `contributing guide <https://github.com/Parsl/parsl/blob/master/CONTRIBUTING.rst>`_.
+

--- a/parsl/addresses.py
+++ b/parsl/addresses.py
@@ -53,7 +53,6 @@ def address_by_query(timeout: float = 30) -> str:
        timeout : float
           Timeout for the request in seconds. Default: 30s
     """
-    # raise BaseException("BENC:  in abq")
     logger.debug("Finding address by querying remote service")
     response = requests.get('https://api.ipify.org', timeout=timeout)
 

--- a/parsl/addresses.py
+++ b/parsl/addresses.py
@@ -53,6 +53,7 @@ def address_by_query(timeout: float = 30) -> str:
        timeout : float
           Timeout for the request in seconds. Default: 30s
     """
+    # raise BaseException("BENC:  in abq")
     logger.debug("Finding address by querying remote service")
     response = requests.get('https://api.ipify.org', timeout=timeout)
 

--- a/parsl/tests/configs/exex_local.py
+++ b/parsl/tests/configs/exex_local.py
@@ -5,19 +5,20 @@ from parsl.launchers import SimpleLauncher
 from parsl.config import Config
 from parsl.executors import ExtremeScaleExecutor
 
-config = Config(
-    executors=[
-        ExtremeScaleExecutor(
-            label="Extreme_Local",
-            worker_debug=True,
-            ranks_per_node=4,
-            provider=LocalProvider(
-                channel=LocalChannel(),
-                init_blocks=1,
-                max_blocks=1,
-                launcher=SimpleLauncher(),
+def fresh_config():
+    return Config(
+        executors=[
+            ExtremeScaleExecutor(
+                label="Extreme_Local",
+                worker_debug=True,
+                ranks_per_node=4,
+                provider=LocalProvider(
+                    channel=LocalChannel(),
+                    init_blocks=1,
+                    max_blocks=1,
+                    launcher=SimpleLauncher(),
+                )
             )
-        )
-    ],
-    strategy='none',
-)
+        ],
+        strategy='none',
+    )

--- a/parsl/tests/configs/exex_local.py
+++ b/parsl/tests/configs/exex_local.py
@@ -5,6 +5,7 @@ from parsl.launchers import SimpleLauncher
 from parsl.config import Config
 from parsl.executors import ExtremeScaleExecutor
 
+
 def fresh_config():
     return Config(
         executors=[

--- a/parsl/tests/configs/htex_local.py
+++ b/parsl/tests/configs/htex_local.py
@@ -23,6 +23,3 @@ def fresh_config():
         ],
         strategy='none',
     )
-
-
-config = fresh_config()

--- a/parsl/tests/configs/htex_local_alternate.py
+++ b/parsl/tests/configs/htex_local_alternate.py
@@ -39,6 +39,7 @@ def fresh_config():
     return Config(
         executors=[
             HighThroughputExecutor(
+                address="127.0.0.1",
                 label="htex_Local",
                 working_dir=working_dir,
                 storage_access=[FTPInTaskStaging(), HTTPInTaskStaging(), NoOpFileStaging()],

--- a/parsl/tests/configs/local_adhoc.py
+++ b/parsl/tests/configs/local_adhoc.py
@@ -3,13 +3,14 @@ from parsl.channels import LocalChannel
 from parsl.executors import HighThroughputExecutor
 from parsl.providers import AdHocProvider
 
-config = Config(
-    executors=[
-        HighThroughputExecutor(
-            label='AdHoc',
-            provider=AdHocProvider(
-                channels=[LocalChannel(), LocalChannel()]
+def fresh_config():
+    return Config(
+        executors=[
+            HighThroughputExecutor(
+                label='AdHoc',
+                provider=AdHocProvider(
+                    channels=[LocalChannel(), LocalChannel()]
+                )
             )
-        )
-    ]
-)
+        ]
+    )

--- a/parsl/tests/configs/local_adhoc.py
+++ b/parsl/tests/configs/local_adhoc.py
@@ -3,6 +3,7 @@ from parsl.channels import LocalChannel
 from parsl.executors import HighThroughputExecutor
 from parsl.providers import AdHocProvider
 
+
 def fresh_config():
     return Config(
         executors=[

--- a/parsl/tests/configs/local_threads_http_in_task.py
+++ b/parsl/tests/configs/local_threads_http_in_task.py
@@ -3,11 +3,12 @@ from parsl.data_provider.file_noop import NoOpFileStaging
 from parsl.data_provider.http import HTTPInTaskStaging
 from parsl.executors.threads import ThreadPoolExecutor
 
-config = Config(
-    executors=[
-        ThreadPoolExecutor(
-            label='local_threads_http_in_task',
-            storage_access=[HTTPInTaskStaging(), NoOpFileStaging()]
-        )
-    ]
-)
+def fresh_config():
+    return Config(
+        executors=[
+            ThreadPoolExecutor(
+                label='local_threads_http_in_task',
+                storage_access=[HTTPInTaskStaging(), NoOpFileStaging()]
+            )
+        ]
+    )

--- a/parsl/tests/configs/local_threads_http_in_task.py
+++ b/parsl/tests/configs/local_threads_http_in_task.py
@@ -3,6 +3,7 @@ from parsl.data_provider.file_noop import NoOpFileStaging
 from parsl.data_provider.http import HTTPInTaskStaging
 from parsl.executors.threads import ThreadPoolExecutor
 
+
 def fresh_config():
     return Config(
         executors=[

--- a/parsl/tests/configs/local_threads_no_cache.py
+++ b/parsl/tests/configs/local_threads_no_cache.py
@@ -1,9 +1,10 @@
 from parsl.config import Config
 from parsl.executors.threads import ThreadPoolExecutor
 
-config = Config(
-    executors=[
-        ThreadPoolExecutor(max_threads=4),
-    ],
-    app_cache=False
-)
+def fresh_config():
+    return Config(
+        executors=[
+            ThreadPoolExecutor(max_threads=4),
+        ],
+        app_cache=False
+    )

--- a/parsl/tests/configs/local_threads_no_cache.py
+++ b/parsl/tests/configs/local_threads_no_cache.py
@@ -1,6 +1,7 @@
 from parsl.config import Config
 from parsl.executors.threads import ThreadPoolExecutor
 
+
 def fresh_config():
     return Config(
         executors=[

--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -148,9 +148,8 @@ def load_dfk_local_module(request, pytestconfig):
         local_teardown = getattr(request.module, "local_teardown", None)
         local_config = getattr(request.module, "local_config", None)
 
-        if local_config and not callable(local_config):
-            raise RuntimeError("local_config must now be callable")
-        elif local_config and callable(local_config):
+        if local_config:
+            assert callable(local_config)
             c = local_config()
             assert isinstance(c, parsl.Config)
             dfk = parsl.load(c)

--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -199,12 +199,12 @@ def apply_masks(request, pytestconfig):
     if m is not None:  # is marked as local
         if config != 'local':
             if len(m.args) == 0:
-                pytest.skip('skipping test intended for local config')
+                pytest.skip('skipping non-local config')
             else:
                 pytest.skip(m.args[0])
     else:  # is not marked as local
         if config == 'local':
-            pytest.skip('skipping test intended for explicit config')
+            pytest.skip('skipping local config')
 
 
 @pytest.fixture()

--- a/parsl/tests/sites/test_affinity.py
+++ b/parsl/tests/sites/test_affinity.py
@@ -8,6 +8,7 @@ from parsl import python_app
 import pytest
 import os
 
+
 def local_config():
     return Config(
         executors=[
@@ -25,7 +26,7 @@ def local_config():
             )
         ],
         strategy='none',
-      )
+    )
 
 
 @python_app

--- a/parsl/tests/sites/test_affinity.py
+++ b/parsl/tests/sites/test_affinity.py
@@ -8,23 +8,24 @@ from parsl import python_app
 import pytest
 import os
 
-local_config = Config(
-    executors=[
-        HighThroughputExecutor(
-            label="htex_Local",
-            worker_debug=True,
-            max_workers=2,
-            cpu_affinity='block',
-            available_accelerators=2,
-            provider=LocalProvider(
-                channel=LocalChannel(),
-                init_blocks=1,
-                max_blocks=1,
-            ),
-        )
-    ],
-    strategy='none',
-)
+def local_config():
+    return Config(
+        executors=[
+            HighThroughputExecutor(
+                label="htex_Local",
+                worker_debug=True,
+                max_workers=2,
+                cpu_affinity='block',
+                available_accelerators=2,
+                provider=LocalProvider(
+                    channel=LocalChannel(),
+                    init_blocks=1,
+                    max_blocks=1,
+                ),
+            )
+        ],
+        strategy='none',
+      )
 
 
 @python_app

--- a/parsl/tests/sites/test_local_adhoc.py
+++ b/parsl/tests/sites/test_local_adhoc.py
@@ -1,12 +1,10 @@
 import pytest
 
 from parsl import python_app
-from parsl.tests.configs.local_adhoc import config
+from parsl.tests.configs.local_adhoc import fresh_config as local_config
 
 import logging
 logger = logging.getLogger(__name__)
-
-local_config = config
 
 
 @python_app

--- a/parsl/tests/sites/test_local_exex.py
+++ b/parsl/tests/sites/test_local_exex.py
@@ -2,12 +2,10 @@ import pytest
 
 import parsl
 from parsl.app.app import python_app
-from parsl.tests.configs.exex_local import config
+from parsl.tests.configs.exex_local import fresh_config as local_config
 
 import logging
 logger = logging.getLogger(__name__)
-
-local_config = config
 
 
 @python_app(executors=['Extreme_Local'])

--- a/parsl/tests/sites/test_worker_info.py
+++ b/parsl/tests/sites/test_worker_info.py
@@ -7,6 +7,7 @@ from parsl.executors import HighThroughputExecutor
 from parsl import python_app
 import pytest
 
+
 def local_config():
     return Config(
         executors=[

--- a/parsl/tests/sites/test_worker_info.py
+++ b/parsl/tests/sites/test_worker_info.py
@@ -7,21 +7,22 @@ from parsl.executors import HighThroughputExecutor
 from parsl import python_app
 import pytest
 
-local_config = Config(
-    executors=[
-        HighThroughputExecutor(
-            label="htex_Local",
-            worker_debug=True,
-            max_workers=4,
-            provider=LocalProvider(
-                channel=LocalChannel(),
-                init_blocks=1,
-                max_blocks=1,
-            ),
-        )
-    ],
-    strategy='none',
-)
+def local_config():
+    return Config(
+        executors=[
+            HighThroughputExecutor(
+                label="htex_Local",
+                worker_debug=True,
+                max_workers=4,
+                provider=LocalProvider(
+                    channel=LocalChannel(),
+                    init_blocks=1,
+                    max_blocks=1,
+                ),
+            )
+        ],
+        strategy='none',
+    )
 
 
 @python_app

--- a/parsl/tests/test_bash_apps/test_error_codes.py
+++ b/parsl/tests/test_bash_apps/test_error_codes.py
@@ -10,10 +10,7 @@ import parsl.app.errors as pe
 
 from parsl.app.errors import BashExitFailure
 
-from parsl.tests.configs.local_threads import config
-
-
-local_config = config
+from parsl.tests.configs.local_threads import fresh_config as local_config
 
 
 @bash_app

--- a/parsl/tests/test_error_handling/test_rand_fail.py
+++ b/parsl/tests/test_error_handling/test_rand_fail.py
@@ -7,8 +7,10 @@ from parsl.app.app import python_app
 from parsl.tests.configs.local_threads import fresh_config
 
 
-local_config = fresh_config()
-local_config.retries = 2
+def local_config():
+    c = fresh_config()
+    c.retries = 2
+    return c
 
 
 @python_app

--- a/parsl/tests/test_error_handling/test_retries.py
+++ b/parsl/tests/test_error_handling/test_retries.py
@@ -6,8 +6,11 @@ import parsl
 from parsl import bash_app, python_app
 from parsl.tests.configs.local_threads import fresh_config
 
-local_config = fresh_config()
-local_config.retries = 2
+
+def local_config():
+    c = fresh_config()
+    c.retries = 2
+    return c
 
 
 @python_app

--- a/parsl/tests/test_error_handling/test_retry_handler.py
+++ b/parsl/tests/test_error_handling/test_retry_handler.py
@@ -11,9 +11,11 @@ def half_handler(*args):
     return 0.5
 
 
-local_config = fresh_config()
-local_config.retries = 2
-local_config.retry_handler = half_handler
+def local_config():
+    c = fresh_config()
+    c.retries = 2
+    c.retry_handler = half_handler
+    return c
 
 
 @bash_app

--- a/parsl/tests/test_error_handling/test_retry_handler_failure.py
+++ b/parsl/tests/test_error_handling/test_retry_handler_failure.py
@@ -11,7 +11,8 @@ def retry_handler_raises(exc, task_record):
     raise RuntimeError("retry_handler_raises deliberate exception")
 
 
-local_config = parsl.config.Config(retry_handler=retry_handler_raises)
+def local_config():
+    return parsl.config.Config(retry_handler=retry_handler_raises)
 
 
 @pytest.mark.local

--- a/parsl/tests/test_error_handling/test_serialization_fail.py
+++ b/parsl/tests/test_error_handling/test_serialization_fail.py
@@ -4,8 +4,10 @@ from parsl import python_app
 from parsl.tests.configs.htex_local import fresh_config
 from parsl.executors.errors import SerializationError
 
-local_config = fresh_config()
-local_config.retries = 2
+def local_config():
+    config = fresh_config()
+    config.retries = 2
+    return config
 
 
 @python_app
@@ -26,9 +28,5 @@ def test_serialization_error():
     gen = generator()
     x = fail_pickling(gen)
 
-    try:
-        x.result()
-    except Exception as e:
-        assert isinstance(e, SerializationError)
-    else:
-        raise ValueError
+    assert x.exception() is not None, "Should have got an exception, actually got: " + repr(x.result())
+    assert isinstance(x.exception(), SerializationError)

--- a/parsl/tests/test_error_handling/test_serialization_fail.py
+++ b/parsl/tests/test_error_handling/test_serialization_fail.py
@@ -4,6 +4,7 @@ from parsl import python_app
 from parsl.tests.configs.htex_local import fresh_config
 from parsl.executors.errors import SerializationError
 
+
 def local_config():
     config = fresh_config()
     config.retries = 2

--- a/parsl/tests/test_flowcontrol/test_python.py
+++ b/parsl/tests/test_flowcontrol/test_python.py
@@ -7,6 +7,7 @@ from parsl.tests.configs.htex_local import fresh_config
 def local_config():
     c = fresh_config()
     c.executors[0].init_blocks = 0
+    return c
 
 
 @python_app

--- a/parsl/tests/test_flowcontrol/test_python.py
+++ b/parsl/tests/test_flowcontrol/test_python.py
@@ -4,8 +4,9 @@ from parsl.app.app import python_app
 from parsl.tests.configs.htex_local import fresh_config
 
 
-local_config = fresh_config()
-local_config.executors[0].init_blocks = 0
+def local_config():
+    c = fresh_config()
+    c.executors[0].init_blocks = 0
 
 
 @python_app

--- a/parsl/tests/test_python_apps/test_fail.py
+++ b/parsl/tests/test_python_apps/test_fail.py
@@ -2,10 +2,7 @@ import argparse
 
 import parsl
 from parsl.app.app import python_app
-from parsl.tests.configs.local_threads import config
-
-
-local_config = config
+from parsl.tests.configs.local_threads import fresh_config as local_config
 
 
 @python_app

--- a/parsl/tests/test_python_apps/test_join.py
+++ b/parsl/tests/test_python_apps/test_join.py
@@ -3,9 +3,7 @@ import time
 
 from parsl import join_app, python_app
 
-from parsl.tests.configs.local_threads import fresh_config
-
-local_config = fresh_config()
+from parsl.tests.configs.local_threads import fresh_config as local_config
 
 RESULT_CONSTANT = 3
 

--- a/parsl/tests/test_python_apps/test_memoize_2.py
+++ b/parsl/tests/test_python_apps/test_memoize_2.py
@@ -4,10 +4,7 @@ import pytest
 
 import parsl
 from parsl.app.app import python_app
-from parsl.tests.configs.local_threads_no_cache import config
-
-local_config = config
-
+from parsl.tests.configs.local_threads_no_cache import fresh_config as local_config
 
 @python_app
 def random_uuid(x):

--- a/parsl/tests/test_python_apps/test_memoize_2.py
+++ b/parsl/tests/test_python_apps/test_memoize_2.py
@@ -6,6 +6,7 @@ import parsl
 from parsl.app.app import python_app
 from parsl.tests.configs.local_threads_no_cache import fresh_config as local_config
 
+
 @python_app
 def random_uuid(x):
     import uuid

--- a/parsl/tests/test_python_apps/test_outputs.py
+++ b/parsl/tests/test_python_apps/test_outputs.py
@@ -6,10 +6,7 @@ import shutil
 from concurrent.futures import wait
 
 from parsl import File, python_app
-from parsl.tests.configs.local_threads import config
-
-
-local_config = config
+from parsl.tests.configs.local_threads import fresh_config as local_config
 
 
 @python_app

--- a/parsl/tests/test_regression/test_1480.py
+++ b/parsl/tests/test_regression/test_1480.py
@@ -1,7 +1,6 @@
 from parsl import python_app
 import pytest
-from parsl.tests.configs.htex_local import fresh_config
-local_config = fresh_config()
+from parsl.tests.configs.htex_local import fresh_config as local_config
 
 
 @python_app

--- a/parsl/tests/test_regression/test_1653.py
+++ b/parsl/tests/test_regression/test_1653.py
@@ -1,7 +1,6 @@
 from parsl import python_app
 import pytest
-from parsl.tests.configs.htex_local import fresh_config
-local_config = fresh_config()
+from parsl.tests.configs.htex_local import fresh_config as local_config
 
 
 @python_app

--- a/parsl/tests/test_regression/test_221.py
+++ b/parsl/tests/test_regression/test_221.py
@@ -1,9 +1,7 @@
 import pytest
 
 from parsl.app.app import python_app
-from parsl.tests.configs.htex_local import config
-
-local_config = config
+from parsl.tests.configs.htex_local import fresh_config as local_config
 
 
 @python_app

--- a/parsl/tests/test_scaling/test_scale_down.py
+++ b/parsl/tests/test_scaling/test_scale_down.py
@@ -14,26 +14,27 @@ from parsl.executors import HighThroughputExecutor
 
 logger = logging.getLogger(__name__)
 
-local_config = Config(
-    executors=[
-        HighThroughputExecutor(
-            heartbeat_period=2,
-            heartbeat_threshold=6,
-            poll_period=1,
-            label="htex_local",
-            max_workers=1,
-            provider=LocalProvider(
-                channel=LocalChannel(),
-                init_blocks=0,
-                max_blocks=5,
-                min_blocks=2,
-                launcher=SingleNodeLauncher(),
-            ),
-        )
-    ],
-    max_idletime=5,
-    strategy='htex_auto_scale',
-)
+def local_config():
+    return Config(
+        executors=[
+            HighThroughputExecutor(
+                heartbeat_period=2,
+                heartbeat_threshold=6,
+                poll_period=1,
+                label="htex_local",
+                max_workers=1,
+                provider=LocalProvider(
+                    channel=LocalChannel(),
+                    init_blocks=0,
+                    max_blocks=5,
+                    min_blocks=2,
+                    launcher=SingleNodeLauncher(),
+                ),
+            )
+        ],
+        max_idletime=5,
+        strategy='htex_auto_scale',
+    )
 
 
 @python_app

--- a/parsl/tests/test_scaling/test_scale_down.py
+++ b/parsl/tests/test_scaling/test_scale_down.py
@@ -14,6 +14,7 @@ from parsl.executors import HighThroughputExecutor
 
 logger = logging.getLogger(__name__)
 
+
 def local_config():
     return Config(
         executors=[

--- a/parsl/tests/test_staging/test_docs_2.py
+++ b/parsl/tests/test_staging/test_docs_2.py
@@ -1,8 +1,6 @@
 import pytest
 from parsl import bash_app, File
-from parsl.configs.local_threads import config
-
-local_config = config
+from parsl.tests.configs.local_threads import fresh_config as local_config
 
 
 @bash_app

--- a/parsl/tests/test_staging/test_staging_https.py
+++ b/parsl/tests/test_staging/test_staging_https.py
@@ -7,8 +7,7 @@ import pytest
 # This config is for the local test which will adding an executor.
 # Most tests in this file should be non-local and use the configuration
 # specificed with --config, not this one.
-from parsl.tests.configs.htex_local import fresh_config
-local_config = fresh_config()
+from parsl.tests.configs.htex_local import fresh_config as local_config
 
 
 @python_app

--- a/parsl/tests/test_staging/test_staging_https_in_task.py
+++ b/parsl/tests/test_staging/test_staging_https_in_task.py
@@ -3,10 +3,7 @@ import pytest
 from parsl.app.app import python_app
 from parsl.data_provider.files import File
 
-from parsl.tests.configs.local_threads_http_in_task import config
-
-
-local_config = config
+from parsl.tests.configs.local_threads_http_in_task import fresh_config as local_config
 
 
 @python_app

--- a/parsl/tests/test_threads/test_configs.py
+++ b/parsl/tests/test_threads/test_configs.py
@@ -1,10 +1,8 @@
 import pytest
 
+import parsl
 from parsl.app.app import python_app
-from parsl.tests.configs.local_threads import config
-
-
-local_config = config
+from parsl.tests.configs.local_threads import fresh_config
 
 
 @python_app
@@ -19,6 +17,8 @@ def worker_identify(x, sleep_dur=0.2):
 
 @pytest.mark.local
 def test_parallel_for():
+    config = fresh_config()
+    dfk = parsl.load(config)
     d = []
     for i in range(0, config.executors[0].max_threads):
         d.extend([worker_identify(i)])
@@ -29,6 +29,8 @@ def test_parallel_for():
     process_count = len(set([item.result()['pid'] for item in d]))
     assert thread_count <= config.executors[0].max_threads, "More threads than allowed"
     assert process_count == 1, "More processes than allowed"
+    dfk.cleanup()
+    parsl.clear()
     return d
 
 


### PR DESCRIPTION
# Description

Previously, all test configs would be loaded by pytest - because pytest imports all parsl/test files to look for tests.

This resulted in sometimes expensive construction time costs being paid for each test config on each test run.

This included, for example, determining htex local addresses using calls to external "what is my ip?" APIs.

In some cases, that API would rate-limit calls giving a 30 second delay on each configuration import.

This PR moves tests more towards using the `fresh_config()` style of test configuration, where a config is only constructed when it is needed, by executing `fresh_config()`.

This is also cleaner when `--config local` test cases modify configurations that are shared: test cases now each get a fresh configuration to modify, rather than re-using a possibly modified shared test configuration.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
