### PR TITLE
Install into virtualenv inside CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,17 +30,25 @@ jobs:
         # this is to make the workqueue binary installer happy
         sudo apt-get install -y libpython3.5
 
+    - name: setup virtual env
+      run: |
+        make virtualenv
+        source .venv/bin/activate
+
     - name: make deps clean_coverage
       run: |
+        source .venv/bin/activate
         make deps
         make clean_coverage
 
     - name: make test
       run: |
+        source .venv/bin/activate
         make test
 
     - name: Documentation checks
       run: |
+        source .venv/bin/activate
         pip install .[docs]
         sudo apt-get install -y pandoc
         cd docs
@@ -61,12 +69,14 @@ jobs:
 
     - name: Checking parsl-visualize
       run: |
+        source .venv/bin/activate
         sudo apt-get install -y graphviz
         pip install .[monitoring]
         parsl/tests/test-viz.sh
 
     - name: make coverage
       run: |
+        source .venv/bin/activate
         make coverage
 
     - name: Archive runinfo logs


### PR DESCRIPTION
This is motivated by upcoming PR #2923 which adds a RADICAL-Pilot executor: that executor is able to re-use a submit side virtualenv, but not able to re-use `--user` level installs.

This should not change any other behaviour of the CI: packages will be installed at different paths, but anything that was reliant on those paths being a specific values is suspicious.

## Type of change

- New feature (non-breaking change that adds functionality)
