### PR TITLE
Document calling other systems using @join_app and Futures

### DIFF
--- a/docs/userguide/joins.rst
+++ b/docs/userguide/joins.rst
@@ -3,9 +3,26 @@
 Join Apps
 =========
 
-Join apps allows an app to define a sub-workflow: the app can launch other apps
-and incorporate them into the main task graph. They can be specified using the
-`join_app` decorator.
+Join apps, defined with the ``@join_app`` decorator, are a form of app that can
+launch other pieces of a workflow: for example a Parsl sub-workflow, or a task
+that runs in some other system.
+
+Parsl sub-workflows
+-------------------
+
+One reason for launching Parsl apps from inside a join app, rather than
+directly in the main workflow code, is because the definitions of those tasks
+are not known well enough at the start of the workflow.
+
+For example, a workflow might run an expensive step to detect some objects
+in an image, and then on each object, run a further expensive step. Because
+the number of objects is not known at the start of the workflow, but instead
+only after an expensive step has completed, the subsequent tasks cannot be
+defined until after that step has completed.
+
+In simple cases, the main workflow script can be stopped using
+``Future.result()`` and join apps are not necessary, but in more complicated
+cases, that approach can severely limit concurrency.
 
 Join apps allow more naunced dependencies to be expressed that can help with:
 
@@ -13,13 +30,24 @@ Join apps allow more naunced dependencies to be expressed that can help with:
 * more focused error propagation - allowing more of an ultimately failing workflow to complete
 * more useful monitoring information
 
+Using Futures from other components
+-----------------------------------
+
+Sometimes, a workflow might need to incorporate tasks from other systems that
+run asynchronously but do not need a Parsl worker allocated for their entire
+run. An example of this is delegating some work into Globus Compute: work can
+be given to Globus Compute, but Parsl does not need to keep a worker allocated
+to that task while it runs. Instead, Parsl can be told to wait for the ``Future``
+returned by Globus Compute to complete.
+
 Usage
 -----
 
-A `join_app` looks quite like a `python_app`, but should return one or more ``Future`` objects,
-rather than a value. After the python code has run, the app invocation will not
-complete until those Futures have completed, and the return value of the `join_app`
-will be the return values (or exception) from those Futures.
+A `join_app` looks quite like a `python_app`, but should return one or more
+``Future`` objects, rather than a value. Once the Python code has run, the
+app will wait for those Futures to complete without occuping a Parsl worker,
+and when those Futures complete, their contents will be the return value
+of the `join_app`.
 
 For example:
 
@@ -34,25 +62,14 @@ For example:
     x: Future = some_app()
     return x  # note that x is a Future, not a value
 
-  # example.result() == 3
+  assert example.result() == 3
 
-What/why/how can you do with a join app
----------------------------------------
+Example of a Parsl sub-workflow
+-------------------------------
 
-join apps are useful when a workflow needs to launch some apps, but it doesn't
-know what those apps are until some earlier apps are completed.
-
-For example, a pre-processing stage might be followed by n middle stages,
-but the value of n is not known until pre-processing is complete; or the
-choice of app to run might depend on the output of pre-processing.
-
-In the following example, a pre-processing stage is followed by a choice of
-option 1 or option 2 apps, with a post-processing stage afterwards. All of the
-example apps are toy apps that are intended to demonstrate control/data flow
-but they are based on a real use case.
-
-Here is the implementation using join apps. Afterwards, there are some
-examples of the problems that arise trying to implement this without join apps.
+This example workflow shows a preprocessing step, followed by
+a middle stage that is chosen by the result of the pre-processing step
+(either option 1 or option 2) followed by a know post-processing step.
 
 .. code-block:: python
 
@@ -62,12 +79,10 @@ examples of the problems that arise trying to implement this without join apps.
 
   @python_app
   def option_one(x):
-    # do some stuff
     return x*2
 
   @python_app
   def option_two(x):
-    # do some more stuff
     return (-x) * 2
 
   @join_app
@@ -79,34 +94,32 @@ examples of the problems that arise trying to implement this without join apps.
 
   @python_app
   def post_process(x):
-    return str(x) # convert x to a string
+    return str(x)
 
-  # here is a simple workflow using these apps:
-  # post_process(process(pre_process()))).result() == "6"
-  # pre_process gives the number 3, process turns it into 6,
-  # and post_process stringifys it to "6" 
-
-So why do we need process to be a ``@join_app`` for this to work?
+  assert post_process(process(pre_process()))).result() == "6"
 
 * Why can't process be a regular python function?
 
 ``process`` needs to inspect the value of ``x`` to make a decision about
 what app to launch. So it needs to defer execution until after the
-pre-processing stage has completed. In parsl, the way to defer that is
-using apps: the execution of process will happen when the future returned
-by pre_process has completed.
+pre-processing stage has completed. In Parsl, the way to defer that is
+using apps: even though ``process`` is invoked at the start of the workflow,
+it will execute later on, when the Future returned by ``pre_process`` has a
+value.
 
 * Why can't process be a @python_app?
 
-A python app, if run in a `parsl.executors.ThreadPoolExecutor`, can launch more parsl apps;
-so a python app implementation of process() would be able to inspect x and
-launch ``option_{one, two}``.
+A Python app, if run in a `parsl.executors.ThreadPoolExecutor`, can launch
+more parsl apps; so a ``python_app`` implementation of process() would be able
+to inspect x and choose and invoke the appropriate ``option_{one, two}``.
 
 From launching the ``option_{one, two}`` app, the app body python code would
 get a ``Future[int]`` - a ``Future`` that will eventually contain ``int``.
 
-But now, we want to (at submission time) invoke post_process, and have it wait
-until the relevant ``option_{one, two}`` app has completed.
+But, we want to invoke ``post_process`` at submission time near the start of
+workflow so that Parsl knows about as many tasks as possible. But we don't
+want it to execute until the value of the chosen ``option_{one, two}`` app
+is known.
 
 If we don't have join apps, how can we do this?
 
@@ -180,6 +193,63 @@ too.
 
 What join apps add is the ability for parsl to unwrap that Future[Future[int]] into a
 Future[int] in a "sensible" way (eg it doesn't need to block a worker).
+
+
+.. _label-join-globus-compute:
+
+Example of invoking a Futures-driven task from another system
+-------------------------------------------------------------
+
+
+This example shows launching some activity in another system, without
+occupying a Parsl worker while that activity happens: in this example, work is
+delegated to Globus Compute, which performs the work elsewhere. When the work
+is completed, Globus Compute will put the result into the future that it
+returns, and then (because the Parsl app is a ``@join_app``), that result will
+be used as the result of the Parsl app.
+
+As above, the motivation for doing this inside an app, rather than in the
+top level is that sufficient information to launch the Globus Compute task
+might not be available at start of the workflow.
+
+This workflow will run a first stage, ``const_five``, on a Parsl worker,
+then using the result of that stage, pass the result as a parameter to a
+Globus Compute task, getting a ``Future`` from that submission. Then, the
+results of the Globus Compute task will be passed onto a second Parsl
+local task, ``times_two``.
+
+.. code-block:: python
+
+  import parsl
+  from globus_compute_sdk import Executor
+
+  tutorial_endpoint_uuid = '4b116d3c-1703-4f8f-9f6f-39921e5864df'
+  gce = Executor(endpoint_id=tutorial_endpoint_uuid)
+
+  def increment_in_funcx(n):
+      return n+1
+
+  @parsl.join_app
+  def increment_in_parsl(n):
+      future = gce.submit(increment_in_funcx, n)
+      return future
+
+  @parsl.python_app
+  def times_two(n):
+      return n*2
+
+  @parsl.python_app
+  def const_five():
+      return 5
+
+  parsl.load()
+
+  workflow = times_two(increment_in_parsl(const_five()))
+
+  r = workflow.result()
+
+  assert r == (5+1)*2
+
 
 Terminology
 -----------

--- a/docs/userguide/plugins.rst
+++ b/docs/userguide/plugins.rst
@@ -64,3 +64,16 @@ types, and raises an exception on unknown types:
 
 You can plug in your own type-specific hash code for additional types that
 you need and understand using `id_for_memo`.
+
+
+Invoking other asynchronous components
+--------------------------------------
+
+Parsl code can invoke other asynchronous components which return Futures, and
+integrate those Futures into the task graph: Parsl apps can be given any
+`concurrent.futures.Future` as a dependency, even if those futures do not come
+from invoking a Parsl app. This includes as the return value of a
+``join_app``.
+
+An specific example of this is integrating Globus Compute tasks into a Parsl
+task graph. See :ref:`label-join-globus-compute`


### PR DESCRIPTION
This description focuses on Globus Compute, but it can apply to other components with a Futures driven API.

Fixes #2786 

## Type of change

- Documentation update
