### PR TITLE
Adding typing info for HTEX

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -1,3 +1,4 @@
+import typing
 from concurrent.futures import Future
 import typeguard
 import logging
@@ -523,16 +524,23 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         logger.debug("Sent hold request to manager: {}".format(worker_id))
 
     @property
-    def outstanding(self):
+    def outstanding(self) -> int:
+        """Returns the count of tasks outstanding across the interchange
+        and managers"""
         outstanding_c = self.command_client.run("OUTSTANDING_C")
         return outstanding_c
 
     @property
-    def connected_workers(self):
+    def connected_workers(self) -> int:
+        """Returns the count of workers across all connected managers"""
         workers = self.command_client.run("WORKERS")
         return workers
 
-    def connected_managers(self):
+    def connected_managers(self) -> List[Dict[str, typing.Any]]:
+        """Returns a list of dicts one for each connected managers.
+        The dict contains info on manager(str:manager_id), block_id,
+        worker_count, tasks(int), idle_durations(float), active(bool)
+        """
         managers = self.command_client.run("MANAGERS")
         return managers
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -527,22 +527,19 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
     def outstanding(self) -> int:
         """Returns the count of tasks outstanding across the interchange
         and managers"""
-        outstanding_c = self.command_client.run("OUTSTANDING_C")
-        return outstanding_c
+        return self.command_client.run("OUTSTANDING_C")
 
     @property
     def connected_workers(self) -> int:
         """Returns the count of workers across all connected managers"""
-        workers = self.command_client.run("WORKERS")
-        return workers
+        return self.command_client.run("WORKERS")
 
     def connected_managers(self) -> List[Dict[str, typing.Any]]:
         """Returns a list of dicts one for each connected managers.
         The dict contains info on manager(str:manager_id), block_id,
         worker_count, tasks(int), idle_durations(float), active(bool)
         """
-        managers = self.command_client.run("MANAGERS")
-        return managers
+        return self.command_client.run("MANAGERS")
 
     def _hold_block(self, block_id):
         """ Sends hold command to all managers which are in a specific block


### PR DESCRIPTION
# Description

This PR only adds some typing info for these methods/properties on the `HighThroughputExecutor`:

* `HTEX.outstanding`
* `HTEX.connected_workers`
* `HTEX.connected_managers`


## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintentance/cleanup
