### PR TITLE
Do not return a value from a pytest case, to fix a deprecation warning

### DIFF
--- a/parsl/tests/test_bash_apps/test_error_codes.py
+++ b/parsl/tests/test_bash_apps/test_error_codes.py
@@ -74,7 +74,6 @@ def test_div_0(test_fn=div_0):
     print(os.listdir('.'))
     os.remove('std.err')
     os.remove('std.out')
-    return True
 
 
 @pytest.mark.issue363


### PR DESCRIPTION
This fixes this pytest warning:

  PytestReturnNotNoneWarning: Expected None, but
  test_bash_apps/test_error_codes.py::test_div_0 returned True, which
  will be an error in a future version of pytest.
  Did you mean to use `assert` instead of `return`?

## Type of change

- Code maintentance/cleanup
