### PR TITLE
Rearrange serializer caching to fix issue #2555

### DIFF
--- a/parsl/serialize/base.py
+++ b/parsl/serialize/base.py
@@ -1,6 +1,5 @@
 from abc import abstractmethod
 import logging
-import functools
 
 from typing import Any
 
@@ -40,16 +39,6 @@ class SerializerBase:
         identifier : bytes
         """
         return self._identifier
-
-    def enable_caching(self, maxsize: int = 128) -> None:
-        """ Add functools.lru_cache onto the serialize, deserialize methods
-        """
-
-        # ignore types here because mypy at the moment is not fond of monkeypatching
-        self.serialize = functools.lru_cache(maxsize=maxsize)(self.serialize)  # type: ignore[method-assign]
-        self.deserialize = functools.lru_cache(maxsize=maxsize)(self.deserialize)  # type: ignore[method-assign]
-
-        return
 
     @abstractmethod
     def serialize(self, data: Any) -> bytes:

--- a/parsl/serialize/concretes.py
+++ b/parsl/serialize/concretes.py
@@ -1,4 +1,5 @@
 import dill
+import functools
 import pickle
 import logging
 
@@ -14,16 +15,34 @@ class PickleSerializer(SerializerBase):
     * functions defined in a interpreter/notebook
     * classes defined in local context and not importable using a fully qualified name
     * closures, generators and coroutines
-    * [sometimes] issues with wrapped/decorated functions
     """
 
     _identifier = b'01'
-    _for_code = True
+    _for_code = False
     _for_data = True
 
     def serialize(self, data: Any) -> bytes:
         return pickle.dumps(data)
 
+    def deserialize(self, body: bytes) -> Any:
+        return pickle.loads(body)
+
+
+class PickleCallableSerializer(SerializerBase):
+    """This serializer is a variant of the PickleSerializer that will
+    serialize and deserialize callables using an lru_cache, under the
+    assumption that callables are immutable and so can be cached.
+    """
+
+    _identifier = b'C1'
+    _for_code = True
+    _for_data = False
+
+    @functools.lru_cache
+    def serialize(self, data: Any) -> bytes:
+        return pickle.dumps(data)
+
+    @functools.lru_cache
     def deserialize(self, body: bytes) -> Any:
         return pickle.loads(body)
 
@@ -41,11 +60,30 @@ class DillSerializer(SerializerBase):
     """
 
     _identifier = b'02'
-    _for_code = True
+    _for_code = False
     _for_data = True
 
     def serialize(self, data: Any) -> bytes:
         return dill.dumps(data)
 
+    def deserialize(self, body: bytes) -> Any:
+        return dill.loads(body)
+
+
+class DillCallableSerializer(SerializerBase):
+    """This serializer is a variant of the DillSerializer that will
+    serialize and deserialize callables using an lru_cache, under the
+    assumption that callables are immutable and so can be cached.
+    """
+
+    _identifier = b'C2'
+    _for_code = True
+    _for_data = False
+
+    @functools.lru_cache
+    def serialize(self, data: Any) -> bytes:
+        return dill.dumps(data)
+
+    @functools.lru_cache
     def deserialize(self, body: bytes) -> Any:
         return dill.loads(body)

--- a/parsl/serialize/facade.py
+++ b/parsl/serialize/facade.py
@@ -14,7 +14,6 @@ methods_for_data = {}
 
 for key in METHODS_MAP_CODE:
     methods_for_code[key] = METHODS_MAP_CODE[key]()
-    methods_for_code[key].enable_caching(maxsize=128)
 
 for key in METHODS_MAP_DATA:
     methods_for_data[key] = METHODS_MAP_DATA[key]()

--- a/parsl/tests/test_serialization/test_2555_caching_deserializer.py
+++ b/parsl/tests/test_serialization/test_2555_caching_deserializer.py
@@ -1,0 +1,34 @@
+import parsl
+import pytest
+
+from parsl.tests.configs.htex_local import fresh_config as local_config
+
+
+@parsl.python_app
+def return_range(x):
+    return list(range(x))
+
+
+@pytest.mark.local
+def test_range_identities():
+    x = 3
+
+    fut1 = return_range(x)
+    res1 = fut1.result()
+
+    fut2 = return_range(x)
+    res2 = fut2.result()
+
+    # Check that the returned futures are different, by both usual
+    # Python equalities.
+    # This is not strictly part of the regression test for #2555
+    # but will detect related unexpected Future caching.
+
+    assert(fut1 != fut2)
+    assert(id(fut1) != id(fut2))
+
+    # check that the two invocations returned the same value...
+    assert res1 == res2
+
+    # ... but in two different objects.
+    assert(id(res1) != id(res2))

--- a/parsl/tests/test_serialization/test_2555_caching_deserializer.py
+++ b/parsl/tests/test_serialization/test_2555_caching_deserializer.py
@@ -24,11 +24,11 @@ def test_range_identities():
     # This is not strictly part of the regression test for #2555
     # but will detect related unexpected Future caching.
 
-    assert(fut1 != fut2)
-    assert(id(fut1) != id(fut2))
+    assert fut1 != fut2
+    assert id(fut1) != id(fut2)
 
     # check that the two invocations returned the same value...
     assert res1 == res2
 
     # ... but in two different objects.
-    assert(id(res1) != id(res2))
+    assert id(res1) != id(res2)


### PR DESCRIPTION
Prior to this PR:
parsl.serialize.facade monkeypatches some serializer objects to create new serializers, but does not generate new identifiers for those new serializers, so two serializers exist in the serializer globals with the same identifier.

This patching is done to make some new serializers that have caching behaviour.

This leads to issue #2555, where data from one serializer is deserialized using one of the these dynamically defined serializers, incorrectly.

This PR removes that monkeypatching and moves caching behaviour into two new serializers explicitly defined for the type of objects that should be cached.

This adds two new serializer identifiers, which means there is an incompatible wire protocol change: older versions of parsl will not be able to deserialize callables serialised after this PR.

This PR adds a regression test for issue #2555 that fails before this PR.

Fixes issue #2555

## Type of change

- Bug fix
- Breaking change to wire protocol
