### PR TITLE
Remove or reduce some test sleeps

### DIFF
--- a/parsl/tests/test_python_apps/test_garbage_collect.py
+++ b/parsl/tests/test_python_apps/test_garbage_collect.py
@@ -1,30 +1,36 @@
-import parsl
+import threading
 import time
 
+import pytest
+
+import parsl
 from parsl.app.app import python_app
+from parsl.tests.configs.local_threads import fresh_config as local_config  # noqa
 
 
 @python_app
-def slow_double(x):
-    import time
-    time.sleep(0.1)
+def slow_double(x, may_continue: threading.Event):
+    may_continue.wait()
     return x * 2
 
 
+@pytest.mark.local
 def test_garbage_collect():
     """ Launches an app with a dependency and waits till it's done and asserts that
     the internal refs were wiped
     """
-    x = slow_double(slow_double(10))
+    evt = threading.Event()
+    x = slow_double(10, evt)
+    x = slow_double(x, evt)
 
-    if x.done() is False:
-        assert parsl.dfk().tasks[x.tid]['app_fu'] == x, "Tasks table should have app_fu ref before done"
+    assert parsl.dfk().tasks[x.tid]['app_fu'] == x, "Tasks table should have app_fu ref before done"
 
-    x.result()
+    evt.set()
+    assert x.result() == 10 * 4
     if parsl.dfk().checkpoint_mode is not None:
         # We explicit call checkpoint if checkpoint_mode is enabled covering
         # cases like manual/periodic where checkpointing may be deferred.
         parsl.dfk().checkpoint()
 
-    time.sleep(0.2)  # Give enough time for task wipes to work
+    time.sleep(0.01)  # Give enough time for task wipes to work
     assert x.tid not in parsl.dfk().tasks, "Task record should be wiped after task completion"

--- a/parsl/tests/test_python_apps/test_mapred.py
+++ b/parsl/tests/test_python_apps/test_mapred.py
@@ -1,19 +1,15 @@
-import argparse
+import pytest
 
-import parsl
 from parsl.app.app import python_app
-from parsl.tests.configs.local_threads import config
 
 
 @python_app
-def fan_out(x, dur):
-    import time
-    time.sleep(dur)
+def times_two(x):
     return x * 2
 
 
 @python_app
-def accumulate(inputs=[]):
+def accumulate(inputs=()):
     return sum(inputs)
 
 
@@ -22,38 +18,17 @@ def accumulate_t(*args):
     return sum(args)
 
 
-def test_mapred_type1(width=2):
-    """MapReduce test with the reduce stage taking futures in inputs=[]
-    """
-
-    futs = []
-    for i in range(1, width + 1):
-        fu = fan_out(i, 1)
-        futs.extend([fu])
-
-    print("Fan out : ", futs)
-
+@pytest.mark.parametrize("width", (2, 3, 5))
+def test_mapred_type1(width):
+    """MapReduce test with the reduce stage taking futures in inputs=[]"""
+    futs = [times_two(i) for i in range(width)]
     red = accumulate(inputs=futs)
-    # print([(i, i.done()) for i in futs])
-    r = sum([x * 2 for x in range(1, width + 1)])
-    assert r == red.result(), "[TEST] MapRed type1 expected %s, got %s" % (
-        r, red.result())
+    assert red.result() == 2 * sum(range(width))
 
 
-def test_mapred_type2(width=2):
-    """MapReduce test with the reduce stage taking futures on the args
-    """
-
-    futs = []
-    for i in range(1, width + 1):
-        fu = fan_out(i, 0.1)
-        futs.extend([fu])
-
-    print("Fan out : ", futs)
-
+@pytest.mark.parametrize("width", (2, 3, 5))
+def test_mapred_type2(width):
+    """MapReduce test with the reduce stage taking futures on the args"""
+    futs = [times_two(i) for i in range(width)]
     red = accumulate_t(*futs)
-
-    # print([(i, i.done()) for i in futs])
-    r = sum([x * 2 for x in range(1, width + 1)])
-    assert r == red.result(), "[TEST] MapRed type2 expected %s, got %s" % (
-        r, red.result())
+    assert red.result() == 2 * sum(range(width))

--- a/parsl/tests/test_python_apps/test_memoize_bad_id_for_memo.py
+++ b/parsl/tests/test_python_apps/test_memoize_bad_id_for_memo.py
@@ -29,9 +29,8 @@ def noop_app(x, inputs=[], cache=True):
 
 
 @python_app
-def sleep(t):
-    import time
-    time.sleep(t)
+def some_func(_t):
+    pass
 
 
 def test_python_unmemoizable():
@@ -51,14 +50,14 @@ def test_python_failing_memoizer():
 
 
 def test_python_unmemoizable_after_dep():
-    sleep_fut = sleep(1)
-    fut = noop_app(Unmemoizable(), inputs=[sleep_fut])
+    memoizable_fut = some_func(1)
+    fut = noop_app(Unmemoizable(), inputs=[memoizable_fut])
     with pytest.raises(ValueError):
         fut.result()
 
 
 def test_python_failing_memoizer_afer_dep():
-    sleep_fut = sleep(1)
-    fut = noop_app(FailingMemoizable(), inputs=[sleep_fut])
+    memoizable_fut = some_func(1)
+    fut = noop_app(FailingMemoizable(), inputs=[memoizable_fut])
     with pytest.raises(ValueError):
         fut.result()

--- a/parsl/tests/test_python_apps/test_overview.py
+++ b/parsl/tests/test_python_apps/test_overview.py
@@ -1,8 +1,4 @@
-import argparse
-
-import parsl
 from parsl.app.app import python_app
-from parsl.tests.configs.local_threads import config
 
 
 @python_app
@@ -11,50 +7,17 @@ def app_double(x):
 
 
 @python_app
-def app_sum(inputs=[]):
+def app_sum(inputs=()):
     return sum(inputs)
-
-
-@python_app
-def slow_app_double(x, sleep_dur=0.05):
-    import time
-    time.sleep(sleep_dur)
-    return x * 2
 
 
 def test_1(N=10):
     """Testing code snippet from the documentation
     """
 
-    # Create a list of integers
-    items = range(0, N)
-
-    # Map Phase : Apply an *app* function to each item in list
-    mapped_results = []
-    for i in items:
-        x = app_double(i)
-        mapped_results.append(x)
+    # Create a list of integers, then apply *app* function to each
+    items = range(N)
+    mapped_results = list(map(app_double, items))
 
     total = app_sum(inputs=mapped_results)
-
-    assert total.result() != sum(items), "Sum is wrong {0} != {1}".format(
-        total.result(), sum(items))
-
-
-def test_2(N=10):
-    """Testing code snippet from the documentation
-    """
-
-    # Create a list of integers
-    items = range(0, N)
-
-    # Map Phase : Apply an *app* function to each item in list
-    mapped_results = []
-    for i in items:
-        x = slow_app_double(i)
-        mapped_results.append(x)
-
-    total = app_sum(inputs=mapped_results)
-
-    assert total.result() != sum(items), "Sum is wrong {0} != {1}".format(
-        total.result(), sum(items))
+    assert total.result() == 2 * sum(items)


### PR DESCRIPTION
- Make some test code more Pythonic (e.g., generators, list comprehension)
- Remove a number of unnecessary sleep calls (or vastly reduce)
- Teach some tests to `assert`
- Remove more `print()`s

## Type of change
- Code maintenance/cleanup
