### PR TITLE
Switch empty dfk() error from ConfigurationError to NoDataFlowKernelError

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1438,5 +1438,5 @@ class DataFlowKernelLoader:
     def dfk(cls) -> DataFlowKernel:
         """Return the currently-loaded DataFlowKernel."""
         if cls._dfk is None:
-            raise ConfigurationError('Must first load config')
+            raise NoDataFlowKernelError('Must first load config')
         return cls._dfk


### PR DESCRIPTION
This is in support of
https://github.com/Parsl/parsl/issues/2873#issuecomment-1726540856

This will break anyone relying on particular exception classes coming from this call.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Code maintentance/cleanup
