### PR TITLE
Make pytest fail when tasks are running after a test

### DIFF
--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -243,7 +243,7 @@ def setup_data(tmpd_cwd):
 
 
 @pytest.fixture(autouse=True, scope='function')
-def wait_for_task_completion(pytestconfig):
+def assert_no_outstanding_tasks(pytestconfig):
     """If we're in a config-file based mode, wait for task completion between
        each test. This will detect early on (by hanging) if particular test
        tasks are not finishing, rather than silently falling off the end of
@@ -254,7 +254,11 @@ def wait_for_task_completion(pytestconfig):
     config = pytestconfig.getoption('config')[0]
     yield
     if config != 'local':
-        parsl.dfk().wait_for_current_tasks()
+        logger.info("Checking no outstanding tasks")
+        for task_record in parsl.dfk().tasks.values():
+            fut = task_record['app_fu']
+            assert fut.done(), f"Incomplete task found, task id {task_record['id']}"
+        logger.info("No outstanding tasks found")
 
 
 def pytest_make_collect_report(collector):

--- a/parsl/tests/test_python_apps/test_lifted.py
+++ b/parsl/tests/test_python_apps/test_lifted.py
@@ -89,8 +89,10 @@ def test_returns_a_class_instance():
 
 def test_returns_a_class_instance_no_underscores():
     # test that _underscore attribute references are not lifted
+    f = returns_a_class_instance()
     with pytest.raises(AttributeError):
-        returns_a_class_instance()._nosuchattribute.result()
+        f._nosuchattribute.result()
+    f.exception()  # wait for f to complete before the test ends
 
 
 @pytest.mark.skip("returning classes is not supported in WorkQueue or Task Vine - see issue #2908")


### PR DESCRIPTION
When pressing ctrl-c in pytest, prior to this PR, it would hang as wait_for_task_completion would be called in the unwinding of the fixture stack. However, because ctrl-c was pressed, tasks wouldn't be expected to all complete.

This PR changes that to assert that all tasks are completed, rather than *waiting* for all tasks to complete.

A non-finished task now gives a test error - which is arguably better anyway because it more aggressively flushes out tests that do not perform a complete shutdown.

This means that pressing ctrl-C in a pytest leads to an assertion error; when previously it led to a hang.

One recently introduced test is fixed to conform to this new requirement.

This is part of safe-shutdown work.

## Type of change

- New feature (non-breaking change that adds functionality)
- Code maintentance/cleanup
