### PR TITLE
Rewrite file paths in WorkQueue coprocess mode, for non shared-fs

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -860,7 +860,11 @@ def _work_queue_submit_wait(*,
                     logger.debug("Sending executor task {} with command: {}".format(task.id, command_str))
                     t = wq.Task(command_str)
                 else:
-                    t = wq.RemoteTask("run_parsl_task", "parsl_coprocess", task.map_file, task.function_file, task.result_file)
+                    t = wq.RemoteTask("run_parsl_task",
+                                      "parsl_coprocess",
+                                      os.path.basename(task.map_file),
+                                      os.path.basename(task.function_file),
+                                      os.path.basename(task.result_file))
                     t.specify_exec_method("direct")
                     logger.debug("Sending executor task {} to coprocess".format(task.id))
 


### PR DESCRIPTION
Prior to this, Work Queue staged the relevant function files in (and attempted to stage the missing result files out), but the coprocess worker code was given the original (non-staged) paths.

This worked in shared-fs environments: the staged files were ignored, and the original files were used, but broke in non-shared-fs environments.

This PR uses the staged filename (the basename), as already happens with non-coprocess mode.

Fixes #2728

## Type of change

- Bug fix (non-breaking change that fixes an issue)
