### PR TITLE
Add more info to DependencyError for non-task Futures

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -854,10 +854,13 @@ class DataFlowKernel:
                 try:
                     new_args.extend([dep.result()])
                 except Exception as e:
-                    if hasattr(dep, 'task_record'):
-                        tid = dep.task_record['id']
+                    # If this Future is associated with a task inside this DFK,
+                    # then refer to the task ID.
+                    # Otherwise make a repr of the Future object.
+                    if hasattr(dep, 'task_record') and dep.task_record['dfk'] == self:
+                        tid = "task " + repr(dep.task_record['id'])
                     else:
-                        tid = None
+                        tid = repr(dep)
                     dep_failures.extend([(e, tid)])
             else:
                 new_args.extend([dep])

--- a/parsl/dataflow/errors.py
+++ b/parsl/dataflow/errors.py
@@ -36,7 +36,9 @@ class DependencyError(DataFlowException):
        in a dependency.
 
     Args:
-         - dependent_exceptions_tids: List of dependency task IDs which failed
+         - dependent_exceptions_tids: List of exceptions and identifiers for
+           dependencies which failed. The identifier might be a task ID or
+           the repr of a non-DFK Future.
          - task_id: Task ID of the task that failed because of the dependency error
     """
 
@@ -45,8 +47,9 @@ class DependencyError(DataFlowException):
         self.task_id = task_id
 
     def __str__(self) -> str:
-        dep_tids = [tid for (exception, tid) in self.dependent_exceptions_tids]
-        return "Dependency failure for task {} with failed dependencies from tasks {}".format(self.task_id, dep_tids)
+        dep_ids = [tid for (exception, tid) in self.dependent_exceptions_tids]
+        deps = ", ".join(dep_ids)
+        return f"Dependency failure for task {self.task_id} with failed dependencies from {deps}"
 
 
 class JoinError(DataFlowException):

--- a/parsl/dataflow/errors.py
+++ b/parsl/dataflow/errors.py
@@ -47,8 +47,7 @@ class DependencyError(DataFlowException):
         self.task_id = task_id
 
     def __str__(self) -> str:
-        dep_ids = [tid for (exception, tid) in self.dependent_exceptions_tids]
-        deps = ", ".join(dep_ids)
+        deps = ", ".join(tid for _exc, tid in self.dependent_exceptions_tids)
         return f"Dependency failure for task {self.task_id} with failed dependencies from {deps}"
 
 

--- a/parsl/tests/test_python_apps/test_dep_standard_futures.py
+++ b/parsl/tests/test_python_apps/test_dep_standard_futures.py
@@ -33,4 +33,12 @@ def test_future_fail_dependency():
 
     plain_fut.set_exception(ValueError("Plain failure"))
 
-    assert isinstance(parsl_fut.exception(), DependencyError)
+    ex = parsl_fut.exception()
+
+    # check that what we got is a dependency error...
+    assert isinstance(ex, DependencyError)
+
+    # and that the dependency error string mentions the dependency
+    # Future, plain_fut, somewhere in its str
+
+    assert str(plain_fut) in str(ex)

--- a/parsl/tests/test_python_apps/test_dep_standard_futures.py
+++ b/parsl/tests/test_python_apps/test_dep_standard_futures.py
@@ -41,4 +41,4 @@ def test_future_fail_dependency():
     # and that the dependency error string mentions the dependency
     # Future, plain_fut, somewhere in its str
 
-    assert str(plain_fut) in str(ex)
+    assert repr(plain_fut) in str(ex)

--- a/parsl/tests/test_python_apps/test_depfail_propagation.py
+++ b/parsl/tests/test_python_apps/test_depfail_propagation.py
@@ -19,7 +19,12 @@ def test_depfail_once():
 
     assert isinstance(f1.exception(), Exception)
     assert not isinstance(f1.exception(), DependencyError)
+
     assert isinstance(f2.exception(), DependencyError)
+
+    # check that the task ID of the failing task is mentioned
+    # in the DependencyError message
+    assert ("task " + str(f1.task_record['id'])) in str(f2.exception())
 
 
 def test_depfail_chain():

--- a/parsl/tests/test_python_apps/test_depfail_propagation.py
+++ b/parsl/tests/test_python_apps/test_depfail_propagation.py
@@ -19,7 +19,6 @@ def test_depfail_once():
 
     assert isinstance(f1.exception(), Exception)
     assert not isinstance(f1.exception(), DependencyError)
-
     assert isinstance(f2.exception(), DependencyError)
 
     # check that the task ID of the failing task is mentioned


### PR DESCRIPTION
In some situations, a dependency in a dependency error does not have a task ID (becuase it is not an AppFuture) (case 1), or has a task ID from a different DFK (case 2)

Previously:

Case 1: the dependency error listed a task ID as `None`.

Case 2: the dependency error listed a task ID as if it was that task in the same DFK as the dependent task.

In both those cases now, the error message renders those "foreign" Futures using repr.

This PR also tidies up list formatting to remove []-brackets around the list of dependencies.

Now:

Dependency failure for task 0 with failed dependencies from <Future at 0x7f8ca335ef90 state=finished raised ValueError>

Previously:

Dependency failure for task 0 with failed dependencies from [None]

# Changed Behaviour

The task ID entry of `DependencyError.dependency_exceptions_tids` attributed was previously an `int` or `None`, even though it is annotated as a str. It is now a str. Anyone relying on that programmatically will have to change their code.

## Type of change

- Update to human readable text: Documentation/error messages/comments
