### PR TITLE
Make htex.connected_managers IPC call into a function

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -534,10 +534,9 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         workers = self.command_client.run("WORKERS")
         return workers
 
-    @property
     def connected_managers(self):
-        workers = self.command_client.run("MANAGERS")
-        return workers
+        managers = self.command_client.run("MANAGERS")
+        return managers
 
     def _hold_block(self, block_id):
         """ Sends hold command to all managers which are in a specific block
@@ -548,7 +547,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
              Block identifier of the block to be put on hold
         """
 
-        managers = self.connected_managers
+        managers = self.connected_managers()
 
         for manager in managers:
             if manager['block_id'] == block_id:
@@ -664,7 +663,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         if block_ids:
             block_ids_to_kill = block_ids
         else:
-            managers = self.connected_managers
+            managers = self.connected_managers()
             block_info = {}  # block id -> list( tasks, idle duration )
             for manager in managers:
                 if not manager['active']:

--- a/parsl/tests/test_scaling/test_scale_down.py
+++ b/parsl/tests/test_scaling/test_scale_down.py
@@ -53,7 +53,7 @@ def test_scale_out():
     dfk = parsl.dfk()
 
     logger.info("initial asserts")
-    assert len(dfk.executors['htex_local'].connected_managers) == 0, "Expected 0 managers at start"
+    assert len(dfk.executors['htex_local'].connected_managers()) == 0, "Expected 0 managers at start"
     assert dfk.executors['htex_local'].outstanding == 0, "Expected 0 tasks at start"
 
     logger.info("launching tasks")
@@ -63,7 +63,7 @@ def test_scale_out():
     time.sleep(15)
 
     logger.info("asserting 5 managers")
-    assert len(dfk.executors['htex_local'].connected_managers) == 5, "Expected 5 managers after some time"
+    assert len(dfk.executors['htex_local'].connected_managers()) == 5, "Expected 5 managers after some time"
 
     logger.info("waiting for all futures to complete")
     [x.result() for x in fus]
@@ -75,6 +75,6 @@ def test_scale_out():
     time.sleep(25)
 
     logger.info("asserting 2 managers remain")
-    assert len(dfk.executors['htex_local'].connected_managers) == 2, "Expected 2 managers when no tasks, lower bound by min_blocks"
+    assert len(dfk.executors['htex_local'].connected_managers()) == 2, "Expected 2 managers when no tasks, lower bound by min_blocks"
 
     logger.info("test passed")


### PR DESCRIPTION
Prior to this PR, htex.connected_managers was a `@property`, which makes reasoning about the effect behaviour of code using this property harder to reason about:

For example, in htex scaling down code, when the interchange code is gone away, the value of executor.connected_managers is a silent hang, not a value.

Two other IPC @property values are not changed by this PR, connected_workers and outstanding, because they are exposed outside of the executor, to core scaling code, and I would like to think about that a bit more.

## Type of change

- Code maintentance/cleanup
