### PR TITLE
Remove unreachable code when app_fu is None

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1283,9 +1283,6 @@ class DataFlowKernel:
                 for task_record in checkpoint_queue:
                     task_id = task_record['id']
 
-                    if task_record['app_fu'] is None:
-                        continue
-
                     app_fu = task_record['app_fu']
 
                     if app_fu.done() and app_fu.exception() is None:


### PR DESCRIPTION
The task record entry app_fu is never None:
it is either missing (during construction) or a Future.

So, this None check will never fire.

Discovered by mypy 0.5.1 warn_unreachable

## Type of change

- Code maintentance/cleanup
