### PR TITLE
Remove test output file before running test

### DIFF
--- a/parsl/tests/test_bash_apps/test_memoize_ignore_args.py
+++ b/parsl/tests/test_bash_apps/test_memoize_ignore_args.py
@@ -35,7 +35,10 @@ def test_memo_stdout():
 
     # this should be memoized, so not create benc.test.y
     path_y = "test.memo.stdout.y"
-    assert not os.path.exists(path_y)
+
+    if os.path.exists(path_y):
+        os.remove(path_y)
+
     no_checkpoint_stdout_app(stdout=path_y).result()
     assert not os.path.exists(path_y)
 


### PR DESCRIPTION
If the test output file happens to exist, the test will fail even though there is nothing wrong.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
