### PR TITLE
Fix flake8 error from upcoming Python 3.12

### DIFF
--- a/parsl/benchmark/perf.py
+++ b/parsl/benchmark/perf.py
@@ -48,7 +48,7 @@ def performance(*, resources: dict, target_t: float):
 
         submitted_t = time.time()
         print(f"All {n} tasks submitted ... waiting for completion")
-        print(f"Submission took {submitted_t - start_t:.3f} seconds = {n/(submitted_t - start_t):.3f} tasks/second")
+        print(f"Submission took {submitted_t - start_t:.3f} seconds = {n / (submitted_t - start_t):.3f} tasks/second")
 
         for f in concurrent.futures.as_completed(fs):
             assert f.result() == 7


### PR DESCRIPTION
In Python 3.12, f-strings vs flake8 has more whitespace checking, in line with whitespace checking in other Python expressions, as part of a broader rationalisation of f-string implementation:
https://docs.python.org/3.12/whatsnew/3.12.html#whatsnew312-pep701

## Type of change

- Code maintentance/cleanup
