### PR TITLE
Switch on mypy warn-redundant-casts

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -6,6 +6,7 @@ plugins = sqlmypy
 #                  which is commonly done with manager IDs in the parsl
 #                  codebase.
 disable_error_code = str-bytes-safe
+warn_redundant_casts = True
 
 [mypy-non_existent.*]
 ignore_missing_imports = True


### PR DESCRIPTION
This gives motivation to remove casts that can become redundant as more type information becomes available as type annotations are added later.

This comes from benc-mypy branch.

## Type of change

- Code maintentance/cleanup
