### PR TITLE
Limiting action perms to contents:write

### DIFF
--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -20,7 +20,7 @@ on:
         default: ''
 
 permissions:
-  contents: read-all|write-all
+  contents: write
 
 jobs:
 

--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -20,7 +20,7 @@ on:
         default: ''
 
 permissions:
-  contents: read
+  contents: read-all|write-all
 
 jobs:
 


### PR DESCRIPTION
# Description

Setting perms to write, since the previous line from docs apparently doesn't work.


## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
