### PR TITLE
Pin release process to Python 3.11

### DIFF
--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -39,9 +39,11 @@ jobs:
         if git tag --contains HEAD | grep -e '^[0-9]\{4\}\.[0-9]\{2\}\.[0-9]\{2\}$' ; then exit 1 ; fi
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        # The release process needs distusils - see Parsl issue #2934
+        # which was removed from Python 3.12
+        python-version: '3.11'
 
     - name: Set version info
       id: version_setter

--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        # The release process needs distusils - see Parsl issue #2934
+        # The release process needs distutils - see Parsl issue #2934
         # which was removed from Python 3.12
         python-version: '3.11'
 


### PR DESCRIPTION
The release process previously used whichever environment the actions/setup-python action chose to use in the 3.x range. Python 3.12 and the current release process are incompatible, and auto-releases broke when actions/setup-python chose to supply Python 3.12. This PR pins the release to Python 3.11, which will remain in a supported state until October 2027. Beyond that, this release process will probably need some re-engineering to work.

Attempts to fix #2934

## Type of change

- Bug fix (non-breaking change that fixes an issue)
