### PR TITLE
Parse serialization headers only once

### DIFF
--- a/parsl/serialize/base.py
+++ b/parsl/serialize/base.py
@@ -21,9 +21,6 @@ class SerializerBase:
         """
         super().__init_subclass__(**kwargs)
 
-        assert len(cls._identifier) == 3
-        assert cls._identifier[2] == 10  # \n in decimal
-
         if cls._for_code:
             METHODS_MAP_CODE[cls._identifier] = cls
         if cls._for_data:
@@ -42,19 +39,6 @@ class SerializerBase:
         identifier : str
         """
         return self._identifier
-
-    def chomp(self, payload: bytes) -> bytes:
-        """ If the payload starts with the identifier, return the remaining block
-
-        Parameters
-        ----------
-        payload : str
-            Payload blob
-        """
-        s_id, payload = payload.split(b'\n', 1)
-        if (s_id + b'\n') != self.identifier:
-            raise TypeError("Buffer does not start with parsl.serialize identifier:{!r}".format(self.identifier))
-        return payload
 
     def enable_caching(self, maxsize: int = 128) -> None:
         """ Add functools.lru_cache onto the serialize, deserialize methods

--- a/parsl/serialize/concretes.py
+++ b/parsl/serialize/concretes.py
@@ -17,18 +17,15 @@ class PickleSerializer(SerializerBase):
     * [sometimes] issues with wrapped/decorated functions
     """
 
-    _identifier = b'01\n'
+    _identifier = b'01'
     _for_code = True
     _for_data = True
 
     def serialize(self, data: Any) -> bytes:
-        x = pickle.dumps(data)
-        return self.identifier + x
+        return pickle.dumps(data)
 
-    def deserialize(self, payload: bytes) -> Any:
-        chomped = self.chomp(payload)
-        data = pickle.loads(chomped)
-        return data
+    def deserialize(self, body: bytes) -> Any:
+        return pickle.loads(body)
 
 
 class DillSerializer(SerializerBase):
@@ -43,15 +40,12 @@ class DillSerializer(SerializerBase):
     * closures
     """
 
-    _identifier = b'02\n'
+    _identifier = b'02'
     _for_code = True
     _for_data = True
 
     def serialize(self, data: Any) -> bytes:
-        x = dill.dumps(data)
-        return self.identifier + x
+        return dill.dumps(data)
 
-    def deserialize(self, payload: bytes) -> Any:
-        chomped = self.chomp(payload)
-        data = dill.loads(chomped)
-        return data
+    def deserialize(self, body: bytes) -> Any:
+        return dill.loads(body)

--- a/parsl/serialize/facade.py
+++ b/parsl/serialize/facade.py
@@ -10,7 +10,6 @@ logger = logging.getLogger(__name__)
 """ Instantiate the appropriate classes
 """
 headers = list(METHODS_MAP_CODE.keys()) + list(METHODS_MAP_DATA.keys())
-header_size = len(headers[0])
 
 methods_for_code = {}
 methods_for_data = {}
@@ -70,7 +69,7 @@ def serialize(obj: Any, buffer_threshold: int = int(1e6)) -> bytes:
     if callable(obj):
         for method in methods_for_code.values():
             try:
-                result = method.serialize(obj)
+                result = method._identifier + b'\n' + method.serialize(obj)
             except Exception as e:
                 result = e
                 continue
@@ -79,7 +78,7 @@ def serialize(obj: Any, buffer_threshold: int = int(1e6)) -> bytes:
     else:
         for method in methods_for_data.values():
             try:
-                result = method.serialize(obj)
+                result = method._identifier + b'\n' + method.serialize(obj)
             except Exception as e:
                 result = e
                 continue
@@ -102,11 +101,12 @@ def deserialize(payload: bytes) -> Any:
        Payload object to be deserialized
 
     """
-    header = payload[0:header_size]
+    header, body = payload.split(b'\n', 1)
+
     if header in methods_for_code:
-        result = methods_for_code[header].deserialize(payload)
+        result = methods_for_code[header].deserialize(body)
     elif header in methods_for_data:
-        result = methods_for_data[header].deserialize(payload)
+        result = methods_for_data[header].deserialize(body)
     else:
         raise TypeError("Invalid header: {!r} in data payload. Buffer is either corrupt or not created by ParslSerializer".format(header))
 

--- a/parsl/serialize/facade.py
+++ b/parsl/serialize/facade.py
@@ -9,8 +9,6 @@ logger = logging.getLogger(__name__)
 
 """ Instantiate the appropriate classes
 """
-headers = list(METHODS_MAP_CODE.keys()) + list(METHODS_MAP_DATA.keys())
-
 methods_for_code = {}
 methods_for_data = {}
 


### PR DESCRIPTION
Prior to this PR, the serialization header was parsed twice during deserialization, and in two different ways, leading to an awkward header format: the header must be exactly three bytes long for one (length based) parser, and the third byte must be a \n for the other (new-line based) parser.

This PR removes the length based parser, instead allowing an arbitrary length \n-terminated header.

Backwards/forwards compatibility:
The parsl serialization wire format is not a user exposed interface, as parsl requires the same version of parsl to be installed at all locations in a parsl deployment.

This PR does not change any on the wire byte sequences when used with the two existing de*serializers, but opens the opportunity for future implementations to use more than two bytes for identifiers.

Performance:
I made a basic benchmark of serializing and deserializing a few thousand integers (deliberately using a simple object like `int` so that the object processing would be quite small, allowing changes in header time more chance to show up). My main concern with this PR is that I didn't make things noticeably worse, not to improve performance.

After this PR, a serialization->deserialization round trip is about 200ns faster (1165ns before vs 965ns after), so I am happy that this PR does not] damage performance.

Future:
This is part of ongoing work to introduce user pluggable de*serializers.

## Type of change

- Code maintentance/cleanup
