### PR TITLE
run mypy on all of parsl/ tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,14 +46,7 @@ clean_coverage:
 
 .PHONY: mypy
 mypy: ## run mypy checks
-	MYPYPATH=$(CWD)/mypy-stubs mypy parsl/tests/configs/
-	MYPYPATH=$(CWD)/mypy-stubs mypy parsl/tests/test*/
-	MYPYPATH=$(CWD)/mypy-stubs mypy parsl/tests/sites/
-        # only the top level of monitoring is checked here because the visualization code does not type check
-	MYPYPATH=$(CWD)/mypy-stubs mypy parsl/app/ parsl/channels/ parsl/dataflow/ parsl/data_provider/ parsl/launchers parsl/providers/ parsl/monitoring/*py parsl/monitoring/queries/*py
-        # process worker pool is explicitly listed to check, because it is not
-        # imported from anywhere in core parsl python code.
-	MYPYPATH=$(CWD)/mypy-stubs mypy parsl/executors/high_throughput/process_worker_pool.py parsl/executors/high_throughput/interchange.py
+	MYPYPATH=$(CWD)/mypy-stubs mypy parsl/
 
 .PHONY: local_thread_test
 local_thread_test: ## run all tests with local_thread config


### PR DESCRIPTION
Previously, only explicitly named subtrees were checked. Previous PRs have tidied up typechecking problems so that this PR can apply mypy to all of parsl/

## Type of change

- Code maintentance/cleanup
