### PR TITLE
Add version constraints on typing-extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pyzmq>=17.1.2
 typeguard>=2.10,<3
-typing-extensions
+typing-extensions>=4.6,<5
 types-paramiko
 types-requests
 types-six


### PR DESCRIPTION
Parsl PR #2678 breaks with typing-extensions==4.5.0. See that PR for some further information. This PR adds a lower bound to be later than 4.5.0, and also a major version upper bound to work with typing-extensions Semantic Versioning.

## Type of change

- Bug fix (non-breaking change that fixes an issue)
