### PR TITLE
Change log level for get_all_addresses and get_any_address

### DIFF
--- a/parsl/addresses.py
+++ b/parsl/addresses.py
@@ -110,7 +110,7 @@ def get_all_addresses() -> Set[str]:
         try:
             s_addresses.add(address_by_interface(interface))
         except Exception:
-            logger.exception("Ignoring failure to fetch address from interface {}".format(interface))
+            logger.info("Ignoring failure to fetch address from interface {}".format(interface))
 
     resolution_functions: List[Callable[[], str]]
     resolution_functions = [address_by_hostname, address_by_route, address_by_query]
@@ -118,7 +118,7 @@ def get_all_addresses() -> Set[str]:
         try:
             s_addresses.add(f())
         except Exception:
-            logger.exception("Ignoring an address finder exception")
+            logger.info("Ignoring an address finder exception")
 
     return s_addresses
 
@@ -137,7 +137,7 @@ def get_any_address() -> str:
             addr = address_by_interface(interface)
             return addr
         except Exception:
-            logger.exception("Ignoring failure to fetch address from interface {}".format(interface))
+            logger.info("Ignoring failure to fetch address from interface {}".format(interface))
 
     resolution_functions: List[Callable[[], str]]
     resolution_functions = [address_by_hostname, address_by_route, address_by_query]
@@ -146,7 +146,7 @@ def get_any_address() -> str:
             addr = f()
             return addr
         except Exception:
-            logger.exception("Ignoring an address finder exception")
+            logger.info("Ignoring an address finder exception")
 
     if addr == '':
         raise Exception('Cannot find address of the local machine.')


### PR DESCRIPTION

# Description

Logging an exception for every missed address resolution has these issues:
* Even when there are no faults, users stumble on these and we receive spurious fault reports over slack. It makes for a bad first impression
* These non-critical errors act as a diversion from real faults for users attempting to debug on their own.

PR only changes the log level for these non-critical errors from `logging.exception` to `logging.info`, but we'll not have a traceback.

Before:
```
1690831678.348826 2023-07-31 14:27:58 MainProcess-2772 MainThread-8640217792 parsl.addresses:113 get_all_addresses ERROR: Ignoring failure to fetch address from interface lo0
Traceback (most recent call last):
  File "/Users/yadu/src/parsl/parsl/addresses.py", line 111, in get_all_addresses
    s_addresses.add(address_by_interface(interface))
  File "/Users/yadu/opt/anaconda3/envs/parsl_py3.9/lib/python3.9/site-packages/typeguard/__init__.py", line 1033, in wrapper
    retval = func(*args, **kwargs)
  File "/Users/yadu/src/parsl/parsl/addresses.py", line 93, in address_by_interface
    return socket.inet_ntoa(fcntl.ioctl(
OSError: [Errno 6] Device not configured
1690831678.349179 2023-07-31 14:27:58 MainProcess-2772 MainThread-8640217792 parsl.addresses:113 get_all_addresses ERROR: Ignoring failure to fetch address from interface en0
Traceback (most recent call last):
  File "/Users/yadu/src/parsl/parsl/addresses.py", line 111, in get_all_addresses
    s_addresses.add(address_by_interface(interface))
  File "/Users/yadu/opt/anaconda3/envs/parsl_py3.9/lib/python3.9/site-packages/typeguard/__init__.py", line 1033, in wrapper
    retval = func(*args, **kwargs)
  File "/Users/yadu/src/parsl/parsl/addresses.py", line 93, in address_by_interface
    return socket.inet_ntoa(fcntl.ioctl(
OSError: [Errno 6] Device not configured
```

After:
```
1690992888.703371 2023-08-02 11:14:48 MainProcess-13046 MainThread-8667611840 parsl.executors.high_throughput.executor:217 __init__ DEBUG: Initializing HighThroughputExecutor
1690992888.704128 2023-08-02 11:14:48 MainProcess-13046 MainThread-8667611840 parsl.addresses:113 get_all_addresses INFO: Ignoring failure to fetch address from interface lo0
1690992888.704360 2023-08-02 11:14:48 MainProcess-13046 MainThread-8667611840 parsl.addresses:113 get_all_addresses INFO: Ignoring failure to fetch address from interface en0
1690992888.704520 2023-08-02 11:14:48 MainProcess-13046 MainThread-8667611840 parsl.addresses:113 get_all_addresses INFO: Ignoring failure to fetch address from interface anpi1
```

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.


- Code maintentance/cleanup
