### PR TITLE
Remove mypy reference to Extreme Scale Executor

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -80,9 +80,6 @@ disallow_any_expr = True
 [mypy-parsl.executors.high_throughput.interchange.*]
 check_untyped_defs = True
 
-[mypy-parsl.executors.extreme_scale.*]
-ignore_errors = True
-
 [mypy-parsl.monitoring.*]
 disallow_untyped_decorators = True
 check_untyped_defs = True


### PR DESCRIPTION
This executor was removed in PR #2747

## Type of change

- Code maintentance/cleanup
