### PR TITLE
Tidyup messy join app refactoring PR #2621

### DIFF
--- a/parsl/app/app.py
+++ b/parsl/app/app.py
@@ -73,15 +73,14 @@ def python_app(function=None,
                data_flow_kernel: Optional[DataFlowKernel] = None,
                cache: bool = False,
                executors: Union[List[str], Literal['all']] = 'all',
-               ignore_for_cache: Optional[List[str]] = None,
-               join: bool = False):
+               ignore_for_cache: Optional[List[str]] = None):
     """Decorator function for making python apps.
 
     Parameters
     ----------
     function : function
         Do not pass this keyword argument directly. This is needed in order to allow for omitted parenthesis,
-        for example, ``@join_app`` if using all defaults or ``@python_app(walltime=120)``. If the
+        for example, ``@python_app`` if using all defaults or ``@python_app(walltime=120)``. If the
         decorator is used alone, function will be the actual function being decorated, whereas if it
         is called with arguments, function will be None. Default is None.
     data_flow_kernel : DataFlowKernel
@@ -112,7 +111,6 @@ def python_app(function=None,
 def join_app(function=None,
              data_flow_kernel: Optional[DataFlowKernel] = None,
              cache: bool = False,
-             executors: Union[List[str], Literal['all']] = 'all',
              ignore_for_cache: Optional[List[str]] = None):
     """Decorator function for making join apps
 


### PR DESCRIPTION
PR #2621 didn't remove the user facing join parameter it was intended to, instead just ignoring it.

That PR #2621 also added a new executors parameter to the join_app decorator, which is then ignored (as it should be - because join_apps should be forced to run in the _parsl_internal executor). This PR removes that spurious parameter.

This will be a breaking change for anyone explicitly specifying the _parsl_internal decorator to join_app, or for anyone explicitly specifying join=False to python_app. (Other uses of those parameters are already broken because those parameters are ignored, and they will now be broken in different ways)

## Type of change

- Code maintentance/cleanup
