### PR TITLE
Force two iterations in parsl-perf for proper warmup

### DIFF
--- a/parsl/benchmark/perf.py
+++ b/parsl/benchmark/perf.py
@@ -4,6 +4,8 @@ import time
 import concurrent.futures
 import parsl
 
+min_iterations = 2
+
 
 # TODO: factor with conftest.py where this is copy/pasted from?
 def load_dfk_from_config(filename):
@@ -34,7 +36,7 @@ def performance(*, resources: dict, target_t: float):
 
     iteration = 1
 
-    while delta_t < threshold_t:
+    while delta_t < threshold_t or iteration <= min_iterations:
         print(f"==== Iteration {iteration} ====")
         print(f"Will run {n} tasks to target {target_t} seconds runtime")
         start_t = time.time()


### PR DESCRIPTION
Prior to this PR, if the first iteration takes longer than the target time (120s by default) due to warmup, rather than due to raw task throughput, the task rate from the first iteration will be used.

This PR forces two iterations, so that the first iteration forces warmup and a second iteration always to make a meaurement in warmed-up state.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
