### PR TITLE
Improved extraction of the job ID from sbatch stdout

### DIFF
--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -73,8 +73,8 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
     scheduler_options : str
         String to prepend to the #SBATCH blocks in the submit script to the scheduler.
     regex_job_id : str
-        The regular expression used to extract the job ID from the `sbatch` standard output.
-        The default is `r"Submitted batch job (?P<id>\\S*)"`, where `id` is the regular expression
+        The regular expression used to extract the job ID from the ``sbatch`` standard output.
+        The default is ``r"Submitted batch job (?P<id>\\S*)"``, where ``id`` is the regular expression
         symbolic group for the job ID.
     worker_init : str
         Command to be run before starting a worker, such as 'module load Anaconda; source activate env'.

--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -74,7 +74,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         String to prepend to the #SBATCH blocks in the submit script to the scheduler.
     regex_job_id : str
         The regular expression used to extract the job ID from the `sbatch` standard output.
-        The default is `r"Submitted batch job (?P<id>\S*)"`, where `id` is the regular expression
+        The default is `r"Submitted batch job (?P<id>\\S*)"`, where `id` is the regular expression
         symbolic group for the job ID.
     worker_init : str
         Command to be run before starting a worker, such as 'module load Anaconda; source activate env'.


### PR DESCRIPTION
# Description

On the HPC I'm working (VSC clusters in Flemish universities, Belgium), the output of the `sbatch` command is slightly different from the default and therefore not processed correctly. The consequence is that submitted jobs for workers are not terminated when Parsl shuts down. This error did not result in an error message in `parsl.log`.

This is an example of the output of `sbatch` on one of the VSC clusters:

```
Submitted batch job 60060368 on cluster slaking
```

The fix proposed in this PR introduces a minimal customization with a more robust default than the current implementation. The proposed default is consistent with the current behavior and works for us too.

I'm happy to address any concerns. Thank you for considering this change and for making Parls in the first place!

## Type of change

- Bug fix (non-breaking change that fixes an issue)
