### PR TITLE
Remove unnecessary log output in CI

### DIFF
--- a/parsl/executors/taskvine/install-taskvine.sh
+++ b/parsl/executors/taskvine/install-taskvine.sh
@@ -2,15 +2,17 @@
 
 set -xe
 
-if [ "$CCTOOLS_VERSION" == "" ] ; then
+if [[ -z $CCTOOLS_VERSION ]]; then
   echo Environment variable CCTOOLS_VERSION must be set
   exit 1
 fi
 
-if [ -f "/etc/redhat-release" ]; then
-    wget -O /tmp/cctools.tar.gz "https://github.com/cooperative-computing-lab/cctools/releases/download/release/$CCTOOLS_VERSION/cctools-$CCTOOLS_VERSION-x86_64-centos8.tar.gz"
-else    
-    wget -O /tmp/cctools.tar.gz "https://github.com/cooperative-computing-lab/cctools/releases/download/release/$CCTOOLS_VERSION/cctools-$CCTOOLS_VERSION-x86_64-ubuntu20.04.tar.gz"
-fi
+TARBALL="cctools-$CCTOOLS_VERSION-x86_64-ubuntu20.04.tar.gz"
+[[ -f "/etc/redhat-release" ]] && TARBALL="cctools-$CCTOOLS_VERSION-x86_64-centos8.tar.gz"
+
+# If stderr is *not* a TTY, then disable progress bar and show HTTP response headers
+[[ ! -t 1 ]] && NO_VERBOSE="--no-verbose" SHOW_HEADERS="-S"
+wget "$NO_VERBOSE" "$SHOW_HEADERS" -O /tmp/cctools.tar.gz "https://github.com/cooperative-computing-lab/cctools/releases/download/release/$CCTOOLS_VERSION/$TARBALL"
+
 mkdir -p /tmp/cctools
-tar -C /tmp/cctools -zxvf /tmp/cctools.tar.gz --strip-components=1
+tar -C /tmp/cctools -zxf /tmp/cctools.tar.gz --strip-components=1


### PR DESCRIPTION
No need to scroll past the progress bar in the CI -- use of the logs there is almost always a retrospective, so save some bits.

- remove `wget`'s progress output
- remove `tar`'s verbose flag

## Type of change

- Code maintenance/cleanup
