### PR TITLE
Fix LocalProvider docstring formatting ugliness

### DIFF
--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -28,8 +28,9 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
         Ratio of provisioned task slots to active tasks. A parallelism value of 1 represents aggressive
         scaling where as many resources as possible are used; parallelism close to 0 represents
         the opposite situation in which as few resources as possible (i.e., min_blocks) are used.
-    move_files : Optional[Bool]: should files be moved? by default, Parsl will try to figure
-        this out itself (= None). If True, then will always move. If False, will never move.
+    move_files : Optional[Bool]
+        Should files be moved? by default, Parsl will try to figure this out itself (= None).
+        If True, then will always move. If False, will never move.
     worker_init : str
         Command to be run before starting a worker, such as 'module load Anaconda; source activate env'.
     """


### PR DESCRIPTION
before:
![image](https://github.com/Parsl/parsl/assets/280107/115284a8-4288-4fec-a0df-57616f1095de)

after:

![image](https://github.com/Parsl/parsl/assets/280107/b440d375-632f-472f-8287-8d21f298f656)


# Changed Behaviour

Parsl behaviour should not be changed by this

## Type of change

- Update to human readable text: Documentation/error messages/comments

