### PR TITLE
Remove unused re-used DFK default configuration object

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -69,7 +69,7 @@ class DataFlowKernel:
     """
 
     @typechecked
-    def __init__(self, config: Config = Config()) -> None:
+    def __init__(self, config: Config) -> None:
         """Initialize the DataFlowKernel.
 
         Parameters


### PR DESCRIPTION
The default configuration actually comes from `DataFlowKernelLoader.load()` and the `Config()` object specified in the `DataFlowKernel.__init__` default parameters is never used, as all constructions of DataFlowKernel in the codebase specify a config.

This comes from flake8-bugbear

## Type of change

- Code maintentance/cleanup
