### PR TITLE
Cleanup some test file detritus

### DIFF
--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -211,16 +211,16 @@ def apply_masks(request, pytestconfig):
             pytest.skip('intended for explicit config')
 
 
-@pytest.fixture()
-def setup_data():
-    import os
-    if not os.path.isdir('data'):
-        os.mkdir('data')
+@pytest.fixture
+def setup_data(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
 
-    with open("data/test1.txt", 'w') as f:
+    with open(data_dir / "test1.txt", "w") as f:
         f.write("1\n")
-    with open("data/test2.txt", 'w') as f:
+    with open(data_dir / "test2.txt", "w") as f:
         f.write("2\n")
+    return data_dir
 
 
 @pytest.fixture(autouse=True, scope='function')

--- a/parsl/tests/test_data/test_file_apps.py
+++ b/parsl/tests/test_data/test_file_apps.py
@@ -1,38 +1,33 @@
-import os
-
 import pytest
 
-import parsl
 from parsl.app.app import bash_app
 from parsl.data_provider.files import File
-from parsl.tests.configs.local_threads import config
 
 
 @bash_app
-def cat(inputs=[], outputs=[], stdout=None, stderr=None):
-    infiles = ' '.join([i.filepath for i in inputs])
-    return """echo {i}
-    cat {i} &> {o}
-    """.format(i=infiles, o=outputs[0])
+def cat(inputs=(), outputs=(), stdout=None, stderr=None):
+    infiles = " ".join(i.filepath for i in inputs)
+    return f"cat {infiles} &> {outputs[0]}"
 
 
-@pytest.mark.usefixtures('setup_data')
 @pytest.mark.staging_required
-def test_files():
-
-    if os.path.exists('cat_out.txt'):
-        os.remove('cat_out.txt')
-
-    fs = [File('data/' + f) for f in os.listdir('data')]
-    x = cat(inputs=fs, outputs=[File('cat_out.txt')],
-            stdout='f_app.out', stderr='f_app.err')
+def test_files(setup_data):
+    fs = sorted(str(setup_data / f) for f in setup_data.iterdir())
+    fs = list(map(File, fs))
+    x = cat(
+        inputs=fs,
+        outputs=[File(str(setup_data / "cat_out.txt"))],
+        stdout=str(setup_data / "f_app.out"),
+        stderr=str(setup_data / "f_app.err"),
+    )
+    x.result()
     d_x = x.outputs[0]
-    print(x.result())
-    print(d_x, type(d_x))
+    data = open(d_x.filepath).read().strip()
+    assert "1\n2" == data, "Per setup_data fixture"
 
 
 @bash_app
-def increment(inputs=[], outputs=[], stdout=None, stderr=None):
+def increment(inputs=(), outputs=(), stdout=None, stderr=None):
     # Place double braces to avoid python complaining about missing keys for {item = $1}
     return """
     x=$(cat {i})
@@ -40,35 +35,26 @@ def increment(inputs=[], outputs=[], stdout=None, stderr=None):
     """.format(i=inputs[0], o=outputs[0])
 
 
-@pytest.mark.usefixtures('setup_data')
 @pytest.mark.staging_required
-def test_increment(depth=5):
+def test_increment(tmp_path, depth=5):
     """Test simple pipeline A->B...->N
     """
-    # Create the first file
-    open("test0.txt", 'w').write('0\n')
+    # Test setup
+    first_fpath = tmp_path / "test0.txt"
+    first_fpath.write_text("0\n")
 
-    # Create the first entry in the dictionary holding the futures
-    prev = File("test0.txt")
-    futs = {}
+    prev = [File(str(first_fpath))]
+    futs = []
     for i in range(1, depth):
-        print("Launching {0} with {1}".format(i, prev))
+        f = increment(
+            inputs=prev,
+            outputs=[File(str(tmp_path / f"test{i}.txt"))],
+            stdout=str(tmp_path / f"incr{i}.out"),
+            stderr=str(tmp_path / f"incr{i}.err"),
+        )
+        prev = f.outputs
+        futs.append((i, prev[0]))
 
-        if os.path.exists('test{0}.txt'.format(i)):
-            os.remove('test{0}.txt'.format(i))
-
-        fu = increment(inputs=[prev],  # Depend on the future from previous call
-                       # Name the file to be created here
-                       outputs=[File("test{0}.txt".format(i))],
-                       stdout="incr{0}.out".format(i),
-                       stderr="incr{0}.err".format(i))
-        [prev] = fu.outputs
-        futs[i] = prev
-        print(prev.filepath)
-
-    for key in futs:
-        if key > 0:
-            fu = futs[key]
-            data = open(fu.result().filepath, 'r').read().strip()
-            assert data == str(
-                key), "[TEST] incr failed for key:{0} got:{1}".format(key, data)
+    for i, f in futs:
+        data = open(f.result().filepath).read().strip()
+        assert data == str(i)

--- a/parsl/tests/test_data/test_file_staging.py
+++ b/parsl/tests/test_data/test_file_staging.py
@@ -1,88 +1,25 @@
-import os
 import pytest
+
 from parsl.app.app import bash_app
 from parsl.data_provider.files import File
 
 
 @bash_app
-def cat(inputs=[], outputs=[], stdout=None, stderr=None):
-    infiles = ' '.join([i.filepath for i in inputs])
-    return """echo {i}
-    cat {i} &> {o}
-    """.format(i=infiles, o=outputs[0])
-
-
-@pytest.mark.usefixtures('setup_data')
-@pytest.mark.issue363
-def test_files():
-
-    if os.path.exists('cat_out.txt'):
-        os.remove('cat_out.txt')
-
-    fs = [File('data/' + f) for f in os.listdir('data')]
-    x = cat(inputs=fs, outputs=[File('cat_out.txt')],
-            stdout='f_app.out', stderr='f_app.err')
-    d_x = x.outputs[0]
-    print(x.result())
-    print(d_x, type(d_x))
-
-
-@bash_app
-def increment(inputs=[], outputs=[], stdout=None, stderr=None):
-    # Place double braces to avoid python complaining about missing keys for {item = $1}
-    return """
-    x=$(cat {i})
-    echo $(($x+1)) > {o}
-    """.format(i=inputs[0], o=outputs[0])
+def cat(inputs=(), outputs=(), stdout=None, stderr=None):
+    infiles = " ".join(i.filepath for i in inputs)
+    return f"cat {infiles} &> {outputs[0]}\n"
 
 
 @pytest.mark.staging_required
-def test_regression_200():
+def test_regression_200(tmp_path):
     """Regression test for #200. Pickleablility of Files"""
+    opath = tmp_path / "test_output.txt"
+    fpath = tmp_path / "test.txt"
 
-    if os.path.exists('test_output.txt'):
-        os.remove('test_output.txt')
+    fpath.write_text("Hello World")
+    f = cat(inputs=[File(str(fpath))], outputs=[File(str(opath))])
 
-    with open("test.txt", 'w') as f:
-        f.write("Hello World")
-
-    fu = cat(inputs=[File("test.txt")],
-             outputs=[File("test_output.txt")])
-    fu.result()
-
-    fi = fu.outputs[0].result()
-    print("type of fi: {}".format(type(fi)))
-    with open(str(fi), 'r') as f:
-        data = f.readlines()
-        assert "Hello World" in data, "Missed data"
-
-
-@pytest.mark.staging_required
-def test_increment(depth=5):
-    """Test simple pipeline A->B...->N
-    """
-    # Create the first file
-    open("test0.txt", 'w').write('0\n')
-
-    # Create the first entry in the dictionary holding the futures
-    prev = File("test0.txt")
-    futs = {}
-    for i in range(1, depth):
-        if os.path.exists('test{0}.txt'.format(i)):
-            os.remove('test{0}.txt'.format(i))
-        print("Launching {0} with {1}".format(i, prev))
-        fu = increment(inputs=[prev],  # Depend on the future from previous call
-                       # Name the file to be created here
-                       outputs=[File("test{0}.txt".format(i))],
-                       stdout="incr{0}.out".format(i),
-                       stderr="incr{0}.err".format(i))
-        [prev] = fu.outputs
-        futs[i] = prev
-        print(prev.filepath)
-
-    for key in futs:
-        if key > 0:
-            fu = futs[key]
-            data = open(fu.result().filepath, 'r').read().strip()
-            assert data == str(
-                key), "[TEST] incr failed for key:{0} got:{1}".format(key, data)
+    f.result()
+    with open(f.outputs[0].filepath) as f:
+        data = f.read()
+        assert "Hello World" == data


### PR DESCRIPTION
- Use the well-known `tmp_path` fixture.
- Remove duplicated tests

## Type of change

- Code maintenance/cleanup
