### PR TITLE
Remove manager to interchange work requests to speedup sequential task distribution

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -364,9 +364,9 @@ class Interchange(object):
             self.socks = dict(poller.poll(timeout=poll_period))
 
             self.process_task_outgoing_incoming(interesting_managers, hub_channel, kill_event)
-            self.process_tasks_to_send(interesting_managers)
             self.process_results_incoming(interesting_managers, hub_channel)
             self.expire_bad_managers(interesting_managers, hub_channel)
+            self.process_tasks_to_send(interesting_managers)
 
         delta = time.time() - start
         logger.info("Processed {} tasks in {} seconds".format(self.count, delta))

--- a/parsl/executors/high_throughput/manager_record.py
+++ b/parsl/executors/high_throughput/manager_record.py
@@ -7,7 +7,6 @@ class ManagerRecord(TypedDict, total=False):
     block_id: Optional[str]
     tasks: List[Any]
     worker_count: int
-    free_capacity: int
     max_capacity: int
     active: bool
     hostname: str

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -280,11 +280,6 @@ class Manager(object):
                 self.heartbeat_to_incoming()
                 last_beat = time.time()
 
-            if pending_task_count < self.max_queue_size and ready_worker_count > 0:
-                logger.debug("Requesting tasks: {}".format(ready_worker_count))
-                msg = ((ready_worker_count).to_bytes(4, "little"))
-                self.task_incoming.send(msg)
-
             socks = dict(poller.poll(timeout=poll_timer))
 
             if self.task_incoming in socks and socks[self.task_incoming] == zmq.POLLIN:


### PR DESCRIPTION
[single-latency.py.txt](https://github.com/Parsl/parsl/files/10582032/single-latency.py.txt)
Prior to this PR, the interchange calculated how many tasks to send to a manager based on the minimum of: how many tasks the manager most recently requested (minus sent tasks); how many tasks the manager has total capacity for, minus the number of tasks in flight.

The most recently requested count is made on an exponential backoff, which continues to backoff when a manager is saturated with long tasks. That means that the requested task count is sometimes not updated for quite a long time.

This PR removes that clause entirely, and the code that delivers that information. Now the interchange relies only on the computed maximum capacity minus the number of tasks in flight - this code was added in PR #881, but alongside the previous "manager requests work" value.

A new task will be dispatched when a result arrives from a manager, freeing up a slot, rather than on a separate free_capacity poll: so new task dispatch is now much more event driven.

On my laptop on `master` prior to this PR, the attached demonstrator code shows that when tasks execute quickly, tasks begin executing just over 1 or just over 2 poll_periods after submission; but when tasks take a long time and a manager is saturated, backoff of poll periods in the manager means that the manager remains idle for sometimes 9 seconds before starting to execute a task.

After this PR, the same code shows tasks executing in just over one poll period in both situations.
I have tried this with a range of poll periods from 10 to 500ms.

With smaller poll periods, 1 .. 3 ms, I have noticed that the slow task saturated case takes a few ms longer for task dispatch compared to the fast task path. I have not investigated why that happens, and I don't intend to for this PR.

@WardLT noticed this behaviour in May 2022, and it is still present at time of writing this PR.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
