### PR TITLE
Tighten MissingOutputs file type

### DIFF
--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -64,10 +64,9 @@ class MissingOutputs(ParslError):
 
     Contains:
     reason(string)
-    outputs(List of strings/files..)
+    outputs(List of files)
     """
-
-    def __init__(self, reason: str, outputs: List[Union[str, File]]) -> None:
+    def __init__(self, reason: str, outputs: List[File]) -> None:
         super().__init__(reason, outputs)
         self.reason = reason
         self.outputs = outputs


### PR DESCRIPTION
Outputs must be Files - although early on in Parsl, it was possible to specify them as string pathnames. This now-removed string-or-File dual annotation is probably a holdover from that.

## Type of change

- Code maintentance/cleanup
