### PR TITLE
Remove a comment that became irrelevant a long time ago

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -473,7 +473,6 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
 
         logger.debug("Creating executor task {} for function {} with args {}".format(executor_task_id, func, args))
 
-        # Pickle the result into object to pass into message buffer
         function_file = self._path_in_task(executor_task_id, "function")
         result_file = self._path_in_task(executor_task_id, "result")
         map_file = self._path_in_task(executor_task_id, "map")


### PR DESCRIPTION
This comment was introduced in commit 525641f16c68f7ac2415fe577a7d20951c0ce86a in 2019

## Type of change

- Code maintentance/cleanup
