### PR TITLE
Remove mypy configuration for removed ExecutorStatus

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -32,11 +32,6 @@ disallow_untyped_defs = True
 disallow_any_expr = True
 disallow_any_decorated = True
 
-[mypy-parsl.dataflow.executor_status.*]
-disallow_untyped_defs = True
-disallow_any_expr = True
-disallow_any_decorated = True
-
 [mypy-parsl.dataflow.futures.*]
 disallow_untyped_defs = True
 disallow_any_decorated = True


### PR DESCRIPTION
ExecutorStatus and its containing module were removed in PR #2835.

## Type of change

- Code maintentance/cleanup
