### PR TITLE
Tidy DataFuture initialisation

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -137,7 +137,6 @@ Exceptions
     parsl.app.errors.BashAppNoReturn
     parsl.app.errors.BashExitFailure
     parsl.app.errors.MissingOutputs
-    parsl.app.errors.NotFutureError
     parsl.app.errors.ParslError
     parsl.errors.OptionalModuleMissing
     parsl.executors.errors.ExecutorError

--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -19,13 +19,6 @@ class ParslError(Exception):
     """
 
 
-class NotFutureError(ParslError):
-    """A non future item was passed to a function that expected a future.
-
-    This is basically a type error.
-    """
-
-
 class AppException(ParslError):
     """An error raised during execution of an app.
 


### PR DESCRIPTION
This performs stronger runtime type checking on the initializer, removes code paths where a DataFuture is constructed with a string (which was turned into an error case in PR #1412)
and removes NotFutureError, as that type error is now handled by the typeguard.typechecked decorator.

This comes from work on the benc-mypy branch.

## Type of change

- Code maintentance/cleanup
