### PR TITLE
Upgrade flake8 in preparation for Python 3.12

### DIFF
--- a/parsl/addresses.py
+++ b/parsl/addresses.py
@@ -113,7 +113,8 @@ def get_all_addresses() -> Set[str]:
             logger.exception("Ignoring failure to fetch address from interface {}".format(interface))
             pass
 
-    resolution_functions = [address_by_hostname, address_by_route, address_by_query]  # type: List[Callable[[], str]]
+    resolution_functions: List[Callable[[], str]]
+    resolution_functions = [address_by_hostname, address_by_route, address_by_query]
     for f in resolution_functions:
         try:
             s_addresses.add(f())

--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -16,7 +16,8 @@ logger = logging.getLogger(__name__)
 
 # these will be shared between all executors that do not explicitly
 # override, so should not contain executor-specific state
-default_staging = [NoOpFileStaging(), FTPSeparateTaskStaging(), HTTPSeparateTaskStaging()]  # type: List[Staging]
+default_staging: List[Staging]
+default_staging = [NoOpFileStaging(), FTPSeparateTaskStaging(), HTTPSeparateTaskStaging()]
 
 
 class DataManager:

--- a/parsl/data_provider/files.py
+++ b/parsl/data_provider/files.py
@@ -44,7 +44,7 @@ class File:
         self.netloc = parsed_url.netloc
         self.path = parsed_url.path
         self.filename = os.path.basename(self.path)
-        self.local_path = None  # type: Optional[str]
+        self.local_path: Optional[str] = None
 
     def cleancopy(self) -> "File":
         """Returns a copy of the file containing only the global immutable state,

--- a/parsl/dataflow/memoization.py
+++ b/parsl/dataflow/memoization.py
@@ -176,7 +176,7 @@ class Memoizer:
             - hash (str) : A unique hash string
         """
 
-        t = []  # type: List[bytes]
+        t: List[bytes] = []
 
         # if kwargs contains an outputs parameter, that parameter is removed
         # and normalised differently - with output_ref set to True.

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -261,7 +261,7 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         self.storage_access = storage_access
         self.use_cache = use_cache
         self.working_dir = working_dir
-        self.registered_files = set()  # type: Set[str]
+        self.registered_files: Set[str] = set()
         self.full_debug = full_debug
         self.source = True if pack else source
         self.pack = pack

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -139,7 +139,7 @@ class MonitoringHub(RepresentationMixin):
         self._dfk_channel = None  # type: Any
 
         if _db_manager_excepts:
-            raise(_db_manager_excepts)
+            raise _db_manager_excepts
 
         self.client_address = client_address
         self.client_port_range = client_port_range
@@ -170,12 +170,23 @@ class MonitoringHub(RepresentationMixin):
         self.logger.debug("Initializing ZMQ Pipes to client")
         self.monitoring_hub_active = True
 
-        comm_q = SizedQueue(maxsize=10)  # type: Queue[Union[Tuple[int, int], str]]
-        self.exception_q = SizedQueue(maxsize=10)  # type: Queue[Tuple[str, str]]
-        self.priority_msgs = SizedQueue()  # type: Queue[Tuple[Any, int]]
-        self.resource_msgs = SizedQueue()  # type: Queue[AddressedMonitoringMessage]
-        self.node_msgs = SizedQueue()  # type: Queue[AddressedMonitoringMessage]
-        self.block_msgs = SizedQueue()  # type:  Queue[AddressedMonitoringMessage]
+        comm_q: Queue[Union[Tuple[int, int], str]]
+        comm_q = SizedQueue(maxsize=10)
+
+        self.exception_q: Queue[Tuple[str, str]]
+        self.exception_q = SizedQueue(maxsize=10)
+
+        self.priority_msgs: Queue[Tuple[Any, int]]
+        self.priority_msgs = SizedQueue()
+
+        self.resource_msgs: Queue[AddressedMonitoringMessage]
+        self.resource_msgs = SizedQueue()
+
+        self.node_msgs: Queue[AddressedMonitoringMessage]
+        self.node_msgs = SizedQueue()
+
+        self.block_msgs: Queue[AddressedMonitoringMessage]
+        self.block_msgs = SizedQueue()
 
         self.router_proc = ForkProcess(target=router_starter,
                                        args=(comm_q, self.exception_q, self.priority_msgs, self.node_msgs, self.block_msgs, self.resource_msgs),
@@ -328,7 +339,7 @@ def filesystem_receiver(logdir: str, q: "queue.Queue[AddressedMonitoringMessage]
                 with open(full_path_filename, "rb") as f:
                     message = deserialize(f.read())
                 logger.info(f"Message received is: {message}")
-                assert(isinstance(message, tuple))
+                assert isinstance(message, tuple)
                 q.put(cast(AddressedMonitoringMessage, message))
                 os.remove(full_path_filename)
             except Exception:

--- a/parsl/providers/cluster_provider.py
+++ b/parsl/providers/cluster_provider.py
@@ -67,9 +67,9 @@ class ClusterProvider(ExecutionProvider):
         self.walltime = walltime
         self.cmd_timeout = cmd_timeout
         if not callable(self.launcher):
-            raise(BadLauncher(self.launcher,
+            raise BadLauncher(self.launcher,
                               "Launcher for executor: {} is of type: {}. Expects a parsl.launcher.launcher.Launcher or callable".format(
-                                  label, type(self.launcher))))
+                                  label, type(self.launcher)))
 
         self.script_dir = None
 

--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -128,7 +128,8 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         self.kube_client = client.CoreV1Api()
 
         # Dictionary that keeps track of jobs, keyed on job_id
-        self.resources = {}  # type: Dict[object, Dict[str, Any]]
+        self.resources: Dict[object, Dict[str, Any]]
+        self.resources = {}
 
     def submit(self, cmd_string, tasks_per_node, job_name="parsl"):
         """ Submit a job

--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -124,7 +124,7 @@ def load_dfk_session(request, pytestconfig):
 
         yield
 
-        if(parsl.dfk() != dfk):
+        if parsl.dfk() != dfk:
             raise RuntimeError("DFK changed unexpectedly during test")
         dfk.cleanup()
         parsl.clear()
@@ -158,16 +158,16 @@ def load_dfk_local_module(request, pytestconfig):
             assert isinstance(c, parsl.Config)
             dfk = parsl.load(c)
 
-        if(callable(local_setup)):
+        if callable(local_setup):
             local_setup()
 
         yield
 
-        if(callable(local_teardown)):
+        if callable(local_teardown):
             local_teardown()
 
-        if(local_config):
-            if(parsl.dfk() != dfk):
+        if local_config:
+            if parsl.dfk() != dfk:
                 raise RuntimeError("DFK changed unexpectedly during test")
             dfk.cleanup()
             parsl.clear()

--- a/parsl/tests/test_bash_apps/test_pipeline.py
+++ b/parsl/tests/test_bash_apps/test_pipeline.py
@@ -52,7 +52,7 @@ def test_increment(depth=5):
     futs = {}
     for i in range(1, depth):
         print("Launching {0} with {1}".format(i, prev))
-        assert(isinstance(prev, DataFuture) or isinstance(prev, File))
+        assert isinstance(prev, DataFuture) or isinstance(prev, File)
         output = File("test{0}.txt".format(i))
         fu = increment(inputs=[prev],  # Depend on the future from previous call
                        # Name the file to be created here
@@ -62,7 +62,7 @@ def test_increment(depth=5):
         [prev] = fu.outputs
         futs[i] = prev
         print(prev.filepath)
-        assert(isinstance(prev, DataFuture))
+        assert isinstance(prev, DataFuture)
 
     for key in futs:
         if key > 0:

--- a/parsl/tests/test_error_handling/test_retry_handler.py
+++ b/parsl/tests/test_error_handling/test_retry_handler.py
@@ -61,4 +61,4 @@ def test_retry():
     with pytest.raises(parsl.app.errors.BashExitFailure):
         fu.result()
 
-    assert(fu.exception().exitcode == 5)
+    assert fu.exception().exitcode == 5

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -55,7 +55,7 @@ def get_all_checkpoints(rundir: str = "runinfo") -> List[str]:
 
     """
 
-    if(not os.path.isdir(rundir)):
+    if not os.path.isdir(rundir):
         return []
 
     dirs = sorted(os.listdir(rundir))
@@ -99,7 +99,7 @@ def get_last_checkpoint(rundir: str = "runinfo") -> List[str]:
     last_runid = dirs[-1]
     last_checkpoint = os.path.abspath(f'{rundir}/{last_runid}/checkpoint')
 
-    if(not(os.path.isdir(last_checkpoint))):
+    if not os.path.isdir(last_checkpoint):
         return []
 
     return [last_checkpoint]


### PR DESCRIPTION
The previous flake8 would not install with Python 3.12beta1.

This much newer version of flake8 catches many new occurences of two errors:

F401 XXX imported but unused  - where XXX is used in a comment style # type: annotation.

E275 missing whitespace after keyword

This PR fixes all of those

## Type of change

- Code maintentance/cleanup
