### PR TITLE
Separate monitoring core and visualization dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ wqex_local_test: $(CCTOOLS_INSTALL)  ## run all tests with workqueue_ex config
 
 .PHONY: config_local_test
 config_local_test:
-	pip3 install ".[monitoring,proxystore]"
+	pip3 install ".[monitoring,viz,proxystore]"
 	pytest parsl/tests/ -k "not cleannet" --config local --random-order --durations 10
 
 .PHONY: site_test

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ wqex_local_test: $(CCTOOLS_INSTALL)  ## run all tests with workqueue_ex config
 
 .PHONY: config_local_test
 config_local_test:
-	pip3 install ".[monitoring,viz,proxystore]"
+	pip3 install ".[monitoring,visualization,proxystore]"
 	pytest parsl/tests/ -k "not cleannet" --config local --random-order --durations 10
 
 .PHONY: site_test

--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -56,7 +56,7 @@ Visualization
 To run the web dashboard utility ``parsl-visualize`` you first need to install
 its dependencies:
 
-   $ pip install 'parsl[monitoring]'
+   $ pip install 'parsl[monitoring,visualization]'
 
 To view the web dashboard while or after a Parsl program has executed, run
 the ``parsl-visualize`` utility::

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,9 @@ with open('requirements.txt') as f:
 
 extras_require = {
     'monitoring' : [
-        'sqlalchemy>=1.4,<2',
+        'sqlalchemy>=1.4,<2'
+    ],
+    'visualization' : [
         'pydot',
         'networkx>=2.5,<2.6',
         'Flask>=1.0.2',


### PR DESCRIPTION
This reflects a difference in code maturity and maintenance between the two: monitoring core is much more maintained and stable than visualization at the moment.

Work with LSST has repeatedly encountered dependency problems caused by the visualization dependencies, even though those dependencies are not need by LSST, and this separation allows the visualization dependencies to be skipped.

Breaking change:
If you are using visualization you will now need to:

  pip install parsl[monitoring,visualization]

to get all of the dependencies previously installed by [monitoring]

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Code maintentance/cleanup
