### PR TITLE
Make parsl-perf iterations have at least 1 task

### DIFF
--- a/parsl/benchmark/perf.py
+++ b/parsl/benchmark/perf.py
@@ -62,7 +62,7 @@ def performance(*, resources: dict, target_t: float):
         print(f"Runtime: actual {delta_t:.3f}s vs target {target_t}s")
         print(f"Tasks per second: {rate:.3f}")
 
-        n = int(target_t * rate)
+        n = max(1, int(target_t * rate))
 
         iteration += 1
 


### PR DESCRIPTION
Prior to this PR: In some startup situations, the estimated number of tasks for the next iteration can round down to 0, and then parsl-perf can sometimes enter an infinite loop without increasing the loop size:

==== Iteration 29463 ====
Will run 0 tasks to target 20.0 seconds runtime
Submitting tasks / invoking apps
All 0 tasks submitted ... waiting for completion
Submission took 2.1457672119140625e-06 seconds = 0.0 tasks/second Runtime: 1.049041748046875e-05s vs target 20.0
Tasks per second: 0.0

## Type of change

- Bug fix (non-breaking change that fixes an issue)
