### PR TITLE
Remove unused type-check in dfk._count_deps

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -262,9 +262,8 @@ class DataFlowKernel:
         """
         count = 0
         for dep in depends:
-            if isinstance(dep, Future):
-                if not dep.done():
-                    count += 1
+            if not dep.done():
+                count += 1
 
         return count
 


### PR DESCRIPTION
The list of dependencies is always a sequence of futures, so there is no need to check the type of each element.

# Changed Behaviour

none

## Type of change

- Code maintentance/cleanup
