### PR TITLE
Changing environment variables for SYCL devices

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -570,7 +570,7 @@ def worker(worker_id, pool_id, pool_size, task_queue, result_queue, worker_queue
         os.environ["ROCR_VISIBLE_DEVICES"] = accelerator
         os.environ["ZE_AFFINITY_MASK"] = accelerator
         os.environ["ZE_ENABLE_PCI_ID_DEVICE_ORDER"] = '1'
-        
+
         logger.info(f'Pinned worker to accelerator: {accelerator}')
 
     while True:

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -569,7 +569,7 @@ def worker(worker_id, pool_id, pool_size, task_queue, result_queue, worker_queue
         os.environ["CUDA_VISIBLE_DEVICES"] = accelerator
         os.environ["ROCR_VISIBLE_DEVICES"] = accelerator
         os.environ["ZE_AFFINITY_MASK"] = accelerator
-        os.environ["ZE_ENABLE_PCI_ID_DEVICE_ORDER"]='1'
+        os.environ["ZE_ENABLE_PCI_ID_DEVICE_ORDER"] = '1'
         
         logger.info(f'Pinned worker to accelerator: {accelerator}')
 

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -568,7 +568,11 @@ def worker(worker_id, pool_id, pool_size, task_queue, result_queue, worker_queue
     if accelerator is not None:
         os.environ["CUDA_VISIBLE_DEVICES"] = accelerator
         os.environ["ROCR_VISIBLE_DEVICES"] = accelerator
-        os.environ["SYCL_DEVICE_FILTER"] = f"*:*:{accelerator}"
+        if '.' in str(accelerator):
+            os.environ["ZE_AFFINITY_MASK"] = accelerator
+            os.environ["ZE_ENABLE_PCI_ID_DEVICE_ORDER"]='1'
+        else:
+            os.environ["SYCL_DEVICE_FILTER"] = f"*:*:{accelerator}"
         logger.info(f'Pinned worker to accelerator: {accelerator}')
 
     while True:

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -568,11 +568,9 @@ def worker(worker_id, pool_id, pool_size, task_queue, result_queue, worker_queue
     if accelerator is not None:
         os.environ["CUDA_VISIBLE_DEVICES"] = accelerator
         os.environ["ROCR_VISIBLE_DEVICES"] = accelerator
-        if '.' in str(accelerator):
-            os.environ["ZE_AFFINITY_MASK"] = accelerator
-            os.environ["ZE_ENABLE_PCI_ID_DEVICE_ORDER"]='1'
-        else:
-            os.environ["SYCL_DEVICE_FILTER"] = f"*:*:{accelerator}"
+        os.environ["ZE_AFFINITY_MASK"] = accelerator
+        os.environ["ZE_ENABLE_PCI_ID_DEVICE_ORDER"]='1'
+        
         logger.info(f'Pinned worker to accelerator: {accelerator}')
 
     while True:


### PR DESCRIPTION
# Description

This PR changes the SYCL environment variable for gpu discovery from SYCL_DEVICE_FILTER to ZE_AFFINITY_MASK.  I've been doing tests with SYCL devices and I found that setting both caused conflicts in some programs.  I was told in private communications that SYCL_DEVICE_FILTER has never been used or tested.  I removed it and added ZE_AFFINITY_MASK.

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

