### PR TITLE
Switch WQ test config to fresh_config style

### DIFF
--- a/parsl/tests/configs/workqueue_ex.py
+++ b/parsl/tests/configs/workqueue_ex.py
@@ -5,5 +5,7 @@ from parsl.data_provider.http import HTTPInTaskStaging
 from parsl.data_provider.ftp import FTPInTaskStaging
 from parsl.data_provider.file_noop import NoOpFileStaging
 
-config = Config(executors=[WorkQueueExecutor(port=9000,
-                                             storage_access=[FTPInTaskStaging(), HTTPInTaskStaging(), NoOpFileStaging()])])
+
+def fresh_config():
+    return Config(executors=[WorkQueueExecutor(port=9000,
+                                               storage_access=[FTPInTaskStaging(), HTTPInTaskStaging(), NoOpFileStaging()])])


### PR DESCRIPTION
This allows use of the WQ config in locally-marked tests.

## Type of change

- Code maintentance/cleanup
