### PR TITLE
Chain exceptions on WorkQueueTaskFailure when a cause is available

### DIFF
--- a/parsl/executors/workqueue/errors.py
+++ b/parsl/executors/workqueue/errors.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from parsl.errors import ParslError
 from parsl.app.errors import AppException
 
@@ -7,10 +9,10 @@ class WorkQueueTaskFailure(AppException):
 
     Contains:
     reason(string)
-    status(int)
+    status(optional exception)
     """
 
-    def __init__(self, reason, status):
+    def __init__(self, reason: str, status: Optional[Exception]):
         self.reason = reason
         self.status = status
 


### PR DESCRIPTION
This will add exception chaining when an underlying exception is available, so that reporting of a WorkQueueTaskError will include before the WorkQueueTaskError. This means, in the case of a FileNotFoundError, that the filename that could not be found will now be reported.

```
 FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/work/parsl/parsl/runinfo/003/WorkQueueExecutor/function_data/0011/result'

parsl/executors/workqueue/executor.py:1059: FileNotFoundError

The above exception was the direct cause of the following exception:
```
