### PR TITLE
Adding broad write perms to allow gh actions to make tag

### DIFF
--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -19,8 +19,7 @@ on:
         required: false
         default: ''
 
-permissions:
-  contents: read
+permissions: write-all
 
 jobs:
 


### PR DESCRIPTION
# Description

This PR updates the permission block from `contents: read` to `write-all` which is the broadest permission statement.
The plan is to confirm to first confirm with this PR that the current tag writing failure can be fixed by the write permission grant and then refine it to the specific grant needed just to write tags.

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
