### PR TITLE
Move serialization error definitions into parsl.serialize

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -139,8 +139,6 @@ Exceptions
     parsl.errors.OptionalModuleMissing
     parsl.executors.errors.ExecutorError
     parsl.executors.errors.ScalingFailed
-    parsl.executors.errors.SerializationError
-    parsl.executors.errors.DeserializationError
     parsl.executors.errors.BadMessage
     parsl.dataflow.errors.DataFlowException
     parsl.dataflow.errors.BadCheckpoint
@@ -161,6 +159,8 @@ Exceptions
     parsl.channels.errors.FileCopyException
     parsl.executors.high_throughput.errors.WorkerLost
     parsl.executors.high_throughput.interchange.ManagerLost
+    parsl.serialize.errors.DeserializationError
+    parsl.serialize.errors.SerializationError
 
 Internal
 ========

--- a/parsl/executors/errors.py
+++ b/parsl/executors/errors.py
@@ -58,19 +58,6 @@ class DeserializationError(ParslError):
         return "Failed to deserialize return objects. Reason:{}".format(self.reason)
 
 
-class SerializationError(ParslError):
-    """ Failure to serialize data arguments for the tasks
-    """
-
-    def __init__(self, fname):
-        self.fname = fname
-        self.troubleshooting = "https://parsl.readthedocs.io/en/latest/faq.html#addressing-serializationerror"
-
-    def __str__(self):
-        return "Failed to serialize data objects for {}. Refer {} ".format(self.fname,
-                                                                           self.troubleshooting)
-
-
 class BadMessage(ParslError):
     """ Mangled/Poorly formatted/Unsupported message received
     """

--- a/parsl/executors/errors.py
+++ b/parsl/executors/errors.py
@@ -47,17 +47,6 @@ class ScalingFailed(ExecutorError):
         return f"Executor {self.executor.label} failed to scale due to: {self.reason}"
 
 
-class DeserializationError(ParslError):
-    """ Failure at the Deserialization of results/exceptions from remote workers
-    """
-
-    def __init__(self, reason):
-        self.reason = reason
-
-    def __str__(self):
-        return "Failed to deserialize return objects. Reason:{}".format(self.reason)
-
-
 class BadMessage(ParslError):
     """ Mangled/Poorly formatted/Unsupported message received
     """

--- a/parsl/executors/flux/executor.py
+++ b/parsl/executors/flux/executor.py
@@ -21,10 +21,11 @@ from parsl.utils import RepresentationMixin
 from parsl.executors.status_handling import NoStatusHandlingExecutor
 from parsl.executors.flux.execute_parsl_task import __file__ as _WORKER_PATH
 from parsl.executors.flux.flux_instance_manager import __file__ as _MANAGER_PATH
-from parsl.executors.errors import SerializationError, ScalingFailed
+from parsl.executors.errors import ScalingFailed
 from parsl.providers import LocalProvider
 from parsl.providers.base import ExecutionProvider
 from parsl.serialize import pack_apply_message, deserialize
+from parsl.serialize.errors import SerializationError
 from parsl.app.errors import AppException
 
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -12,13 +12,12 @@ from typing import List, Optional, Tuple, Union
 import math
 
 from parsl.serialize import pack_apply_message, deserialize
-from parsl.serialize.errors import SerializationError
+from parsl.serialize.errors import SerializationError, DeserializationError
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.executors.high_throughput import zmq_pipes
 from parsl.executors.high_throughput import interchange
 from parsl.executors.errors import (
     BadMessage, ScalingFailed,
-    DeserializationError,
     UnsupportedFeatureError
 )
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -12,12 +12,13 @@ from typing import List, Optional, Tuple, Union
 import math
 
 from parsl.serialize import pack_apply_message, deserialize
+from parsl.serialize.errors import SerializationError
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.executors.high_throughput import zmq_pipes
 from parsl.executors.high_throughput import interchange
 from parsl.executors.errors import (
     BadMessage, ScalingFailed,
-    DeserializationError, SerializationError,
+    DeserializationError,
     UnsupportedFeatureError
 )
 

--- a/parsl/serialize/errors.py
+++ b/parsl/serialize/errors.py
@@ -21,4 +21,4 @@ class SerializationError(ParslError):
         self.troubleshooting = "https://parsl.readthedocs.io/en/latest/faq.html#addressing-serializationerror"
 
     def __str__(self) -> str:
-        return "Failed to serialize objects for an invocation of function {self.fname}. Refer {self.troubleshooting}"
+        return f"Failed to serialize objects for an invocation of function {self.fname}. Refer {self.troubleshooting}"

--- a/parsl/serialize/errors.py
+++ b/parsl/serialize/errors.py
@@ -1,6 +1,17 @@
 from parsl.errors import ParslError
 
 
+class DeserializationError(ParslError):
+    """Failure at the deserialization of results/exceptions from remote workers.
+    """
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+
+    def __str__(self) -> str:
+        return f"Failed to deserialize objects. Reason: {self.reason}"
+
+
 class SerializationError(ParslError):
     """Failure to serialize task objects.
     """
@@ -10,5 +21,4 @@ class SerializationError(ParslError):
         self.troubleshooting = "https://parsl.readthedocs.io/en/latest/faq.html#addressing-serializationerror"
 
     def __str__(self) -> str:
-        return "Failed to serialize objects for an invocation of function {}. Refer {} ".format(self.fname,
-                                                                                                self.troubleshooting)
+        return "Failed to serialize objects for an invocation of function {self.fname}. Refer {self.troubleshooting}"

--- a/parsl/serialize/errors.py
+++ b/parsl/serialize/errors.py
@@ -1,0 +1,14 @@
+from parsl.errors import ParslError
+
+
+class SerializationError(ParslError):
+    """Failure to serialize task objects.
+    """
+
+    def __init__(self, fname: str) -> None:
+        self.fname = fname
+        self.troubleshooting = "https://parsl.readthedocs.io/en/latest/faq.html#addressing-serializationerror"
+
+    def __str__(self) -> str:
+        return "Failed to serialize objects for an invocation of function {}. Refer {} ".format(self.fname,
+                                                                                                self.troubleshooting)

--- a/parsl/tests/test_error_handling/test_serialization_fail.py
+++ b/parsl/tests/test_error_handling/test_serialization_fail.py
@@ -2,7 +2,7 @@ import pytest
 
 from parsl import python_app
 from parsl.tests.configs.htex_local import fresh_config
-from parsl.executors.errors import SerializationError
+from parsl.serialize.errors import SerializationError
 
 
 def local_config():


### PR DESCRIPTION
This is in expectation of at least one more exception being added related to serialization as part of ongoing serializer plugin work.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Code maintentance/cleanup
