### PR TITLE
Update gh actions to push tags

### DIFF
--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -36,6 +36,10 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: '3.x'
+
+    - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel
@@ -45,7 +49,7 @@ jobs:
         ./tag_and_release.sh update_version
         ./tag_and_release.sh package
       env:
-        SUFFIX: ${{ inputs.suffix }}
+        VERSION: ${{ steps.date.outputs.date }}${{ inputs.suffix }}
 
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29

--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -46,12 +46,13 @@ jobs:
         ./tag_and_release.sh package
       env:
         SUFFIX: ${{ inputs.suffix }}
+
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
         user: __token__
         # Set the following to publish to TestPypi instead
-        # password: ${{ secrets.TESTPYPI_API_TOKEN }}
-        # repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.TESTPYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
 
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        # password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -60,3 +60,10 @@ jobs:
         repository_url: https://test.pypi.org/legacy/
 
         # password: ${{ secrets.PYPI_API_TOKEN }}
+
+    - name: Mint a tag
+      uses: actions/checkout@v3
+      uses: rickstaa/action-create-tag@v1
+      with:
+        tag: ${{ steps.date.outputs.date }}${{ inputs.suffix }}
+        message: "Release version: ${{ steps.date.outputs.date }}${{ inputs.suffix }}"

--- a/tag_and_release.sh
+++ b/tag_and_release.sh
@@ -52,13 +52,13 @@ release () {
 }
 
 update_version () {
-    target_version=$(date +%Y.%m.%d)$SUFFIX
+    target_version=$VERSION
     echo "Target version = $target_version"
     cat << EOF > parsl/version.py
 """Set module version.
 
-<Major>.<Minor>.<maintenance>[alpha/beta/..]
-Alphas will be numbered like this -> 0.4.0a0
+Year.Month.Day[alpha/beta/..]
+Alphas will be numbered like this -> 2024.12.10a0
 """
 VERSION = '$target_version'
 EOF


### PR DESCRIPTION
# Description

This PR updates our weekly release pipeline to mint a release tag.

* GH action now passes `VERSION` env var to `tag_and_release.sh`
* GH action will now mint a new tag matching the version pushed to pypi

## Type of change

Fixes #2451 and #2462 

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
- Code maintentance/cleanup
