### PR TITLE
Tidy types around CPU affinity

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -10,7 +10,7 @@ import pickle
 import time
 import queue
 import uuid
-from typing import Sequence, Optional, Union
+from typing import Sequence, Optional
 
 import zmq
 import math
@@ -62,7 +62,7 @@ class Manager:
                  heartbeat_threshold=120,
                  heartbeat_period=30,
                  poll_period=10,
-                 cpu_affinity=False,
+                 cpu_affinity=False, # BAD - should go away in PR 2973.
                  available_accelerators: Sequence[str] = ()):
         """
         Parameters
@@ -540,7 +540,7 @@ def worker(
     monitoring_queue: queue.Queue,
     ready_worker_count: Synchronized,
     tasks_in_progress: DictProxy,
-    cpu_affinity: Union[str, bool],
+    cpu_affinity: str,
     accelerator: Optional[str],
     block_id: str,
     task_queue_timeout: int,
@@ -732,6 +732,7 @@ if __name__ == "__main__":
     parser.add_argument("-r", "--result_port", required=True,
                         help="REQUIRED: Result port for posting results to the interchange")
     parser.add_argument("--cpu-affinity", type=str, choices=["none", "block", "alternating", "block-reverse"],
+                        required=True,
                         help="Whether/how workers should control CPU affinity.")
     parser.add_argument("--available-accelerators", type=str, nargs="*",
                         help="Names of available accelerators")


### PR DESCRIPTION
Prior to this PR:

In practice, the --cpu-affinity parameter was always specified, and when a user does not specify any value in the HighThroughputExecutor, the default value of `'none'` will be passed in to this parameter. So in practice, throughout process_worker_pool, all cpu_affinity variables will be a string, 'none' by default, or as specified by users.

The commandline args code allows --cpu-affinity to be omitted. This results in cpu-affinity having the value `None`. This is not handled properly by the worker code, which assumes that one of the explicit string values will be supplied, and will (I think - I haven't tested) raise:

> raise ValueError("Affinity strategy {} is not supported".format(cpu_affinity))

in this case.

The type annotations for the worker allow cpu_affinity to be either a bool or a string, and the default value of cpu_affinity in Manager.__init__ (which is never used, because it is always overridden by the commandline argument value, even when no commandline argument is explicitly supplied) is a bool, False. This was probably intended to mean "no cpu affinity", which is what is actually implemented by the string `'none'`.

Passing a bool value True or False here also looks like it is not implemented in the worker and will (I think - I haven't tested) also raise:

> raise ValueError("Affinity strategy {} is not supported".format(cpu_affinity))

This PR gets rid of the above broken values:

`None` - by requiring --cpu-affinity to be always supplied. Due to the above described handling of None, that commandline argument is already required, but that requirement is not caught at the argparser level.

bools - by tightening the type annotation of the worker, and removing one of the unused default values on Manager. This parameter was already required, due to the above described handling of bools, but that requirement is not caught at the Python invocation level.

This should leave this value only accepting strings.

# Changed Behaviour

I think this codepath only affects codepaths that result in errors.

# Fixes

Type error that @cms21 encountered implementing #2990

## Type of change

- Code maintentance/cleanup
