### PR TITLE
Rename a test_* function that isn't a pytest test

### DIFF
--- a/parsl/tests/sites/test_start_method.py
+++ b/parsl/tests/sites/test_start_method.py
@@ -12,7 +12,7 @@ from parsl import python_app
 
 
 @python_app()
-def test_function():
+def get_pid():
     return os.getpid()
 
 
@@ -47,7 +47,7 @@ def config(start_method: str, **kwargs):
 def test_spawn_method(start_method: str):
     with config(start_method):
         # Get the PID for the child function as a way of making sure it launches
-        future = test_function()
+        future = get_pid()
         remote_pid = future.result()
         assert remote_pid != os.getpid()
 


### PR DESCRIPTION
pytest was giving a warning here that test_function wasn't a function (and if it was, it would have tried to run it as a test).

In the parsl/tests/ directory, only pytest tests are allowed to use module level names of the form test_*.

## Type of change

- Code maintentance/cleanup
