### PR TITLE
Set OpenMP environment variables when imposing affinity

### DIFF
--- a/docs/userguide/configuring.rst
+++ b/docs/userguide/configuring.rst
@@ -347,7 +347,7 @@ Thread affinity is accomplished in two ways.
 Each worker first sets the affinity for the Python process using `the affinity mask <https://docs.python.org/3/library/os.html#os.sched_setaffinity>`_,
 which may not be available on all operating systems.
 It then sets environment variables to control 
-`OpenMP thread affinity <https://hpc-tutorials.llnl.gov/openmp/ProcessThreadAffinity.pdf>`
+`OpenMP thread affinity <https://hpc-tutorials.llnl.gov/openmp/ProcessThreadAffinity.pdf>`_
 so that any subprocesses launched by a worker which use OpenMP know which processors are valid.
 These include `OMP_NUM_THREADS`, `GOMP_COMP_AFFINITY`, and `KMP_THREAD_AFFINITY`.
 

--- a/docs/userguide/configuring.rst
+++ b/docs/userguide/configuring.rst
@@ -343,6 +343,14 @@ Select the best blocking strategy for processor's cache hierarchy (choose 'alter
         strategy='none',
     )
 
+Thread affinity is accomplished in two ways.
+Each worker first sets the affinity for the Python process using `the affinity mask <https://docs.python.org/3/library/os.html#os.sched_setaffinity>`_,
+which may not be available on all operating systems.
+It then sets environment variables to control 
+`OpenMP thread affinity <https://hpc-tutorials.llnl.gov/openmp/ProcessThreadAffinity.pdf>`
+so that any subprocesses launched by a worker which use OpenMP know which processors are valid.
+These include `OMP_NUM_THREADS`, `GOMP_COMP_AFFINITY`, and `KMP_THREAD_AFFINITY`.
+
 Ad-Hoc Clusters
 ---------------
 

--- a/docs/userguide/configuring.rst
+++ b/docs/userguide/configuring.rst
@@ -349,7 +349,7 @@ which may not be available on all operating systems.
 It then sets environment variables to control 
 `OpenMP thread affinity <https://hpc-tutorials.llnl.gov/openmp/ProcessThreadAffinity.pdf>`_
 so that any subprocesses launched by a worker which use OpenMP know which processors are valid.
-These include `OMP_NUM_THREADS`, `GOMP_COMP_AFFINITY`, and `KMP_THREAD_AFFINITY`.
+These include ``OMP_NUM_THREADS``, ``GOMP_COMP_AFFINITY``, and ``KMP_THREAD_AFFINITY``.
 
 Ad-Hoc Clusters
 ---------------

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -619,7 +619,7 @@ def worker(worker_id, pool_id, pool_size, task_queue, result_queue, worker_queue
         logger.info("All processing finished for task {}".format(tid))
 
 
-def start_file_logger(filename,urank, name='parsl', level=logging.DEBUG, format_string=None):
+def start_file_logger(filename, rank, name='parsl', level=logging.DEBUG, format_string=None):
     """Add a stream log handler.
 
     Args:

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -560,6 +560,13 @@ def worker(worker_id, pool_id, pool_size, task_queue, result_queue, worker_queue
         else:
             raise ValueError("Affinity strategy {} is not supported".format(cpu_affinity))
 
+        # Set the affinity for OpenMP
+        #  See: https://hpc-tutorials.llnl.gov/openmp/ProcessThreadAffinity.pdf
+        proc_list = ",".join(map(str, my_cores))
+        os.environ["OMP_NUM_THREADS"] = str(len(my_cores))
+        os.environ["GOMP_CPU_AFFINITY"] = proc_list  # Compatible with GCC OpenMP
+        os.environ["KMP_AFFINITY"] = f"explicit,proclist=[{proc_list}]"  # For Intel OpenMP
+
         # Set the affinity for this worker
         os.sched_setaffinity(0, my_cores)
         logger.info("Set worker CPU affinity to {}".format(my_cores))
@@ -612,7 +619,7 @@ def worker(worker_id, pool_id, pool_size, task_queue, result_queue, worker_queue
         logger.info("All processing finished for task {}".format(tid))
 
 
-def start_file_logger(filename, rank, name='parsl', level=logging.DEBUG, format_string=None):
+def start_file_logger(filename,urank, name='parsl', level=logging.DEBUG, format_string=None):
     """Add a stream log handler.
 
     Args:


### PR DESCRIPTION
# Description

Sets the thread affinity for subprocesses that use OpenMP launched by a Parsl worker by setting the environment variables.

Fixes #2528. Though, as discussed, we're unsure if this can be done a better way.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
- Documentation update
