### PR TITLE
Point release target from test.pypi to pypi on Github Actions

### DIFF
--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -59,10 +59,10 @@ jobs:
       with:
         user: __token__
         # Set the following to publish to TestPypi instead
-        password: ${{ secrets.TESTPYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        # password: ${{ secrets.TESTPYPI_API_TOKEN }}
+        # repository_url: https://test.pypi.org/legacy/
 
-        # password: ${{ secrets.PYPI_API_TOKEN }}
+        password: ${{ secrets.PYPI_API_TOKEN }}
 
     - name: Mint a tag
       uses: rickstaa/action-create-tag@v1


### PR DESCRIPTION
# Description

The test releases and tagging worked in the last iteration. Logs are here: https://github.com/Parsl/parsl/actions/runs/4285181155/jobs/7463141066

With that, I'm pointing the action to push releases to Pypi instead of test.pypi.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
