### PR TITLE
Clarify that args can be any Sequence

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -20,7 +20,7 @@ from parsl.serialize import deserialize
 
 from parsl.monitoring.message_type import MessageType
 from parsl.monitoring.types import AddressedMonitoringMessage, TaggedMonitoringMessage
-from typing import cast, Any, Callable, Dict, List, Optional, Union
+from typing import cast, Any, Callable, Dict, Optional, Sequence, Union
 
 _db_manager_excepts: Optional[Exception]
 
@@ -285,7 +285,7 @@ class MonitoringHub(RepresentationMixin):
 
     @staticmethod
     def monitor_wrapper(f: Any,
-                        args: List,
+                        args: Sequence,
                         kwargs: Dict,
                         try_id: int,
                         task_id: int,
@@ -295,7 +295,7 @@ class MonitoringHub(RepresentationMixin):
                         sleep_dur: float,
                         radio_mode: str,
                         monitor_resources: bool,
-                        run_dir: str) -> Tuple[Callable, List, Dict]:
+                        run_dir: str) -> Tuple[Callable, Sequence, Dict]:
         return parsl.monitoring.remote.monitor_wrapper(f, args, kwargs, try_id, task_id, monitoring_hub_url,
                                                        run_id, logging_level, sleep_dur, radio_mode,
                                                        monitor_resources, run_dir)

--- a/parsl/monitoring/remote.py
+++ b/parsl/monitoring/remote.py
@@ -10,7 +10,7 @@ from parsl.process_loggers import wrap_with_logs
 
 from parsl.monitoring.message_type import MessageType
 from parsl.monitoring.radios import MonitoringRadio, UDPRadio, HTEXRadio, FilesystemRadio
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ monitoring_wrapper_cache = {}
 
 
 def monitor_wrapper(f: Any,           # per app
-                    args: List,       # per invocation
+                    args: Sequence,   # per invocation
                     kwargs: Dict,     # per invocation
                     x_try_id: int,    # per invocation
                     x_task_id: int,   # per invocation
@@ -29,7 +29,7 @@ def monitor_wrapper(f: Any,           # per app
                     sleep_dur: float,  # per workflow
                     radio_mode: str,   # per executor
                     monitor_resources: bool,  # per workflow
-                    run_dir: str) -> Tuple[Callable, List, Dict]:
+                    run_dir: str) -> Tuple[Callable, Sequence, Dict]:
     """Wrap the Parsl app with a function that will call the monitor function and point it at the correct pid when the task begins.
     """
 


### PR DESCRIPTION
The type of args is ambiguous within the DFK - someties its a list, sometimes its a tuple...

Some parts of the DFK (for example TaskRecord) aready accomodate this by using a Sequence.

This PR extends that to more places.

This is part of work towards a statically typed DFK: issue #2540

## Type of change

- Code maintentance/cleanup
