### PR TITLE
Move ParslError to top level error module

### DIFF
--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -8,15 +8,9 @@ from tblib import Traceback
 from six import reraise
 
 from parsl.data_provider.files import File
+from parsl.errors import ParslError
 
 logger = logging.getLogger(__name__)
-
-
-class ParslError(Exception):
-    """Base class for all exceptions.
-
-    Only to be invoked when a more specific error is not available.
-    """
 
 
 class AppException(ParslError):

--- a/parsl/errors.py
+++ b/parsl/errors.py
@@ -1,6 +1,11 @@
-from parsl.app.errors import ParslError
-
 from typing import List
+
+
+class ParslError(Exception):
+    """Base class for all exceptions.
+
+    Only to be invoked when a more specific error is not available.
+    """
 
 
 class OptionalModuleMissing(ParslError):

--- a/parsl/executors/errors.py
+++ b/parsl/executors/errors.py
@@ -1,5 +1,5 @@
 """Exceptions raise by Executors."""
-from parsl.app.errors import ParslError
+from parsl.errors import ParslError
 from parsl.executors.base import ParslExecutor
 
 

--- a/parsl/executors/workqueue/errors.py
+++ b/parsl/executors/workqueue/errors.py
@@ -1,7 +1,8 @@
-import parsl.app.errors as perror
+from parsl.errors import ParslError
+from parsl.app.errors import AppException
 
 
-class WorkQueueTaskFailure(perror.AppException):
+class WorkQueueTaskFailure(AppException):
     """A failure executing a task in workqueue
 
     Contains:
@@ -14,7 +15,7 @@ class WorkQueueTaskFailure(perror.AppException):
         self.status = status
 
 
-class WorkQueueFailure(perror.ParslError):
+class WorkQueueFailure(ParslError):
     """A failure in the work queue executor that prevented the task to be
     executed.""
     """


### PR DESCRIPTION
This error is not specifically dataflow related, and could be used as a base exception in a bunch of other places, once this move is done.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Code maintentance/cleanup
