### PR TITLE
Standardize HTEX worker process initiation

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -398,15 +398,7 @@ class Manager:
                     except KeyError:
                         logger.info("Worker {} was not busy when it died".format(worker_id))
 
-                    p = self.mpProcess(target=worker, args=(worker_id,
-                                                            self.uid,
-                                                            self.worker_count,
-                                                            self.pending_task_queue,
-                                                            self.pending_result_queue,
-                                                            self.ready_worker_queue,
-                                                            self._tasks_in_progress,
-                                                            self.cpu_affinity),
-                                       name="HTEX-Worker-{}".format(worker_id))
+                    p = self._start_worker(worker_id)
                     self.procs[worker_id] = p
                     logger.info("Worker {} has been restarted".format(worker_id))
 
@@ -423,18 +415,7 @@ class Manager:
 
         self.procs = {}
         for worker_id in range(self.worker_count):
-            p = self.mpProcess(target=worker,
-                               args=(worker_id,
-                                     self.uid,
-                                     self.worker_count,
-                                     self.pending_task_queue,
-                                     self.pending_result_queue,
-                                     self.ready_worker_queue,
-                                     self._tasks_in_progress,
-                                     self.cpu_affinity,
-                                     self.available_accelerators[worker_id] if self.accelerators_available else None),
-                               name="HTEX-Worker-{}".format(worker_id))
-            p.start()
+            p = self._start_worker(worker_id)
             self.procs[worker_id] = p
 
         logger.debug("Workers started")
@@ -475,6 +456,25 @@ class Manager:
         delta = time.time() - start
         logger.info("process_worker_pool ran for {} seconds".format(delta))
         return
+
+    def _start_worker(self, worker_id: int):
+        p = self.mpProcess(
+            target=worker,
+            args=(
+                worker_id,
+                self.uid,
+                self.worker_count,
+                self.pending_task_queue,
+                self.pending_result_queue,
+                self.ready_worker_queue,
+                self._tasks_in_progress,
+                self.cpu_affinity,
+                self.available_accelerators[worker_id] if self.accelerators_available else None,
+            ),
+            name="HTEX-Worker-{}".format(worker_id),
+        )
+        p.start()
+        return p
 
 
 def execute_task(bufs):

--- a/parsl/tests/test_error_handling/test_htex_worker_failure.py
+++ b/parsl/tests/test_error_handling/test_htex_worker_failure.py
@@ -19,7 +19,8 @@ def kill_worker():
 
 
 @pytest.mark.local
-def test_htex_worker_failure():
-    with pytest.raises(WorkerLost):
-        f = kill_worker()
-        f.result()
+def test_htex_worker_failures():
+    for _ in range(3):
+        with pytest.raises(WorkerLost):
+            f = kill_worker()
+            f.result()


### PR DESCRIPTION
## Description

The HTEX worker watchdog was missing a worker argument and not starting any processes. This PR standardizes the initiation of worker processes to ensure consistency and fix the watchdog.

I also expanded the worker failure tests to cover restarts by the worker watchdog. 

Fixes #2972

## Type of change

- Bug fix
- Code maintentance/cleanup
