### PR TITLE
Make interchange threads daemons for less-hangy exit

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -351,11 +351,13 @@ class Interchange(object):
         start = time.time()
 
         self._task_puller_thread = threading.Thread(target=self.task_puller,
-                                                    name="Interchange-Task-Puller")
+                                                    name="Interchange-Task-Puller",
+                                                    daemon=True)
         self._task_puller_thread.start()
 
         self._command_thread = threading.Thread(target=self._command_server,
-                                                name="Interchange-Command")
+                                                name="Interchange-Command",
+                                                daemon=True)
         self._command_thread.start()
 
         kill_event = threading.Event()


### PR DESCRIPTION
When the interchange is killed by SIGINT/Ctrl-C, the main thread exits (due to a SIGINT generated KeyboardInterrupt exception) but the other two interchange threads do not. This means that the interchange process hangs without exiting.

With the behaviour introduced by this PR, the main thread ending will now cause the (now daemon) threads to end too.

This behaviour is different from the SIGTERM behaviour (which is how a clean parsl shutdown happens) - a SIGTERM kills all threads without opportunity for catching the exit, in the current signal handler configuration.

To recreate:

run:

```
pytest parsl/tests/ --config parsl/tests/configs/htex_local_alternate.py  -k 'not cleannet'
```

press ctrl-C after a while

observe a hang and that the interchange process is still alive.

After this PR,

observe a hang and that the interchange process has terminated.

The pytest hang in this post-PR situation comes from a couple of other places at least, that this PR does not address, but it's no longer in the interchange.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
