### PR TITLE
Fix mutable ignore_for_cache default in python apps

### DIFF
--- a/parsl/app/python.py
+++ b/parsl/app/python.py
@@ -36,7 +36,7 @@ def timeout(f, seconds: float):
 class PythonApp(AppBase):
     """Extends AppBase to cover the Python App."""
 
-    def __init__(self, func, data_flow_kernel=None, cache=False, executors='all', ignore_for_cache=[], join=False):
+    def __init__(self, func, data_flow_kernel=None, cache=False, executors='all', ignore_for_cache=None, join=False):
         super().__init__(
             wrap_error(func),
             data_flow_kernel=data_flow_kernel,


### PR DESCRIPTION
The rest of the codebase already accepts `None` as a default here (for example, the corresponding parameter to bash_app) so there aren't any further code changes needed to deal with this.

This comes from working through flake8-bugbear errors in draft PR #2832

## Type of change

- Code maintentance/cleanup
