### PR TITLE
Make `max_threads` type `Optional[int]` in `ThreadPoolExecutor`

### DIFF
--- a/parsl/executors/threads.py
+++ b/parsl/executors/threads.py
@@ -18,7 +18,7 @@ class ThreadPoolExecutor(ParslExecutor, RepresentationMixin):
 
     Parameters
     ----------
-    max_threads : int
+    max_threads : Optional[int]
         Number of threads. Default is 2.
     thread_name_prefix : string
         Thread name prefix
@@ -27,7 +27,7 @@ class ThreadPoolExecutor(ParslExecutor, RepresentationMixin):
     """
 
     @typeguard.typechecked
-    def __init__(self, label: str = 'threads', max_threads: int = 2,
+    def __init__(self, label: str = 'threads', max_threads: Optional[int] = 2,
                  thread_name_prefix: str = '', storage_access: Optional[List[Staging]] = None,
                  working_dir: Optional[str] = None):
         ParslExecutor.__init__(self)


### PR DESCRIPTION
# Description

The `ThreadPoolExecutor` forces the `max_threads` kwarg to be of type `int`. However, since `max_threads` inevitably makes its way into `concurrent.futures.ThreadPoolExecutor`, [which can take `max_workers=None`](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor), I have modified the type hint to be `Optional[int]`. 

Happy to add a test if you feel it warrants one.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature (non-breaking change that adds functionality)
