### PR TITLE
Remove mypy no_implicit_optional except at top level

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -22,7 +22,6 @@ ignore_missing_imports = True
 # listed per package; but unless/until that happens, the more-strictly-checked
 # code should be listed here:
 [mypy-parsl.providers.provider_base.*]
-no_implicit_optional = True
 disallow_untyped_decorators = True
 warn_unused_ignores = True
 check_untyped_defs = True
@@ -37,7 +36,6 @@ check_untyped_defs = True
 ignore_errors = True
 
 [mypy-parsl.monitoring.*]
-no_implicit_optional = True
 disallow_untyped_decorators = True
 warn_unused_ignores = True
 check_untyped_defs = True


### PR DESCRIPTION
no_implicit_optional was turned on for the whole tree in PR #2509 so does not need turning on for subtrees any more.

## Type of change

- Code maintentance/cleanup
