### PR TITLE
Remove scaling_enabled attribute of executors

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -32,6 +32,7 @@ from parsl.dataflow.rundirs import make_rundir
 from parsl.dataflow.states import States, FINAL_STATES, FINAL_FAILURE_STATES
 from parsl.dataflow.taskrecord import TaskRecord
 from parsl.dataflow.usage_tracking.usage import UsageTracker
+from parsl.executors.status_handling import BlockProviderExecutor
 from parsl.executors.threads import ThreadPoolExecutor
 from parsl.process_loggers import wrap_with_logs
 from parsl.providers.provider_base import JobStatus, JobState
@@ -1100,7 +1101,7 @@ class DataFlowKernel(object):
 
         for executor in self.executors.values():
             if not executor.bad_state_is_set:
-                if executor.scaling_enabled:
+                if isinstance(executor, BlockProviderExecutor):
                     logger.info(f"Scaling in executor {executor.label}")
                     job_ids = executor.provider.resources.keys()
                     block_ids = executor.scale_in(len(job_ids))

--- a/parsl/dataflow/strategy.py
+++ b/parsl/dataflow/strategy.py
@@ -6,6 +6,7 @@ from typing import List
 
 from parsl.dataflow.executor_status import ExecutorStatus
 from parsl.executors import HighThroughputExecutor
+from parsl.executors.status_handling import BlockProviderExecutor
 from parsl.providers.provider_base import JobState
 from parsl.process_loggers import wrap_with_logs
 
@@ -174,7 +175,7 @@ class Strategy(object):
         for exec_status in status_list:
             executor = exec_status.executor
             label = executor.label
-            if not executor.scaling_enabled:
+            if not isinstance(executor, BlockProviderExecutor):
                 logger.debug(f"Not strategizing for executor {label} because scaling not enabled")
                 continue
             logger.debug(f"Strategizing for executor {label}")

--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 from concurrent.futures import Future
 from typing import Any, Callable, Dict, Optional, List
 
@@ -103,15 +103,6 @@ class ParslExecutor(metaclass=ABCMeta):
         """Shutdown the executor.
 
         This includes all attached resources such as workers and controllers.
-        """
-        pass
-
-    @abstractproperty
-    def scaling_enabled(self) -> bool:
-        """Specify if scaling is enabled.
-
-        The callers of ParslExecutors need to differentiate between Executors
-        and Executors wrapped in a resource provider
         """
         pass
 

--- a/parsl/executors/extreme_scale/executor.py
+++ b/parsl/executors/extreme_scale/executor.py
@@ -185,7 +185,6 @@ class ExtremeScaleExecutor(HighThroughputExecutor, RepresentationMixin):
         self.launch_cmd = l_cmd
         logger.debug("Launch command: {}".format(self.launch_cmd))
 
-        self._scaling_enabled = True
         logger.debug("Starting ExtremeScaleExecutor with provider:\n%s", self.provider)
         if hasattr(self.provider, 'init_blocks'):
             try:

--- a/parsl/executors/flux/executor.py
+++ b/parsl/executors/flux/executor.py
@@ -302,9 +302,6 @@ class FluxExecutor(NoStatusHandlingExecutor, RepresentationMixin):
     def scale_out(self):
         pass
 
-    def scaling_enabled(self):
-        return False
-
 
 def _submit_wrapper(
     submission_queue: queue.Queue, stop_event: threading.Event, *args, **kwargs

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -331,7 +331,6 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         self.launch_cmd = l_cmd
         logger.debug("Launch command: {}".format(self.launch_cmd))
 
-        self._scaling_enabled = True
         logger.debug("Starting HighThroughputExecutor with provider:\n%s", self.provider)
 
         # TODO: why is this a provider property?
@@ -609,10 +608,6 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
 
         # Return the future
         return fut
-
-    @property
-    def scaling_enabled(self):
-        return self._scaling_enabled
 
     def create_monitoring_info(self, status):
         """ Create a msg for monitoring based on the poll status

--- a/parsl/executors/low_latency/executor.py
+++ b/parsl/executors/low_latency/executor.py
@@ -88,7 +88,6 @@ class LowLatencyExecutor(BlockProviderExecutor, RepresentationMixin):
             self.launch_cmd = l_cmd
             logger.debug("Launch command: {}".format(self.launch_cmd))
 
-            self._scaling_enabled = True
             logger.debug(
                 "Starting LowLatencyExecutor with provider:\n%s", self.provider)
             if hasattr(self.provider, 'init_blocks'):
@@ -106,7 +105,6 @@ class LowLatencyExecutor(BlockProviderExecutor, RepresentationMixin):
                     logger.error("Scaling out failed: {}".format(e))
                     raise e
         else:
-            self._scaling_enabled = False
             logger.debug("Starting LowLatencyExecutor with no provider")
 
     def _start_local_queue_process(self):
@@ -212,10 +210,6 @@ class LowLatencyExecutor(BlockProviderExecutor, RepresentationMixin):
 
         # Return the future
         return self.tasks[task_id]
-
-    @property
-    def scaling_enabled(self):
-        return self._scaling_enabled
 
     def scale_out(self, blocks=1):
         """Scales out the number of active workers by the number of blocks specified.

--- a/parsl/executors/swift_t.py
+++ b/parsl/executors/swift_t.py
@@ -194,7 +194,6 @@ class TurbineExecutor(NoStatusHandlingExecutor):
         self.worker = mp.Process(target=runner, args=(self.outgoing_q, self.incoming_q))
         self.worker.start()
         logger.debug("Created worker : %s", self.worker)
-        self._scaling_enabled = False
 
     def _queue_management_worker(self):
         """Listen to the queue for task status messages and handle them.
@@ -331,10 +330,6 @@ class TurbineExecutor(NoStatusHandlingExecutor):
 
         # Return the future
         return self.tasks[task_id]
-
-    @property
-    def scaling_enabled(self):
-        return self._scaling_enabled
 
     def scale_out(self, blocks=1):
         """Scales out the number of active workers by 1.

--- a/parsl/executors/threads.py
+++ b/parsl/executors/threads.py
@@ -32,7 +32,6 @@ class ThreadPoolExecutor(NoStatusHandlingExecutor, RepresentationMixin):
                  working_dir: Optional[str] = None):
         NoStatusHandlingExecutor.__init__(self)
         self.label = label
-        self._scaling_enabled = False
         self.max_threads = max_threads
         self.thread_name_prefix = thread_name_prefix
 
@@ -45,10 +44,6 @@ class ThreadPoolExecutor(NoStatusHandlingExecutor, RepresentationMixin):
     def start(self):
         self.executor = cf.ThreadPoolExecutor(max_workers=self.max_threads,
                                               thread_name_prefix=self.thread_name_prefix)
-
-    @property
-    def scaling_enabled(self):
-        return self._scaling_enabled
 
     def submit(self, func, resource_specification, *args, **kwargs):
         """Submits work to the thread pool.

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -230,8 +230,6 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
                  function_dir: Optional[str] = None):
         BlockProviderExecutor.__init__(self, provider=provider,
                                        block_error_handler=True)
-        self._scaling_enabled = True
-
         if not _work_queue_enabled:
             raise OptionalModuleMissing(['work_queue'], "WorkQueueExecutor requires the work_queue module.")
 
@@ -684,11 +682,6 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
 
         logger.debug("Work Queue shutdown completed")
         return True
-
-    def scaling_enabled(self):
-        """Specify if scaling is enabled. Not enabled in Work Queue.
-        """
-        return self._scaling_enabled
 
     def run_dir(self, value=None):
         """Path to the run directory.


### PR DESCRIPTION
After this PR, if an executor should be scaled, that is indicated by subclassing BlockProviderExecutor - see issue #2539.

This PR works alongside PR #2537 which removed the executor.managed attribute.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Code maintentance/cleanup
