### PR TITLE
[not for merge] Try out newer typeguard across all python versions in CI, for comparison with an lsst/perlmutter issue #2750

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyzmq>=17.1.2
-typeguard>=2.10
+typeguard>=2.13
 typing-extensions
 globus-sdk
 dill


### PR DESCRIPTION
for debugging some lsst vs perlmutter behaviour i am seeing