### PR TITLE
Add major version upper bound for typeguard

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyzmq>=17.1.2
-typeguard>=2.10
+typeguard>=2.10,<3
 typing-extensions
 types-paramiko
 types-requests


### PR DESCRIPTION
Typeguard 3.0.0 was published to pypi on 2023-03-14. This is incompatible with the version of pytest that is used in the parsl test suite.

This PR adds an upper bound to keep typeguard in the 2.x range.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
