### PR TITLE
Use pickle instead of parsl.serialize for memo hashes

### DIFF
--- a/parsl/dataflow/memoization.py
+++ b/parsl/dataflow/memoization.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import hashlib
 from functools import lru_cache, singledispatch
 import logging
+import pickle
 from parsl.dataflow.taskrecord import TaskRecord
 
 from typing import Dict, Any, List, Optional, TYPE_CHECKING
@@ -11,7 +12,6 @@ if TYPE_CHECKING:
 
 from concurrent.futures import Future
 
-from parsl.serialize import serialize
 import types
 
 logger = logging.getLogger(__name__)
@@ -54,8 +54,8 @@ def id_for_memo(obj: object, output_ref: bool = False) -> bytes:
 @id_for_memo.register(int)
 @id_for_memo.register(float)
 @id_for_memo.register(type(None))
-def id_for_memo_serialize(obj: object, output_ref: bool = False) -> bytes:
-    return serialize(obj)
+def id_for_memo_pickle(obj: object, output_ref: bool = False) -> bytes:
+    return pickle.dumps(obj)
 
 
 @id_for_memo.register(list)
@@ -68,7 +68,7 @@ def id_for_memo_list(denormalized_list: list, output_ref: bool = False) -> bytes
     for e in denormalized_list:
         normalized_list.append(id_for_memo(e, output_ref=output_ref))
 
-    return serialize(normalized_list)
+    return pickle.dumps(normalized_list)
 
 
 @id_for_memo.register(tuple)
@@ -81,7 +81,7 @@ def id_for_memo_tuple(denormalized_tuple: tuple, output_ref: bool = False) -> by
     for e in denormalized_tuple:
         normalized_list.append(id_for_memo(e, output_ref=output_ref))
 
-    return serialize(normalized_list)
+    return pickle.dumps(normalized_list)
 
 
 @id_for_memo.register(dict)
@@ -100,7 +100,7 @@ def id_for_memo_dict(denormalized_dict: dict, output_ref: bool = False) -> bytes
     for k in keys:
         normalized_list.append(id_for_memo(k))
         normalized_list.append(id_for_memo(denormalized_dict[k], output_ref=output_ref))
-    return serialize(normalized_list)
+    return pickle.dumps(normalized_list)
 
 
 # the LRU cache decorator must be applied closer to the id_for_memo_function call
@@ -112,7 +112,7 @@ def id_for_memo_function(f: types.FunctionType, output_ref: bool = False) -> byt
     This means that changing source code (other than the function name) will
     not cause a checkpoint invalidation.
     """
-    return serialize(["types.FunctionType", f.__name__, f.__module__])
+    return pickle.dumps(["types.FunctionType", f.__name__, f.__module__])
 
 
 class Memoizer:


### PR DESCRIPTION
Some memoisation functions are implemented by serializing values to generate hash material: this is done under the weak assumption that serializing the same value will always give the same hash material.

This PR tries to make that assumption stronger by forcing a particular serialization method for those memoization functions, as the serialization code moves towards allowing arbitrary user pluggable serialization functions that are much less likely to have that property.

This aligns with the explicit use of pickle to store checkpoints to disk, rather than parsl.serialize: memo/checkpointing is now entirely pickle based for serialization, leaving parsl.serialize only for moving objects to/from workers. This behaviour might be revisited later, with more awareness in parsl.serialize about these two other uses of serialization (memo-hashing objects, and moving objects through time).

This comes from work on parsl+proxystore prototype in PR https://github.com/Parsl/parsl/pull/2718/files

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
