### PR TITLE
Fix name of loggers in parsl

### DIFF
--- a/parsl/executors/low_latency/interchange.py
+++ b/parsl/executors/low_latency/interchange.py
@@ -2,7 +2,10 @@
 
 import logging
 import zmq
+from parsl.log_utils import set_file_logger
 # import time
+
+logger = logging.getLogger(__name__)
 
 
 class Interchange(object):
@@ -14,8 +17,11 @@ class Interchange(object):
                  worker_port=None,
                  worker_port_range=(54000, 55000)
                  ):
-        global logger
-        start_file_logger("interchange.log")
+        set_file_logger(
+            logger.name,
+            filename="interchange.log",
+            format_string="%(asctime)s %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
+        )
         logger.info("Init Interchange")
 
         self.context = zmq.Context()
@@ -85,42 +91,6 @@ class Interchange(object):
             # if not active_flag and last + 1 < time.time():
             #    logger.debug("Nothing in the past 1s round")
             #    last = time.time()
-
-
-def start_file_logger(filename,
-                      name="parsl.executors.interchange",
-                      level=logging.DEBUG,
-                      format_string=None):
-    """Add a stream log handler.
-
-    Parameters
-    ---------
-
-    filename: string
-        Name of the file to write logs to. Required.
-    name: string
-        Logger name. Default="parsl.executors.interchange"
-    level: logging.LEVEL
-        Set the logging level. Default=logging.DEBUG
-        - format_string (string): Set the format string
-    format_string: string
-        Format string to use.
-
-    Returns
-    -------
-        None.
-    """
-    if format_string is None:
-        format_string = "%(asctime)s %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
-
-    global logger
-    logger = logging.getLogger(name)
-    logger.setLevel(level)
-    handler = logging.FileHandler(filename)
-    handler.setLevel(level)
-    formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
 
 
 def starter(comm_q, *args, **kwargs):

--- a/parsl/executors/low_latency/interchange.py
+++ b/parsl/executors/low_latency/interchange.py
@@ -87,7 +87,10 @@ class Interchange(object):
             #    last = time.time()
 
 
-def start_file_logger(filename, name='interchange', level=logging.DEBUG, format_string=None):
+def start_file_logger(filename,
+                      name="parsl.executors.interchange",
+                      level=logging.DEBUG,
+                      format_string=None):
     """Add a stream log handler.
 
     Parameters

--- a/parsl/log_utils.py
+++ b/parsl/log_utils.py
@@ -25,7 +25,13 @@ DEFAULT_FORMAT = (
 
 
 @typeguard.typechecked
-def set_stream_logger(name: str = 'parsl', level: int = logging.DEBUG, format_string: Optional[str] = None, stream: Optional[io.TextIOWrapper] = None):
+def set_stream_logger(
+        name: str = "parsl",
+        level: int = logging.DEBUG,
+        format_string: Optional[str] = None,
+        stream: Optional[io.TextIOWrapper] = None,
+        propagate: bool = True,
+) -> logging.Logger:
     """Add a stream log handler.
 
     Args:
@@ -36,7 +42,7 @@ def set_stream_logger(name: str = 'parsl', level: int = logging.DEBUG, format_st
             If not specified, the default stream for logging.StreamHandler is used.
 
     Returns:
-         - None
+         - logging.Logger instance
     """
     if format_string is None:
         # format_string = "%(asctime)s %(name)s [%(levelname)s] Thread:%(thread)d %(message)s"
@@ -49,16 +55,24 @@ def set_stream_logger(name: str = 'parsl', level: int = logging.DEBUG, format_st
     formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
     handler.setFormatter(formatter)
     logger.addHandler(handler)
+    logger.propagate = propagate
 
     # Concurrent.futures errors are also of interest, as exceptions
     # which propagate out of the top of a callback are logged this way
     # and then discarded. (see #240)
     futures_logger = logging.getLogger("concurrent.futures")
     futures_logger.addHandler(handler)
+    return logger
 
 
 @typeguard.typechecked
-def set_file_logger(filename: str, name: str = 'parsl', level: int = logging.DEBUG, format_string: Optional[str] = None):
+def set_file_logger(
+        filename: str,
+        name: str = "parsl",
+        level: int = logging.DEBUG,
+        format_string: Optional[str] = None,
+        propagate: bool = True,
+) -> logging.Logger:
     """Add a file log handler.
 
     Args:
@@ -68,7 +82,7 @@ def set_file_logger(filename: str, name: str = 'parsl', level: int = logging.DEB
         - format_string (string): Set the format string
 
     Returns:
-       -  None
+         - logging.Logger instance
     """
     if format_string is None:
         format_string = DEFAULT_FORMAT
@@ -80,8 +94,10 @@ def set_file_logger(filename: str, name: str = 'parsl', level: int = logging.DEB
     formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
     handler.setFormatter(formatter)
     logger.addHandler(handler)
+    logger.propagate = propagate
 
     # see note in set_stream_logger for notes about logging
     # concurrent.futures
     futures_logger = logging.getLogger("concurrent.futures")
     futures_logger.addHandler(handler)
+    return logger

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -15,7 +15,7 @@ from parsl.monitoring.types import MonitoringMessage, TaggedMonitoringMessage
 from parsl.process_loggers import wrap_with_logs
 from parsl.utils import setproctitle
 
-logger = logging.getLogger("database_manager")
+logger = logging.getLogger(__name__)
 
 X = TypeVar('X')
 
@@ -554,7 +554,7 @@ class DatabaseManager:
         if exception_happened:
             raise RuntimeError("An exception happened sometime during database processing and should have been logged in database_manager.log")
 
-    @wrap_with_logs(target="database_manager")
+    @wrap_with_logs()
     def _migrate_logs_to_internal(self, logs_queue: queue.Queue, queue_tag: str, kill_event: threading.Event) -> None:
         logger.info("Starting processing for queue {}".format(queue_tag))
 
@@ -695,7 +695,7 @@ class DatabaseManager:
         self._kill_event.set()
 
 
-@wrap_with_logs(target="database_manager")
+@wrap_with_logs()
 def dbm_starter(exception_q: "queue.Queue[Tuple[str, str]]",
                 priority_msgs: "queue.Queue[TaggedMonitoringMessage]",
                 node_msgs: "queue.Queue[MonitoringMessage]",

--- a/parsl/process_loggers.py
+++ b/parsl/process_loggers.py
@@ -5,7 +5,10 @@ import functools
 from typing import Callable, Optional
 
 
-def wrap_with_logs(fn: Optional[Callable] = None, target: str = __name__) -> Callable:
+def wrap_with_logs(
+        fn: Optional[Callable] = None,
+        target: Optional[str] = None,
+) -> Callable:
     """Calls the supplied function, and logs whether that
     function raised an exception or terminated normally.
 
@@ -21,7 +24,7 @@ def wrap_with_logs(fn: Optional[Callable] = None, target: str = __name__) -> Cal
             assert func is not None
             thread = threading.current_thread()
             name = f"{func.__name__} on thread {thread.name}"
-            logger = logging.getLogger(target)
+            logger = logging.getLogger(func.__module__ if target is None else target)
 
             try:
                 r = func(*args, **kwargs)


### PR DESCRIPTION
# Description

This PR changes the names of loggers so that they are children of the parsl logger, as well as deduplicating some code.

Elsewhere in Parsl and in other projects, developers use the fully-qualified module name as the name of the logger, which has the advantage that logs bubble up, so all parsl logs can be intercepted with `logger.getLogger("parsl")`.

I also used this opportunity to deduplicate the code which configured logging through global variables. The old code was equivalent to:
```
def setup_logger()
    global logger
    logger = logging.getLogger(name)
    # configure logger

def main():
    setup_logger()
    logger.warn("warning")
```

However, this can be rewritten without global variables and with less code. The documentation guarantees that `logging.getLogger(x)` will return a pointer to the same object no matter where it is called from. The logger object is already a singleton, so it doesn't need to be configured by global variables. That means that we can reuse the code in `parsl.log_utils`.

> Multiple calls to [getLogger()](https://docs.python.org/3/library/logging.html#logging.getLogger) with the same name will always return a reference to the same Logger object.
> 
> - [docs](https://docs.python.org/3/library/logging.html#logger-objects)

## Type of change

- Code maintentance/cleanup
