### PR TITLE
Enable mypy warn_unreachable globally; Describe the only exception

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -9,6 +9,7 @@ no_implicit_optional = True
 
 strict_equality = True
 warn_unused_ignores = True
+warn_unreachable = True
 
 [mypy-non_existent.*]
 ignore_missing_imports = True
@@ -57,14 +58,12 @@ disallow_any_decorated = True
 disallow_untyped_decorators = True
 check_untyped_defs = True
 disallow_subclassing_any = True
-warn_unreachable = True
 disallow_untyped_defs = True
 
 [mypy-parsl.serialize.*]
 disallow_untyped_decorators = True
 check_untyped_defs = True
 disallow_subclassing_any = True
-warn_unreachable = True
 disallow_untyped_defs = True
 
 [mypy-parsl.serialize.proxystore.*]
@@ -77,13 +76,11 @@ disallow_any_expr = True
 
 [mypy-parsl.executors.high_throughput.interchange.*]
 disallow_untyped_defs = True
-warn_unreachable = True
 
 [mypy-parsl.monitoring.*]
 disallow_untyped_decorators = True
 check_untyped_defs = True
 disallow_subclassing_any = True
-warn_unreachable = True
 disallow_untyped_defs = True
 
 # visualization typechecks much less well than the rest of monitoring,
@@ -95,7 +92,6 @@ ignore_errors = True
 ignore_missing_imports = True
 
 [mypy-parsl.utils]
-warn_unreachable = True
 disallow_untyped_defs = True
 
 [mypy-flask_sqlalchemy.*]

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1090,7 +1090,14 @@ class DataFlowKernel:
         """
         run_dir = self.run_dir
         if channel.script_dir is None:
-            channel.script_dir = os.path.join(run_dir, 'submit_scripts')
+
+            # This case will be detected as unreachable by mypy, because of
+            # the type of script_dir, which is str, not Optional[str].
+            # The type system doesn't represent the initialized/uninitialized
+            # state of a channel so cannot represent that a channel needs
+            # its script directory set or not.
+
+            channel.script_dir = os.path.join(run_dir, 'submit_scripts')  # type: ignore[unreachable]
 
             # Only create dirs if we aren't on a shared-fs
             if not channel.isdir(run_dir):


### PR DESCRIPTION
The only exception comes from multi-stage initialization of channels which is not properly represented in the type system.

"Globally" here means for code that is being type-checked - so not (by default) including code with no type annotations.

## Type of change

- Code maintentance/cleanup
