### PR TITLE
Fix missing qos and constraint attributes that broke SlurmProvider in #2986

### DIFF
--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -132,6 +132,8 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         self.exclusive = exclusive
         self.move_files = move_files
         self.account = account
+        self.qos = qos
+        self.constraint = constraint
         self.scheduler_options = scheduler_options + '\n'
         if exclusive:
             self.scheduler_options += "#SBATCH --exclusive\n"


### PR DESCRIPTION
# Description

Adds new options for `SlurmProvider` as attributes to fix #2994

# Fixes

Fixes # 2994

## Type of change

- Bug fix