### PR TITLE
Switch type comparisons from == to is, and upgrade flake8, in preparation for Python 3.12

### DIFF
--- a/parsl/dataflow/memoization.py
+++ b/parsl/dataflow/memoization.py
@@ -60,7 +60,7 @@ def id_for_memo_pickle(obj: object, output_ref: bool = False) -> bytes:
 
 @id_for_memo.register(list)
 def id_for_memo_list(denormalized_list: list, output_ref: bool = False) -> bytes:
-    if type(denormalized_list) != list:
+    if type(denormalized_list) is not list:
         raise ValueError("id_for_memo_list cannot work on subclasses of list")
 
     normalized_list = []
@@ -73,7 +73,7 @@ def id_for_memo_list(denormalized_list: list, output_ref: bool = False) -> bytes
 
 @id_for_memo.register(tuple)
 def id_for_memo_tuple(denormalized_tuple: tuple, output_ref: bool = False) -> bytes:
-    if type(denormalized_tuple) != tuple:
+    if type(denormalized_tuple) is not tuple:
         raise ValueError("id_for_memo_tuple cannot work on subclasses of tuple")
 
     normalized_list = []
@@ -91,7 +91,7 @@ def id_for_memo_dict(denormalized_dict: dict, output_ref: bool = False) -> bytes
     When output_ref=True, the values are normalised as output refs, but
     the keys are not.
     """
-    if type(denormalized_dict) != dict:
+    if type(denormalized_dict) is not dict:
         raise ValueError("id_for_memo_dict cannot work on subclasses of dict")
 
     keys = sorted(denormalized_dict)

--- a/parsl/tests/integration/test_channels/test_ssh_errors.py
+++ b/parsl/tests/integration/test_channels/test_ssh_errors.py
@@ -13,7 +13,7 @@ def test_error_1():
     try:
         connect_and_list("bad.url.gov", "ubuntu")
     except Exception as e:
-        assert type(e) == SSHException, "Expected SSException, got: {0}".format(e)
+        assert type(e) is SSHException, "Expected SSException, got: {0}".format(e)
 
 
 def test_error_2():

--- a/parsl/tests/test_bash_apps/test_keyword_overlaps.py
+++ b/parsl/tests/test_bash_apps/test_keyword_overlaps.py
@@ -3,7 +3,7 @@ import parsl
 
 @parsl.bash_app
 def my_app(cache=7):
-    assert type(cache) == int
+    assert type(cache) is int
     return "true"
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-flake8==6.0.0
+flake8==6.1.0
 ipyparallel
 pandas
 pytest>=7.4.0,<8


### PR DESCRIPTION
Upcoming Python 3.12 (at least in python 3.12-rc1) requires a newer version of flake8 as flake8 6.0.0 gets confused by things happening inside format strings with Python 3.12-rc1.

This PR makes that upgrade.

Flake8 6.1.0 introduces a new rule to use is-equality, rather than ==-equality, when comparing types, and so this PR fixes violations of that rule too. In theory this shouldn't change behaviour.

## Type of change

- Code maintentance/cleanup
