### PR TITLE
Explain a common monitoring port in use exception

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -394,7 +394,10 @@ class MonitoringRouter:
             self.hub_port = self.sock.getsockname()[1]
         else:
             self.hub_port = hub_port
-            self.sock.bind(('0.0.0.0', self.hub_port))
+            try:
+                self.sock.bind(('0.0.0.0', self.hub_port))
+            except Exception as e:
+                raise RuntimeError(f"Could not bind to hub_port {hub_port} because: {e}")
         self.sock.settimeout(self.loop_freq / 1000)
         self.logger.info("Initialized the UDP socket on 0.0.0.0:{}".format(self.hub_port))
 


### PR DESCRIPTION
This happens often when multiple DFKs run on the same host sharing a configuration, and this PR should make the problem more obvious.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
