### PR TITLE
Tidy logger test in monitoring close

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -247,8 +247,7 @@ class MonitoringHub(RepresentationMixin):
                 "The monitoring message sent from DFK to router timed-out after {}ms".format(self.dfk_channel_timeout))
 
     def close(self) -> None:
-        if self.logger:
-            self.logger.info("Terminating Monitoring Hub")
+        self.logger.info("Terminating Monitoring Hub")
         exception_msgs = []
         while True:
             try:


### PR DESCRIPTION
This condition is only needed because earlier use of __del__, which might have meant that self.logger was gone by the time that close was called.

__del__ has mostly been cleaned away from the codebase and so this test should not be needed any more.

## Type of change

- Code maintentance/cleanup
