### PR TITLE
Remove a stdout specification on a python_app in test suite

### DIFF
--- a/parsl/tests/test_python_apps/test_basic.py
+++ b/parsl/tests/test_python_apps/test_basic.py
@@ -17,7 +17,7 @@ def echo(x, string, stdout=None):
 
 
 @python_app
-def import_echo(x, string, stdout=None):
+def import_echo(x, string):
     import time
     time.sleep(0)
     print(string)


### PR DESCRIPTION
Python apps do not have stdout/stderr

## Type of change

- Code maintentance/cleanup
