### PR TITLE
Remove unused STOP message exit path in htex worker pool

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -288,12 +288,7 @@ class Manager:
                 tasks = pickle.loads(pkl_msg)
                 last_interchange_contact = time.time()
 
-                if tasks == 'STOP':
-                    logger.critical("Received stop request")
-                    kill_event.set()
-                    break
-
-                elif tasks == HEARTBEAT_CODE:
+                if tasks == HEARTBEAT_CODE:
                     logger.debug("Got heartbeat from interchange")
 
                 else:


### PR DESCRIPTION
# Changed Behaviour

This code path seems to be unused, so should not change anything.

## Type of change

- Code maintentance/cleanup
