### PR TITLE
Remove a number of leftover test files

### DIFF
--- a/parsl/tests/test_bash_apps/test_basic.py
+++ b/parsl/tests/test_bash_apps/test_basic.py
@@ -1,56 +1,41 @@
-import argparse
 import os
-import pytest
-import shutil
-import time
 import random
 import re
+
+import pytest
 
 import parsl
 from parsl import File
 from parsl.app.app import bash_app
 
-from parsl.tests.configs.local_threads import config
-
 
 @bash_app
-def echo_to_file(inputs=[], outputs=[], stderr='std.err', stdout='std.out'):
+def echo_to_file(inputs=(), outputs=(), stderr=None, stdout=None):
     res = ""
-    for i in inputs:
-        for o in outputs:
+    for o in outputs:
+        for i in inputs:
             res += "echo {} >& {}".format(i, o)
     return res
 
 
 @bash_app
 def foo(x, y, z=10, stdout=None, label=None):
-    return """echo {0} {1} {z}
-    """.format(x, y, z=z)
+    return f"echo {x} {y} {z}"
 
 
 @pytest.mark.issue363
-def test_command_format_1():
-    """Testing command format for BashApps
-    """
+def test_command_format_1(tmpd_cwd):
+    """Testing command format for BashApps"""
 
-    outdir = os.path.abspath('outputs')
-    stdout = os.path.join(outdir, 'foo-std.out')
-    if os.path.exists(stdout):
-        os.remove(stdout)
+    outdir = tmpd_cwd / "outputs"
+    outdir.mkdir()
+    stdout = outdir / "foo-std.out"
 
-    foo_future = foo(1, 4, stdout=stdout)
-    print("[test_command_format_1] foo_future: ", foo_future)
-    contents = None
+    foo_future = foo(1, 4, stdout=str(stdout))
+    assert foo_future.result() == 0, "BashApp had non-zero exit code"
 
-    assert foo_future.result() == 0, "BashApp exited with an error code : {0}".format(
-        foo_future.result())
-
-    with open(stdout, 'r') as stdout_f:
-        contents = stdout_f.read()
-
-    assert contents == '1 4 10\n', 'Output does not match expected string "1 4 10", Got: "{0}"'.format(
-        contents)
-    return True
+    so_content = stdout.read_text().strip()
+    assert so_content == "1 4 10"
 
 
 @pytest.mark.issue363
@@ -61,8 +46,6 @@ def test_auto_log_filename_format():
     rand_int = random.randint(1000, 1000000000)
 
     foo_future = foo(1, rand_int, stdout=parsl.AUTO_LOGNAME, label=app_label)
-    print("[test_auto_log_filename_format] foo_future: ", foo_future)
-    contents = None
 
     assert foo_future.result() == 0, "BashApp exited with an error code : {0}".format(
         foo_future.result())
@@ -77,39 +60,25 @@ def test_auto_log_filename_format():
 
     assert contents == '1 {0} 10\n'.format(rand_int), \
         'Output does not match expected string "1 {0} 10", Got: "{1}"'.format(rand_int, contents)
-    return True
 
 
 @pytest.mark.issue363
-def test_parallel_for(n=3):
-    """Testing a simple parallel for loop
-    """
-    outdir = os.path.join(os.path.abspath('outputs'), 'test_parallel')
-    if not os.path.exists(outdir):
-        os.makedirs(outdir)
-    else:
-        shutil.rmtree(outdir)
-        os.makedirs(outdir)
-
-    d = {}
-
-    start = time.time()
-    for i in range(0, n):
-        d[i] = echo_to_file(
-            inputs=['Hello World {0}'.format(i)],
-            outputs=[File('{0}/out.{1}.txt'.format(outdir, i))],
-            stdout='{0}/std.{1}.out'.format(outdir, i),
-            stderr='{0}/std.{1}.err'.format(outdir, i),
+def test_parallel_for(tmpd_cwd, n=3):
+    """Testing a simple parallel for loop"""
+    outdir = tmpd_cwd / "outputs/test_parallel"
+    outdir.mkdir(parents=True)
+    futs = [
+        echo_to_file(
+            inputs=[f"Hello World {i}"],
+            outputs=[File(str(outdir / f"out.{i}.txt"))],
+            stdout=str(outdir / f"std.{i}.out"),
+            stderr=str(outdir / f"std.{i}.err"),
         )
+        for i in range(n)
+    ]
 
-    assert len(
-        d.keys()) == n, "Only {0}/{1} keys in dict".format(len(d.keys()), n)
+    for f in futs:
+        f.result()
 
-    [d[i].result() for i in d]
-    print("Duration : {0}s".format(time.time() - start))
-    stdout_file_count = len(
-        [item for item in os.listdir(outdir) if item.endswith('.out')])
-    assert stdout_file_count == n, "Only {0}/{1} files in '{2}' ".format(len(os.listdir('outputs/')),
-                                                                         n, outdir)
-    print("[TEST STATUS] test_parallel_for [SUCCESS]")
-    return d
+    stdout_file_count = len(list(outdir.glob("*.out")))
+    assert stdout_file_count == n, sorted(outdir.iterdir())

--- a/parsl/tests/test_bash_apps/test_kwarg_storage.py
+++ b/parsl/tests/test_bash_apps/test_kwarg_storage.py
@@ -1,104 +1,33 @@
-import os
 import pytest
+
 from parsl.app.app import bash_app
 
 
 @bash_app
 def foo(z=2, stdout=None):
-    return """echo {val}
-    """.format(val=z)
+    return f"echo {z}"
 
 
 @pytest.mark.issue363
-def test_command_format_1():
+def test_command_format_1(tmpd_cwd):
     """Testing command format for BashApps
     """
 
-    stdout = os.path.abspath('std.out.0')
-    if os.path.exists(stdout):
-        os.remove(stdout)
+    stdout = tmpd_cwd / "std.out"
+    for exp_value, z in (
+        ("3", 3),
+        ("4", 4),
+        ("5", 5),
+    ):
+        app_fu = foo(z=z, stdout=str(stdout))
+        assert app_fu.result() == 0, "BashApp had non-zero exit"
 
-    app_fu = foo(stdout=stdout)
-    print("app_fu : ", app_fu)
-    contents = None
+        so_content = stdout.read_text().strip()
+        assert so_content == exp_value
+        stdout.unlink()
 
-    assert app_fu.result() == 0, "BashApp exited with an error code : {0}".format(
-        app_fu.result())
+    app_fu = foo(stdout=str(stdout))
+    assert app_fu.result() == 0, "BashApp had non-zero exit"
 
-    with open(stdout, 'r') as stdout_f:
-        contents = stdout_f.read()
-        print("Contents : ", contents)
-
-    if os.path.exists('stdout_file'):
-        os.remove(stdout)
-
-    assert contents == '2\n', 'Output does not match expected string "2", Got: "{0}"'.format(
-        contents)
-
-# ===========
-
-    stdout = os.path.abspath('std.out.1')
-    if os.path.exists(stdout):
-        os.remove(stdout)
-
-    app_fu = foo(z=3, stdout=stdout)
-    print("app_fu : ", app_fu)
-    contents = None
-
-    assert app_fu.result() == 0, "BashApp exited with an error code : {0}".format(
-        app_fu.result())
-
-    with open(stdout, 'r') as stdout_f:
-        contents = stdout_f.read()
-        print("Contents : ", contents)
-
-    if os.path.exists('stdout_file'):
-        os.remove(stdout)
-
-    assert contents == '3\n', 'Output does not match expected string "3", Got: "{0}"'.format(
-        contents)
-
-# ===========
-    stdout = os.path.abspath('std.out.2')
-    if os.path.exists(stdout):
-        os.remove(stdout)
-
-    app_fu = foo(z=4, stdout=stdout)
-    print("app_fu : ", app_fu)
-    contents = None
-
-    assert app_fu.result() == 0, "BashApp exited with an error code : {0}".format(
-        app_fu.result())
-
-    with open(stdout, 'r') as stdout_f:
-        contents = stdout_f.read()
-        print("Contents : ", contents)
-
-    if os.path.exists('stdout_file'):
-        os.remove(stdout)
-
-    assert contents == '4\n', 'Output does not match expected string "4", Got: "{0}"'.format(
-        contents)
-
-# ===========
-    stdout = os.path.abspath('std.out.3')
-    if os.path.exists(stdout):
-        os.remove(stdout)
-
-    app_fu = foo(stdout=stdout)
-    print("app_fu : ", app_fu)
-    contents = None
-
-    assert app_fu.result() == 0, "BashApp exited with an error code : {0}".format(
-        app_fu.result())
-
-    with open(stdout, 'r') as stdout_f:
-        contents = stdout_f.read()
-        print("Contents : ", contents)
-
-    if os.path.exists('stdout_file'):
-        os.remove(stdout)
-
-    assert contents == '2\n', 'Output does not match expected string "2", Got: "{0}"'.format(
-        contents)
-    return True
+    so_content = stdout.read_text().strip()
+    assert so_content == "2"

--- a/parsl/tests/test_bash_apps/test_multiline.py
+++ b/parsl/tests/test_bash_apps/test_multiline.py
@@ -1,21 +1,11 @@
-import argparse
-import os
 import pytest
-import shutil
-import time
 
-import parsl
 from parsl import File
 from parsl.app.app import bash_app
-from parsl.tests.configs.local_threads import config
 
 
 @bash_app
-def multiline(
-        inputs=[],
-        outputs=[],
-        stderr=os.path.abspath('std.err'),
-        stdout=os.path.abspath('std.out')):
+def multiline(inputs=(), outputs=(), stderr=None, stdout=None):
     return """echo {inputs[0]} &> {outputs[0]}
     echo {inputs[1]} &> {outputs[1]}
     echo {inputs[2]} &> {outputs[2]}
@@ -25,39 +15,23 @@ def multiline(
 
 
 @pytest.mark.issue363
-def test_multiline():
-
-    outdir = os.path.abspath('outputs')
-
-    if not os.path.exists(outdir):
-        os.makedirs(outdir)
-    else:
-        shutil.rmtree(outdir)
-        os.makedirs(outdir)
-
+def test_multiline(tmpd_cwd):
+    so, se = tmpd_cwd / "std.out", tmpd_cwd / "std.err"
     f = multiline(
-            inputs=["Hello", "This is", "Cat!"],
-            outputs=[
-                File('{0}/hello.txt'.format(outdir)),
-                File('{0}/this.txt'.format(outdir)),
-                File('{0}/cat.txt'.format(outdir))
-            ]
+        inputs=["Hello", "This is", "Cat!"],
+        outputs=[
+            File(str(tmpd_cwd / "hello.txt")),
+            File(str(tmpd_cwd / "this.txt")),
+            File(str(tmpd_cwd / "cat.txt")),
+        ],
+        stdout=str(so),
+        stderr=str(se),
     )
-    print(f.result())
+    f.result()
 
-    time.sleep(0.1)
-    assert 'hello.txt' in os.listdir(outdir), "hello.txt is missing"
-    assert 'this.txt' in os.listdir(outdir), "this.txt is missing"
-    assert 'cat.txt' in os.listdir(outdir), "cat.txt is missing"
-
-    with open('std.out', 'r') as o:
-        out = o.read()
-        assert out != "Testing STDOUT", "Stdout is bad"
-
-    with open('std.err', 'r') as o:
-        err = o.read()
-        assert err != "Testing STDERR", "Stderr is bad"
-
-    os.remove('std.err')
-    os.remove('std.out')
-    return True
+    flist = list(map(str, (f.name for f in tmpd_cwd.iterdir())))
+    assert 'hello.txt' in flist, "hello.txt is missing"
+    assert 'this.txt' in flist, "this.txt is missing"
+    assert 'cat.txt' in flist, "cat.txt is missing"
+    assert "Testing STDOUT" in so.read_text()
+    assert "Testing STDERR" in se.read_text()

--- a/parsl/tests/test_bash_apps/test_pipeline.py
+++ b/parsl/tests/test_bash_apps/test_pipeline.py
@@ -1,17 +1,12 @@
-import argparse
-import os
 import pytest
 
-import parsl
 from parsl.app.app import bash_app
 from parsl.data_provider.files import File
 from parsl.app.futures import DataFuture
 
-from parsl.tests.configs.local_threads import config
-
 
 @bash_app
-def increment(inputs=[], outputs=[], stdout=None, stderr=None):
+def increment(inputs=(), outputs=(), stdout=None, stderr=None):
     cmd_line = """
     if ! [ -f {inputs[0]} ] ; then exit 43 ; fi
     x=$(cat {inputs[0]})
@@ -21,7 +16,7 @@ def increment(inputs=[], outputs=[], stdout=None, stderr=None):
 
 
 @bash_app
-def slow_increment(dur, inputs=[], outputs=[], stdout=None, stderr=None):
+def slow_increment(dur, inputs=(), outputs=(), stdout=None, stderr=None):
     cmd_line = """
     x=$(cat {inputs[0]})
     echo $(($x+1)) > {outputs[0]}
@@ -30,91 +25,60 @@ def slow_increment(dur, inputs=[], outputs=[], stdout=None, stderr=None):
     return cmd_line
 
 
-def cleanup_work(depth):
-    for i in range(0, depth):
-        fn = "test{0}.txt".format(i)
-        if os.path.exists(fn):
-            os.remove(fn)
-
-
 @pytest.mark.staging_required
-def test_increment(depth=5):
+def test_increment(tmpd_cwd, depth=5):
     """Test simple pipeline A->B...->N
     """
+    fpath = tmpd_cwd / "test0.txt"
+    fpath.write_text("0\n")
 
-    cleanup_work(depth)
-
-    # Create the first file
-    open("test0.txt", 'w').write('0\n')
-
-    # Create the first entry in the dictionary holding the futures
-    prev = File("test0.txt")
-    futs = {}
+    prev = [File(str(fpath))]
+    futs = []
     for i in range(1, depth):
-        print("Launching {0} with {1}".format(i, prev))
-        assert isinstance(prev, DataFuture) or isinstance(prev, File)
-        output = File("test{0}.txt".format(i))
-        fu = increment(inputs=[prev],  # Depend on the future from previous call
-                       # Name the file to be created here
-                       outputs=[output],
-                       stdout="incr{0}.out".format(i),
-                       stderr="incr{0}.err".format(i))
-        [prev] = fu.outputs
-        futs[i] = prev
-        print(prev.filepath)
-        assert isinstance(prev, DataFuture)
+        assert isinstance(prev[0], (DataFuture, File))
+        output = File(str(tmpd_cwd / f"test{i}.txt"))
+        f = increment(
+            inputs=prev,
+            outputs=[output],
+            stdout=str(tmpd_cwd / f"incr{i}.out"),
+            stderr=str(tmpd_cwd / f"incr{i}.err"),
+        )
+        prev = f.outputs
+        futs.append((i, prev[0]))
+        assert isinstance(prev[0], DataFuture)
 
-    for key in futs:
-        if key > 0:
-            fu = futs[key]
-            file = fu.result()
-            filename = file.filepath
+    for key, f in futs:
+        file = f.result()
+        expected = str(tmpd_cwd / f"test{key}.txt")
 
-            # this test is a bit close to a test of the specific implementation
-            # of File
-            assert file.local_path is None, "File on local side has overridden local_path, file: {}".format(repr(file))
-            assert file.filepath == "test{0}.txt".format(key), "Submit side filepath has not been preserved over execution"
-
-            data = open(filename, 'r').read().strip()
-            assert data == str(
-                key), "[TEST] incr failed for key: {0} got data: {1} from filename {2}".format(key, data, filename)
-
-    cleanup_work(depth)
+        assert file.local_path is None, "File on local side has overridden local_path, file: {}".format(repr(file))
+        assert file.filepath == expected, "Submit side filepath has not been preserved over execution"
+        data = open(file.filepath).read().strip()
+        assert data == str(key)
 
 
 @pytest.mark.staging_required
-def test_increment_slow(depth=5, dur=0.5):
+def test_increment_slow(tmpd_cwd, depth=5, dur=0.01):
     """Test simple pipeline slow (sleep.5) A->B...->N
     """
 
-    cleanup_work(depth)
+    fpath = tmpd_cwd / "test0.txt"
+    fpath.write_text("0\n")
 
-    # Create the first file
-    open("test0.txt", 'w').write('0\n')
-
-    prev = File("test0.txt")
-    # Create the first entry in the dictionary holding the futures
-    futs = {}
-    print("************** Type: ", type(dur), dur)
+    prev = [File(str(fpath))]
+    futs = []
     for i in range(1, depth):
-        print("Launching {0} with {1}".format(i, prev))
-        output = File("test{0}.txt".format(i))
-        fu = slow_increment(dur,
-                            # Depend on the future from previous call
-                            inputs=[prev],
-                            # Name the file to be created here
-                            outputs=[output],
-                            stdout="incr{0}.out".format(i),
-                            stderr="incr{0}.err".format(i))
-        [prev] = fu.outputs
-        futs[i] = prev
-        print(prev.filepath)
+        output = File(str(tmpd_cwd / f"test{i}.txt"))
+        f = slow_increment(
+            dur,
+            inputs=prev,
+            outputs=[output],
+            stdout=str(tmpd_cwd / f"incr{i}.out"),
+            stderr=str(tmpd_cwd / f"incr{i}.err"),
+        )
+        prev = f.outputs
+        futs.append((i, prev[0]))
 
-    for key in futs:
-        if key > 0:
-            fu = futs[key]
-            data = open(fu.result().filepath, 'r').read().strip()
-            assert data == str(
-                key), "[TEST] incr failed for key: {0} got: {1}".format(key, data)
-
-    cleanup_work(depth)
+    for key, f in futs:
+        data = open(f.result().filepath).read().strip()
+        assert data == str(key)

--- a/parsl/tests/test_data/test_output_chain_filenames.py
+++ b/parsl/tests/test_data/test_output_chain_filenames.py
@@ -1,46 +1,36 @@
-import argparse
-import os
-
-import pytest
-
-import parsl
-
 from concurrent.futures import Future
+
 from parsl import File
 from parsl.app.app import bash_app
 
 
 @bash_app
-def app1(inputs=[], outputs=[], stdout=None, stderr=None, mock=False):
-    cmd_line = f"""echo 'test' > {outputs[0]}"""
-    return cmd_line
+def app1(inputs=(), outputs=(), stdout=None, stderr=None, mock=False):
+    return f"echo 'test' > {outputs[0]}"
 
 
 @bash_app
-def app2(inputs=[], outputs=[], stdout=None, stderr=None, mock=False):
-
-    with open('somefile.txt', 'w') as f:
-        f.write("%s\n" % inputs[0])
-    cmd_line = f"""echo '{inputs[0]}' > {outputs[0]}"""
-    return cmd_line
+def app2(inputs=(), outputs=(), stdout=None, stderr=None, mock=False):
+    return f"echo '{inputs[0]}' > {outputs[0]}"
 
 
-def test_behavior():
-    app1_future = app1(inputs=[],
-                       outputs=[File("simple-out.txt")])
+def test_behavior(tmpd_cwd):
+    expected_path = str(tmpd_cwd / "simple-out.txt")
+    app1_future = app1(
+        inputs=[],
+        outputs=[File(expected_path)]
+    )
 
     o = app1_future.outputs[0]
     assert isinstance(o, Future)
 
-    app2_future = app2(inputs=[o],
-                       outputs=[File("simple-out2.txt")])
+    app2_future = app2(
+        inputs=[o],
+        outputs=[File(str(tmpd_cwd / "simple-out2.txt"))]
+    )
     app2_future.result()
 
-    expected_name = 'b'
-    with open('somefile.txt', 'r') as f:
-        name = f.read()
-
     with open(app2_future.outputs[0].filepath, 'r') as f:
-        expected_name = f.read()
+        name = f.read().strip()
 
-    assert name == expected_name, "Filename mangled due to DataFuture handling"
+    assert name == expected_path, "Filename mangled due to DataFuture handling"

--- a/parsl/tests/test_docs/test_workflow4.py
+++ b/parsl/tests/test_docs/test_workflow4.py
@@ -1,53 +1,43 @@
-import os
-import parsl
-
-from parsl.app.app import bash_app, python_app
-from parsl.tests.configs.local_threads import config
-from parsl.data_provider.files import File
-
 import pytest
 
-# parsl.set_stream_logger()
+from parsl.app.app import bash_app, python_app
+from parsl.data_provider.files import File
 
 
 @bash_app
-def generate(outputs=[]):
-    return "echo $(( RANDOM % (10 - 5 + 1 ) + 5 )) &> {o}".format(o=outputs[0])
+def generate(outputs=()):
+    return "echo 1 &> {o}".format(o=outputs[0])
 
 
 @bash_app
-def concat(inputs=[], outputs=[], stdout="stdout.txt", stderr='stderr.txt'):
+def concat(inputs=(), outputs=(), stdout=None, stderr=None):
     return "cat {0} >> {1}".format(" ".join(map(lambda x: x.filepath, inputs)), outputs[0])
 
 
 @python_app
-def total(inputs=[]):
-    total = 0
-    with open(inputs[0].filepath, 'r') as f:
-        for line in f:
-            total += int(line)
-    return total
+def total(inputs=()):
+    with open(inputs[0].filepath, "r") as f:
+        return sum(int(line) for line in f)
 
 
 @pytest.mark.staging_required
-def test_parallel_dataflow():
+@pytest.mark.parametrize("width", (5, 10, 15))
+def test_parallel_dataflow(tmpd_cwd, width):
     """Test parallel dataflow from docs on Composing workflows
     """
 
-    if os.path.exists('all.txt'):
-        os.remove('all.txt')
-
     # create 5 files with random numbers
-    output_files = []
-    for i in range(5):
-        if os.path.exists('random-%s.txt' % i):
-            os.remove('random-%s.txt' % i)
-        output_files.append(generate(outputs=[File('random-%s.txt' % i)]))
+    output_files = [
+        generate(outputs=[File(str(tmpd_cwd / f"random-{i}.txt"))])
+        for i in range(width)
+    ]
 
     # concatenate the files into a single file
-    cc = concat(inputs=[i.outputs[0]
-                        for i in output_files], outputs=[File("all.txt")])
+    cc = concat(
+        inputs=[i.outputs[0] for i in output_files],
+        outputs=[File(str(tmpd_cwd / "all.txt"))]
+    )
 
     # calculate the average of the random numbers
     totals = total(inputs=[cc.outputs[0]])
-    print(totals.result())
+    assert totals.result() == len(output_files)


### PR DESCRIPTION
Take advantage of pytest fixtures and update all errant tests accordingly.  In particular, noting that many tests rely on shared fs, use a temporary directory structure rooted inside of the CWD (typically the root Git directory), rather than `tmp_path`'s native use of `TMPDIR`.

The only leftover detritus I didn't engineer removal of was the `runinfo/` directory, which is where Parsl places logs if `parsl.AUTO_LOGNAME` is in play. Given the potential to interplay with a developer's "live" data, I opted to leave this for now.

## Type of change

- Code maintenance/cleanup
