### PR TITLE
Reduce test delay from 45s to 1

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -595,10 +595,9 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         except TypeError:
             raise SerializationError(func.__name__)
 
-        msg = {"task_id": task_id,
-               "buffer": fn_buf}
+        msg = {"task_id": task_id, "buffer": fn_buf}
 
-        # Post task to the the outgoing queue
+        # Post task to the outgoing queue
         self.outgoing_q.put(msg)
 
         # Return the future

--- a/parsl/tests/test_scaling/test_regression_1621.py
+++ b/parsl/tests/test_scaling/test_regression_1621.py
@@ -1,33 +1,27 @@
-# this test is intended to ensure that only one block is launched when only
-# one app is invoked. this is a regression test.
+import threading
 
-import logging
+import pytest
+
 import parsl
 from parsl.channels import LocalChannel
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.launchers import SimpleLauncher
 from parsl.providers import LocalProvider
-import pytest
-
-
-logger = logging.getLogger(__name__)
 
 
 @parsl.python_app
 def app():
     import time
-    time.sleep(45)
+    time.sleep(1)
 
 
 class OneShotLocalProvider(LocalProvider):
     def __init__(self, *args, **kwargs):
-        logger.info("OneShotLocalProvider __init__ with MRO: {}".format(type(self).mro()))
         self.recorded_submits = 0
         super().__init__(*args, **kwargs)
 
     def submit(self, *args, **kwargs):
-        logger.info("OneShotLocalProvider submit")
         self.recorded_submits += 1
         return super().submit(*args, **kwargs)
 
@@ -35,32 +29,44 @@ class OneShotLocalProvider(LocalProvider):
 
 
 @pytest.mark.local
-def test_one_block():
-
+def test_one_block(tmpd_cwd):
+    """
+    this test is intended to ensure that only one block is launched when only
+    one app is invoked. this is a regression test.
+    """
     oneshot_provider = OneShotLocalProvider(
-                    channel=LocalChannel(),
-                    init_blocks=0,
-                    min_blocks=0,
-                    max_blocks=10,
-                    launcher=SimpleLauncher(),
-                )
+        channel=LocalChannel(),
+        init_blocks=0,
+        min_blocks=0,
+        max_blocks=10,
+        launcher=SimpleLauncher(),
+    )
 
     config = Config(
         executors=[
             HighThroughputExecutor(
                 label="htex_local",
+                address="127.0.0.1",
                 worker_debug=True,
                 cores_per_worker=1,
                 provider=oneshot_provider,
+                worker_logdir_root=str(tmpd_cwd)
             )
         ],
         strategy='simple',
     )
 
     parsl.load(config)
+    dfk = parsl.dfk()
 
-    f = app()
-    f.result()
+    def poller():
+        import time
+        while True:
+            dfk.job_status_poller.poll()
+            time.sleep(0.1)
+
+    threading.Thread(target=poller, daemon=True).start()
+    app().result()
     parsl.dfk().cleanup()
     parsl.clear()
 


### PR DESCRIPTION
The key change is to abuse the `JobStatusPoller.poll()` to ping the scale-out logic more often than the hard-coded 5s.  Ping it every tenth of a second for the second it takes the app() to complete.  Nominally, if the scaling logic is correct, then with a single app it won't matter that it's spammed: we'll only scale out a single block total.

## Type of change

- Code maintenance/cleanup
