### PR TITLE
Prune unnecessary warnings in provider docstrings

### DIFF
--- a/parsl/providers/cobalt/cobalt.py
+++ b/parsl/providers/cobalt/cobalt.py
@@ -88,7 +88,7 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
         self.worker_init = worker_init
 
     def _status(self):
-        """ Internal: Do not call. Returns the status list for a list of job_ids
+        """Returns the status list for a list of job_ids
 
         Args:
               self

--- a/parsl/providers/lsf/lsf.py
+++ b/parsl/providers/lsf/lsf.py
@@ -142,7 +142,7 @@ class LSFProvider(ClusterProvider, RepresentationMixin):
         self.worker_init = worker_init
 
     def _status(self):
-        ''' Internal: Do not call. Returns the status list for a list of job_ids
+        '''Returns the status list for a list of job_ids
 
         Args:
               self

--- a/parsl/providers/pbspro/pbspro.py
+++ b/parsl/providers/pbspro/pbspro.py
@@ -91,7 +91,7 @@ class PBSProProvider(TorqueProvider):
         self.select_options = select_options
 
     def _status(self):
-        ''' Internal: Do not call. Returns the status list for a list of job_ids
+        '''Returns the status list for a list of job_ids
 
         Args:
               self

--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -130,7 +130,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         self.worker_init = worker_init + '\n'
 
     def _status(self):
-        ''' Internal: Do not call. Returns the status list for a list of job_ids
+        '''Returns the status list for a list of job_ids
 
         Args:
               self

--- a/parsl/providers/torque/torque.py
+++ b/parsl/providers/torque/torque.py
@@ -103,7 +103,7 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
         self.resources = {}
 
     def _status(self):
-        ''' Internal: Do not call. Returns the status list for a list of job_ids
+        '''Returns the status list for a list of job_ids
 
         Args:
               self


### PR DESCRIPTION
The presence of _ on _status indicates it is internal.

The method is expected to be called - that's why it exists. This PR removes exhortions to the contrary.

## Type of change

- Documentation update
- Code maintentance/cleanup
