### PR TITLE
fix: launch_cmd not set when provided to FluxExecutor

### DIFF
--- a/parsl/executors/flux/executor.py
+++ b/parsl/executors/flux/executor.py
@@ -201,8 +201,8 @@ class FluxExecutor(NoStatusHandlingExecutor, RepresentationMixin):
         self.flux_path = os.path.abspath(flux_path)
         self._task_id_counter = itertools.count()
         self._socket = zmq.Context().socket(zmq.REP)
-        if launch_cmd is None:
-            self.launch_cmd = self.DEFAULT_LAUNCH_CMD
+        # Assumes a launch command cannot be None or empty
+        self.launch_cmd = launch_cmd or self.DEFAULT_LAUNCH_CMD
         self._submission_queue: queue.Queue = queue.Queue()
         self._stop_event = threading.Event()
         # lock to protect self._task_id_counter and also submission/shutdown race


### PR DESCRIPTION
Problem: Currently, the launch_cmd is not set if provided to the FluxExecutor directly. Many jobs are likely to start already with access to a flux instance, in which case the launch command should use flux submit instead of flux start.
Solution: Ensure the launch_cmd is set.

# Description

Please include a summary of the change and (optionally) which issue is fixed. Please also include
relevant motivation and context.

Fixes #2633 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
