### PR TITLE
Remove unused defaults from dfk.submit

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -898,10 +898,10 @@ class DataFlowKernel:
     def submit(self,
                func: Callable,
                app_args: Sequence[Any],
-               executors: Union[str, Sequence[str]] = 'all',
-               cache: bool = False,
-               ignore_for_cache: Optional[Sequence[str]] = None,
-               app_kwargs: Dict[str, Any] = {},
+               executors: Union[str, Sequence[str]],
+               cache: bool,
+               ignore_for_cache: Optional[Sequence[str]],
+               app_kwargs: Dict[str, Any],
                join: bool = False) -> AppFuture:
         """Add task to the dataflow system.
 


### PR DESCRIPTION
All of these parameters are specified by invocations in the relevant app decorators and so these defaults are never used.

Removing the default app_kwargs = {} is especially interesting for mutability safety.

This comes from flake8-bugbear

## Type of change

- Code maintentance/cleanup
