### PR TITLE
Strengthen type checking on serialization code

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -66,6 +66,13 @@ disallow_subclassing_any = True
 warn_unreachable = True
 disallow_untyped_defs = True
 
+[mypy-parsl.serialize.*]
+disallow_untyped_decorators = True
+check_untyped_defs = True
+disallow_subclassing_any = True
+warn_unreachable = True
+disallow_untyped_defs = True
+
 [mypy-parsl.executors.high_throughput.interchange.*]
 check_untyped_defs = True
 

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -594,7 +594,7 @@ def worker(worker_id, pool_id, pool_size, task_queue, result_queue, worker_queue
 
         try:
             result = execute_task(req['buffer'])
-            serialized_result = serialize(result, buffer_threshold=1e6)
+            serialized_result = serialize(result, buffer_threshold=1000000)
         except Exception as e:
             logger.info('Caught an exception: {}'.format(e))
             result_package = {'type': 'result', 'task_id': tid, 'exception': serialize(RemoteExceptionWrapper(*sys.exc_info()))}

--- a/parsl/serialize/base.py
+++ b/parsl/serialize/base.py
@@ -2,6 +2,8 @@ from abc import abstractmethod
 import logging
 import functools
 
+from typing import Any
+
 logger = logging.getLogger(__name__)
 
 # GLOBALS
@@ -13,18 +15,22 @@ class SerializerBase:
     """ Adds shared functionality for all serializer implementations
     """
 
-    def __init_subclass__(cls, *args, **kwargs):
+    def __init_subclass__(cls, **kwargs: Any) -> None:
         """ This forces all child classes to register themselves as
         methods for serializing code or data
         """
-        super().__init_subclass__(*args, **kwargs)
+        super().__init_subclass__(**kwargs)
         if cls._for_code:
             METHODS_MAP_CODE[cls._identifier] = cls
         if cls._for_data:
             METHODS_MAP_DATA[cls._identifier] = cls
 
+    _identifier: bytes
+    _for_code: bool
+    _for_data: bool
+
     @property
-    def identifier(self):
+    def identifier(self) -> bytes:
         """ Get the identifier of the serialization method
 
         Returns
@@ -33,7 +39,7 @@ class SerializerBase:
         """
         return self._identifier
 
-    def chomp(self, payload):
+    def chomp(self, payload: bytes) -> bytes:
         """ If the payload starts with the identifier, return the remaining block
 
         Parameters
@@ -43,21 +49,23 @@ class SerializerBase:
         """
         s_id, payload = payload.split(b'\n', 1)
         if (s_id + b'\n') != self.identifier:
-            raise TypeError("Buffer does not start with parsl.serialize identifier:{}".format(self.identifier))
+            raise TypeError("Buffer does not start with parsl.serialize identifier:{!r}".format(self.identifier))
         return payload
 
-    def enable_caching(self, maxsize=128):
+    def enable_caching(self, maxsize: int = 128) -> None:
         """ Add functools.lru_cache onto the serialize, deserialize methods
         """
 
-        self.serialize = functools.lru_cache(maxsize=maxsize)(self.serialize)
-        self.deserialize = functools.lru_cache(maxsize=maxsize)(self.deserialize)
+        # ignore types here because mypy at the moment is not fond of monkeypatching
+        self.serialize = functools.lru_cache(maxsize=maxsize)(self.serialize)  # type: ignore[method-assign]
+        self.deserialize = functools.lru_cache(maxsize=maxsize)(self.deserialize)  # type: ignore[method-assign]
+
         return
 
     @abstractmethod
-    def serialize(self, data):
+    def serialize(self, data: Any) -> bytes:
         pass
 
     @abstractmethod
-    def deserialize(self, payload):
+    def deserialize(self, payload: bytes) -> Any:
         pass

--- a/parsl/serialize/concretes.py
+++ b/parsl/serialize/concretes.py
@@ -5,6 +5,8 @@ import logging
 logger = logging.getLogger(__name__)
 from parsl.serialize.base import SerializerBase
 
+from typing import Any
+
 
 class PickleSerializer(SerializerBase):
     """ Pickle serialization covers most python objects, with some notable exceptions:
@@ -19,11 +21,11 @@ class PickleSerializer(SerializerBase):
     _for_code = True
     _for_data = True
 
-    def serialize(self, data):
+    def serialize(self, data: Any) -> bytes:
         x = pickle.dumps(data)
         return self.identifier + x
 
-    def deserialize(self, payload):
+    def deserialize(self, payload: bytes) -> Any:
         chomped = self.chomp(payload)
         data = pickle.loads(chomped)
         return data
@@ -45,11 +47,11 @@ class DillSerializer(SerializerBase):
     _for_code = True
     _for_data = True
 
-    def serialize(self, data):
+    def serialize(self, data: Any) -> bytes:
         x = dill.dumps(data)
         return self.identifier + x
 
-    def deserialize(self, payload):
+    def deserialize(self, payload: bytes) -> Any:
         chomped = self.chomp(payload)
         data = dill.loads(chomped)
         return data


### PR DESCRIPTION
This PR switches __init_subclass__  to using only kwargs, as shown in PEP487.
A few docstrings are also corrected and some of the logic is rearranged to make type checking easier.

This is from benc-mypy branch.

## Type of change

- Code maintentance/cleanup
