### PR TITLE
TaskVineExecutor: add option to specify resources and number of slots for a library

### DIFF
--- a/parsl/executors/taskvine/manager.py
+++ b/parsl/executors/taskvine/manager.py
@@ -248,6 +248,22 @@ def _taskvine_submit_wait(ready_task_queue=None,
                                                                      poncho_env=poncho_env_path,
                                                                      init_command=manager_config.init_command,
                                                                      add_env=add_env)
+
+                    # Configure the library if provided
+                    if manager_config.library_config:
+                        lib_cores = manager_config.library_config.get('cores', None)
+                        lib_memory = manager_config.library_config.get('memory', None)
+                        lib_disk = manager_config.library_config.get('disk', None)
+                        lib_slots = manager_config.library_config.get('num_slots', None)
+                        if lib_cores:
+                            serverless_lib.set_cores(lib_cores)
+                        if lib_memory:
+                            serverless_lib.set_memory(lib_memory)
+                        if lib_disk:
+                            serverless_lib.set_disk(lib_disk)
+                        if lib_slots:
+                            serverless_lib.set_function_slots(lib_slots)
+
                     if poncho_env_path:
                         serverless_lib_env_file = m.declare_poncho(poncho_env_path, cache=True, peer_transfer=True)
                         serverless_lib.add_environment(serverless_lib_env_file)

--- a/parsl/executors/taskvine/manager_config.py
+++ b/parsl/executors/taskvine/manager_config.py
@@ -84,6 +84,19 @@ class TaskVineManagerConfig:
         forever.
         Default is 1.
 
+    library_config: Optional[dict]
+        Only and must specify when functions are executed in the serverless mode.
+        Configure the number of function slots and amount of resources
+        a library task can run. A library task is a stateful object that executes
+        functions in the serverless way. Accept the following keywords:
+        'num_slots', 'cores', 'memory (MBs)', 'disk (MBs)'.
+        Default is {'num_slots': 1, 'cores': None, 'memory': None, 'disk': None},
+        which will take all resources of a worker node and run at most 1 function
+        invocation at any given time.
+        E.g., {'num_slots': 4, 'cores': 16, 'memory': 16000, 'disk': 16000} will
+        reserve those resources to the library task to run at most 4 function
+        invocations.
+
     shared_fs: bool
         Whether workers will use a shared filesystem or not. If so, TaskVine
         will not track and transfer files for execution, in exchange for
@@ -159,6 +172,7 @@ class TaskVineManagerConfig:
     app_pack: bool = False
     extra_pkgs: Optional[list] = None
     max_retries: int = 1
+    library_config: Optional[dict] = None
 
     # Performance-specific settings
     shared_fs: bool = False


### PR DESCRIPTION
# Description

This PR adds an option for users to specify resources and number of slots for a library.

Default is `{'num_slots': 1, 'cores': None, 'memory': None, 'disk': None}`, which will take all resources of a worker node and run at most 1 function invocation at any given time.
        
E.g., `{'num_slots': 4, 'cores': 16, 'memory': 16000, 'disk': 16000}` will reserve those resources to the library task to run at most 4 function invocations at any given time.

## Type of change

- New feature

