### PR TITLE
Move types-* requirements into -test-requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
 pyzmq>=17.1.2
 typeguard>=2.10,<3
 typing-extensions>=4.6,<5
-types-paramiko
-types-requests
-types-six
 six
 globus-sdk
 dill

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,6 +11,7 @@ mypy==1.1.1
 types-python-dateutil
 types-requests
 types-six
+types-paramiko
 
 # sqlalchemy is needed for typechecking, so it's here
 # as well as at runtime for optional monitoring execution


### PR DESCRIPTION
These aren't needed at runtime - only for mypy-style development/test.

This reduces the dependency footprint of non-development Parsl, which is intended to help in the lsst_distrib environment which has a lot of other stuff going on.

CI note: CI won't detect problems introduced here, because it always installs test-requirements - so the installed dependencies should end up being roughly the same.

## Type of change

- Code maintentance/cleanup
