### PR TITLE
Remove duplicate import not detected by flake8

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -20,11 +20,9 @@ from parsl.serialize import deserialize
 
 from parsl.monitoring.message_type import MessageType
 from parsl.monitoring.types import AddressedMonitoringMessage, TaggedMonitoringMessage
-from typing import cast, Any, Callable, Dict, Optional, Sequence, Union
+from typing import cast, Any, Callable, Dict, Optional, Sequence, Tuple, Union
 
 _db_manager_excepts: Optional[Exception]
-
-from typing import Optional, Tuple
 
 
 try:


### PR DESCRIPTION
This wasn't detected by flake8, but moving the line above the type for _db_manager_excepts caused flake8 to detect it, so perhaps it is the presence of intervening code between the imports that causes that.

## Type of change

- Code maintentance/cleanup
