### PR TITLE
Label parsl as production in metadata

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -193,6 +193,6 @@
     },
     "runtimePlatform": "Python 3.7",
     "url": "https://github.com/Parsl/parsl",
-    "developmentStatus": "3 - Alpha",
+    "developmentStatus": "active",
     "programmingLanguage": "Python :: 3.7"
 }

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     extras_require=extras_require,
     classifiers=[
         # Maturity
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 5 - Production/Stable',
         # Intended audience
         'Intended Audience :: Developers',
         # Licence, must match with licence above


### PR DESCRIPTION
This should have happened with the 1.0.0 release in PR #1748

## Type of change

- Documentation update
