### PR TITLE
Use __str__, not __repr__, for human readable provider error text

### DIFF
--- a/parsl/providers/errors.py
+++ b/parsl/providers/errors.py
@@ -29,7 +29,7 @@ class SchedulerMissingArgs(ExecutionProviderException):
         self.missing_keywords = missing_keywords
         self.sitename = sitename
 
-    def __repr__(self):
+    def __str__(self):
         return "SchedulerMissingArgs: Pool:{0} Arg:{1}".format(self.sitename, self.missing_keywords)
 
 
@@ -41,7 +41,7 @@ class ScriptPathError(ExecutionProviderException):
         self.script_path = script_path
         self.reason = reason
 
-    def __repr__(self):
+    def __str__(self):
         return "Unable to write submit script:{0} Reason:{1}".format(self.script_path, self.reason)
 
 
@@ -55,7 +55,7 @@ class SubmitException(ExecutionProviderException):
         self.stdout = stdout
         self.stderr = stderr
 
-    def __repr__(self):
+    def __str__(self):
         # TODO: make this more user-friendly
         return "Cannot launch task {0}: {1}; stdout={2}, stderr={3}".format(self.task_name,
                                                                             self.message,


### PR DESCRIPTION
See PR #1966 for more context

# Changed Behaviour

Any error reporting which uses the `repr` of an exception rather than the `str` of an exception will now look more ugly, as the human readable text will now only be available in `str`, not in `repr`. However, Python stack trace information is printed using `str` so at least that style of error reporting should not change here.

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintentance/cleanup
