### PR TITLE
Allow one extra 5s period in scale in test

### DIFF
--- a/parsl/tests/test_scaling/test_scale_down.py
+++ b/parsl/tests/test_scaling/test_scale_down.py
@@ -72,7 +72,7 @@ def test_scale_out():
     assert dfk.executors['htex_local'].outstanding == 0, "Expected 0 outstanding tasks after future completion"
 
     logger.info("waiting a while for scale down")
-    time.sleep(20)
+    time.sleep(25)
 
     logger.info("asserting 2 managers remain")
     assert len(dfk.executors['htex_local'].connected_managers) == 2, "Expected 2 managers when no tasks, lower bound by min_blocks"


### PR DESCRIPTION
Sometimes the scale happens one 5-second period longer than usual (because the idle time is 5 seconds minus tiny amount) and so the workers have not timed out by the time the final assert fires.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
