### PR TITLE
Don't try to start the router if it doesn't exist

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -508,11 +508,9 @@ def router_starter(comm_q: "queue.Queue[Union[Tuple[int, int], str]]",
     else:
         comm_q.put((router.hub_port, router.ic_port))
 
-    router.logger.info("Starting MonitoringRouter in router_starter")
-    try:
-        router.start(priority_msgs, node_msgs, block_msgs, resource_msgs)
-    except Exception as e:
-        router.logger.exception("router.start exception")
-        exception_q.put(('Hub', str(e)))
-
-    router.logger.info("End of router_starter")
+        router.logger.info("Starting MonitoringRouter in router_starter")
+        try:
+            router.start(priority_msgs, node_msgs, block_msgs, resource_msgs)
+        except Exception as e:
+            router.logger.exception("router.start exception")
+            exception_q.put(('Hub', str(e)))


### PR DESCRIPTION
This was leading to exceptions about undefined 'router' when the initial try/except block encountered an error.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
