### PR TITLE
Remove __main__ blocks from test_*

### DIFF
--- a/parsl/tests/sites/test_dynamic_executor.py
+++ b/parsl/tests/sites/test_dynamic_executor.py
@@ -75,7 +75,3 @@ def test_dynamic_executor():
 
     dfk.cleanup()
     parsl.clear()
-
-
-if __name__ == "__main__":
-    test_dynamic_executor()

--- a/parsl/tests/test_bash_apps/test_apptimeout.py
+++ b/parsl/tests/test_bash_apps/test_apptimeout.py
@@ -23,9 +23,3 @@ def test_walltime_longer():
     """Test that an app that runs in less than walltime will succeed."""
     y = echo_to_file(walltime=2)
     y.result()
-
-
-if __name__ == "__main__":
-    parsl.clear()
-    parsl.load(config)
-    test_walltime()

--- a/parsl/tests/test_bash_apps/test_basic.py
+++ b/parsl/tests/test_bash_apps/test_basic.py
@@ -113,23 +113,3 @@ def test_parallel_for(n=3):
                                                                          n, outdir)
     print("[TEST STATUS] test_parallel_for [SUCCESS]")
     return d
-
-
-if __name__ == '__main__':
-    parsl.clear()
-    dfk = parsl.load(config)
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    x = test_parallel_for(int(args.count))
-    y = test_command_format_1()
-    z = test_auto_log_filename_format()
-    # raise_error(0)

--- a/parsl/tests/test_bash_apps/test_file_bug_1.py
+++ b/parsl/tests/test_bash_apps/test_file_bug_1.py
@@ -49,20 +49,3 @@ def test_behavior():
         expected_name = f.read()
 
     assert name == expected_name, "Filename mangled due to DataFuture handling"
-
-
-if __name__ == '__main__':
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    x = test_behavior()
-
-    # raise_error(0)

--- a/parsl/tests/test_bash_apps/test_memoize.py
+++ b/parsl/tests/test_bash_apps/test_memoize.py
@@ -70,20 +70,3 @@ def test_bash_memoization_keywords(n=2):
 
     for i in d:
         assert d[i].exception() is None
-
-
-if __name__ == '__main__':
-    parsl.clear()
-    parsl.load(config)
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    x = test_bash_memoization(n=4)

--- a/parsl/tests/test_bash_apps/test_multiline.py
+++ b/parsl/tests/test_bash_apps/test_multiline.py
@@ -61,17 +61,3 @@ def test_multiline():
     os.remove('std.err')
     os.remove('std.out')
     return True
-
-
-if __name__ == '__main__':
-    parsl.clear()
-    dfk = parsl.load(config)
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    # if args.debug:
-    #    parsl.set_stream_logger()
-    test_multiline()

--- a/parsl/tests/test_bash_apps/test_pipeline.py
+++ b/parsl/tests/test_bash_apps/test_pipeline.py
@@ -118,22 +118,3 @@ def test_increment_slow(depth=5, dur=0.5):
                 key), "[TEST] incr failed for key: {0} got: {1}".format(key, data)
 
     cleanup_work(depth)
-
-
-if __name__ == '__main__':
-    parsl.clear()
-    dfk = parsl.load(config)
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-w", "--width", default="5",
-                        help="width of the pipeline")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    # test_increment(depth=int(args.width))
-    # test_increment(depth=int(args.width))
-    test_increment_slow(depth=int(args.width))

--- a/parsl/tests/test_bash_apps/test_stdout.py
+++ b/parsl/tests/test_bash_apps/test_stdout.py
@@ -113,25 +113,3 @@ def test_stdout_append():
     assert len1 == 1 and len2 == 2, "Line count of output files should be 1 and 2, but:  len1={} len2={}".format(len1, len2)
 
     os.system('rm -f ' + out + ' ' + err)
-
-
-if __name__ == '__main__':
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Enable debug output to console")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    parsl.load(config)
-
-    # test_bad_stdout_specs is omitted because it is called in a
-    # more complicated parameterised fashion by pytest.
-
-    y = test_bad_stderr_file()
-    y = test_stdout_truncate()
-    y = test_stdout_append()

--- a/parsl/tests/test_checkpointing/test_periodic.py
+++ b/parsl/tests/test_checkpointing/test_periodic.py
@@ -64,18 +64,3 @@ def test_periodic(n=4):
         deltas = [tstamp_to_seconds(line) for line in lines]
         assert deltas[1] - deltas[0] < 5.5, "Delta between checkpoints exceeded period"
         assert deltas[2] - deltas[1] < 5.5, "Delta between checkpoints exceeded period"
-
-
-if __name__ == '__main__':
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    x = test_periodic(n=4)

--- a/parsl/tests/test_checkpointing/test_python_checkpoint_1.py
+++ b/parsl/tests/test_checkpointing/test_python_checkpoint_1.py
@@ -51,18 +51,3 @@ def test_initial_checkpoint_write(n=2):
     parsl.clear()
 
     return run_dir, results
-
-
-if __name__ == '__main__':
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    x = test_initial_checkpoint_write(n=4)

--- a/parsl/tests/test_checkpointing/test_python_checkpoint_2.py
+++ b/parsl/tests/test_checkpointing/test_python_checkpoint_2.py
@@ -43,18 +43,3 @@ def test_loading_checkpoint(n=2):
         assert relaunched[i] == results[i], "Expected relaunched to contain cached results from first run"
     parsl.dfk().cleanup()
     parsl.clear()
-
-
-if __name__ == '__main__':
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    x = test_loading_checkpoint()

--- a/parsl/tests/test_checkpointing/test_regression_232.py
+++ b/parsl/tests/test_checkpointing/test_regression_232.py
@@ -84,9 +84,3 @@ def test_regress_232_dfk_exit(count=2):
         print("Tasks from cache : ", tasks)
         assert len(tasks) == count, "Expected {} checkpoint events, got {}".format(
             1, len(tasks))
-
-
-if __name__ == "__main__":
-
-    test_regress_232_task_exit()
-    test_regress_232_dfk_exit()

--- a/parsl/tests/test_checkpointing/test_regression_233.py
+++ b/parsl/tests/test_checkpointing/test_regression_233.py
@@ -73,10 +73,3 @@ def test_checkpoint_availability():
     print(original)
 
     assert cached == original, "All tasks were not cached"
-
-
-if __name__ == "__main__":
-
-    test_checkpoint_availability()
-    # test_regress_234()
-    # test_slower_apps()

--- a/parsl/tests/test_checkpointing/test_regression_239.py
+++ b/parsl/tests/test_checkpointing/test_regression_239.py
@@ -82,8 +82,3 @@ def test_checkpointing_at_dfk_exit():
             pass
         print("Tasks from cache : ", tasks)
         assert len(tasks) == 1, "Expected {} checkpoint events, got {}".format(1, len(tasks))
-
-
-if __name__ == "__main__":
-    test_regression_239()
-    test_checkpointing_at_dfk_exit()

--- a/parsl/tests/test_checkpointing/test_task_exit.py
+++ b/parsl/tests/test_checkpointing/test_task_exit.py
@@ -64,18 +64,3 @@ def test_at_task_exit(n=2):
             pass
 
         assert len(tasks) == n, "Expected {} checkpoint events, got {}".format(n, len(tasks))
-
-
-if __name__ == '__main__':
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default=10, type=int,
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    x = test_at_task_exit(args.count)

--- a/parsl/tests/test_data/test_file.py
+++ b/parsl/tests/test_data/test_file.py
@@ -30,8 +30,3 @@ def test_open():
 
     with open(str(pfile), 'r') as opfile:
         assert (opfile.readlines()[0] == 'Hello')
-
-
-if __name__ == '__main__':
-
-    test_files()

--- a/parsl/tests/test_data/test_file_apps.py
+++ b/parsl/tests/test_data/test_file_apps.py
@@ -72,11 +72,3 @@ def test_increment(depth=5):
             data = open(fu.result().filepath, 'r').read().strip()
             assert data == str(
                 key), "[TEST] incr failed for key:{0} got:{1}".format(key, data)
-
-
-if __name__ == '__main__':
-    parsl.clear()
-    parsl.load(config)
-
-    test_files()
-    test_increment()

--- a/parsl/tests/test_docs/test_tutorial_1.py
+++ b/parsl/tests/test_docs/test_tutorial_1.py
@@ -45,18 +45,3 @@ def test_app_future_result():
     print("Launching and waiting on data_futs")
     print("Done?   : ", sim_fut.done())
     print("Result? : ", sim_fut.result(timeout=1))
-
-
-if __name__ == '__main__':
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    test_data_future_result()

--- a/parsl/tests/test_docs/test_workflow1.py
+++ b/parsl/tests/test_docs/test_workflow1.py
@@ -39,10 +39,3 @@ def test_procedural(N=2):
         item = int(f.read().strip())
         assert item <= N, "Expected file to contain int <= N"
         assert item >= 1, "Expected file to contain int >= 1"
-
-
-if __name__ == "__main__":
-    parsl.clear()
-    parsl.load(config)
-
-    test_procedural()

--- a/parsl/tests/test_docs/test_workflow2.py
+++ b/parsl/tests/test_docs/test_workflow2.py
@@ -41,8 +41,3 @@ def test_parallel(N=2):
     assert doubled_z.result() == N * \
         2, "Expected doubled_z = N*2 = {0}".format(N * 2)
     assert delta > 4 and delta < 5, "Time delta exceeded expected 4 < duration < 5"
-
-
-if __name__ == "__main__":
-
-    test_parallel()

--- a/parsl/tests/test_docs/test_workflow3.py
+++ b/parsl/tests/test_docs/test_workflow3.py
@@ -21,10 +21,3 @@ def test_parallel_for(N=2):
     # wait for all apps to finish and collect the results
     outputs = [i.result() for i in rand_nums]
     return outputs
-
-
-if __name__ == "__main__":
-
-    parsl.clear()
-    parsl.load(config)
-    test_parallel_for()

--- a/parsl/tests/test_docs/test_workflow4.py
+++ b/parsl/tests/test_docs/test_workflow4.py
@@ -51,10 +51,3 @@ def test_parallel_dataflow():
     # calculate the average of the random numbers
     totals = total(inputs=[cc.outputs[0]])
     print(totals.result())
-
-
-if __name__ == "__main__":
-    parsl.clear()
-    parsl.load(config)
-
-    test_parallel_dataflow()

--- a/parsl/tests/test_error_handling/test_rand_fail.py
+++ b/parsl/tests/test_error_handling/test_rand_fail.py
@@ -169,22 +169,3 @@ def test_fail_nowait(numtasks=10):
     # fus[0].result()
     time.sleep(1)
     print("Done")
-
-
-if __name__ == "__main__":
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    test_simple()
-    # test_fail_nowait(numtasks=int(args.count))
-    # test_no_deps(numtasks=int(args.count))
-    # test_fail_sequence(numtasks=int(args.count))
-    # test_deps(numtasks=int(args.count))

--- a/parsl/tests/test_error_handling/test_retries.py
+++ b/parsl/tests/test_error_handling/test_retries.py
@@ -109,20 +109,3 @@ def test_retry():
     fu = succeed_on_retry(fname)
 
     fu.result()
-
-
-if __name__ == "__main__":
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    test_fail_nowait(numtasks=int(args.count))
-    # test_fail_delayed(numtasks=int(args.count))
-    # test_retry()

--- a/parsl/tests/test_flowcontrol/test_python.py
+++ b/parsl/tests/test_flowcontrol/test_python.py
@@ -28,8 +28,3 @@ def test_python(N=2):
     print("Waiting ....")
     for i in range(0, N):
         print(results[0].result())
-
-
-if __name__ == '__main__':
-
-    test_python()

--- a/parsl/tests/test_monitoring/test_basic.py
+++ b/parsl/tests/test_monitoring/test_basic.py
@@ -83,7 +83,3 @@ def test_row_counts():
         assert c >= 1
 
     logger.info("all done")
-
-
-if __name__ == "__main__":
-    test_row_counts()

--- a/parsl/tests/test_python_apps/test_at_scale.py
+++ b/parsl/tests/test_python_apps/test_at_scale.py
@@ -61,20 +61,3 @@ def test_parallel2(n=2):
     print("Total time : ", ttc)
 
     return ttc
-
-
-if __name__ == '__main__':
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    x = test_plain(int(args.count))
-    x = test_parallel(int(args.count))
-    x = test_parallel2(int(args.count))

--- a/parsl/tests/test_python_apps/test_fail.py
+++ b/parsl/tests/test_python_apps/test_fail.py
@@ -104,19 +104,3 @@ def test_deps(numtasks=2):
         assert False, "Expected DependencyError but got: %s" % e
     else:
         raise RuntimeError("Expected DependencyError, but got no exception")
-
-
-if __name__ == "__main__":
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    test_no_deps(numtasks=int(args.count))
-    test_fail_sequence(numtasks=int(args.count))

--- a/parsl/tests/test_python_apps/test_fibonacci_iterative.py
+++ b/parsl/tests/test_python_apps/test_fibonacci_iterative.py
@@ -23,13 +23,3 @@ def test_fibonacci(num=3):
             print(results[i])
         else:
             print(results[i].result())
-
-
-if __name__ == '__main__':
-    parsl.clear()
-    parsl.load(config)
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-a", "--num", default="5",
-                        action="store", dest="a", type=int)
-    args = parser.parse_args()
-    test_fibonacci(args.a)

--- a/parsl/tests/test_python_apps/test_futures.py
+++ b/parsl/tests/test_python_apps/test_futures.py
@@ -129,24 +129,3 @@ def test_fut_case_4():
     assert contents == '3', 'Output does not match expected "3", got: "{0}"'.format(
         result)
     return True
-
-
-if __name__ == '__main__':
-    parsl.clear()
-    parsl.load(config)
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    # x = test_parallel_for(int(args.count))
-    # y = test_fut_case_2()
-    # y = test_fut_case_3()
-    y = test_fut_case_4()
-    # raise_error(0)

--- a/parsl/tests/test_python_apps/test_garbage_collect.py
+++ b/parsl/tests/test_python_apps/test_garbage_collect.py
@@ -28,11 +28,3 @@ def test_garbage_collect():
 
     time.sleep(0.2)  # Give enough time for task wipes to work
     assert x.tid not in parsl.dfk().tasks, "Task record should be wiped after task completion"
-
-
-if __name__ == '__main__':
-
-    from parsl.tests.configs.htex_local_alternate import config
-    parsl.load(config)
-    # parsl.load()
-    test_garbage_collect()

--- a/parsl/tests/test_python_apps/test_mapred.py
+++ b/parsl/tests/test_python_apps/test_mapred.py
@@ -57,33 +57,3 @@ def test_mapred_type2(width=2):
     r = sum([x * 2 for x in range(1, width + 1)])
     assert r == red.result(), "[TEST] MapRed type2 expected %s, got %s" % (
         r, red.result())
-
-
-if __name__ == '__main__':
-
-    parsl.clear()
-    parsl.load(config)
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-w", "--width", default="5",
-                        help="width of the pipeline")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    tests = [test_mapred_type1, test_mapred_type2]
-    for test in tests:
-        print("*" * 50)
-        try:
-
-            test(width=int(args.width))
-        except AssertionError as e:
-            print("[TEST]  %s [FAILED]" % test.__name__)
-            print(e)
-        else:
-            print("[TEST]  %s type [SUCCESS]" % test.__name__)
-
-        print("*" * 50)

--- a/parsl/tests/test_python_apps/test_memoize_1.py
+++ b/parsl/tests/test_python_apps/test_memoize_1.py
@@ -21,20 +21,3 @@ def test_python_memoization(n=2):
         foo = random_uuid(0)
         print(foo.result())
         assert foo.result() == x.result(), "Memoized results were not used"
-
-
-if __name__ == '__main__':
-    parsl.clear()
-    parsl.load(config)
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    x = test_python_memoization(n=4)

--- a/parsl/tests/test_python_apps/test_memoize_2.py
+++ b/parsl/tests/test_python_apps/test_memoize_2.py
@@ -23,18 +23,3 @@ def test_python_memoization(n=2):
         foo = random_uuid(0)
         assert foo.result() != x.result(
         ), "Memoized results were used when memoization was disabled"
-
-
-if __name__ == '__main__':
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    x = test_python_memoization(n=4)

--- a/parsl/tests/test_python_apps/test_memoize_4.py
+++ b/parsl/tests/test_python_apps/test_memoize_4.py
@@ -24,21 +24,3 @@ def test_python_memoization(n=2):
 
     y = random_uuid(0)
     assert x.result() != y.result(), "Memoized results were not used"
-
-
-if __name__ == '__main__':
-    parsl.clear()
-    parsl.load(config)
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    x = test_python_memoization(n=4)
-    # x = test_bash_memoization (n=4)

--- a/parsl/tests/test_python_apps/test_outputs.py
+++ b/parsl/tests/test_python_apps/test_outputs.py
@@ -39,14 +39,3 @@ def test_launch_apps(n=2, outdir='outputs'):
         [item for item in os.listdir(outdir) if item.endswith('.txt')])
     assert stdout_file_count == n, "Only {}/{} files in '{}' ".format(
             len(os.listdir('outputs/')), n, os.listdir(outdir))
-
-
-if __name__ == '__main__':
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    x = test_launch_apps(2, "outputs")
-    # raise_error(0)

--- a/parsl/tests/test_python_apps/test_overview.py
+++ b/parsl/tests/test_python_apps/test_overview.py
@@ -58,29 +58,3 @@ def test_2(N=10):
 
     assert total.result() != sum(items), "Sum is wrong {0} != {1}".format(
         total.result(), sum(items))
-
-
-if __name__ == "__main__":
-
-    parsl.clear()
-    parsl.load(config)
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Debug enable flag")
-    parser.add_argument("-c", "--count", default='100',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    # print("Launching with 10")
-    # test_1(10)
-    print("Launching with {0}".format(args.count))
-    test_1(int(args.count))
-
-    # print("Launching slow with 10")
-    # test_2(10)
-    # print("Launching slow with 20")
-    # test_2(20)

--- a/parsl/tests/test_python_apps/test_pipeline.py
+++ b/parsl/tests/test_python_apps/test_pipeline.py
@@ -36,21 +36,3 @@ def test_increment_slow(depth=2):
 
     print(futs[i])
     print([futs[i].result() for i in futs if not isinstance(futs[i], int)])
-
-
-if __name__ == '__main__':
-    parsl.clear()
-    parsl.load(config)
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-w", "--width", default="5",
-                        help="width of the pipeline")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    # test_increment(depth=int(args.width))
-    test_increment_slow(depth=int(args.width))

--- a/parsl/tests/test_python_apps/test_type5.py
+++ b/parsl/tests/test_python_apps/test_type5.py
@@ -59,32 +59,3 @@ def test_func_2(width=2):
     assert sum([i.result() for i in fu_2]) == sum(
         range(1, width + 1)) * 2, "Sums do not match"
     return fu_2
-
-
-if __name__ == '__main__':
-    parsl.clear()
-    parsl.load(config)
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-w", "--width", default="10",
-                        help="width of the pipeline")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    tests = [test_func_1, test_func_2]
-    for test in tests:
-        print("*" * 50)
-        try:
-
-            test(width=int(args.width))
-        except AssertionError as e:
-            print("[TEST]  %s [FAILED]" % test.__name__)
-            print(e)
-        else:
-            print("[TEST]  %s type [SUCCESS]" % test.__name__)
-
-        print("*" * 50)

--- a/parsl/tests/test_python_apps/test_worker_fail.py
+++ b/parsl/tests/test_python_apps/test_worker_fail.py
@@ -28,21 +28,3 @@ def test_parallel_for(n=2):
     print("Duration : {0}s".format(time.time() - start))
     print("[TEST STATUS] test_parallel_for [SUCCESS]")
     return d
-
-
-if __name__ == '__main__':
-    parsl.clear()
-    parsl.load(config)
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--count", default="10",
-                        help="Count of apps to launch")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    x = test_parallel_for()
-    # x = test_parallel_for(int(args.count))

--- a/parsl/tests/test_regression/test_1480.py
+++ b/parsl/tests/test_regression/test_1480.py
@@ -17,7 +17,3 @@ def test_1480(size=10**6):
     # Before PR#1841 this would have raised a TypeError
     # Now, with the threshold increased this should not trigger any error
     assert len(x.result()) == size, "Lengths do not match"
-
-
-if __name__ == "__main__":
-    test_1480()

--- a/parsl/tests/test_regression/test_1653.py
+++ b/parsl/tests/test_regression/test_1653.py
@@ -19,7 +19,3 @@ def test_1653():
 
     x = compute_descript(size=1000).result()
     assert x.shape == (1000,), "Got incorrect numpy shape"
-
-
-if __name__ == "__main__":
-    test_1653()

--- a/parsl/tests/test_regression/test_221.py
+++ b/parsl/tests/test_regression/test_221.py
@@ -27,8 +27,3 @@ def test_cleanup_behavior_221():
     for i in round_1:
         f = slow_double(i)
         round_2.append(f)
-
-
-if __name__ == "__main__":
-
-    test_cleanup_behavior_221()

--- a/parsl/tests/test_regression/test_226.py
+++ b/parsl/tests/test_regression/test_226.py
@@ -69,9 +69,3 @@ def test_bash_default_arg():
     echo('hello').result()
     with open('std.out', 'r') as f:
         assert f.read().strip() == 'hello there', "Output should be 'hello there'"
-
-
-if __name__ == '__main__':
-    test_no_eq()
-    test_bash_default_arg()
-    test_get_dataframe()

--- a/parsl/tests/test_regression/test_69a.py
+++ b/parsl/tests/test_regression/test_69a.py
@@ -67,9 +67,3 @@ def test_delayed_datafuture():
     state_3 = d_fu.__str__()
     print("State_3 : ", state_3, "Fu:", fu.parent)
     assert "finished" in state_3, "DataFuture should now be finished"
-
-
-if __name__ == "__main__":
-
-    test_immediate_datafuture()
-    test_delayed_datafuture()

--- a/parsl/tests/test_regression/test_69b.py
+++ b/parsl/tests/test_regression/test_69b.py
@@ -123,13 +123,3 @@ def test_5():
     hello2.result()
     with open(hello2.outputs[0].result().filepath, 'r') as f:
         print(f.read())
-
-
-if __name__ == "__main__":
-    parsl.clear()
-    parsl.load(config)
-    test_1()
-    test_2()
-    test_3()
-    test_4()
-    test_5()

--- a/parsl/tests/test_regression/test_854.py
+++ b/parsl/tests/test_regression/test_854.py
@@ -58,9 +58,3 @@ def test_mac_safe_queue_size():
     assert result_q.empty() is False, "Result queue should not be empty"
     qlen = result_q.qsize()
     assert qlen == x + 1, "Result queue should be {}; instead got {}".format(x + 1, qlen)
-
-
-if __name__ == "__main__":
-
-    test_mac_safe_queue()
-    test_mac_safe_queue_size()

--- a/parsl/tests/test_regression/test_97.py
+++ b/parsl/tests/test_regression/test_97.py
@@ -33,9 +33,3 @@ def test_python(N=2):
     print("Waiting ....")
     for i in range(0, N):
         print(results[0].result())
-
-
-if __name__ == '__main__':
-
-    parsl.set_stream_logger()
-    test_python()

--- a/parsl/tests/test_regression/test_98.py
+++ b/parsl/tests/test_regression/test_98.py
@@ -22,16 +22,3 @@ def test_immutable_config(n=2):
 
     dfk.cleanup()
     assert original == after, "Config modified"
-
-
-if __name__ == '__main__':
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    x = test_immutable_config()

--- a/parsl/tests/test_staging/test_staging_globus.py
+++ b/parsl/tests/test_staging/test_staging_globus.py
@@ -69,18 +69,3 @@ def test_stage_in_out_globus():
     assert sorted_file is result_file, "Result file is not the specified input-output file"
 
     assert result_file.local_path is None, "Result file on local side has overridden local_path, file: {}".format(repr(result_file))
-
-
-if __name__ == "__main__":
-
-    import argparse
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
-    args = parser.parse_args()
-
-    if args.debug:
-        parsl.set_stream_logger()
-
-    test_stage_in_out_globus()

--- a/parsl/tests/test_swift.py
+++ b/parsl/tests/test_swift.py
@@ -1,7 +1,5 @@
 import pytest
 
-import parsl
-
 from parsl.executors.swift_t import TurbineExecutor
 
 
@@ -54,13 +52,3 @@ def test_except():
         tex.start()
         x = tex.submit(bad_foo, 5, 10)
         x.result()
-
-
-if __name__ == "__main__":
-    parsl.set_stream_logger()
-
-    # test_simple()
-    # test_slow()
-    test_except()
-
-    print("Done")

--- a/parsl/tests/test_thread_parallelism.py
+++ b/parsl/tests/test_thread_parallelism.py
@@ -63,9 +63,3 @@ def test_parallel_sleep_python(n=3, sleep_dur=2, tolerance=0.3):
     print("Sleep time : {0}, expected ~{1}+/- 0.3s".format(delta, sleep_dur))
     assert delta > sleep_dur - tolerance, "Slept too little"
     assert delta < sleep_dur + tolerance, "Slept too much"
-
-
-if __name__ == "__main__":
-
-    test_parallel_sleep_bash()
-    test_parallel_sleep_python()

--- a/parsl/tests/test_threads/test_configs.py
+++ b/parsl/tests/test_threads/test_configs.py
@@ -32,8 +32,3 @@ def test_parallel_for():
     dfk.cleanup()
     parsl.clear()
     return d
-
-
-if __name__ == "__main__":
-
-    test_parallel_for()

--- a/parsl/tests/test_threads/test_lazy_errors.py
+++ b/parsl/tests/test_threads/test_lazy_errors.py
@@ -26,8 +26,3 @@ def test_lazy_behavior():
     parsl.dfk().cleanup()
     parsl.clear()
     return
-
-
-if __name__ == "__main__":
-
-    test_lazy_behavior()


### PR DESCRIPTION
These tests are all run through pytest, rather than executing as a main process, and the __main__ blocks are often broken which causes problems for static analysis with mypy, and with human understanding of how a test is meant to work.

Previous PRs have removed __main__ blocks from tests individually, but this PR does the entire test_* tree.

## Type of change

- Code maintentance/cleanup
