### PR TITLE
Fix modification of ignore_for_cache when using AUTO_LOGNAME

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -840,6 +840,9 @@ class DataFlowKernel(object):
 
         if ignore_for_cache is None:
             ignore_for_cache = []
+        else:
+            # duplicate so that it can be modified safely later
+            ignore_for_cache = list(ignore_for_cache)
 
         if self.cleanup_called:
             raise RuntimeError("Cannot submit to a DFK that has been cleaned up")

--- a/parsl/tests/test_bash_apps/test_memoize_ignore_args_regr.py
+++ b/parsl/tests/test_bash_apps/test_memoize_ignore_args_regr.py
@@ -1,8 +1,16 @@
+import copy
 import os
 import pytest
 
+from typing import List
+
 import parsl
 from parsl.app.app import bash_app
+
+const_list_x: List[str] = []
+const_list_x_arg: List[str] = copy.deepcopy(const_list_x)
+
+assert const_list_x == const_list_x_arg
 
 
 @bash_app(cache=True, ignore_for_cache=['x'])
@@ -17,32 +25,29 @@ def test_memo_same_at_definition():
     oneshot_app(x=1).result()  # this should be memoized, and will raise a RuntimeError if actually executed
 
 
-@bash_app(cache=True, ignore_for_cache=['stdout'])
-def no_checkpoint_stdout_app_ignore_args(stdout=None):
+@bash_app(cache=True, ignore_for_cache=const_list_x_arg)
+def no_checkpoint_stdout_app(stdout=None):
     return "echo X"
 
 
 @pytest.mark.issue363
 def test_memo_stdout():
 
-    # this should run and create a file named after path_x
+    assert const_list_x == const_list_x_arg
+
     path_x = "test.memo.stdout.x"
     if os.path.exists(path_x):
         os.remove(path_x)
 
-    no_checkpoint_stdout_app_ignore_args(stdout=path_x).result()
+    # this should run and create a file named after path_x
+    no_checkpoint_stdout_app(stdout=path_x).result()
     assert os.path.exists(path_x)
 
-    # this should be memoized, so not create benc.test.y
-    path_y = "test.memo.stdout.y"
-
-    if os.path.exists(path_y):
-        os.remove(path_y)
-
-    no_checkpoint_stdout_app_ignore_args(stdout=path_y).result()
-    assert not os.path.exists(path_y)
+    os.remove(path_x)
+    no_checkpoint_stdout_app(stdout=path_x).result()
+    assert not os.path.exists(path_x)
 
     # this should also be memoized, so not create an arbitrary name
-    z_fut = no_checkpoint_stdout_app_ignore_args(stdout=parsl.AUTO_LOGNAME)
+    z_fut = no_checkpoint_stdout_app(stdout=parsl.AUTO_LOGNAME)
     z_fut.result()
-    assert not os.path.exists(z_fut.stdout)
+    assert const_list_x == const_list_x_arg


### PR DESCRIPTION
When using AUTO_LOGNAME, stderr/stdout are added to ignore_for_cache, because this parameter is different on each invocation, and so invocations will not be cached.

However, what is modified is the ignore_for_cache structure in the function itself, not a local variable inside the invocation, which means that it is modified for all subsequent calls, including calls which do not use AUTO_LOGNAME.

This was found by mypy on the benc-mypy branch.

Fixes #1655 

## Type of change

- Bug fix (non-breaking change that fixes an issue)
