### PR TITLE
Correct incorrect type annotation inside strategy code

### DIFF
--- a/parsl/jobs/strategy.py
+++ b/parsl/jobs/strategy.py
@@ -3,18 +3,27 @@ import logging
 import time
 import math
 import warnings
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, TypedDict
 
 import parsl.jobs.job_status_poller as jsp
 
 from parsl.executors import HighThroughputExecutor
-from parsl.executors.base import ParslExecutor
 from parsl.executors.status_handling import BlockProviderExecutor
 from parsl.jobs.states import JobState
 from parsl.process_loggers import wrap_with_logs
 
 
 logger = logging.getLogger(__name__)
+
+
+class ExecutorState(TypedDict):
+    """Strategy relevant state for an executor
+    """
+
+    idle_since: Optional[float]
+    """The timestamp at which an executor became idle.
+    If the executor is not idle, then None.
+    """
 
 
 class Strategy:
@@ -115,7 +124,7 @@ class Strategy:
 
     def __init__(self, *, strategy: Optional[str], max_idletime: float):
         """Initialize strategy."""
-        self.executors: Dict[str, ParslExecutor]
+        self.executors: Dict[str, ExecutorState]
         self.executors = {}
         self.max_idletime = max_idletime
 


### PR DESCRIPTION
This was not causing an error in master because no uses of the incorrectly annotated attribute (self.executors) were type checked.

This PR introduces a typed dict to represent the (single element) dictionary used for strategy state.

(A futher tidyup could be to remove that typed dict entirely and replace with the single value it contains, but this PR is trying to be descriptive of existing code)

The incorrect type annotation was added in #2712

## Type of change

- Bug fix (non-breaking change that fixes an issue)
- Code maintentance/cleanup
