### PR TITLE
Add return type annotation for log utils, reformat, reconfigure flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,7 +9,7 @@
 # W504: line break after binary operator
 #       (Raised by flake8 even when it is followed)
 ignore = E124, E126, E402, E129, W504
-max-line-length = 160
+max-line-length = 158
 exclude = test_import_fail.py
 # E741 disallows ambiguous single letter names which look like numbers
 # We disable it in visualization code because plotly uses 'l' as

--- a/parsl/log_utils.py
+++ b/parsl/log_utils.py
@@ -25,7 +25,10 @@ DEFAULT_FORMAT = (
 
 
 @typeguard.typechecked
-def set_stream_logger(name: str = 'parsl', level: int = logging.DEBUG, format_string: Optional[str] = None, stream: Optional[io.TextIOWrapper] = None) -> None:
+def set_stream_logger(name: str = 'parsl',
+                      level: int = logging.DEBUG,
+                      format_string: Optional[str] = None,
+                      stream: Optional[io.TextIOWrapper] = None) -> None:
     """Add a stream log handler.
 
     Args:
@@ -58,7 +61,10 @@ def set_stream_logger(name: str = 'parsl', level: int = logging.DEBUG, format_st
 
 
 @typeguard.typechecked
-def set_file_logger(filename: str, name: str = 'parsl', level: int = logging.DEBUG, format_string: Optional[str] = None) -> None:
+def set_file_logger(filename: str,
+                    name: str = 'parsl',
+                    level: int = logging.DEBUG,
+                    format_string: Optional[str] = None) -> None:
     """Add a file log handler.
 
     Args:


### PR DESCRIPTION
Reducing the line length here reduces the longest line in the codebase now, so this PR reconfigures flake8 slightly towards the PEP8 line length limit.

## Type of change

- Code maintentance/cleanup
