### PR TITLE
Fix some schema problems for other database engines

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -21,7 +21,7 @@ X = TypeVar('X')
 
 try:
     import sqlalchemy as sa
-    from sqlalchemy import Column, Text, Float, Boolean, Integer, DateTime, PrimaryKeyConstraint, Table
+    from sqlalchemy import Column, Text, Float, Boolean, BigInteger, Integer, DateTime, PrimaryKeyConstraint, Table
     from sqlalchemy.orm import Mapper
     from sqlalchemy.orm import mapperlib
     from sqlalchemy.orm import sessionmaker
@@ -132,8 +132,7 @@ class Database:
 
     class Status(Base):
         __tablename__ = STATUS
-        task_id = Column(Integer, sa.ForeignKey(
-            'task.task_id'), nullable=False)
+        task_id = Column(Integer, nullable=False)
         task_status_name = Column(Text, nullable=False)
         timestamp = Column(DateTime, nullable=False)
         run_id = Column(Text, sa.ForeignKey('workflow.run_id'), nullable=False)
@@ -206,7 +205,7 @@ class Database:
         uid = Column('uid', Text, nullable=False)
         block_id = Column('block_id', Text, nullable=False)
         cpu_count = Column('cpu_count', Integer, nullable=False)
-        total_memory = Column('total_memory', Integer, nullable=False)
+        total_memory = Column('total_memory', BigInteger, nullable=False)
         active = Column('active', Boolean, nullable=False)
         worker_count = Column('worker_count', Integer, nullable=False)
         python_v = Column('python_v', Text, nullable=False)
@@ -227,10 +226,8 @@ class Database:
 
     class Resource(Base):
         __tablename__ = RESOURCE
-        try_id = Column('try_id', Integer, sa.ForeignKey(
-            'try.try_id'), nullable=False)
-        task_id = Column('task_id', Integer, sa.ForeignKey(
-            'task.task_id'), nullable=False)
+        try_id = Column('try_id', Integer, nullable=False)
+        task_id = Column('task_id', Integer, nullable=False)
         run_id = Column('run_id', Text, sa.ForeignKey(
             'workflow.run_id'), nullable=False)
         timestamp = Column('timestamp', DateTime, nullable=False)


### PR DESCRIPTION
This is driven by a desire to run on top of other database engines, especially PostgreSQL.

See issue #2073, https://github.com/Parsl/parsl/issues/2073

These schema bugs fixed in this PR are not a problem when running on sqlite3, because sqlite3 does not enforce the broken foreign keys or care about integer size in the same way as postgres.

Changes are:

* Remove foreign keys from status and resource tables into the task and try tables. These key relationships are troublesome in two ways:

  i) by the time a resource or status message is processed, the task/try might not have been created in the task/try tables.

  ii) A task_id or try_id is not a unique identifier of an entry in the task/try tables, because those IDs are re-used across runs, so cannot be used as a foreign key, even if the relevant task/try has been added to the task/try table: it would need to be a composite key including the run id.

* The default INTEGER size in postgres is 32 bit signed, which is insufficient for storing the size of memory of systems with more than 2Gb of RAM in the node table.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
