### PR TITLE
Address pytest warning for checkpoint

### DIFF
--- a/parsl/tests/test_checkpointing/test_python_checkpoint_1.py
+++ b/parsl/tests/test_checkpointing/test_python_checkpoint_1.py
@@ -1,10 +1,15 @@
-import argparse
 import os
 import pytest
 
 import parsl
 from parsl import python_app
 from parsl.tests.configs.local_threads import fresh_config
+
+
+def local_config():
+    config = fresh_config()
+    config.checkpoint_mode = "manual"
+    return config
 
 
 @python_app(cache=True)
@@ -18,7 +23,6 @@ def launch_n_random(n=2):
     """
 
     d = [random_app(i) for i in range(0, n)]
-    print("Done launching")
 
     # Block till done
     return [i.result() for i in d]
@@ -28,26 +32,12 @@ def launch_n_random(n=2):
 def test_initial_checkpoint_write(n=2):
     """1. Launch a few apps and write the checkpoint once a few have completed
     """
-    config = fresh_config()
-    config.checkpoint_mode = 'manual'
-    parsl.load(config)
-    results = launch_n_random(n)
+    launch_n_random(n)
 
     cpt_dir = parsl.dfk().checkpoint()
 
     cptpath = cpt_dir + '/dfk.pkl'
-    print("Path exists : ", os.path.exists(cptpath))
-    assert os.path.exists(
-        cptpath), "DFK checkpoint missing: {0}".format(cptpath)
+    assert os.path.exists(cptpath), f"DFK checkpoint missing: {cptpath}"
 
     cptpath = cpt_dir + '/tasks.pkl'
-    print("Path exists : ", os.path.exists(cptpath))
-    assert os.path.exists(
-        cptpath), "Tasks checkpoint missing: {0}".format(cptpath)
-
-    run_dir = parsl.dfk().run_dir
-
-    parsl.dfk().cleanup()
-    parsl.clear()
-
-    return run_dir, results
+    assert os.path.exists(cptpath), f"Tasks checkpoint missing: {cptpath}"


### PR DESCRIPTION
An older test; the only detail of interest for the tests is the checkpoint files, so update accordingly: `assert` the interesting bits (no change), and remove the return.  While here, update test to use the `conftest` infrastructure (`local_config()`).

## Type of change

- Code maintenance/cleanup