### PR TITLE
Deprecate unsafe fork multiprocess in process_worker_pool

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -5,6 +5,7 @@ import threading
 import queue
 import datetime
 import pickle
+import warnings
 from multiprocessing import Queue
 from typing import Dict, Sequence  # noqa F401 (used in type annotation)
 from typing import List, Optional, Tuple, Union
@@ -200,7 +201,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
                  max_workers: Union[int, float] = float('inf'),
                  cpu_affinity: str = 'none',
                  available_accelerators: Union[int, Sequence[str]] = (),
-                 start_method: str = 'fork',
+                 start_method: str = 'spawn',
                  prefetch_capacity: int = 0,
                  heartbeat_threshold: int = 120,
                  heartbeat_period: int = 30,
@@ -253,6 +254,9 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
             raise ValueError('Thread affinity is not available with start method: "thread"')
         if start_method == "thread" and len(available_accelerators) > 0:
             raise ValueError('Accelerator pinning not available with start method: "thread"')
+        if start_method == "fork":
+            logger.warning("The 'fork' start method is deprecated")
+            warnings.warn("The 'fork' start method is deprecated")
 
         # Determine the number of workers per node
         self._workers_per_node = min(max_workers, mem_slots, cpu_slots)


### PR DESCRIPTION
This is part of issue #2343, to remove/reduce the use of the unsafe fork multiprocessing start method throughout Parsl.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
