### PR TITLE
Upgrade flake8 to 5.0.4

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -139,7 +139,7 @@ class MonitoringHub(RepresentationMixin):
         self._dfk_channel = None  # type: Any
 
         if _db_manager_excepts:
-            raise(_db_manager_excepts)
+            raise _db_manager_excepts
 
         self.client_address = client_address
         self.client_port_range = client_port_range
@@ -328,7 +328,7 @@ def filesystem_receiver(logdir: str, q: "queue.Queue[AddressedMonitoringMessage]
                 with open(full_path_filename, "rb") as f:
                     message = deserialize(f.read())
                 logger.info(f"Message received is: {message}")
-                assert(isinstance(message, tuple))
+                assert isinstance(message, tuple)
                 q.put(cast(AddressedMonitoringMessage, message))
                 os.remove(full_path_filename)
             except Exception:

--- a/parsl/providers/cluster_provider.py
+++ b/parsl/providers/cluster_provider.py
@@ -67,9 +67,9 @@ class ClusterProvider(ExecutionProvider):
         self.walltime = walltime
         self.cmd_timeout = cmd_timeout
         if not callable(self.launcher):
-            raise(BadLauncher(self.launcher,
+            raise BadLauncher(self.launcher,
                               "Launcher for executor: {} is of type: {}. Expects a parsl.launcher.launcher.Launcher or callable".format(
-                                  label, type(self.launcher))))
+                                  label, type(self.launcher)))
 
         self.script_dir = None
 

--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -120,7 +120,7 @@ def load_dfk_session(request, pytestconfig):
 
         yield
 
-        if(parsl.dfk() != dfk):
+        if parsl.dfk() != dfk:
             raise RuntimeError("DFK changed unexpectedly during test")
         dfk.cleanup()
         parsl.clear()
@@ -154,16 +154,16 @@ def load_dfk_local_module(request, pytestconfig):
             assert isinstance(c, parsl.Config)
             dfk = parsl.load(c)
 
-        if(callable(local_setup)):
+        if callable(local_setup):
             local_setup()
 
         yield
 
-        if(callable(local_teardown)):
+        if callable(local_teardown):
             local_teardown()
 
-        if(local_config):
-            if(parsl.dfk() != dfk):
+        if local_config:
+            if parsl.dfk() != dfk:
                 raise RuntimeError("DFK changed unexpectedly during test")
             dfk.cleanup()
             parsl.clear()

--- a/parsl/tests/test_bash_apps/test_pipeline.py
+++ b/parsl/tests/test_bash_apps/test_pipeline.py
@@ -52,7 +52,7 @@ def test_increment(depth=5):
     futs = {}
     for i in range(1, depth):
         print("Launching {0} with {1}".format(i, prev))
-        assert(isinstance(prev, DataFuture) or isinstance(prev, File))
+        assert isinstance(prev, DataFuture) or isinstance(prev, File)
         output = File("test{0}.txt".format(i))
         fu = increment(inputs=[prev],  # Depend on the future from previous call
                        # Name the file to be created here
@@ -62,7 +62,7 @@ def test_increment(depth=5):
         [prev] = fu.outputs
         futs[i] = prev
         print(prev.filepath)
-        assert(isinstance(prev, DataFuture))
+        assert isinstance(prev, DataFuture)
 
     for key in futs:
         if key > 0:

--- a/parsl/tests/test_error_handling/test_retry_handler.py
+++ b/parsl/tests/test_error_handling/test_retry_handler.py
@@ -61,4 +61,4 @@ def test_retry():
     with pytest.raises(parsl.app.errors.BashExitFailure):
         fu.result()
 
-    assert(fu.exception().exitcode == 5)
+    assert fu.exception().exitcode == 5

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -55,7 +55,7 @@ def get_all_checkpoints(rundir: str = "runinfo") -> List[str]:
 
     """
 
-    if(not os.path.isdir(rundir)):
+    if not os.path.isdir(rundir):
         return []
 
     dirs = sorted(os.listdir(rundir))
@@ -99,7 +99,7 @@ def get_last_checkpoint(rundir: str = "runinfo") -> List[str]:
     last_runid = dirs[-1]
     last_checkpoint = os.path.abspath(f'{rundir}/{last_runid}/checkpoint')
 
-    if(not(os.path.isdir(last_checkpoint))):
+    if not os.path.isdir(last_checkpoint):
         return []
 
     return [last_checkpoint]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-flake8==3.8.0
+flake8==5.0.4
 importlib-metadata<5  # due to flake8 incompatibility with importlib 5.0.0
 ipyparallel
 pandas


### PR DESCRIPTION
Although a later flake8 is available (6.0.0) it requires Python >=3.8

This PR also fixes flake8 errors which appear after the upgrade, which are to do with missing whitespace when using C-style bracketing for if/not/assert.

## Type of change

- Code maintentance/cleanup
