### PR TITLE
Add test that visualization coloring tables color each known state

### DIFF
--- a/parsl/monitoring/visualization/plots/default/workflow_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_plots.py
@@ -9,6 +9,22 @@ import networkx as nx
 from parsl.monitoring.visualization.utils import timestamp_to_int, num_to_timestamp, DB_DATE_FORMAT
 
 
+# gantt_colors must assign a color value for every state name defined
+# in parsl/dataflow/states.py
+gantt_colors = {'unsched': 'rgb(240, 240, 240)',
+                'pending': 'rgb(168, 168, 168)',
+                'launched': 'rgb(100, 255, 255)',
+                'running': 'rgb(0, 0, 255)',
+                'running_ended': 'rgb(64, 64, 255)',
+                'joining': 'rgb(128, 128, 255)',
+                'dep_fail': 'rgb(255, 128, 255)',
+                'failed': 'rgb(200, 0, 0)',
+                'exec_done': 'rgb(0, 200, 0)',
+                'memo_done': 'rgb(64, 200, 64)',
+                'fail_retryable': 'rgb(200, 128,128)'
+               }
+
+
 def task_gantt_plot(df_task, df_status, time_completed=None):
 
     # if the workflow is not recorded as completed, then assume
@@ -47,25 +63,9 @@ def task_gantt_plot(df_task, df_status, time_completed=None):
                               }
             parsl_tasks.extend([last_status_bar])
 
-    # colours must assign a colour value for every state name defined
-    # in parsl/dataflow/states.py
-
-    colors = {'unsched': 'rgb(240, 240, 240)',
-              'pending': 'rgb(168, 168, 168)',
-              'launched': 'rgb(100, 255, 255)',
-              'running': 'rgb(0, 0, 255)',
-              'running_ended': 'rgb(64, 64, 255)',
-              'joining': 'rgb(128, 128, 255)',
-              'dep_fail': 'rgb(255, 128, 255)',
-              'failed': 'rgb(200, 0, 0)',
-              'exec_done': 'rgb(0, 200, 0)',
-              'memo_done': 'rgb(64, 200, 64)',
-              'fail_retryable': 'rgb(200, 128,128)'
-             }
-
     fig = ff.create_gantt(parsl_tasks,
                           title="",
-                          colors=colors,
+                          colors=gantt_colors,
                           group_tasks=True,
                           show_colorbar=True,
                           index_col='Resource',
@@ -194,6 +194,20 @@ def total_tasks_plot(df_task, df_status, columns=20):
     return plot(fig, show_link=False, output_type="div", include_plotlyjs=False)
 
 
+dag_state_colors = {"unsched": (0, 'rgb(240, 240, 240)'),
+                    "pending": (1, 'rgb(168, 168, 168)'),
+                    "launched": (2, 'rgb(100, 255, 255)'),
+                    "running": (3, 'rgb(0, 0, 255)'),
+                    "dep_fail": (4, 'rgb(255, 128, 255)'),
+                    "failed": (5, 'rgb(200, 0, 0)'),
+                    "exec_done": (6, 'rgb(0, 200, 0)'),
+                    "memo_done": (7, 'rgb(64, 200, 64)'),
+                    "fail_retryable": (8, 'rgb(200, 128,128)'),
+                    "joining": (9, 'rgb(128, 128, 255)'),
+                    "running_ended": (10, 'rgb(64, 64, 255)')
+                   }
+
+
 def workflow_dag_plot(df_tasks, group_by_apps=True):
     G = nx.DiGraph(directed=True)
     nodes = df_tasks['task_id'].unique()
@@ -215,18 +229,7 @@ def workflow_dag_plot(df_tasks, group_by_apps=True):
         groups_list = {app: (i, None) for i, app in enumerate(
             df_tasks['task_func_name'].unique())}
     else:
-        groups_list = {"unsched": (0, 'rgb(240, 240, 240)'),
-                       "pending": (1, 'rgb(168, 168, 168)'),
-                       "launched": (2, 'rgb(100, 255, 255)'),
-                       "running": (3, 'rgb(0, 0, 255)'),
-                       "dep_fail": (4, 'rgb(255, 128, 255)'),
-                       "failed": (5, 'rgb(200, 0, 0)'),
-                       "exec_done": (6, 'rgb(0, 200, 0)'),
-                       "memo_done": (7, 'rgb(64, 200, 64)'),
-                       "fail_retryable": (8, 'rgb(200, 128,128)'),
-                       "joining": (9, 'rgb(128, 128, 255)'),
-                       "running_ended": (10, 'rgb(64, 64, 255)')
-                      }
+        groups_list = dag_state_colors
 
     node_traces = [...] * len(groups_list)
 

--- a/parsl/tests/test_monitoring/test_viz_colouring.py
+++ b/parsl/tests/test_monitoring/test_viz_colouring.py
@@ -1,0 +1,17 @@
+import pytest
+from parsl.dataflow.states import States
+
+
+@pytest.mark.local
+def test_all_states_colored() -> None:
+    """This checks that the coloring tables in parsl-visualize contain
+    a color for each state defined in the task state enumeration.
+    """
+
+    # imports inside test because viz can't be imported in an environment
+    # with no monitoring installed
+    import parsl.monitoring.visualization.plots.default.workflow_plots as workflow_plots
+
+    for s in States:
+        assert s.name in workflow_plots.gantt_colors
+        assert s.name in workflow_plots.dag_state_colors


### PR DESCRIPTION
This is a regression test for PR #2708, issue #2681, that will also detect other new states added to the states enumeration without being added to the coloring tables.

In order to be able to test this way, this PR moves the two coloring tables to be module scope, instead of local scope inside a method.

## Type of change

- Code maintentance/cleanup
