### PR TITLE
Rename test python_app

### DIFF
--- a/parsl/tests/test_radical/test_mpi_funcs.py
+++ b/parsl/tests/test_radical/test_mpi_funcs.py
@@ -5,7 +5,7 @@ from parsl.tests.configs.local_radical_mpi import fresh_config as local_config
 
 
 @parsl.python_app
-def test_mpi_func(msg, sleep, comm=None, parsl_resource_specification={}):
+def some_mpi_func(msg, sleep, comm=None, parsl_resource_specification={}):
     import time
     msg = 'hello %d/%d: %s' % (comm.rank, comm.size, msg)
     time.sleep(sleep)
@@ -23,6 +23,6 @@ def test_radical_mpi(n=7):
     # radical runtime system to run this function in MPI env
     for i in range(2, n):
         spec = {'ranks': i}
-        t = test_mpi_func(msg='mpi.func.%06d' % i, sleep=1, comm=None, parsl_resource_specification=spec)
+        t = some_mpi_func(msg='mpi.func.%06d' % i, sleep=1, comm=None, parsl_resource_specification=spec)
         apps.append(t)
     assert [len(app.result()) for app in apps] == list(range(2, n))


### PR DESCRIPTION
Pytest looks for test functions with the word `test` in them.  But this is _not_ a test, per se, but rather a kernel for testing.  Odd distinction I suppose ...

Renaming to remove a (correct) Pytest warning

## Type of change

- Code maintenance/cleanup
