### PR TITLE
Eliminate trivially unnecessary # noqa statements

### DIFF
--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -5,8 +5,6 @@ from typing_extensions import Literal, Self
 
 from parsl.jobs.states import JobStatus
 
-import parsl  # noqa F401
-
 
 class ParslExecutor(metaclass=ABCMeta):
     """Executors are abstractions that represent available compute resources

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -8,7 +8,7 @@ import datetime
 import pickle
 import warnings
 from multiprocessing import Queue
-from typing import Dict, Sequence  # noqa F401 (used in type annotation)
+from typing import Dict, Sequence
 from typing import List, Optional, Tuple, Union, Callable
 import math
 

--- a/parsl/executors/radical/executor.py
+++ b/parsl/executors/radical/executor.py
@@ -196,7 +196,7 @@ class RadicalPilotExecutor(ParslExecutor, RepresentationMixin):
                     if task.exit_code == 0:
                         parsl_task.set_result(int(task.exit_code))
                     else:
-                        parsl_task.set_exception(BashExitFailure(task.name,  # noqa: F405
+                        parsl_task.set_exception(BashExitFailure(task.name,
                                                                  task.exit_code))
                 else:
                     if task.exception:

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -6,7 +6,6 @@ from abc import abstractmethod, abstractproperty
 from concurrent.futures import Future
 from typing import List, Any, Dict, Optional, Tuple, Union, Callable
 
-import parsl  # noqa F401
 from parsl.executors.base import ParslExecutor
 from parsl.executors.errors import BadStateException, ScalingFailed
 from parsl.jobs.states import JobStatus, JobState

--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -1,9 +1,8 @@
 import logging
-import parsl  # noqa F401 (used in string type annotation)
+import parsl
 import time
 import zmq
-from typing import Dict, Sequence
-from typing import List  # noqa F401 (used in type annotation)
+from typing import Dict, List, Sequence
 
 from parsl.jobs.states import JobStatus, JobState
 from parsl.jobs.strategy import Strategy

--- a/parsl/tests/test_python_apps/test_garbage_collect.py
+++ b/parsl/tests/test_python_apps/test_garbage_collect.py
@@ -5,7 +5,7 @@ import pytest
 
 import parsl
 from parsl.app.app import python_app
-from parsl.tests.configs.local_threads import fresh_config as local_config  # noqa
+from parsl.tests.configs.local_threads import fresh_config as local_config
 
 
 @python_app

--- a/parsl/tests/test_regression/test_1606_wait_for_current_tasks.py
+++ b/parsl/tests/test_regression/test_1606_wait_for_current_tasks.py
@@ -4,7 +4,7 @@ import time
 import pytest
 
 import parsl
-from parsl.tests.configs.local_threads import fresh_config as local_config  # noqa
+from parsl.tests.configs.local_threads import fresh_config as local_config
 
 
 @parsl.python_app


### PR DESCRIPTION
Remove one unused import of `parsl` entirely. This is probably good for import loop untangling generally anyway.

Remove some F401s that come from older type-checking code not being able to see imports used inside type annotations.

Remove some test-suite noqas that are defined for the entire test suite in .flake8

This PR leaves three # noqa statements in place because removing them is more complicated.

# Changed Behaviour

Developers using non-test-suite static checkers might find their checker is angry now.

Removal of `import parsl` in the executor base might cause changes to import order.

## Type of change

- Code maintentance/cleanup
