### PR TITLE
Rework _get_error in simple_error_handler to give more information

### DIFF
--- a/parsl/jobs/errors.py
+++ b/parsl/jobs/errors.py
@@ -1,0 +1,7 @@
+from parsl.errors import ParslError
+
+
+class TooManyJobFailuresError(ParslError):
+    """Indicates that executor is shut down because of too many block failures.
+    """
+    pass

--- a/parsl/jobs/simple_error_handler.py
+++ b/parsl/jobs/simple_error_handler.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 import parsl.executors.status_handling as status_handling
 from parsl.jobs.states import JobStatus, JobState
+from parsl.jobs.errors import TooManyJobFailuresError
 
 
 def simple_error_handler(executor: status_handling.BlockProviderExecutor, status: Dict[str, JobStatus], threshold: int):
@@ -27,18 +28,25 @@ def _get_error(status: Dict[str, JobStatus]) -> Exception:
     err = ""
     count = 1
     for js in status.values():
+        err = err + f"Error {count}:\n"
+        count += 1
+
         if js.message is not None:
-            err = err + "{}. {}\n".format(count, js.message)
-            count += 1
+            err = err + f"\t{js.message}\n"
+
+        if js.exit_code is not None:
+            err = err + f"\tEXIT CODE: {js.exit_code}\n"
+
         stdout = js.stdout_summary
         if stdout:
             err = err + "\tSTDOUT: {}\n".format(stdout)
+
         stderr = js.stderr_summary
         if stderr:
             err = err + "\tSTDERR: {}\n".format(stderr)
 
     if len(err) == 0:
-        err = "[No error message received]"
+        err = "No error messages received"
     # wrapping things in an exception here doesn't really help in providing more information
     # than the string itself
-    return Exception(err)
+    return TooManyJobFailuresError(err)


### PR DESCRIPTION
Before (in pytest output, with htex launch_cmd="/bin/false"):

```
Exception: 	STDOUT: Found cores : 8
Launching worker: 1
```

After:

```
parsl.jobs.errors.TooManyJobFailuresError: Error 1:
	EXIT CODE: 1
	STDOUT: Found cores : 8
Launching worker: 1
```

* Fix counting so it counts even when js.message is None

* Add exit code

* Use a new error subclass rather than Exception

* Pluralise messages in for no-messages string and remove brackets

  '[No error message received]' vs 'No error messages received'

# Description

Please include a summary of the change and (optionally) which issue is fixed. Please also include
relevant motivation and context.

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
- Code maintentance/cleanup
