### PR TITLE
Remove unused return value of HOLD_WORKER and replace with a log message

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -505,7 +505,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         else:
             logger.error("Management thread already exists, returning")
 
-    def hold_worker(self, worker_id):
+    def hold_worker(self, worker_id: str) -> None:
         """Puts a worker on hold, preventing scheduling of additional tasks to it.
 
         This is called "hold" mostly because this only stops scheduling of tasks,
@@ -517,9 +517,8 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         worker_id : str
             Worker id to be put on hold
         """
-        c = self.command_client.run("HOLD_WORKER;{}".format(worker_id))
+        self.command_client.run("HOLD_WORKER;{}".format(worker_id))
         logger.debug("Sent hold request to manager: {}".format(worker_id))
-        return c
 
     @property
     def outstanding(self):

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -312,10 +312,11 @@ class Interchange:
                     if manager_id in self._ready_managers:
                         m = self._ready_managers[manager_id]
                         m['active'] = False
-                        reply = True
                         self._send_monitoring_info(hub_channel, m)
                     else:
-                        reply = False
+                        logger.warning("Worker to hold was not in ready managers list")
+
+                    reply = None
 
                 else:
                     reply = None


### PR DESCRIPTION
Previously the return value, which indicated if a worker to hold was in the ready managers dictionary or not, was discarded. This PR makes that code path now log an explicit warning in the interchange.

## Type of change

- Code maintentance/cleanup
