### PR TITLE
Remove three dead assignments from local channel

### DIFF
--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -51,10 +51,6 @@ class LocalChannel(Channel, RepresentationMixin):
         Raises:
         None.
         '''
-        retcode = -1
-        stdout = None
-        stderr = None
-
         current_env = copy.deepcopy(self._envs)
         current_env.update(envs)
 


### PR DESCRIPTION
These initial values will never be used and in the stdout/err case, can give the impression that stdout, stderr might be returned as None. There is no code path which uses these initial assignments as the function will raise an exception in the case that they are not all re-assigned later on.

## Type of change

- Code maintentance/cleanup
