### PR TITLE
Tighten channel permissions so working directories are not world writable

### DIFF
--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -98,13 +98,13 @@ class LocalChannel(Channel, RepresentationMixin):
         if os.path.dirname(source) != dest_dir:
             try:
                 shutil.copyfile(source, local_dest)
-                os.chmod(local_dest, 0o777)
+                os.chmod(local_dest, 0o700)
 
             except OSError as e:
                 raise FileCopyException(e, self.hostname)
 
         else:
-            os.chmod(local_dest, 0o777)
+            os.chmod(local_dest, 0o700)
 
         return local_dest
 
@@ -130,7 +130,7 @@ class LocalChannel(Channel, RepresentationMixin):
 
         return os.path.isdir(path)
 
-    def makedirs(self, path, mode=0o777, exist_ok=False):
+    def makedirs(self, path, mode=0o700, exist_ok=False):
         """Create a directory.
 
         If intermediate directories do not exist, they will be created.

--- a/parsl/channels/ssh/ssh.py
+++ b/parsl/channels/ssh/ssh.py
@@ -176,7 +176,7 @@ class SSHChannel(Channel, RepresentationMixin):
         try:
             self._valid_sftp_client().put(local_source, remote_dest, confirm=True)
             # Set perm because some systems require the script to be executable
-            self._valid_sftp_client().chmod(remote_dest, 0o777)
+            self._valid_sftp_client().chmod(remote_dest, 0o700)
         except Exception as e:
             logger.exception("File push from local source {} to remote destination {} failed".format(
                 local_source, remote_dest))
@@ -237,7 +237,7 @@ class SSHChannel(Channel, RepresentationMixin):
 
         return result
 
-    def makedirs(self, path, mode=0o777, exist_ok=False):
+    def makedirs(self, path, mode=0o700, exist_ok=False):
         """Create a directory on the remote side.
 
         If intermediate directories do not exist, they will be created.


### PR DESCRIPTION
Previously parsl created directories with mode 0o777. Mode 0o777 allows arbitrary other users to write into the working directories, including modifying files created by channels which are then subsequently executed.

This PR replaces that mode by 0o700 which allows user access but excludes group and world access.

Partially addresses #836

## Type of change

- Bug fix (non-breaking change that fixes an issue)
