### PR TITLE
Remove log reference to "remote mode"

### DIFF
--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -214,7 +214,7 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
             logger.debug("Pushing start script")
             script_path = self.channel.push_file(script_path, self.channel.script_dir)
 
-        logger.debug("Launching in remote mode")
+        logger.debug("Launching")
         # We need to capture the exit code and the streams, so we put them in files. We also write
         # '-' to the exit code file to isolate potential problems with writing to files in the
         # script directory


### PR DESCRIPTION
PR #1471 removed the special casing that gave a remote mode and a local mode, distinct from LocalChannel and the various SSH channels, and since then the code has always followed the code path that used to be "remote mode".

## Type of change

- Documentation update
- Code maintentance/cleanup
