### PR TITLE
Bump CI upload-artifact to latest version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,7 @@ jobs:
 
     - name: Archive runinfo logs
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: runinfo-${{ matrix.python-version }}
         path: runinfo/


### PR DESCRIPTION
This is while investigating suspicious behaviour where runinfo directories from multiple jobs are becoming jumbled into the same runinfo zip files. I haven't seen anything that specifically says this will fix behaviour, but I'd like to see what happens with latest version before opening an upload-artifact issue.

# Changed Behaviour

This changes CI so should not change anything exposed to a user. upload-artifact crashes fairly often in CI, and this PR will perhaps change the frequency of that.

## Type of change

- Code maintentance/cleanup
