### PR TITLE
Update PR template based on my recent experiences

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,14 +3,19 @@
 Please include a summary of the change and (optionally) which issue is fixed. Please also include
 relevant motivation and context.
 
+# Changed Behaviour
+
+Which existing user workflows or functionality will behave differently after this PR?
+
+# Fixes
+
 Fixes # (issue)
 
 ## Type of change
 
 Choose which options apply, and delete the ones which do not apply.
 
-- Bug fix (non-breaking change that fixes an issue)
-- New feature (non-breaking change that adds functionality)
-- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- Documentation update
+- Bug fix
+- New feature
+- Update to human readable text: Documentation/error messages/comments
 - Code maintentance/cleanup


### PR DESCRIPTION
This PR adds a "mandatory" breaking changes section.

Rather than the previous assumption that bug fixes and new features would not break anything, this now assumes that all code changes might break something and encourages the pull-requester to think about this more seriously.

This PR also expands "Documentation update" to refer to anything involving human readable text.

## Type of change

- Documentation update
