### PR TITLE
Remove execute_wait stdout, stderr optionality

### DIFF
--- a/parsl/channels/base.py
+++ b/parsl/channels/base.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
 
-from typing import Dict, Optional, Tuple
+from typing import Dict, Tuple
 
 
 class Channel(metaclass=ABCMeta):
@@ -38,7 +38,7 @@ class Channel(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def execute_wait(self, cmd: str, walltime: int = 0, envs: Dict[str, str] = {}) -> Tuple[int, Optional[str], Optional[str]]:
+    def execute_wait(self, cmd: str, walltime: int = 0, envs: Dict[str, str] = {}) -> Tuple[int, str, str]:
         ''' Executes the cmd, with a defined walltime.
 
         Args:
@@ -49,9 +49,7 @@ class Channel(metaclass=ABCMeta):
             - envs (Dict[str, str]) : Environment variables to push to the remote side
 
         Returns:
-            - (exit_code, stdout, stderr) (int, optional string, optional string)
-              If the exit code is a failure code, the stdout and stderr return values
-              may be None.
+            - (exit_code, stdout, stderr) (int, string, string)
         '''
         pass
 


### PR DESCRIPTION
No in-codebase channels return None for stdout or stderr, and some cluster providers (at least pbspro and slurm) do not handle the case when stdout is None, instead assuming it will be a str.

This PR makes those assumptions concrete.

This PR will introduce API breakage for any externally implemented channels which return None here, although in practice because of the above, it's likely that use of those channels woudl already be broken.

However, I am not aware of any externally implemented channels.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Code maintentance/cleanup
