### PR TITLE
Set ZMQ receive timeouts in the interchange to prevent blocking threads

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -138,12 +138,14 @@ class Interchange(object):
         self.context = zmq.Context()
         self.task_incoming = self.context.socket(zmq.DEALER)
         self.task_incoming.set_hwm(0)
+        self.task_incoming.RCVTIMEO = 1000
         self.task_incoming.connect("tcp://{}:{}".format(client_address, client_ports[0]))
         self.results_outgoing = self.context.socket(zmq.DEALER)
         self.results_outgoing.set_hwm(0)
         self.results_outgoing.connect("tcp://{}:{}".format(client_address, client_ports[1]))
 
         self.command_channel = self.context.socket(zmq.REP)
+        self.command_channel.RCVTIMEO = 1000
         self.command_channel.connect("tcp://{}:{}".format(client_address, client_ports[2]))
         logger.info("Connected to client")
 


### PR DESCRIPTION

# Description

Without the `RCVTIMEO` the `task_puller` thread and `_command_server` on the interchange block indefinitely and do not break when the kill_event is set. Since the recv_pyobj call is in c-land it has a tendency to ignore signals.

This is rolling back changes from this PR: https://github.com/Parsl/parsl/pull/2438
While we do not wait for the kill event, we still need the thread exit from the ZMQ context where it seems to ignore signals. 

Currently, this is blocking/causing hangs on funcX tests wherever we use HTEX.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
