### PR TITLE
Mark radical MPI test

### DIFF
--- a/parsl/tests/test_radical/test_mpi_funcs.py
+++ b/parsl/tests/test_radical/test_mpi_funcs.py
@@ -17,6 +17,7 @@ apps = []
 
 
 @pytest.mark.local
+@pytest.mark.radical
 def test_radical_mpi(n=7):
     # rank size should be > 1 for the
     # radical runtime system to run this function in MPI env


### PR DESCRIPTION
A temporary measure to allow testing locally on dev setups that don't have `radical.pilot` installed and/or working.  Use with:

```console
$ pytest parsl/tests/ -k "not radical" ...
```

For now, this is not _implemented_ anywhere (e.g., not in `Makefile`) so it's strictly a manual usage.  At some point, the tests are due for an overhaul to clean up the testing situation.  I won't enumerate the specifics here, but suffice to say that this is a on-going conversation.

## Type of change

- Code maintentance/cleanup