### PR TITLE
Add slurmprovider options

### DIFF
--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -47,6 +47,10 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
     account : str
         Slurm account to which to charge resources used by the job. If unspecified or ``None``, the job will use the
         user's default account.
+    queue : str
+        Slurm queue to place job in. If unspecified or ``None``, no queue slurm directive will be specified.
+    constraint : str
+        Slurm job constraint, often used to choose cpu or gpu type. If unspecified or ``None``, no constraint slurm directive will be added.
     channel : Channel
         Channel for accessing this provider. Possible channels include
         :class:`~parsl.channels.LocalChannel` (the default),

--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -136,7 +136,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         if account:
             self.scheduler_options += "#SBATCH --account={}\n".format(account)
         if queue:
-            self.scheduler_options += "#SBATCH --queue={}\n".format(queue)
+            self.scheduler_options += "#SBATCH --qos={}\n".format(queue)
         if constraint:
             self.scheduler_options += "#SBATCH --constraint={}\n".format(constraint)
 

--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -92,6 +92,8 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
     def __init__(self,
                  partition: Optional[str] = None,
                  account: Optional[str] = None,
+                 queue: Optional[str] = None,
+                 constraint: Optional[str] = None,
                  channel: Channel = LocalChannel(),
                  nodes_per_block: int = 1,
                  cores_per_node: Optional[int] = None,
@@ -133,6 +135,11 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
             self.scheduler_options += "#SBATCH --partition={}\n".format(partition)
         if account:
             self.scheduler_options += "#SBATCH --account={}\n".format(account)
+        if queue:
+            self.scheduler_options += "#SBATCH --queue={}\n".format(queue)
+        if constraint:
+            self.scheduler_options += "#SBATCH --constraint={}\n".format(constraint)
+
         self.regex_job_id = regex_job_id
         self.worker_init = worker_init + '\n'
 


### PR DESCRIPTION
# Description

Adds optional parameters to `SlurmProvider` for choosing the `queue` and `constraint` slurm options. This makes the `SlurmProvider` easier to work on NERSC systems which uses these options for job submissions. Queue is used to choose the jobs priority ([regular, debug, realtime, etc.](https://docs.nersc.gov/jobs/policy/#qos-limits-and-charges)) and constraint to choose between cpu and gpu nodes on Perlmutter.

# Changed Behaviour

Current users would have had to place the options in `scheduler_options` which is unchanged. Users now have the option to adopt the new parameters in their code, or continue to use `scheduler_options`.

## Type of change

- New feature