### PR TITLE
Remove an unused path from flake8 exclude line

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,7 +10,7 @@
 #       (Raised by flake8 even when it is followed)
 ignore = E124, E126, E402, E129, W504
 max-line-length = 160
-exclude = parsl/executors/serialize/, test_import_fail.py
+exclude = test_import_fail.py
 # E741 disallows ambiguous single letter names which look like numbers
 # We disable it in visualization code because plotly uses 'l' as
 # a keyword arg


### PR DESCRIPTION
parsl/executors/serialize was removed in PR #1806 in 2020 which introduced the current serialization system.

## Type of change

- Code maintentance/cleanup
