### PR TITLE
Remove unused import (from `ruff . --fix`)

### DIFF
--- a/parsl/executors/workqueue/parsl_coprocess.py
+++ b/parsl/executors/workqueue/parsl_coprocess.py
@@ -2,7 +2,6 @@
 
 import sys
 from parsl.app.errors import RemoteExceptionWrapper
-import parsl.executors.workqueue.exec_parsl_function as epf
 
 import socket
 import json


### PR DESCRIPTION
# Description

I applied [ruff](https://github.com/astral-sh/ruff) autofixes (i.e. `ruff . --fix`) to the source code, which found... precisely one unused import. 😅 

## Type of change

- Code maintentance/cleanup
