### PR TITLE
Remove test_1606 sleep

### DIFF
--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -161,9 +161,9 @@ def load_dfk_local_module(request, pytestconfig):
     parsl.load. It should be a Callable that returns a parsl Config object.
 
     If local_setup and/or local_teardown are callables (such as functions) in
-    the test module, they they will be invoked before/after the tests. This
-    can be used to perform more interesting DFK initialisation not possible
-    with local_config.
+    the test module, they will be invoked before/after the tests. This can
+    be used to perform more interesting DFK initialisation not possible with
+    local_config.
     """
 
     config = pytestconfig.getoption('config')[0]

--- a/parsl/tests/test_regression/test_1606_wait_for_current_tasks.py
+++ b/parsl/tests/test_regression/test_1606_wait_for_current_tasks.py
@@ -1,17 +1,42 @@
+import threading
+import time
+
+import pytest
+
 import parsl
+from parsl.tests.configs.local_threads import fresh_config as local_config  # noqa
 
 
 @parsl.python_app
-def slow_app(delay):
-    import time
-    time.sleep(delay)
+def slow_app(evt: threading.Event):
+    evt.wait()
 
 
+@pytest.mark.local
 def test_wait_for_tasks():
-    slow_app(5)
-    slow_app(10)  # This test has a higher task ID, and runs for a longer period
-    slow_app(3)  # This test has a higher task ID, but runs for a shorter period
-    parsl.dfk().wait_for_current_tasks()
-    # the regression reported in #1606 is that wait_for_current_tasks
-    # fails due to tasks being removed from the DFK tasks dict as they
-    # complete, introduced in #1543.
+    """
+    gh#1606 reported that wait_for_current_tasks fails due to tasks being removed
+    from the DFK tasks dict as they complete; bug introduced in #1543.
+    """
+    def test_kernel(may_wait: threading.Event):
+        e1, e2 = threading.Event(), threading.Event()
+
+        # app_slow is in *middle* of internal DFK data structure
+        app_fast1, app_slow, app_fast2 = slow_app(e1), slow_app(e2), slow_app(e1)
+
+        may_wait.set()  # initiated wait in outer test
+        time.sleep(0.01)
+
+        e1.set()
+
+        while not all(f.done() for f in (app_fast1, app_fast2)):
+            time.sleep(0.01)
+
+        e2.set()
+        app_slow.result()
+
+    may_continue = threading.Event()
+    threading.Thread(target=test_kernel, daemon=True, args=(may_continue,)).start()
+
+    may_continue.wait()
+    parsl.dfk().wait_for_current_tasks()  # per sleeps, waits for all 3 tasks


### PR DESCRIPTION
This tests internal DFK data structures; only necessary to run locally.  This means we can use `threading.Event()` to enact this test, rather than sleeping the day away.

## Type of change

- Code maintenance/cleanup
