### PR TITLE
Remove unmanaged/managed executor concept

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1066,9 +1066,7 @@ class DataFlowKernel(object):
 
         This involves releasing all resources explicitly.
 
-        If the executors are managed by the DFK, then we call scale_in on each of
-        the executors and call executor.shutdown. Otherwise, executor cleanup is left to
-        the user.
+        We call scale_in on each of the executors and call executor.shutdown.
         """
         logger.info("DFK cleanup initiated")
 
@@ -1101,7 +1099,7 @@ class DataFlowKernel(object):
         logger.info("Scaling in and shutting down executors")
 
         for executor in self.executors.values():
-            if executor.managed and not executor.bad_state_is_set:
+            if not executor.bad_state_is_set:
                 if executor.scaling_enabled:
                     logger.info(f"Scaling in executor {executor.label}")
                     job_ids = executor.provider.resources.keys()
@@ -1116,10 +1114,8 @@ class DataFlowKernel(object):
                 logger.info(f"Shutting down executor {executor.label}")
                 executor.shutdown()
                 logger.info(f"Shut down executor {executor.label}")
-            elif executor.managed and executor.bad_state_is_set:  # and bad_state_is_set
+            else:  # and bad_state_is_set
                 logger.warning(f"Not shutting down executor {executor.label} because it is in bad state")
-            else:
-                logger.info(f"Not shutting down executor {executor.label} because it is unmanaged")
 
         logger.info("Terminated executors")
         self.time_completed = datetime.datetime.now()

--- a/parsl/dataflow/usage_tracking/usage.py
+++ b/parsl/dataflow/usage_tracking/usage.py
@@ -180,7 +180,7 @@ class UsageTracker (object):
         """
         app_count = self.dfk.task_count
 
-        site_count = len([x for x in self.dfk.config.executors if x.managed])
+        site_count = len(self.dfk.config.executors)
 
         app_fails = self.dfk.task_state_counts[States.failed] + self.dfk.task_state_counts[States.dep_fail]
 

--- a/parsl/executors/extreme_scale/executor.py
+++ b/parsl/executors/extreme_scale/executor.py
@@ -103,9 +103,6 @@ class ExtremeScaleExecutor(HighThroughputExecutor, RepresentationMixin):
     worker_debug : Bool
         Enables engine debug logging.
 
-    managed : Bool
-        If this executor is managed by the DFK or externally handled.
-
     ranks_per_node : int
         Specify the ranks to be launched per node.
 
@@ -132,8 +129,7 @@ class ExtremeScaleExecutor(HighThroughputExecutor, RepresentationMixin):
                  worker_debug=False,
                  ranks_per_node=1,
                  heartbeat_threshold=120,
-                 heartbeat_period=30,
-                 managed=True):
+                 heartbeat_period=30):
 
         super().__init__(label=label,
                          provider=provider,
@@ -146,8 +142,7 @@ class ExtremeScaleExecutor(HighThroughputExecutor, RepresentationMixin):
                          working_dir=working_dir,
                          worker_debug=worker_debug,
                          heartbeat_threshold=heartbeat_threshold,
-                         heartbeat_period=heartbeat_period,
-                         managed=managed)
+                         heartbeat_period=heartbeat_period)
 
         self.ranks_per_node = ranks_per_node
 

--- a/parsl/executors/flux/executor.py
+++ b/parsl/executors/flux/executor.py
@@ -152,8 +152,6 @@ class FluxExecutor(NoStatusHandlingExecutor, RepresentationMixin):
 
     Parameters
     ----------
-    managed: bool
-        If this executor is managed by the DFK or externally handled.
     working_dir: str
         Directory in which the executor should place its files, possibly overwriting
         existing files. If ``None``, generate a unique directory.
@@ -181,7 +179,6 @@ class FluxExecutor(NoStatusHandlingExecutor, RepresentationMixin):
     def __init__(
         self,
         provider: Optional[ExecutionProvider] = None,
-        managed: bool = True,
         working_dir: Optional[str] = None,
         label: str = "FluxExecutor",
         flux_executor_kwargs: Mapping = {},
@@ -196,7 +193,6 @@ class FluxExecutor(NoStatusHandlingExecutor, RepresentationMixin):
         if working_dir is None:
             working_dir = self.label + "_" + str(uuid.uuid4())
         self.working_dir = os.path.abspath(working_dir)
-        self.managed = managed
         # check that flux_path is an executable, or look for flux in PATH
         if flux_path is None:
             flux_path = shutil.which("flux")

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -119,9 +119,6 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
     worker_debug : Bool
         Enables worker debug logging.
 
-    managed : Bool
-        If this executor is managed by the DFK or externally handled.
-
     cores_per_worker : float
         cores to be assigned to each worker. Oversubscription is possible
         by setting cores_per_worker < 1.0. Default=1
@@ -209,7 +206,6 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
                  heartbeat_period: int = 30,
                  poll_period: int = 10,
                  address_probe_timeout: Optional[int] = None,
-                 managed: bool = True,
                  worker_logdir_root: Optional[str] = None,
                  block_error_handler: bool = True):
 
@@ -221,7 +217,6 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         self.worker_debug = worker_debug
         self.storage_access = storage_access
         self.working_dir = working_dir
-        self.managed = managed
         self.cores_per_worker = cores_per_worker
         self.mem_per_worker = mem_per_worker
         self.max_workers = max_workers

--- a/parsl/executors/low_latency/executor.py
+++ b/parsl/executors/low_latency/executor.py
@@ -36,7 +36,6 @@ class LowLatencyExecutor(BlockProviderExecutor, RepresentationMixin):
                  worker_debug=False,
                  workers_per_node=1,
                  #  cores_per_worker=1.0,
-                 managed=True
                  ):
         logger.debug("Initializing LowLatencyExecutor")
 
@@ -49,7 +48,6 @@ class LowLatencyExecutor(BlockProviderExecutor, RepresentationMixin):
         # if len(self.storage_access) > 1:
         # raise ConfigurationError('Multiple storage access schemes are not supported')
         self.working_dir = working_dir
-        self.managed = managed
         self.blocks = []
         self.workers_per_node = workers_per_node
 

--- a/parsl/executors/swift_t.py
+++ b/parsl/executors/swift_t.py
@@ -169,7 +169,7 @@ class TurbineExecutor(NoStatusHandlingExecutor):
 
     """
 
-    def __init__(self, label='turbine', storage_access=None, working_dir=None, managed=True):
+    def __init__(self, label='turbine', storage_access=None, working_dir=None):
         """Initialize the thread pool.
 
         Trying to implement the emews model.
@@ -180,7 +180,6 @@ class TurbineExecutor(NoStatusHandlingExecutor):
         self.label = label
         self.storage_access = storage_access
         self.working_dir = working_dir
-        self.managed = managed
 
     def start(self):
         self.mp_manager = mp.Manager()

--- a/parsl/executors/threads.py
+++ b/parsl/executors/threads.py
@@ -24,15 +24,12 @@ class ThreadPoolExecutor(NoStatusHandlingExecutor, RepresentationMixin):
         Thread name prefix
     storage_access : list of :class:`~parsl.data_provider.staging.Staging`
         Specifications for accessing data this executor remotely.
-    managed : bool
-        If True, parsl will control dynamic scaling of this executor, and be responsible. Otherwise,
-        this is managed by the user.
     """
 
     @typeguard.typechecked
     def __init__(self, label: str = 'threads', max_threads: int = 2,
                  thread_name_prefix: str = '', storage_access: Optional[List[Staging]] = None,
-                 working_dir: Optional[str] = None, managed: bool = True):
+                 working_dir: Optional[str] = None):
         NoStatusHandlingExecutor.__init__(self)
         self.label = label
         self._scaling_enabled = False
@@ -44,7 +41,6 @@ class ThreadPoolExecutor(NoStatusHandlingExecutor, RepresentationMixin):
         # [] is a list with no storage access in it at all
         self.storage_access = storage_access
         self.working_dir = working_dir
-        self.managed = managed
 
     def start(self):
         self.executor = cf.ThreadPoolExecutor(max_workers=self.max_threads,

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -100,10 +100,6 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
             Location for Parsl to perform app delegation to the Work
             Queue system. Defaults to current directory.
 
-        managed: bool
-            Whether this executor is managed by the DFK or externally handled.
-            Default is True (managed by DFK).
-
         project_name: str
             If a project_name is given, then Work Queue will periodically
             report its status and performance back to the global WQ catalog,
@@ -212,7 +208,6 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
                  label: str = "WorkQueueExecutor",
                  provider: ExecutionProvider = LocalProvider(),
                  working_dir: str = ".",
-                 managed: bool = True,
                  project_name: Optional[str] = None,
                  project_password_file: Optional[str] = None,
                  address: Optional[str] = None,
@@ -241,7 +236,6 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
             raise OptionalModuleMissing(['work_queue'], "WorkQueueExecutor requires the work_queue module.")
 
         self.label = label
-        self.managed = managed
         self.task_queue = multiprocessing.Queue()  # type: multiprocessing.Queue
         self.collector_queue = multiprocessing.Queue()  # type: multiprocessing.Queue
         self.blocks = {}  # type: Dict[str, str]


### PR DESCRIPTION
Unmanaged executors are poorly defined and not tested, and reading the few codepaths involved can be a bit confusing when trying to understand scaling logic.

## Type of change

- Code maintentance/cleanup
