### PR TITLE
Remove unused scaling_enabled method from adhoc provider

### DIFF
--- a/parsl/providers/ad_hoc/ad_hoc.py
+++ b/parsl/providers/ad_hoc/ad_hoc.py
@@ -239,10 +239,6 @@ class AdHocProvider(ExecutionProvider, RepresentationMixin):
         return rets
 
     @property
-    def scaling_enabled(self):
-        return True
-
-    @property
     def label(self):
         return self._label
 


### PR DESCRIPTION
scaling_enabled usually lives on executors, not on providers, and this method never seems to be invoked.

## Type of change

- Code maintentance/cleanup
