### PR TITLE
Add a regression test for broken SlurmProvider repr(), issue #2994

### DIFF
--- a/parsl/tests/test_providers/test_slurm_instantiate.py
+++ b/parsl/tests/test_providers/test_slurm_instantiate.py
@@ -1,0 +1,16 @@
+import pytest
+
+from parsl.providers import SlurmProvider
+
+
+@pytest.mark.local
+def test_slurm_instantiate_regression_2994():
+    """This test checks that repr can be executed on SlurmProvider.
+    This does not need a SLURM installation around.
+
+    Because of the behaviour of RepresentationMixin, it's a relatively
+    common problem to break repr when adding new parameters to the
+    SlurmProvider, and this tests that repr does not raise an exception.
+    """
+    p = SlurmProvider()
+    repr(p)


### PR DESCRIPTION
This test checks that repr runs ok for SlurmProvider. That's a method that one might expect would always work, but RepresentationMixin has been a source of exceptions in the past (although with #2996, it would hopefully be less aggressive).

It might be useful to make this sort of repr test for more classes that are not otherwise tested.

This test does not need a slurm installation, as it does not test any interactions with slurm itself.