### PR TITLE
Add notes justifying why historical sections of docs have been made historical

### DIFF
--- a/docs/devguide/design.rst
+++ b/docs/devguide/design.rst
@@ -1,6 +1,12 @@
 Historical: Swift vs Parsl
 --------------------------
 
+.. note::
+   This section describes comparisons between Parsl and an earlier workflow
+   system, Swift, as part of a justification for the early prototyping stages
+   of Parsl development. It is no longer relevant for modern Parsl users, but
+   remains of historical interest.
+
 The following text is not well structured, and is mostly a brain dump that needs to be organized.
 Moving from Swift to an established language (python) came with its own tradeoffs. We get the backing
 of a rich and very well known language to handle the language aspects as well as the libraries.

--- a/docs/devguide/roadmap.rst
+++ b/docs/devguide/roadmap.rst
@@ -1,6 +1,10 @@
 Historical: Roadmap
 ===================
 
+.. note::
+   This roadmap has not been current since version 0.7.0, and does not reflect
+   changes in direction and funding since that time. For this reason, this
+   roadmap is marked as historical.
 
 Before diving into the roadmap, a quick retrospective look at the evolution of workflow
 solutions that came before Parsl from the workflows group at UChicago and Argonne National Laboratory.

--- a/docs/devguide/roadmap.rst
+++ b/docs/devguide/roadmap.rst
@@ -2,8 +2,8 @@ Historical: Roadmap
 ===================
 
 .. note::
-   This roadmap has not been current since version 0.7.0, and does not reflect
-   changes in direction and funding since that time. For this reason, this
+   This roadmap has not been current since version 0.9.0 in 2019, and does
+   not reflect changes in project direction then. For this reason, this
    roadmap is marked as historical.
 
 Before diving into the roadmap, a quick retrospective look at the evolution of workflow


### PR DESCRIPTION
This is intended to help new readers understand the context of why these sections of been kept, rather than deleted.

## Type of change

- Documentation update
