### PR TITLE
Remove pickle serializer for callables

### DIFF
--- a/parsl/serialize/concretes.py
+++ b/parsl/serialize/concretes.py
@@ -28,25 +28,6 @@ class PickleSerializer(SerializerBase):
         return pickle.loads(body)
 
 
-class PickleCallableSerializer(SerializerBase):
-    """This serializer is a variant of the PickleSerializer that will
-    serialize and deserialize callables using an lru_cache, under the
-    assumption that callables are immutable and so can be cached.
-    """
-
-    _identifier = b'C1'
-    _for_code = True
-    _for_data = False
-
-    @functools.lru_cache
-    def serialize(self, data: Any) -> bytes:
-        return pickle.dumps(data)
-
-    @functools.lru_cache
-    def deserialize(self, body: bytes) -> Any:
-        return pickle.loads(body)
-
-
 class DillSerializer(SerializerBase):
     """ Dill serialization works on a superset of object including the ones covered by pickle.
     However for most cases pickle is faster. For most callable objects the additional overhead


### PR DESCRIPTION
This serializer, in current practical parsl cases, will raise an exception every time and fall through to the dill callable serializer, because it cannot serialize the wrappers that Parsl user functions are wrapped in.

Were it actually able to serialize, it would in many usecases generate invalid serializations, rather than raising an exception: in any case where an app was defined in a main file rather than in an importable file (eg. simple workflow scripts, REPLs like Jupyter notebooks)

## Type of change

- New feature (non-breaking change that adds(removes) functionality)
