### PR TITLE
Clarify that serializer ID selects a deserializer

### DIFF
--- a/parsl/serialize/base.py
+++ b/parsl/serialize/base.py
@@ -35,11 +35,12 @@ class SerializerBase:
 
     @property
     def identifier(self) -> bytes:
-        """ Get the identifier of the serialization method
+        """Get that identifier that will be used to indicate in byte streams
+        that this class should be used for deserialization.
 
         Returns
         -------
-        identifier : str
+        identifier : bytes
         """
         return self._identifier
 


### PR DESCRIPTION
This ambiguity in serializer ID use is the root of issue #2555 where parsl.serialize ends up with two different serializers sharing the same ID, and both able to deserialize (in different ways) the same serialized data.

## Type of change

- Documentation update
