### PR TITLE
Correct process_worker_pool --debug arg help

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -623,7 +623,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", "--debug", action='store_true',
-                        help="Count of apps to launch")
+                        help="Enable logging at DEBUG level")
     parser.add_argument("-a", "--addresses", default='',
                         help="Comma separated list of addresses at which the interchange could be reached")
     parser.add_argument("-l", "--logdir", default="process_worker_pool_logs",


### PR DESCRIPTION
# Changed Behaviour

In normal usage a user wouldn't see this changed help text - only if they were trying to start their own htex worker pool outside of parsl's scaling mechanism

## Type of change

- Update to human readable text: Documentation/error messages/comments