### PR TITLE
Move an idempotent loop out of another loop in serialization

### DIFF
--- a/parsl/serialize/facade.py
+++ b/parsl/serialize/facade.py
@@ -19,8 +19,8 @@ for key in METHODS_MAP_CODE:
     methods_for_code[key] = METHODS_MAP_CODE[key]()
     methods_for_code[key].enable_caching(maxsize=128)
 
-    for key in METHODS_MAP_DATA:
-        methods_for_data[key] = METHODS_MAP_DATA[key]()
+for key in METHODS_MAP_DATA:
+    methods_for_data[key] = METHODS_MAP_DATA[key]()
 
 
 def _list_methods() -> Tuple[Dict[bytes, SerializerBase], Dict[bytes, SerializerBase]]:


### PR DESCRIPTION
This inner loop populates a table of data serializers, which should happen at the same level as populating the table of code serializers, rather than as an inner loop of code serializer population.

This inner loop is idempotent, so the behaviour should mostly be unchanged by this PR, but in the obscure situation that someone modifies serialisation so that it has no code serializers, only data serializers, then before this PR, I think those data serializers would not be visible to users, as the inner loop would never be executed.

This was introduced by PR #2467 which moved away from using a class singleton to using the module as the singleton.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
