### PR TITLE
Allow join_apps to return []

### DIFF
--- a/parsl/tests/test_python_apps/test_join.py
+++ b/parsl/tests/test_python_apps/test_join.py
@@ -139,3 +139,15 @@ def test_one_error_one_result():
     de0 = e.dependent_exceptions_tids[0][0]
     assert isinstance(de0, InnerError)
     assert de0.args[0] == "Error A"
+
+
+@join_app
+def app_no_futures():
+    return []
+
+
+def test_no_futures():
+    # tests that a list of futures that contains no futures will
+    # complete - regression test for issue #2792
+    f = app_no_futures()
+    assert f.result() == []


### PR DESCRIPTION
Prior to this PR, a join app returning an empty list, rather than a list with at least one Future, would hang at the joining stage. This is because join completion code was only invoked when Futures in the return list complete: with an empty list, that would be invoked 0 times.

There's no conceptual reason why a join app shouldn't return an empty list: (an example application, imagine, when processing n regions with n subtasks, identified by an earlier step, but that step identified n=0 regions, so there would be n=0 subtasks, and a list of length n=0 inner Futures to wait on.

This PR makes join completion code happen in the empty list case immediately, rather than indirecting it via completion callbacks on inner futures which do not exist.

This PR includes a regression test which, before this PR, hangs due to issue #2792.

Fixes issue #2792

## Type of change

- Bug fix (non-breaking change that fixes an issue)
