### PR TITLE
Make serializer registration explicit

### DIFF
--- a/parsl/serialize/base.py
+++ b/parsl/serialize/base.py
@@ -5,29 +5,12 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# GLOBALS
-METHODS_MAP_CODE = {}
-METHODS_MAP_DATA = {}
-
 
 class SerializerBase:
     """ Adds shared functionality for all serializer implementations
     """
 
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        """ This forces all child classes to register themselves as
-        methods for serializing code or data
-        """
-        super().__init_subclass__(**kwargs)
-
-        if cls._for_code:
-            METHODS_MAP_CODE[cls._identifier] = cls
-        if cls._for_data:
-            METHODS_MAP_DATA[cls._identifier] = cls
-
     _identifier: bytes
-    _for_code: bool
-    _for_data: bool
 
     @property
     def identifier(self) -> bytes:

--- a/parsl/serialize/concretes.py
+++ b/parsl/serialize/concretes.py
@@ -18,8 +18,6 @@ class PickleSerializer(SerializerBase):
     """
 
     _identifier = b'01'
-    _for_code = False
-    _for_data = True
 
     def serialize(self, data: Any) -> bytes:
         return pickle.dumps(data)
@@ -41,8 +39,6 @@ class DillSerializer(SerializerBase):
     """
 
     _identifier = b'02'
-    _for_code = False
-    _for_data = True
 
     def serialize(self, data: Any) -> bytes:
         return dill.dumps(data)
@@ -58,8 +54,6 @@ class DillCallableSerializer(SerializerBase):
     """
 
     _identifier = b'C2'
-    _for_code = True
-    _for_data = False
 
     @functools.lru_cache
     def serialize(self, data: Any) -> bytes:

--- a/parsl/serialize/facade.py
+++ b/parsl/serialize/facade.py
@@ -1,22 +1,34 @@
-from parsl.serialize.concretes import *  # noqa: F403,F401
-from parsl.serialize.base import METHODS_MAP_DATA, METHODS_MAP_CODE
+from parsl.serialize.base import SerializerBase
 import logging
 
-from typing import Any, List, Union
+from typing import Any, Dict, List, Union
 
 logger = logging.getLogger(__name__)
 
+import parsl.serialize.concretes as concretes
 
-""" Instantiate the appropriate classes
-"""
+
+methods_for_code: Dict[bytes, SerializerBase]
 methods_for_code = {}
+
+
+def register_method_for_code(s: SerializerBase) -> None:
+    methods_for_code[s.identifier] = s
+
+
+register_method_for_code(concretes.DillCallableSerializer())
+
+
+methods_for_data: Dict[bytes, SerializerBase]
 methods_for_data = {}
 
-for key in METHODS_MAP_CODE:
-    methods_for_code[key] = METHODS_MAP_CODE[key]()
 
-for key in METHODS_MAP_DATA:
-    methods_for_data[key] = METHODS_MAP_DATA[key]()
+def register_method_for_data(s: SerializerBase) -> None:
+    methods_for_data[s.identifier] = s
+
+
+register_method_for_data(concretes.PickleSerializer())
+register_method_for_data(concretes.DillSerializer())
 
 
 def pack_apply_message(func: Any, args: Any, kwargs: Any, buffer_threshold: int = int(128 * 1e6)) -> bytes:

--- a/parsl/serialize/facade.py
+++ b/parsl/serialize/facade.py
@@ -1,15 +1,13 @@
-from parsl.serialize.base import SerializerBase
 import logging
-
 from typing import Any, Dict, List, Union
+
+import parsl.serialize.concretes as concretes
+from parsl.serialize.base import SerializerBase
 
 logger = logging.getLogger(__name__)
 
-import parsl.serialize.concretes as concretes
 
-
-methods_for_code: Dict[bytes, SerializerBase]
-methods_for_code = {}
+methods_for_code: Dict[bytes, SerializerBase] = {}
 
 
 def register_method_for_code(s: SerializerBase) -> None:
@@ -19,8 +17,7 @@ def register_method_for_code(s: SerializerBase) -> None:
 register_method_for_code(concretes.DillCallableSerializer())
 
 
-methods_for_data: Dict[bytes, SerializerBase]
-methods_for_data = {}
+methods_for_data: Dict[bytes, SerializerBase] = {}
 
 
 def register_method_for_data(s: SerializerBase) -> None:


### PR DESCRIPTION
Previously registration was implicit in the class definition, using a subclass hook. This makes it a bit awkward to work with the set of registered serializers:

* serializers would be registered at definition time (which because of non-deterministic import order) makes the order awkward to understand if serialisers are defined in more than one module.

* serializers could not be defined without being registered

This PR makes the set of serializers more explicit, with the defaults registered at import of the facade module. Definitions of serializers in concretes.py (or anywhere else) now do not result in a registration.

This is part of a move towards user-pluggable serializers, although this PR does not actually support adding more user serializers (as they will not be imported on the distant end).

## Type of change

- New feature (non-breaking change that adds functionality)
