### PR TITLE
Reduce depth to work with WQ for delayed tests

### DIFF
--- a/parsl/tests/test_python_apps/test_type5.py
+++ b/parsl/tests/test_python_apps/test_type5.py
@@ -13,18 +13,16 @@ def add_xy(x, y):
     return x + y
 
 
-@pytest.mark.parametrize("n", (2, 3, 5))
-def test_func_linked_to_previous_result(n):
-    futs = (map_x2(i) for i in range(1, n + 1))
-    for _ in range(1, n - 1):
+def test_func_linked_to_previous_result(depth=2):
+    futs = (map_x2(i) for i in range(1, depth + 1))
+    for _ in range(1, depth - 1):
         futs = (map_x2(fut) for fut in futs)
     futs = [map_x2(fut) for fut in futs]
 
-    assert sum(f.result() for f in futs) == (2 ** n) * sum(range(1, n + 1))
+    assert sum(f.result() for f in futs) == (2 ** depth) * sum(range(1, depth + 1))
 
 
-@pytest.mark.parametrize("width", (2, 4, 8, 32))
-def test_func_linked_to_multiple_previous_results(width):
+def test_func_linked_to_multiple_previous_results(width=4):
     futs = (map_x2(i) for i in range(1, width + 1))
     f_it = iter(futs)
 


### PR DESCRIPTION
Based on analysis by BenC with WorkQueue, noted that the parametrization of this test hits WQ's weakspot: depth.  So, reduce it's depth for our tests. 

## Type of change

- Code maintenance/cleanup
