### PR TITLE
Make changes towards supporting SQLAlchemy 2.0

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-plugins = sqlmypy
+plugins = sqlalchemy.ext.mypy.plugin
 
 # globally disabled error codes:
 #   str-bytes-safe warns that a byte string is formatted into a string.

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -25,7 +25,7 @@ try:
     from sqlalchemy.orm import Mapper
     from sqlalchemy.orm import mapperlib
     from sqlalchemy.orm import sessionmaker
-    from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy.orm import declarative_base
 except ImportError:
     _sqlalchemy_enabled = False
 else:
@@ -68,7 +68,7 @@ class Database:
         self.session = Session()
 
     def _get_mapper(self, table_obj: Table) -> Mapper:
-        all_mappers = set()
+        all_mappers: Set[Mapper] = set()
         for mapper_registry in mapperlib._all_registries():  # type: ignore
             all_mappers.update(mapper_registry.mappers)
         mapper_gen = (

--- a/parsl/tests/test_monitoring/test_basic.py
+++ b/parsl/tests/test_monitoring/test_basic.py
@@ -25,6 +25,7 @@ def test_row_counts():
     # would otherwise fail to import and break even a basic test
     # run.
     import sqlalchemy
+    from sqlalchemy import text
     from parsl.tests.configs.htex_local_alternate import fresh_config
 
     if os.path.exists("runinfo/monitoring.db"):
@@ -47,37 +48,37 @@ def test_row_counts():
     engine = sqlalchemy.create_engine("sqlite:///runinfo/monitoring.db")
     with engine.begin() as connection:
 
-        result = connection.execute("SELECT COUNT(*) FROM workflow")
+        result = connection.execute(text("SELECT COUNT(*) FROM workflow"))
         (c, ) = result.first()
         assert c == 1
 
-        result = connection.execute("SELECT COUNT(*) FROM task")
+        result = connection.execute(text("SELECT COUNT(*) FROM task"))
         (c, ) = result.first()
         assert c == 1
 
-        result = connection.execute("SELECT COUNT(*) FROM try")
+        result = connection.execute(text("SELECT COUNT(*) FROM try"))
         (c, ) = result.first()
         assert c == 1
 
-        result = connection.execute("SELECT COUNT(*) FROM status, try "
-                                    "WHERE status.task_id = try.task_id "
-                                    "AND status.task_status_name='exec_done' "
-                                    "AND task_try_time_running is NULL")
+        result = connection.execute(text("SELECT COUNT(*) FROM status, try "
+                                         "WHERE status.task_id = try.task_id "
+                                         "AND status.task_status_name='exec_done' "
+                                         "AND task_try_time_running is NULL"))
         (c, ) = result.first()
         assert c == 0
 
         # Two entries: one showing manager active, one inactive
-        result = connection.execute("SELECT COUNT(*) FROM node")
+        result = connection.execute(text("SELECT COUNT(*) FROM node"))
         (c, ) = result.first()
         assert c == 2
 
         # There should be one block polling status
         # local provider has a status_polling_interval of 5s
-        result = connection.execute("SELECT COUNT(*) FROM block")
+        result = connection.execute(text("SELECT COUNT(*) FROM block"))
         (c, ) = result.first()
         assert c >= 2
 
-        result = connection.execute("SELECT COUNT(*) FROM resource")
+        result = connection.execute(text("SELECT COUNT(*) FROM resource"))
         (c, ) = result.first()
         assert c >= 1
 

--- a/parsl/tests/test_monitoring/test_db_locks.py
+++ b/parsl/tests/test_monitoring/test_db_locks.py
@@ -16,6 +16,7 @@ def this_app():
 def test_row_counts():
     from parsl.tests.configs.htex_local_alternate import fresh_config
     import sqlalchemy
+    from sqlalchemy import text
     if os.path.exists("runinfo/monitoring.db"):
         logger.info("Monitoring database already exists - deleting")
         os.remove("runinfo/monitoring.db")
@@ -43,8 +44,8 @@ def test_row_counts():
 
     logger.info("Getting a read lock on the monitoring database")
     with engine.begin() as readlock_connection:
-        readlock_connection.execute("BEGIN TRANSACTION")
-        result = readlock_connection.execute("SELECT COUNT(*) FROM workflow")
+        readlock_connection.execute(text("BEGIN TRANSACTION"))
+        result = readlock_connection.execute(text("SELECT COUNT(*) FROM workflow"))
         (c, ) = result.first()
         assert c == 1
         # now readlock_connection should have a read lock that will
@@ -70,15 +71,15 @@ def test_row_counts():
     logger.info("checking database content")
     with engine.begin() as connection:
 
-        result = connection.execute("SELECT COUNT(*) FROM workflow")
+        result = connection.execute(text("SELECT COUNT(*) FROM workflow"))
         (c, ) = result.first()
         assert c == 1
 
-        result = connection.execute("SELECT COUNT(*) FROM task")
+        result = connection.execute(text("SELECT COUNT(*) FROM task"))
         (c, ) = result.first()
         assert c == 1
 
-        result = connection.execute("SELECT COUNT(*) FROM try")
+        result = connection.execute(text("SELECT COUNT(*) FROM try"))
         (c, ) = result.first()
         assert c == 1
 

--- a/parsl/tests/test_monitoring/test_fuzz_zmq.py
+++ b/parsl/tests/test_monitoring/test_fuzz_zmq.py
@@ -17,6 +17,7 @@ def this_app():
 def test_row_counts():
     from parsl.tests.configs.htex_local_alternate import fresh_config
     import sqlalchemy
+    from sqlalchemy import text
 
     if os.path.exists("runinfo/monitoring.db"):
         logger.info("Monitoring database already exists - deleting")
@@ -81,15 +82,15 @@ def test_row_counts():
     engine = sqlalchemy.create_engine("sqlite:///runinfo/monitoring.db")
     with engine.begin() as connection:
 
-        result = connection.execute("SELECT COUNT(*) FROM workflow")
+        result = connection.execute(text("SELECT COUNT(*) FROM workflow"))
         (c, ) = result.first()
         assert c == 1
 
-        result = connection.execute("SELECT COUNT(*) FROM task")
+        result = connection.execute(text("SELECT COUNT(*) FROM task"))
         (c, ) = result.first()
         assert c == 4
 
-        result = connection.execute("SELECT COUNT(*) FROM try")
+        result = connection.execute(text("SELECT COUNT(*) FROM try"))
         (c, ) = result.first()
         assert c == 4
 

--- a/parsl/tests/test_monitoring/test_memoization_representation.py
+++ b/parsl/tests/test_monitoring/test_memoization_representation.py
@@ -15,6 +15,7 @@ def this_app(x):
 @pytest.mark.local
 def test_hashsum():
     import sqlalchemy
+    from sqlalchemy import text
     from parsl.tests.configs.htex_local_alternate import fresh_config
 
     if os.path.exists("runinfo/monitoring.db"):
@@ -56,24 +57,24 @@ def test_hashsum():
 
         # we should have three tasks, but with only two tries, because the
         # memo try should be missing
-        result = connection.execute("SELECT COUNT(*) FROM task")
+        result = connection.execute(text("SELECT COUNT(*) FROM task"))
         (task_count, ) = result.first()
         assert task_count == 4
 
         # this will check that the number of task rows for each hashsum matches the above app invocations
-        result = connection.execute(f"SELECT COUNT(task_hashsum) FROM task WHERE task_hashsum='{f1.task_def['hashsum']}'")
+        result = connection.execute(text(f"SELECT COUNT(task_hashsum) FROM task WHERE task_hashsum='{f1.task_def['hashsum']}'"))
         (hashsum_count, ) = result.first()
         assert hashsum_count == 3
 
-        result = connection.execute(f"SELECT COUNT(task_hashsum) FROM task WHERE task_hashsum='{f2.task_def['hashsum']}'")
+        result = connection.execute(text(f"SELECT COUNT(task_hashsum) FROM task WHERE task_hashsum='{f2.task_def['hashsum']}'"))
         (hashsum_count, ) = result.first()
         assert hashsum_count == 1
 
-        result = connection.execute("SELECT COUNT(*) FROM status WHERE task_status_name='exec_done'")
+        result = connection.execute(text("SELECT COUNT(*) FROM status WHERE task_status_name='exec_done'"))
         (memo_count, ) = result.first()
         assert memo_count == 2
 
-        result = connection.execute("SELECT COUNT(*) FROM status WHERE task_status_name='memo_done'")
+        result = connection.execute(text("SELECT COUNT(*) FROM status WHERE task_status_name='memo_done'"))
         (memo_count, ) = result.first()
         assert memo_count == 2
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,7 +12,13 @@ mypy==1.1.1
 types-python-dateutil
 types-requests
 types-six
-sqlalchemy-stubs
+
+# sqlalchemy is needed for typechecking, so it's here
+# as well as at runtime for optional monitoring execution
+# (where it's specified in setup.py)
+sqlalchemy>=1.4,<2
+sqlalchemy2-stubs
+
 Sphinx==4.5.0
 twine
 wheel


### PR DESCRIPTION
This PR makes the code able to run with SQLAlchemy 2.0, but does not change the version constraint, as the way that type annotations are handled has changed, and mypy can't be configured in a way which works with both SQLAlchemy 1.4 and 2.0

## Type of change

- New feature (non-breaking change that adds functionality)
