### PR TITLE
Strengthen type annotations in parsl.utils

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -50,6 +50,10 @@ ignore_errors = True
 [mypy-parsl.tests.configs.local_user_opts]
 ignore_missing_imports = True
 
+[mypy-parsl.utils]
+warn_unreachable = True
+disallow_untyped_defs = True
+
 [mypy-flask_sqlalchemy.*]
 ignore_missing_imports = True
 

--- a/parsl/executors/workqueue/exec_parsl_function.py
+++ b/parsl/executors/workqueue/exec_parsl_function.py
@@ -64,9 +64,10 @@ def remap_all_files(mapping, fn_args, fn_kwargs):
         if kwarg in ["inputs", "outputs"]:
             remap_list_of_files(mapping, maybe_file)
         if kwarg in ["stdout", "stderr"]:
-            (fname, mode) = get_std_fname_mode(kwarg, maybe_file)
-            if fname in mapping:
-                fn_kwargs[kwarg] = (mapping[fname], mode)
+            if maybe_file:
+                (fname, mode) = get_std_fname_mode(kwarg, maybe_file)
+                if fname in mapping:
+                    fn_kwargs[kwarg] = (mapping[fname], mode)
         else:
             # Treat anything else as a possible File to be remapped.
             remap_location(mapping, maybe_file)

--- a/parsl/tests/test_bash_apps/test_stdout.py
+++ b/parsl/tests/test_bash_apps/test_stdout.py
@@ -48,10 +48,9 @@ def test_bad_stdout_specs(spec):
     try:
         fn.result()
     except Exception as e:
-        assert isinstance(
-            e, perror.BadStdStreamFile), "Expected BadStdStreamFile, got: {0}".format(type(e))
+        assert isinstance(e, TypeError) or isinstance(e, perror.BadStdStreamFile), "Exception is wrong type"
     else:
-        assert False, "Did not raise expected exception BadStdStreamFile"
+        assert False, "Did not raise expected exception"
 
     return
 
@@ -68,9 +67,8 @@ def test_bad_stderr_file():
 
     try:
         fn.result()
-    except Exception as e:
-        assert isinstance(
-            e, perror.BadStdStreamFile), "Expected BadStdStreamFile, got: {0}".format(type(e))
+    except perror.BadStdStreamFile:
+        pass
     else:
         assert False, "Did not raise expected exception BadStdStreamFile"
 

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -105,11 +105,10 @@ def get_last_checkpoint(rundir: str = "runinfo") -> List[str]:
     return [last_checkpoint]
 
 
+@typeguard.typechecked
 def get_std_fname_mode(fdname: str, stdfspec: Union[str, Tuple[str, str]]) -> Tuple[str, str]:
     import parsl.app.errors as pe
-    if stdfspec is None:
-        return None, None
-    elif isinstance(stdfspec, str):
+    if isinstance(stdfspec, str):
         fname = stdfspec
         mode = 'a+'
     elif isinstance(stdfspec, tuple):
@@ -118,13 +117,6 @@ def get_std_fname_mode(fdname: str, stdfspec: Union[str, Tuple[str, str]]) -> Tu
                    f"{len(stdfspec)}")
             raise pe.BadStdStreamFile(msg, TypeError('Bad Tuple Length'))
         fname, mode = stdfspec
-        if not isinstance(fname, str) or not isinstance(mode, str):
-            msg = (f"std descriptor {fdname} has unexpected type "
-                   f"{type(stdfspec)}")
-            raise pe.BadStdStreamFile(msg, TypeError('Bad Tuple Type'))
-    else:
-        msg = f"std descriptor {fdname} has unexpected type {type(stdfspec)}"
-        raise pe.BadStdStreamFile(msg, TypeError('Bad Tuple Type'))
     return fname, mode
 
 
@@ -255,11 +247,11 @@ class AtomicIDCounter:
     """A class to allocate counter-style IDs, in a thread-safe way.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.count = 0
         self.lock = threading.Lock()
 
-    def get_id(self):
+    def get_id(self) -> int:
         with self.lock:
             new_id = self.count
             self.count += 1


### PR DESCRIPTION
This PR removes some manual type checks in favour of typeguard, which will use the same annotations as mypy.

## Type of change

- Code maintentance/cleanup
