### PR TITLE
Make resource monitor exit when monitored process has gone away

### DIFF
--- a/parsl/monitoring/remote.py
+++ b/parsl/monitoring/remote.py
@@ -262,7 +262,7 @@ def monitor(pid: int,
     next_send = time.time()
     accumulate_dur = 5.0  # TODO: make configurable?
 
-    while not terminate_event.is_set():
+    while not terminate_event.is_set() and pm.is_running():
         logging.debug("start of monitoring loop")
         try:
             d = accumulate_and_prepare()


### PR DESCRIPTION
Issue #2840 reports that the process monitor does not always exit if the workflow process exits unexpectedly, and looking at the cpython implementation, it looks like these processes will only be terminated at worker shutdown if the worker shuts down normally. If it is surprise terminated/killed, it will not shut down its dependent daemons such as any resource monitors it has launched.

This PR adds a liveness check for the process that it is monitoring, which is the parent worker process; so that if that process goes away without telling the resource monitor to exit, then the resource monitor will exit anyway.

Fixes #2840

## Type of change

- Bug fix (non-breaking change that fixes an issue)
