### PR TITLE
Split and remove JobErrorHandler

### DIFF
--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -167,14 +167,12 @@ class ParslExecutor(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def handle_errors(self, error_handler: "parsl.jobs.job_error_handler.JobErrorHandler",
-                      status: Dict[str, JobStatus]) -> None:
+    def handle_errors(self, status: Dict[str, JobStatus]) -> None:
         """This method is called by the error management infrastructure after a status poll. The
         executor implementing this method is then responsible for detecting abnormal conditions
         based on the status of submitted jobs. If the executor does not implement any special
         error handling, this method should return False, in which case a generic error handling
         scheme will be used.
-        :param error_handler: a reference to the generic error handler calling this method
         :param status: status of all jobs launched by this executor
         """
         pass

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -12,6 +12,7 @@ from parsl.jobs.states import JobStatus, JobState
 from parsl.providers.base import ExecutionProvider
 from parsl.utils import AtomicIDCounter
 
+import parsl.jobs.simple_error_handler as error_handler
 
 logger = logging.getLogger(__name__)
 
@@ -136,7 +137,7 @@ class BlockProviderExecutor(ParslExecutor):
     def error_management_enabled(self):
         return self.block_error_handler
 
-    def handle_errors(self, error_handler: "parsl.jobs.job_error_handler.JobErrorHandler",
+    def handle_errors(self, _unused: "parsl.jobs.job_error_handler.JobErrorHandler",
                       status: Dict[str, JobStatus]) -> None:
         if not self.block_error_handler:
             return
@@ -236,7 +237,7 @@ class NoStatusHandlingExecutor(ParslExecutor):
     def status(self):
         return {}
 
-    def handle_errors(self, error_handler: "parsl.jobs.job_error_handler.JobErrorHandler",
+    def handle_errors(self, _unused: "parsl.jobs.job_error_handler.JobErrorHandler",
                       status: Dict[str, JobStatus]) -> None:
         pass
 

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -137,8 +137,7 @@ class BlockProviderExecutor(ParslExecutor):
     def error_management_enabled(self):
         return self.block_error_handler
 
-    def handle_errors(self, _unused: "parsl.jobs.job_error_handler.JobErrorHandler",
-                      status: Dict[str, JobStatus]) -> None:
+    def handle_errors(self, status: Dict[str, JobStatus]) -> None:
         if not self.block_error_handler:
             return
         init_blocks = 3
@@ -237,8 +236,7 @@ class NoStatusHandlingExecutor(ParslExecutor):
     def status(self):
         return {}
 
-    def handle_errors(self, _unused: "parsl.jobs.job_error_handler.JobErrorHandler",
-                      status: Dict[str, JobStatus]) -> None:
+    def handle_errors(self, status: Dict[str, JobStatus]) -> None:
         pass
 
     @property

--- a/parsl/jobs/job_error_handler.py
+++ b/parsl/jobs/job_error_handler.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from typing import List, Dict
+from typing import List
 
 import parsl.jobs.job_status_poller as jsp
-
-from parsl.executors.base import ParslExecutor
-from parsl.jobs.states import JobStatus, JobState
 
 
 class JobErrorHandler:
@@ -17,40 +14,3 @@ class JobErrorHandler:
         if not es.executor.error_management_enabled:
             return
         es.executor.handle_errors(self, es.status)
-
-    def simple_error_handler(self, executor: ParslExecutor, status: Dict[str, JobStatus], threshold: int):
-        (total_jobs, failed_jobs) = _count_jobs(status)
-        if total_jobs >= threshold and failed_jobs == total_jobs:
-            executor.set_bad_state_and_fail_all(_get_error(status))
-
-
-def _count_jobs(status: Dict[str, JobStatus]):
-    total = 0
-    failed = 0
-    for js in status.values():
-        total += 1
-        if js.state == JobState.FAILED:
-            failed += 1
-    return total, failed
-
-
-def _get_error(status: Dict[str, JobStatus]) -> Exception:
-    """Concatenate all errors."""
-    err = ""
-    count = 1
-    for js in status.values():
-        if js.message is not None:
-            err = err + "{}. {}\n".format(count, js.message)
-            count += 1
-        stdout = js.stdout_summary
-        if stdout:
-            err = err + "\tSTDOUT: {}\n".format(stdout)
-        stderr = js.stderr_summary
-        if stderr:
-            err = err + "\tSTDERR: {}\n".format(stderr)
-
-    if len(err) == 0:
-        err = "[No error message received]"
-    # wrapping things in an exception here doesn't really help in providing more information
-    # than the string itself
-    return Exception(err)

--- a/parsl/jobs/job_error_handler.py
+++ b/parsl/jobs/job_error_handler.py
@@ -13,4 +13,4 @@ class JobErrorHandler:
     def _check_irrecoverable_executor(self, es: jsp.PollItem):
         if not es.executor.error_management_enabled:
             return
-        es.executor.handle_errors(self, es.status)
+        es.executor.handle_errors(es.status)

--- a/parsl/jobs/job_error_handler.py
+++ b/parsl/jobs/job_error_handler.py
@@ -6,9 +6,12 @@ import parsl.jobs.job_status_poller as jsp
 
 
 class JobErrorHandler:
-    def run(self, status: List[jsp.PollItem]):
-        for es in status:
-            _check_irrecoverable_executor(es)
+    pass
+
+
+def run(status: List[jsp.PollItem]):
+    for es in status:
+        _check_irrecoverable_executor(es)
 
 
 def _check_irrecoverable_executor(es: jsp.PollItem):

--- a/parsl/jobs/job_error_handler.py
+++ b/parsl/jobs/job_error_handler.py
@@ -1,16 +1,5 @@
 from __future__ import annotations
 
-from typing import List
-
-import parsl.jobs.job_status_poller as jsp
-
 
 class JobErrorHandler:
     pass
-
-
-def run(status: List[jsp.PollItem]):
-    for es in status:
-        if not es.executor.error_management_enabled:
-            return
-        es.executor.handle_errors(es.status)

--- a/parsl/jobs/job_error_handler.py
+++ b/parsl/jobs/job_error_handler.py
@@ -19,36 +19,38 @@ class JobErrorHandler:
         es.executor.handle_errors(self, es.status)
 
     def simple_error_handler(self, executor: ParslExecutor, status: Dict[str, JobStatus], threshold: int):
-        (total_jobs, failed_jobs) = self.count_jobs(status)
+        (total_jobs, failed_jobs) = _count_jobs(status)
         if total_jobs >= threshold and failed_jobs == total_jobs:
-            executor.set_bad_state_and_fail_all(self.get_error(status))
+            executor.set_bad_state_and_fail_all(_get_error(status))
 
-    def count_jobs(self, status: Dict[str, JobStatus]):
-        total = 0
-        failed = 0
-        for js in status.values():
-            total += 1
-            if js.state == JobState.FAILED:
-                failed += 1
-        return total, failed
 
-    def get_error(self, status: Dict[str, JobStatus]) -> Exception:
-        """Concatenate all errors."""
-        err = ""
-        count = 1
-        for js in status.values():
-            if js.message is not None:
-                err = err + "{}. {}\n".format(count, js.message)
-                count += 1
-            stdout = js.stdout_summary
-            if stdout:
-                err = err + "\tSTDOUT: {}\n".format(stdout)
-            stderr = js.stderr_summary
-            if stderr:
-                err = err + "\tSTDERR: {}\n".format(stderr)
+def _count_jobs(status: Dict[str, JobStatus]):
+    total = 0
+    failed = 0
+    for js in status.values():
+        total += 1
+        if js.state == JobState.FAILED:
+            failed += 1
+    return total, failed
 
-        if len(err) == 0:
-            err = "[No error message received]"
-        # wrapping things in an exception here doesn't really help in providing more information
-        # than the string itself
-        return Exception(err)
+
+def _get_error(status: Dict[str, JobStatus]) -> Exception:
+    """Concatenate all errors."""
+    err = ""
+    count = 1
+    for js in status.values():
+        if js.message is not None:
+            err = err + "{}. {}\n".format(count, js.message)
+            count += 1
+        stdout = js.stdout_summary
+        if stdout:
+            err = err + "\tSTDOUT: {}\n".format(stdout)
+        stderr = js.stderr_summary
+        if stderr:
+            err = err + "\tSTDERR: {}\n".format(stderr)
+
+    if len(err) == 0:
+        err = "[No error message received]"
+    # wrapping things in an exception here doesn't really help in providing more information
+    # than the string itself
+    return Exception(err)

--- a/parsl/jobs/job_error_handler.py
+++ b/parsl/jobs/job_error_handler.py
@@ -1,5 +1,0 @@
-from __future__ import annotations
-
-
-class JobErrorHandler:
-    pass

--- a/parsl/jobs/job_error_handler.py
+++ b/parsl/jobs/job_error_handler.py
@@ -8,9 +8,10 @@ import parsl.jobs.job_status_poller as jsp
 class JobErrorHandler:
     def run(self, status: List[jsp.PollItem]):
         for es in status:
-            self._check_irrecoverable_executor(es)
+            _check_irrecoverable_executor(es)
 
-    def _check_irrecoverable_executor(self, es: jsp.PollItem):
-        if not es.executor.error_management_enabled:
-            return
-        es.executor.handle_errors(es.status)
+
+def _check_irrecoverable_executor(es: jsp.PollItem):
+    if not es.executor.error_management_enabled:
+        return
+    es.executor.handle_errors(es.status)

--- a/parsl/jobs/job_error_handler.py
+++ b/parsl/jobs/job_error_handler.py
@@ -11,10 +11,6 @@ class JobErrorHandler:
 
 def run(status: List[jsp.PollItem]):
     for es in status:
-        _check_irrecoverable_executor(es)
-
-
-def _check_irrecoverable_executor(es: jsp.PollItem):
-    if not es.executor.error_management_enabled:
-        return
-    es.executor.handle_errors(es.status)
+        if not es.executor.error_management_enabled:
+            return
+        es.executor.handle_errors(es.status)

--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -5,6 +5,8 @@ import zmq
 from typing import Dict, Sequence
 from typing import List  # noqa F401 (used in type annotation)
 
+import parsl.jobs.job_error_handler as error_handler
+
 from parsl.executors.base import ParslExecutor
 from parsl.jobs.job_error_handler import JobErrorHandler
 from parsl.jobs.states import JobStatus, JobState
@@ -112,7 +114,7 @@ class JobStatusPoller(Timer):
 
     def poll(self):
         self._update_state()
-        self._error_handler.run(self._poll_items)
+        error_handler.run(self._poll_items)
         self._strategy.strategize(self._poll_items)
 
     def _update_state(self) -> None:

--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -6,7 +6,6 @@ from typing import Dict, Sequence
 from typing import List  # noqa F401 (used in type annotation)
 
 from parsl.executors.base import ParslExecutor
-from parsl.jobs.job_error_handler import JobErrorHandler
 from parsl.jobs.states import JobStatus, JobState
 from parsl.jobs.strategy import Strategy
 from parsl.monitoring.message_type import MessageType
@@ -107,7 +106,6 @@ class JobStatusPoller(Timer):
         self.dfk = dfk
         self._strategy = Strategy(strategy=dfk.config.strategy,
                                   max_idletime=dfk.config.max_idletime)
-        self._error_handler = JobErrorHandler()
         super().__init__(self.poll, interval=5, name="JobStatusPoller")
 
     def poll(self):

--- a/parsl/jobs/simple_error_handler.py
+++ b/parsl/jobs/simple_error_handler.py
@@ -1,0 +1,42 @@
+from typing import Dict
+
+from parsl.executors.base import ParslExecutor
+from parsl.jobs.states import JobStatus, JobState
+
+
+def simple_error_handler(executor: ParslExecutor, status: Dict[str, JobStatus], threshold: int):
+    (total_jobs, failed_jobs) = _count_jobs(status)
+    if total_jobs >= threshold and failed_jobs == total_jobs:
+        executor.set_bad_state_and_fail_all(_get_error(status))
+
+
+def _count_jobs(status: Dict[str, JobStatus]):
+    total = 0
+    failed = 0
+    for js in status.values():
+        total += 1
+        if js.state == JobState.FAILED:
+            failed += 1
+    return total, failed
+
+
+def _get_error(status: Dict[str, JobStatus]) -> Exception:
+    """Concatenate all errors."""
+    err = ""
+    count = 1
+    for js in status.values():
+        if js.message is not None:
+            err = err + "{}. {}\n".format(count, js.message)
+            count += 1
+        stdout = js.stdout_summary
+        if stdout:
+            err = err + "\tSTDOUT: {}\n".format(stdout)
+        stderr = js.stderr_summary
+        if stderr:
+            err = err + "\tSTDERR: {}\n".format(stderr)
+
+    if len(err) == 0:
+        err = "[No error message received]"
+    # wrapping things in an exception here doesn't really help in providing more information
+    # than the string itself
+    return Exception(err)


### PR DESCRIPTION
Before this PR: The JobErrorHandler class had no state and was used effectively as a repository of stateless library functions, which are called from two distinct pieces of code.

This PR removes the JobErrorHandler class, moving the code into two locations:

`JobErrorHandler.run` (and its helper method `__check_irrecoverable_executor`) are called by `JobStatusPoller` to give each executor a chance to run its own error handler. This code is moved into JobStatusPoller.

`simple_error_handler` (and its helper methods `count_jobs` and `get_error`) are called by the `BlockProviderExecutor` implementation of error handling. They are moved into a new file, `simple_error_handler.py` directly inside that module (rather than inside a class).

After these changes, instances of `JobErrorHandler` are no longer used after being initialised - so the now-empty JobErrorHandler and its containing module are deleted.

This PR is not intended to change any behaviour.

## Type of change

- Code maintentance/cleanup
