### PR TITLE
TaskVineExecutor: add serverless execution mode for tasks

### DIFF
--- a/parsl/executors/taskvine/exec_parsl_function.py
+++ b/parsl/executors/taskvine/exec_parsl_function.py
@@ -149,21 +149,8 @@ def execute_function(namespace, function_code, result_name):
     return result
 
 
-def run():
+def run(map_file, function_file, argument_file, result_file):
     try:
-        # parse the four required command line arguments:
-        # map_file: contains a pickled dictionary to map original names to
-        #           names at the execution site.
-        # function_file: contains the pickled parsl function to execute.
-        # argument_file: contains the pickled arguments to the function call.
-        # result_file: any output (including exceptions) will be written to
-        #              this file.
-        try:
-            (map_file, function_file, argument_file, result_file) = sys.argv[1:]
-        except ValueError:
-            print("Usage:\n\t{} function argument result mapping\n".format(sys.argv[0]))
-            raise
-
         try:
             (namespace, function_code, result_name) = load_function(map_file, function_file, argument_file)
         except Exception:
@@ -189,4 +176,16 @@ def run():
 
 
 if __name__ == "__main__":
-    run() 
+    # parse the four required command line arguments:
+    # map_file: contains a pickled dictionary to map original names to
+    #           names at the execution site.
+    # function_file: contains the pickled parsl function to execute.
+    # argument_file: contains the pickled arguments to the function call.
+    # result_file: any output (including exceptions) will be written to
+    #              this file.
+    try:
+        (map_file, function_file, argument_file, result_file) = sys.argv[1:]
+    except ValueError:
+        print("Usage:\n\t{} function argument result mapping\n".format(sys.argv[0]))
+        raise
+    run(map_file, function_file, argument_file, result_file) 

--- a/parsl/executors/taskvine/exec_parsl_function.py
+++ b/parsl/executors/taskvine/exec_parsl_function.py
@@ -165,7 +165,9 @@ def run(map_file, function_file, argument_file, result_file):
     except Exception:
         traceback.print_exc()
         result = RemoteExceptionWrapper(*sys.exc_info())
-
+    
+    with open('/tmp/test_exec_parsl.tmp', 'w') as f:
+        f.write('debug' + str(result))
     # Write out function result to the result file
     try:
         dump_result_to_file(result_file, result)

--- a/parsl/executors/taskvine/exec_parsl_function.py
+++ b/parsl/executors/taskvine/exec_parsl_function.py
@@ -82,7 +82,7 @@ def unpack_object(serialized_obj, user_namespace):
     from parsl.serialize import deserialize
     obj = deserialize(serialized_obj)
     return obj
-    
+
 
 def encode_function(user_namespace, fn, fn_name, fn_args, fn_kwargs):
     """ Register the given function to the given namespace."""
@@ -165,9 +165,7 @@ def run(map_file, function_file, argument_file, result_file):
     except Exception:
         traceback.print_exc()
         result = RemoteExceptionWrapper(*sys.exc_info())
-    
-    with open('/tmp/test_exec_parsl.tmp', 'w') as f:
-        f.write('debug' + str(result))
+
     # Write out function result to the result file
     try:
         dump_result_to_file(result_file, result)
@@ -190,4 +188,4 @@ if __name__ == "__main__":
     except ValueError:
         print("Usage:\n\t{} function argument result mapping\n".format(sys.argv[0]))
         raise
-    run(map_file, function_file, argument_file, result_file) 
+    run(map_file, function_file, argument_file, result_file)

--- a/parsl/executors/taskvine/exec_parsl_function.py
+++ b/parsl/executors/taskvine/exec_parsl_function.py
@@ -79,25 +79,10 @@ def remap_all_files(mapping, fn_args, fn_kwargs):
 
 
 def unpack_object(serialized_obj, user_namespace):
-    #from parsl.serialize import unpack_apply_message
     from parsl.serialize import deserialize
-    #obj = unpack_apply_message(serialized_obj, user_namespace, copy=False)
     obj = deserialize(serialized_obj)
     return obj
     
-
-#def unpack_function(function_info, user_namespace):
-#    """ Unpack a function according to its encoding scheme."""
-#    return unpack_byte_code_function(function_info, user_namespace)
-#
-#
-#def unpack_byte_code_function(function_info, user_namespace):
-#    """ Returns a function object, a default name, positional arguments, and keyword arguments
-#    for a function."""
-#    from parsl.serialize import unpack_apply_message
-#    func, args, kwargs = unpack_apply_message(function_info["byte code"], user_namespace, copy=False)
-#    return (func, 'parsl_function_name', args, kwargs)
-
 
 def encode_function(user_namespace, fn, fn_name, fn_args, fn_kwargs):
     """ Register the given function to the given namespace."""
@@ -146,7 +131,6 @@ def load_function(map_file, function_file, argument_file):
     fn_args = args_dict['args']
     fn_kwargs = args_dict['kwargs']
     fn_name = 'parsl_tmp_func_name'
-    #(fn, fn_name, fn_args, fn_kwargs) = unpack_function(function_info, user_ns)
 
     mapping = load_pickled_file(map_file)
     remap_all_files(mapping, fn_args, fn_kwargs)
@@ -159,7 +143,6 @@ def load_function(map_file, function_file, argument_file):
 def execute_function(namespace, function_code, result_name):
     # On executing the function inside the namespace, its result will be in a
     # variable named result_name.
-    #raise Exception(f'function_code: {function_code}, namespace: {namespace}')
     exec(function_code, namespace, namespace)
     result = namespace.get(result_name)
 

--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -26,7 +26,6 @@ from typing import List, Optional, Union
 import parsl.utils as putils
 from parsl.utils import setproctitle
 from parsl.data_provider.staging import Staging
-from parsl.serialize import pack_apply_message
 from parsl.serialize import serialize
 from parsl.data_provider.files import File
 from parsl.errors import OptionalModuleMissing
@@ -393,9 +392,6 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
 
             logger.debug("Creating executor task {} with function at: {}, argument at: {}, and result to be found at: {}".format(executor_task_id, function_file, argument_file, result_file))
 
-            # Pickle the result into object to pass into message buffer
-            #self._serialize_function(function_file, func, args, kwargs)
-
             # Serialize both function object and arguments, separately
             self._serialize_object(function_file, func)
             args_dict = {'args': args, 'kwargs': kwargs}
@@ -478,15 +474,6 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         serialized_obj = serialize(obj, buffer_threshold=1024 * 1024)
         with open(path, 'wb') as f_out:
             pickle.dump(serialized_obj, f_out)
-
-    #def _serialize_function(self, fn_path, parsl_fn, parsl_fn_args, parsl_fn_kwargs):
-    #    """Takes the function application parsl_fn(*parsl_fn_args, **parsl_fn_kwargs)
-    #    and serializes it to the file fn_path."""
-    #    function_info = {"byte code": pack_apply_message(parsl_fn, parsl_fn_args, parsl_fn_kwargs,
-    #                                                     buffer_threshold=1024 * 1024)}
-
-    #    with open(fn_path, "wb") as f_out:
-    #        pickle.dump(function_info, f_out)
 
     def _construct_map_file(self, map_file, input_files, output_files):
         """ Map local filepath of parsl files to the filenames at the execution worker.

--- a/parsl/executors/taskvine/factory.py
+++ b/parsl/executors/taskvine/factory.py
@@ -1,0 +1,64 @@
+import logging
+import time
+
+from parsl.process_loggers import wrap_with_logs
+from parsl.executors.taskvine.errors import TaskVineFactoryFailure
+
+from ndcctools.taskvine import Factory
+
+logger = logging.getLogger(__name__)
+
+
+@wrap_with_logs
+def _taskvine_factory(should_stop, factory_config):
+    logger.debug("Starting TaskVine factory process")
+
+    try:
+        # create the factory according to the project name if given
+        if factory_config._project_name:
+            factory = Factory(batch_type=factory_config.batch_type,
+                              manager_name=factory_config._project_name,
+                              )
+        else:
+            factory = Factory(batch_type=factory_config.batch_type,
+                              manager_host_port=f"{factory_config._project_address}:{factory_config._project_port}",
+                             )
+    except Exception as e:
+        raise TaskVineFactoryFailure(f'Cannot create factory with exception {e}')
+
+    # Set attributes of this factory
+    if factory_config._project_password_file:
+        factory.password = factory_config._project_password_file
+    factory.factory_timeout = factory_config.factory_timeout
+    factory.scratch_dir = factory_config.scratch_dir
+    factory.min_workers = factory_config.min_workers
+    factory.max_workers = factory_config.max_workers
+    factory.workers_per_cycle = factory_config.workers_per_cycle
+
+    if factory_config.worker_options:
+        factory.extra_options = factory_config.worker_options
+    factory.timeout = factory_config.worker_timeout
+    if factory_config.cores:
+        factory.cores = factory_config.cores
+    if factory_config.gpus:
+        factory.gpus = factory_config.gpus
+    if factory_config.memory:
+        factory.memory = factory_config.memory
+    if factory_config.disk:
+        factory.disk = factory_config.disk
+    if factory_config.python_env:
+        factory.python_env = factory_config.python_env
+
+    if factory_config.condor_requirements:
+        factory.condor_requirements = factory_config.condor_requirements
+    if factory_config.batch_options:
+        factory.batch_options = factory_config.batch_options
+
+    # setup factory context and sleep for a second in every loop to
+    # avoid wasting CPU
+    with factory:
+        while not should_stop.value:
+            time.sleep(1)
+
+    logger.debug("Exiting TaskVine factory process")
+    return 0

--- a/parsl/executors/taskvine/manager.py
+++ b/parsl/executors/taskvine/manager.py
@@ -1,0 +1,468 @@
+import logging
+import hashlib
+import subprocess
+import os
+import pickle
+import queue
+import shutil
+import uuid
+
+from parsl.utils import setproctitle
+from parsl.process_loggers import wrap_with_logs
+from parsl.executors.taskvine import exec_parsl_function
+from parsl.executors.taskvine.utils import VineTaskToParsl
+from parsl.executors.taskvine.utils import run_parsl_function
+
+try:
+    from ndcctools.taskvine import cvine
+    from ndcctools.taskvine import Manager
+    from ndcctools.taskvine import Task
+    from ndcctools.taskvine import FunctionCall
+    from ndcctools.taskvine.cvine import VINE_ALLOCATION_MODE_MAX_THROUGHPUT
+    from ndcctools.taskvine.cvine import VINE_ALLOCATION_MODE_EXHAUSTIVE_BUCKETING
+    from ndcctools.taskvine.cvine import VINE_ALLOCATION_MODE_MAX
+except ImportError:
+    _taskvine_enabled = False
+else:
+    _taskvine_enabled = True
+
+logger = logging.getLogger(__name__)
+
+
+def _set_manager_attributes(m, config):
+    """ Set various manager global attributes."""
+    if config.project_password_file:
+        m.set_password_file(config.project_password_file)
+
+    # Autolabeling resources require monitoring to be enabled
+    if config.autolabel:
+        m.enable_monitoring()
+        if config.autolabel_window is not None:
+            m.tune('category-steady-n-tasks', config.autolabel_window)
+
+    # Specify number of workers to wait for before sending the first task
+    if config.wait_for_workers:
+        m.tune("wait-for-workers", config.wait_for_workers)
+
+    # Enable peer transfer feature between workers if specified
+    if config.enable_peer_transfers:
+        m.enable_peer_transfers()
+
+
+def _prepare_environment_serverless(manager_config, env_cache_dir, poncho_create_script):
+    # Return path to a packaged poncho environment
+    poncho_env_path = ''
+    if not manager_config.shared_fs:
+        if manager_config.env_pack is None:
+            raise Exception('TaskVine manager needs env_pack to be specified when running tasks in serverless mode and with no shared_fs')
+
+        poncho_env_path = manager_config.env_pack
+
+        # If a conda environment name or path is given, then use the hash of the headers of
+        # all contained packages as the name of the to-be-packaged poncho tarball,
+        # and package it if it's not cached.
+        if not poncho_env_path.endswith('tar.gz'):
+            if os.path.isabs(poncho_env_path):
+                conda_env_signature = hashlib.md5(subprocess.check_output(['conda', 'list', '-p', poncho_env_path, '--json'])).hexdigest()
+                logger.debug(f'Signature of conda environment at {poncho_env_path}: {conda_env_signature}')
+            else:
+                conda_env_signature = hashlib.md5(subprocess.check_output(['conda', 'list', '-n', poncho_env_path, '--json'])).hexdigest()
+                logger.debug(f'Signature of conda environment named {poncho_env_path}: {conda_env_signature}')
+
+            # If env is cached then use it,
+            # else create a new env tarball
+            poncho_env_path = os.path.join(env_cache_dir, '.'.join([conda_env_signature, 'tar.gz']))
+            if not os.path.isfile(poncho_env_path):
+                logger.debug(f'No cached poncho environment. Creating poncho environment for library task at {poncho_env_path}')
+                try:
+                    subprocess.run([poncho_create_script, manager_config.env_pack, poncho_env_path], stdout=subprocess.DEVNULL, check=True)
+                except Exception:
+                    logger.error('Cannot create a poncho environment. Removing it.')
+                    if os.path.isfile(poncho_env_path):
+                        os.remove(poncho_env_path)
+                    raise
+            else:
+                logger.debug(f'Found cached poncho environment at {poncho_env_path}. Reusing it.')
+        else:
+            logger.debug(f'Use the given poncho environment at {manager_config.env_pack} to setup library task.')
+    return poncho_env_path
+
+
+def _prepare_environment_regular(m, manager_config, t, task, poncho_env_to_file, poncho_create_script):
+    # Add environment file to the task if possible
+    # Prioritize local poncho environment over global poncho environment
+    # (local: use app_pack, global: use env_pack)
+    poncho_env_file = None
+
+    # check if env_pack is specified
+    if manager_config.env_pack is not None:
+
+        # check if the environment file is not already created
+        if manager_config.env_pack not in poncho_env_to_file:
+
+            # if the environment is already packaged as a tarball, then add the file
+            # otherwise it is an environment name or path, so create a poncho tarball then add it
+            if not manager_config.env_pack.endswith('.tar.gz'):
+                env_tarball = str(uuid.uuid4()) + '.tar.gz'
+                logger.debug(f'Creating a poncho environment at {env_tarball} from conda environment {manager_config.env_pack}')
+                subprocess.run([poncho_create_script, manager_config.env_pack, env_tarball], stdout=subprocess.DEVNULL, check=True)
+            poncho_env_file = m.declare_poncho(env_tarball, cache=True, peer_transfer=True)
+            poncho_env_to_file[manager_config.env_pack] = poncho_env_file
+        else:
+            poncho_env_file = poncho_env_to_file[manager_config.env_pack]
+            logger.debug(f'Found cached poncho environment for {manager_config.env_pack}. Reusing it.')
+
+    # check if app_pack is used, override if possible
+    if task.env_pkg is not None:
+        if task.env_pkg not in poncho_env_to_file:
+            poncho_env_file = m.declare_poncho(task.env_pkg, cache=True, peer_transfer=True)
+            poncho_env_to_file[task.env_pkg] = poncho_env_file
+        else:
+            poncho_env_file = poncho_env_to_file[task.env_pkg]
+
+    # Add environment to the task
+    if poncho_env_file is not None:
+        t.add_environment(poncho_env_file)
+
+
+@wrap_with_logs
+def _taskvine_submit_wait(ready_task_queue=None,
+                          finished_task_queue=None,
+                          should_stop=None,
+                          manager_config=None
+                          ):
+    """Process to handle Parsl app submissions to the TaskVine objects.
+    Takes in Parsl functions submitted using submit(), and creates a
+    TaskVine task with the appropriate specifications, which is then
+    submitted to TaskVine. After tasks are completed, processes the
+    exit status and exit code of the task, and sends results to the
+    TaskVine collector thread.
+    To avoid python's global interpreter lock with taskvine's wait, this
+    function should be launched as a process, not as a lightweight thread. This
+    means that any communication should be done using the multiprocessing
+    module capabilities, rather than shared memory.
+    """
+    logger.debug("Starting TaskVine Submit/Wait Process")
+    setproctitle("parsl: TaskVine submit/wait")
+
+    # Enable debugging flags and create logging file
+    if manager_config.vine_log_dir is not None:
+        logger.debug("Setting debugging flags and creating logging file at {}".format(manager_config.vine_log_dir))
+
+    # Create TaskVine queue object
+    logger.debug("Creating TaskVine Object")
+    try:
+        logger.debug("Listening on port {}".format(manager_config.port))
+        m = Manager(port=manager_config.port,
+                    name=manager_config.project_name,
+                    run_info_path=manager_config.vine_log_dir)
+    except Exception as e:
+        logger.error("Unable to create TaskVine object: {}".format(e))
+        raise e
+
+    # Specify TaskVine manager attributes
+    _set_manager_attributes(m, manager_config)
+
+    # Get parent pid, useful to shutdown this process when its parent, the taskvine
+    # executor process, exits.
+    orig_ppid = os.getppid()
+
+    result_file_of_task_id = {}  # Mapping executor task id -> result file.
+
+    poncho_env_to_file = {}  # Mapping poncho_env id to File object in TaskVine
+
+    # Mapping of parsl local file name to TaskVine File object
+    # dict[str] -> vine File object
+    parsl_file_name_to_vine_file = {}
+
+    # Mapping of tasks from vine id to parsl id
+    # Dict[str] -> str
+    vine_id_to_executor_task_id = {}
+
+    # Find poncho scripts to create and activate an environment tarball
+    poncho_create_script = shutil.which("poncho_package_create")
+
+    # Declare helper script as cache-able and peer-transferable
+    exec_parsl_function_file = m.declare_file(exec_parsl_function.__file__, cache=True, peer_transfer=True)
+
+    # Flag to make sure library for serverless tasks is declared and installed only once.
+    lib_installed = False
+
+    # Create cache dir for environment files
+    env_cache_dir = os.path.join(manager_config.vine_log_dir, 'vine-cache', 'vine-poncho-env-cache')
+    os.makedirs(env_cache_dir, exist_ok=True)
+
+    logger.debug("Entering main loop of TaskVine manager")
+
+    while not should_stop.value:
+        # Monitor the task queue
+        ppid = os.getppid()
+        if ppid != orig_ppid:
+            logger.debug("new Process")
+            break
+
+        # Submit tasks
+        while ready_task_queue.qsize() > 0 and not should_stop.value:
+            # Obtain task from ready_task_queue
+            try:
+                task = ready_task_queue.get(timeout=1)
+                logger.debug("Removing executor task from queue")
+            except queue.Empty:
+                logger.debug("Queue is empty")
+                continue
+            if task.exec_mode == 'regular':
+                # Create command string
+                launch_cmd = "python3 exec_parsl_function.py {mapping} {function} {argument} {result}"
+                if manager_config.init_command != '':
+                    launch_cmd = "{init_cmd} " + launch_cmd
+                command_str = launch_cmd.format(init_cmd=manager_config.init_command,
+                                                mapping=os.path.basename(task.map_file),
+                                                function=os.path.basename(task.function_file),
+                                                argument=os.path.basename(task.argument_file),
+                                                result=os.path.basename(task.result_file))
+                logger.debug("Sending executor task {} (mode: regular) with command: {}".format(task.executor_id, command_str))
+                try:
+                    t = Task(command_str)
+                except Exception as e:
+                    logger.error("Unable to create executor task (mode:regular): {}".format(e))
+                    finished_task_queue.put_nowait(VineTaskToParsl(executor_id=task.executor_id,
+                                                                   result_received=False,
+                                                                   result=None,
+                                                                   reason="task could not be created by taskvine",
+                                                                   status=-1))
+                    continue
+            elif task.exec_mode == 'serverless':
+                if not lib_installed:
+                    # Declare and install common library for serverless tasks.
+                    # Library requires an environment setup properly, which is
+                    # different from setup of regular tasks.
+                    # If shared_fs is True, then no environment preparation is done.
+                    # Only the core serverless code is created.
+                    poncho_env_path = _prepare_environment_serverless(manager_config, env_cache_dir, poncho_create_script)
+
+                    # Don't automatically add environment so manager can declare and cache the vine file associated with the environment file
+                    add_env = False
+                    serverless_lib = m.create_library_from_functions('common-parsl-taskvine-lib',
+                                                                     run_parsl_function,
+                                                                     poncho_env=poncho_env_path,
+                                                                     init_command=manager_config.init_command,
+                                                                     add_env=add_env)
+                    if poncho_env_path:
+                        serverless_lib_env_file = m.declare_poncho(poncho_env_path, cache=True, peer_transfer=True)
+                        serverless_lib.add_environment(serverless_lib_env_file)
+                        poncho_env_to_file[manager_config.env_pack] = serverless_lib_env_file
+                        logger.debug(f'Created library task using poncho environment at {poncho_env_path}.')
+                    else:
+                        logger.debug('Created minimal library task with no environment.')
+
+                    m.install_library(serverless_lib)
+                    lib_installed = True
+                try:
+                    # run_parsl_function only needs remote names of map_file, function_file, argument_file,
+                    # and result_file, which are simply named map, function, argument, result.
+                    # These names are given when these files are declared below.
+                    t = FunctionCall('common-parsl-taskvine-lib', run_parsl_function.__name__, 'map', 'function', 'argument', 'result')
+                except Exception as e:
+                    logger.error("Unable to create executor task (mode:serverless): {}".format(e))
+                    finished_task_queue.put_nowait(VineTaskToParsl(executor_id=task.executor_id,
+                                                                   result_received=False,
+                                                                   result=None,
+                                                                   reason="task could not be created by taskvine",
+                                                                   status=-1))
+            else:
+                raise Exception(f'Unrecognized task mode {task.exec_mode}. Exiting...')
+
+            # prepare environment for regular tasks if not using shared_fs
+            if task.exec_mode == 'regular' and not manager_config.shared_fs:
+                _prepare_environment_regular(m, manager_config, t, task, poncho_env_to_file, poncho_create_script)
+
+            t.set_category(task.category)
+
+            # Set autolabel mode
+            if manager_config.autolabel:
+                if manager_config.autolabel_algorithm == 'max-xput':
+                    m.set_category_mode(task.category, VINE_ALLOCATION_MODE_MAX_THROUGHPUT)
+                elif manager_config.autolabel_algorithm == 'bucketing':
+                    m.set_category_mode(task.category, VINE_ALLOCATION_MODE_EXHAUSTIVE_BUCKETING)
+                elif manager_config.autolabel_algorithm == 'max':
+                    m.set_category_mode(task.category, VINE_ALLOCATION_MODE_MAX)
+                else:
+                    logger.warning(f'Unrecognized autolabeling algorithm named {manager_config.autolabel_algorithm} for taskvine manager.')
+                    raise Exception(f'Unrecognized autolabeling algorithm named {manager_config.autolabel_algorithm} for taskvine manager.')
+
+            if task.cores is not None:
+                t.set_cores(task.cores)
+            if task.memory is not None:
+                t.set_memory(task.memory)
+            if task.disk is not None:
+                t.set_disk(task.disk)
+            if task.gpus is not None:
+                t.set_gpus(task.gpus)
+            if task.priority is not None:
+                t.set_priority(task.priority)
+            if task.running_time_min is not None:
+                t.set_time_min(task.running_time_min)
+
+            if manager_config.max_retries is not None:
+                logger.debug(f"Specifying max_retries {manager_config.max_retries}")
+                t.set_retries(manager_config.max_retries)
+
+            # Specify environment variables for the task
+            if manager_config.env_vars is not None:
+                for var in manager_config.env_vars:
+                    t.set_env_var(str(var), str(manager_config.env_vars[var]))
+
+            if task.exec_mode == 'regular':
+                # Add helper files that execute parsl functions on remote nodes
+                # only needed to add as file for tasks with 'regular' mode
+                t.add_input(exec_parsl_function_file, "exec_parsl_function.py")
+
+            # Declare and add task-specific function, data, and result files to task
+            task_function_file = m.declare_file(task.function_file, cache=False, peer_transfer=False)
+            t.add_input(task_function_file, "function")
+
+            task_argument_file = m.declare_file(task.argument_file, cache=False, peer_transfer=False)
+            t.add_input(task_argument_file, "argument")
+
+            task_map_file = m.declare_file(task.map_file, cache=False, peer_transfer=False)
+            t.add_input(task_map_file, "map")
+
+            task_result_file = m.declare_file(task.result_file, cache=False, peer_transfer=False)
+            t.add_output(task_result_file, "result")
+
+            result_file_of_task_id[str(task.executor_id)] = task.result_file
+
+            logger.debug("Executor task id: {}".format(task.executor_id))
+
+            # Specify input/output files that need to be staged.
+            # Absolute paths are assumed to be in shared filesystem, and thus
+            # not staged by taskvine.
+            # Files that share the same local path are assumed to be the same
+            # and thus use the same Vine File object if detected.
+            if not manager_config.shared_fs:
+                for spec in task.input_files:
+                    if spec.stage:
+                        if spec.parsl_name in parsl_file_name_to_vine_file:
+                            task_in_file = parsl_file_name_to_vine_file[spec.parsl_name]
+                        else:
+                            task_in_file = m.declare_file(spec.parsl_name, cache=spec.cache, peer_transfer=True)
+                            parsl_file_name_to_vine_file[spec.parsl_name] = task_in_file
+                        t.add_input(task_in_file, spec.parsl_name)
+
+                for spec in task.output_files:
+                    if spec.stage:
+                        if spec.parsl_name in parsl_file_name_to_vine_file:
+                            task_out_file = parsl_file_name_to_vine_file[spec.parsl_name]
+                        else:
+                            task_out_file = m.declare_file(spec.parsl_name, cache=spec.cache, peer_transfer=True)
+                        t.add_output(task_out_file, spec.parsl_name)
+
+            # Submit the task to the TaskVine object
+            logger.debug("Submitting executor task {}, {} to TaskVine".format(task.executor_id, t))
+            try:
+                vine_id = m.submit(t)
+                logger.debug("Submitted executor task {} to TaskVine".format(task.executor_id))
+                vine_id_to_executor_task_id[str(vine_id)] = str(task.executor_id), task.exec_mode
+            except Exception as e:
+                logger.error("Unable to submit task to taskvine: {}".format(e))
+                finished_task_queue.put_nowait(VineTaskToParsl(executor_id=task.executor_id,
+                                                               result_received=False,
+                                                               result=None,
+                                                               reason="task could not be submited to taskvine",
+                                                               status=-1))
+                continue
+
+            logger.debug("Executor task {} submitted as TaskVine task with id {}".format(task.executor_id, vine_id))
+
+        # If the queue is not empty wait on the TaskVine queue for a task
+        task_found = True
+        if not m.empty():
+            while task_found and not should_stop.value:
+                # Obtain the task from the queue
+                t = m.wait(1)
+                if t is None:
+                    task_found = False
+                    continue
+                logger.debug('Found a task')
+                executor_task_id = vine_id_to_executor_task_id[str(t.id)][0]
+                vine_id_to_executor_task_id.pop(str(t.id))
+
+                # When a task is found
+                result_file = result_file_of_task_id.pop(executor_task_id)
+
+                logger.debug(f"completed executor task info: {executor_task_id}, {t.category}, {t.command}, {t.std_output}")
+
+                # A tasks completes 'succesfully' if it has result file,
+                # and it can be loaded. This may mean that the 'success' is
+                # an exception.
+                logger.debug("Looking for result in {}".format(result_file))
+                try:
+                    with open(result_file, "rb") as f_in:
+                        result = pickle.load(f_in)
+                    logger.debug("Found result in {}".format(result_file))
+                    finished_task_queue.put_nowait(VineTaskToParsl(executor_id=executor_task_id,
+                                                                   result_received=True,
+                                                                   result=result,
+                                                                   reason=None,
+                                                                   status=t.exit_code))
+                # If a result file could not be generated, explain the
+                # failure according to taskvine error codes. We generate
+                # an exception and wrap it with RemoteExceptionWrapper, to
+                # match the positive case.
+                except Exception as e:
+                    reason = _explain_taskvine_result(t)
+                    logger.debug("Did not find result in {}".format(result_file))
+                    logger.debug("Wrapper Script status: {}\nTaskVine Status: {}"
+                                 .format(t.exit_code, t.result))
+                    logger.debug("Task with executor id {} / vine id {} failed because:\n{}"
+                                 .format(executor_task_id, t.id, reason))
+                    finished_task_queue.put_nowait(VineTaskToParsl(executor_id=executor_task_id,
+                                                                   result_received=False,
+                                                                   result=e,
+                                                                   reason=reason,
+                                                                   status=t.exit_code))
+
+    logger.debug("Exiting TaskVine Monitoring Process")
+    return 0
+
+
+def _explain_taskvine_result(vine_task):
+    """Returns a string with the reason why a task failed according to taskvine."""
+
+    vine_result = vine_task.result
+    reason = "taskvine result: "
+    if vine_result == cvine.VINE_RESULT_SUCCESS:
+        reason += "succesful execution with exit code {}".format(vine_task.return_status)
+    elif vine_result == cvine.VINE_RESULT_OUTPUT_MISSING:
+        reason += "The result file was not transfered from the worker.\n"
+        reason += "This usually means that there is a problem with the python setup,\n"
+        reason += "or the wrapper that executes the function."
+        reason += "\nTrace:\n" + str(vine_task.output)
+    elif vine_result == cvine.VINE_RESULT_INPUT_MISSING:
+        reason += "missing input file"
+    elif vine_result == cvine.VINE_RESULT_STDOUT_MISSING:
+        reason += "stdout has been truncated"
+    elif vine_result == cvine.VINE_RESULT_SIGNAL:
+        reason += "task terminated with a signal"
+    elif vine_result == cvine.VINE_RESULT_RESOURCE_EXHAUSTION:
+        reason += "task used more resources than requested"
+    elif vine_result == cvine.VINE_RESULT_MAX_END_TIME:
+        reason += "task ran past the specified end time"
+    elif vine_result == cvine.VINE_RESULT_UNKNOWN:
+        reason += "result could not be classified"
+    elif vine_result == cvine.VINE_RESULT_FORSAKEN:
+        reason += "task failed, but not a task error"
+    elif vine_result == cvine.VINE_RESULT_MAX_RETRIES:
+        reason += "unable to complete after specified number of retries"
+    elif vine_result == cvine.VINE_RESULT_MAX_WALL_TIME:
+        reason += "task ran for more than the specified time"
+    elif vine_result == cvine.VINE_RESULT_RMONITOR_ERROR:
+        reason += "task failed because the monitor did not produce an output"
+    elif vine_result == cvine.VINE_RESULT_OUTPUT_TRANSFER_ERROR:
+        reason += "task failed because output transfer fails"
+    elif vine_result == cvine.VINE_RESULT_FIXED_LOCATION_MISSING:
+        reason += "task failed because no worker could satisfy the fixed \n"
+        reason += "location input file requirements"
+    else:
+        reason += "unable to process TaskVine system failure"
+    return reason

--- a/parsl/executors/taskvine/manager_config.py
+++ b/parsl/executors/taskvine/manager_config.py
@@ -47,6 +47,7 @@ class TaskVineManagerConfig:
         Used to encapsulate package dependencies of tasks to
         execute them remotely without needing a shared filesystem.
         Recommended way to manage tasks' dependency requirements.
+        All tasks will be executed in the encapsulated environment.
         If an absolute path to a conda environment or a conda
         environment name is given, TaskVine will package the conda
         environment in a tarball and send it along with tasks to be

--- a/parsl/executors/taskvine/utils.py
+++ b/parsl/executors/taskvine/utils.py
@@ -12,6 +12,7 @@ class ParslTaskToVine:
                  output_files: list,               # list of output files to this function
                  map_file: Optional[str],          # pickled file containing mapping of local to remote names of files
                  function_file: Optional[str],     # pickled file containing the function information
+                 argument_file: Optional[str],     # pickled file containing the arguments to the function call
                  result_file: Optional[str],       # path to the pickled result object of the function execution
                  cores: Optional[float],           # number of cores to allocate
                  memory: Optional[int],            # amount of memory in MBs to allocate
@@ -26,6 +27,7 @@ class ParslTaskToVine:
         self.category = category
         self.map_file = map_file
         self.function_file = function_file
+        self.argument_file = argument_file
         self.result_file = result_file
         self.input_files = input_files
         self.output_files = output_files

--- a/parsl/executors/taskvine/utils.py
+++ b/parsl/executors/taskvine/utils.py
@@ -77,7 +77,8 @@ class ParslFileToVine:
         self.cache = cache
 
 
-def run_parsl_function():
+def run_parsl_function(map_file, function_file, argument_file, result_file):
     # This function assumes that parsl module is importable on remote nodes
+    # and executes function after reading relevant files.
     from parsl.executors.taskvine.exec_parsl_function import run
-    run()
+    run(map_file, function_file, argument_file, result_file)

--- a/parsl/executors/taskvine/utils.py
+++ b/parsl/executors/taskvine/utils.py
@@ -78,7 +78,8 @@ class ParslFileToVine:
 
 
 def run_parsl_function(map_file, function_file, argument_file, result_file):
-    # This function assumes that parsl module is importable on remote nodes
-    # and executes function after reading relevant files.
+    """
+    Wrapper function to deploy with FunctionCall as serverless tasks.
+    """
     from parsl.executors.taskvine.exec_parsl_function import run
     run(map_file, function_file, argument_file, result_file)

--- a/parsl/executors/taskvine/utils.py
+++ b/parsl/executors/taskvine/utils.py
@@ -75,3 +75,9 @@ class ParslFileToVine:
         self.parsl_name = parsl_name
         self.stage = stage
         self.cache = cache
+
+
+def run_parsl_function():
+    # This function assumes that parsl module is importable on remote nodes
+    from parsl.executors.taskvine.exec_parsl_function import run
+    run()

--- a/parsl/tests/configs/taskvine_ex.py
+++ b/parsl/tests/configs/taskvine_ex.py
@@ -9,5 +9,5 @@ from parsl.data_provider.file_noop import NoOpFileStaging
 
 def fresh_config():
     return Config(executors=[TaskVineExecutor(manager_config=TaskVineManagerConfig(port=9000),
-                                              use_factory=True,
+                                              worker_launch_method='factory',
                                               storage_access=[FTPInTaskStaging(), HTTPInTaskStaging(), NoOpFileStaging()])])

--- a/parsl/tests/scaling_tests/vineex_local.py
+++ b/parsl/tests/scaling_tests/vineex_local.py
@@ -5,7 +5,7 @@ from parsl.providers import LocalProvider
 
 config = Config(
     executors=[TaskVineExecutor(label='VineExec',
-                                use_factory=True,
+                                worker_launch_method='factory',
                                 manager_config=TaskVineManagerConfig(port=50055),
         )]
 )


### PR DESCRIPTION
# Description

This PR is a follow-up to PR https://github.com/Parsl/parsl/pull/2809 with the following changes:
- Add support for serverless execution mode for tasks. Users can now declare serverless tasks like this:
```
@python_app
def f(x, parsl_resource_specification={'exec_mode': 'serverless'}):
    ...
```
Under the hood, a library task is deployed to each worker and forks itself to execute an actual task/function call.
- Add support for full conda environment replication on worker nodes for both serverless and regular tasks. Given a conda environment, TaskVine will distribute and cache it efficiently, so a shared filesystem is not required. The benefit mainly lies in the assumption that the conda environment can be huge in size and thousands of tasks asking the shared filesystem for the same environment directory at the same time is not very performant. TaskVine on the other hand keeps track of where files are at and has an implicit throttle mechanism to data distribution so things don't go haywire.
- Add support for no conda environment replication, provided that environment is properly setup on worker nodes. Turning on `shared_fs` flag and add some setup code to `init_command` would turn off almost all TaskVine data-aware magic and the workflow run will mostly use the shared filesystem instead (e.g., `init_command="conda run -p path/to/conda"`). This serves as the baseline behavior for TaskVineExecutor.
- Refactor `executor.py` into {`executor.py`, `manager.py`, and `factory.py`} as they are different components.
- Change API: `use_factory` to `worker_launch_method`.
- Some variable renaming and additional logging.

Potential improvements: 
- Caching of functions and large arguments on both the manager and worker sides. Support for function caching is relatively easy and the benefit is that a function doesn't have to be serialized/deserialized every time it's called. Support for argument caching is more tricky and may require some help from Parsl (e.g., some annotations of immutable/sharable/cacheable data from users so some additional APIs are needed - data-intensive parsl?).
- App chaining: If apps are chained like this: `f(g(x)).result()`, then the best case is for the result of g(x) to be cached on the worker and f will be sent there, pick up the result, and then execute. Current implementation will send g(x) back to the manager, then send g(x) out again with f, which is inefficient. Implementing app chaining/imtermediate result caching needs some help from Parsl as well, as of now the dfk implicitly gives executors a stream of tasks instead of a graph.
- Performance improvement: policy to automate object caching and resource allocation for function calls.
- Anything else?

Fixes # (issue)
N/A

## Type of change
- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Code maintentance/cleanup
