### PR TITLE
Add upper bound to SQLAlchemy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 extras_require = {
     'monitoring' : [
-        'sqlalchemy>=1.3.0',
+        'sqlalchemy>=1.3.0,<2',
         'pydot',
         'networkx>=2.5,<2.6',
         'Flask>=1.0.2',


### PR DESCRIPTION
The current parsl code (at least in the test suite) is incompatible with >=2 which was released in the last few days.

## Type of change
- Bug fix (non-breaking change that fixes an issue)
- Code maintentance/cleanup
