### PR TITLE
Use spawn for process worker pool

### DIFF
--- a/parsl/executors/high_throughput/monitoring_info.py
+++ b/parsl/executors/high_throughput/monitoring_info.py
@@ -3,6 +3,7 @@
 # then be acquired by any other code running in
 # a worker context - specifically the monitoring
 # wrapper code.
-from typing import Optional
+import multiprocessing
+from typing import Optional, Union
 from queue import Queue
-result_queue: Optional[Queue] = None
+result_queue: Optional[Union[Queue, multiprocessing.Queue]] = None

--- a/parsl/executors/high_throughput/monitoring_info.py
+++ b/parsl/executors/high_throughput/monitoring_info.py
@@ -3,7 +3,6 @@
 # then be acquired by any other code running in
 # a worker context - specifically the monitoring
 # wrapper code.
-import multiprocessing
-from typing import Optional, Union
+from typing import Optional
 from queue import Queue
-result_queue: Optional[Union[Queue, multiprocessing.Queue]] = None
+result_queue: Optional[Queue] = None

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -10,7 +10,7 @@ import pickle
 import time
 import queue
 import uuid
-from typing import Sequence, Optional
+from typing import Sequence, Optional, Union
 
 import zmq
 import math
@@ -18,7 +18,7 @@ import json
 import psutil
 import multiprocessing
 from multiprocessing.managers import DictProxy
-from multiprocessing.sharedctypes import SynchronizedBase
+from multiprocessing.sharedctypes import Synchronized
 
 from parsl.process_loggers import wrap_with_logs
 
@@ -174,9 +174,9 @@ class Manager:
         if mem_per_worker and mem_per_worker > 0:
             mem_slots = math.floor(available_mem_on_node / mem_per_worker)
 
-        self.worker_count = min(max_workers,
-                                mem_slots,
-                                math.floor(cores_on_node / cores_per_worker))
+        self.worker_count: int = min(max_workers,
+                                     mem_slots,
+                                     math.floor(cores_on_node / cores_per_worker))
 
         self.pending_task_queue = SpawnContext.Queue()
         self.pending_result_queue = SpawnContext.Queue()
@@ -492,12 +492,12 @@ def execute_task(bufs):
 def worker(
     worker_id: int,
     pool_id: str,
-    pool_size: float,
+    pool_size: int,
     task_queue: multiprocessing.Queue,
     result_queue: multiprocessing.Queue,
-    ready_worker_count: SynchronizedBase,
+    ready_worker_count: Synchronized,
     tasks_in_progress: DictProxy,
-    cpu_affinity: bool,
+    cpu_affinity: Union[str, bool],
     accelerator: Optional[str],
     block_id: str,
     logdir: str,

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -255,7 +255,7 @@ class Manager:
                 pending_task_count = self.pending_task_queue.qsize()
             except NotImplementedError:
                 # Ref: https://github.com/python/cpython/blob/6d5e0dc0e330f4009e8dc3d1642e46b129788877/Lib/multiprocessing/queues.py#L125
-                pending_task_count = f"sem_getvalue() is not supported on {platform.system()}"
+                pending_task_count = f"pending task count is not available on {platform.system()}"
 
             logger.debug("ready workers: {}, pending tasks: {}".format(self.ready_worker_count.value,
                                                                        pending_task_count))

--- a/parsl/multiprocessing.py
+++ b/parsl/multiprocessing.py
@@ -1,4 +1,4 @@
-"""Helpers for cross-plaform multiprocessing support.
+"""Helpers for cross-platform multiprocessing support.
 """
 
 import logging
@@ -10,9 +10,12 @@ from typing import Callable, Type
 
 logger = logging.getLogger(__name__)
 
+ForkContext = multiprocessing.get_context("fork")
+SpawnContext = multiprocessing.get_context("spawn")
+
 # maybe ForkProcess should be: Callable[..., Process] so as to make
 # it clear that it returns a Process always to the type checker?
-ForkProcess: Type = multiprocessing.get_context('fork').Process
+ForkProcess: Type = ForkContext.Process
 
 
 class MacSafeQueue(multiprocessing.queues.Queue):


### PR DESCRIPTION
## Description

To avoid issues with forked processes and threads (see #2343), we will use spawn calls to start HTEX workers.

- Created spawn and fork multiprocessing context objects that we can use throughout the codebase to increase clarity on how we start processes.

- Migrated away from using the `MacSafeQueue` in the process worker pool since it was only needed to get the sizes of two queues for a single debug log statement.

- Replaced `ready_worker_queue` with `ready_worker_count`. The former was a multiprocessing `Queue` that we only used to track the number of workers that are ready to receive tasks. The latter is a multiprocessing `Value`, which is a more appropriate data structure.

- Created an HTEX manager thread to transfer monitoring messages from a managed queue, which we can utilize across processes started in fork and spawn contexts, to the results queue. We separate the queues so that the results queue does not rely on a manager process, which causes slower queue operations.

## Type of change

- Bug fix
