### PR TITLE
Verify a test pre-condition

### DIFF
--- a/parsl/tests/test_python_apps/test_timeout.py
+++ b/parsl/tests/test_python_apps/test_timeout.py
@@ -15,9 +15,13 @@ def kernel(fail=False):
         raise TimeoutTestSpecificException()
 
 
-@pytest.mark.parametrize("timeout_dur", (0.005, 0.01, 0.1))
-def test_timeout(timeout_dur):
-    timeout(kernel, timeout_dur)()
+def test_timeout():
+    timeout_dur = 0.1
+    try:
+        timeout(kernel, timeout_dur)()  # nominally returns "instantly"
+    except AppTimeout:
+        pytest.skip("Pre-condition failed: result not received in timely fashion")
+        assert False
 
     try:
         time.sleep(timeout_dur + 0.01)  # this is the verification
@@ -25,7 +29,7 @@ def test_timeout(timeout_dur):
         assert False, "Timer was not cancelled!"
 
 
-@pytest.mark.parametrize("timeout_dur", (0.005, 0.01, 0.1))
+@pytest.mark.parametrize("timeout_dur", (0.005, 0.01))
 def test_timeout_after_exception(timeout_dur):
     with pytest.raises(TimeoutTestSpecificException):
         timeout(kernel, timeout_dur)(True)


### PR DESCRIPTION
As seen in CI at least once, it's possible that the noop() function takes too long to complete.  Address by:

- increasing the timeout
- removing the now-deemed-extraneous other parameterizations
- and verifying the test pre-condition first.  ("We expect to get a result!")

Reference problem observed: https://github.com/Parsl/parsl/pull/2812#issuecomment-1645072179

## Type of change

- Code maintenance/cleanup
