### PR TITLE
New method for assigning cpu affinity

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -725,7 +725,14 @@ if __name__ == "__main__":
                         help="Poll period used in milliseconds")
     parser.add_argument("-r", "--result_port", required=True,
                         help="REQUIRED: Result port for posting results to the interchange")
-    parser.add_argument("--cpu-affinity", type=str, choices=["none", "block", "alternating", "block-reverse"],
+
+    def strategyorlist(s):
+        if s in ["none", "block", "alternating", "block-reverse"]:
+            return s
+        if s[0:4] == "list":
+            return s
+    
+    parser.add_argument("--cpu-affinity", type=strategyorlist, #choices=["none", "block", "alternating", "block-reverse"],
                         help="Whether/how workers should control CPU affinity.")
     parser.add_argument("--available-accelerators", type=str, nargs="*",
                         help="Names of available accelerators")

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -732,7 +732,7 @@ if __name__ == "__main__":
         if s[0:4] == "list":
             return s
     
-    parser.add_argument("--cpu-affinity", type=strategyorlist, #choices=["none", "block", "alternating", "block-reverse"],
+    parser.add_argument("--cpu-affinity", type=strategyorlist,
                         help="Whether/how workers should control CPU affinity.")
     parser.add_argument("--available-accelerators", type=str, nargs="*",
                         help="Names of available accelerators")


### PR DESCRIPTION
# Description

This provides a new method for setting cpu affinity via a method similar to setting thread binding in mpiexec calls.

In the config object, users can now pass a string of this type:
`cpu_affinity="list:<worker1_threads>:<worker2_threads>:<worker3_threads>"`

Each worker's threads can be specified as a comma separated list or a hyphenated range:
`thread1,thread2,thread3`
or
`thread_start-thread_end`

An example for Sunspot/Aurora:
`cpu_affinity="list:0-7,104-111:8-15,112-119:16-23,120-127:24-31,128-135:32-39,136-143:40-47,144-151:52-59,156-163:60-67,164-171:68-75,172-179:76-83,180-187:84-91,188-195:92-99,196-203"`

This example assigns 16 threads each to 12 workers. Note that there are threads that are skipped; this is because the total number of hardware threads is not evenly divisible by the number of GPUs.

This will give a user more flexibility in setting cpu affinity and also allows them to leave idle certain threads if they choose (currently required by all cpu-affinity strategies in parsl).

If the number of thread "ranks" (colon separated thread lists/ranges) doesn't match the total number of workers an exception will be raised.

# Changed Behaviour

No current behavior is changed

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature
