### PR TITLE
Use the term "task record" instead of "task def(inition)" more consistently

### DIFF
--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -59,32 +59,32 @@ class AppFuture(Future):
 
     """
 
-    def __init__(self, task_def: TaskRecord) -> None:
+    def __init__(self, task_record: TaskRecord) -> None:
         """Initialize the AppFuture.
 
         Args:
 
         KWargs:
-             - task_def : The DFK task definition dictionary for the task represented
-                   by this future.
+             - task_record : The TaskRecord for the task represented by
+               this future.
         """
         super().__init__()
         self._update_lock = threading.Lock()
         self._outputs: Sequence[DataFuture]
         self._outputs = []
-        self.task_def = task_def
+        self.task_record = task_record
 
     @property
     def stdout(self) -> Optional[str]:
-        return self.task_def['kwargs'].get('stdout')
+        return self.task_record['kwargs'].get('stdout')
 
     @property
     def stderr(self) -> Optional[str]:
-        return self.task_def['kwargs'].get('stderr')
+        return self.task_record['kwargs'].get('stderr')
 
     @property
     def tid(self) -> int:
-        return self.task_def['id']
+        return self.task_record['id']
 
     def cancel(self) -> bool:
         raise NotImplementedError("Cancel not implemented")
@@ -113,7 +113,7 @@ class AppFuture(Future):
 
            Returns: str
         """
-        return self.task_def['status'].name
+        return self.task_record['status'].name
 
     @property
     def outputs(self) -> Sequence[DataFuture]:

--- a/parsl/tests/test_error_handling/test_python_walltime.py
+++ b/parsl/tests/test_error_handling/test_python_walltime.py
@@ -27,8 +27,8 @@ def test_python_longer_walltime_at_invocation():
 def test_python_walltime_wrapped_names():
     f = my_app(0.01, walltime=6)
     assert f.result() == 7
-    assert f.task_def['func'].__name__ == "my_app"
-    assert f.task_def['func_name'] == "my_app"
+    assert f.task_record['func'].__name__ == "my_app"
+    assert f.task_record['func_name'] == "my_app"
 
 
 def test_python_bad_decorator_args():

--- a/parsl/tests/test_monitoring/test_memoization_representation.py
+++ b/parsl/tests/test_monitoring/test_memoization_representation.py
@@ -41,9 +41,9 @@ def test_hashsum():
     f4 = this_app(4)
     assert f4.result() == 5
 
-    assert f1.task_def['hashsum'] == f3.task_def['hashsum']
-    assert f1.task_def['hashsum'] == f4.task_def['hashsum']
-    assert f1.task_def['hashsum'] != f2.task_def['hashsum']
+    assert f1.task_record['hashsum'] == f3.task_record['hashsum']
+    assert f1.task_record['hashsum'] == f4.task_record['hashsum']
+    assert f1.task_record['hashsum'] != f2.task_record['hashsum']
 
     logger.info("cleaning up parsl")
     parsl.dfk().cleanup()
@@ -62,11 +62,11 @@ def test_hashsum():
         assert task_count == 4
 
         # this will check that the number of task rows for each hashsum matches the above app invocations
-        result = connection.execute(text(f"SELECT COUNT(task_hashsum) FROM task WHERE task_hashsum='{f1.task_def['hashsum']}'"))
+        result = connection.execute(text(f"SELECT COUNT(task_hashsum) FROM task WHERE task_hashsum='{f1.task_record['hashsum']}'"))
         (hashsum_count, ) = result.first()
         assert hashsum_count == 3
 
-        result = connection.execute(text(f"SELECT COUNT(task_hashsum) FROM task WHERE task_hashsum='{f2.task_def['hashsum']}'"))
+        result = connection.execute(text(f"SELECT COUNT(task_hashsum) FROM task WHERE task_hashsum='{f2.task_record['hashsum']}'"))
         (hashsum_count, ) = result.first()
         assert hashsum_count == 1
 


### PR DESCRIPTION
This will be a breaking change for any user that references the (now renamed) `task_def` attribute of an AppFuture.

## Type of change

- Code maintentance/cleanup
