### PR TITLE
Refactor test for readability

### DIFF
--- a/parsl/tests/test_checkpointing/test_python_checkpoint_2.py
+++ b/parsl/tests/test_checkpointing/test_python_checkpoint_2.py
@@ -1,11 +1,25 @@
-import argparse
+import contextlib
 import os
 import pytest
 import parsl
 from parsl import python_app
 
-from parsl.tests.configs.local_threads import config
 from parsl.tests.configs.local_threads_checkpoint import fresh_config
+
+
+@contextlib.contextmanager
+def parsl_configured(run_dir, **kw):
+    c = fresh_config()
+    c.run_dir = run_dir
+    for config_attr, config_val in kw.items():
+        setattr(c, config_attr, config_val)
+    dfk = parsl.load(c)
+    for ex in dfk.executors.values():
+        ex.working_dir = run_dir
+    yield dfk
+
+    parsl.dfk().cleanup()
+    parsl.clear()
 
 
 @python_app(cache=True)
@@ -22,24 +36,16 @@ def launch_n_random(n=2):
 
 
 @pytest.mark.local
-def test_loading_checkpoint(n=2):
+def test_loading_checkpoint(tmpd_cwd, n=4):
     """Load memoization table from previous checkpoint
     """
-    config.checkpoint_mode = 'task_exit'
-    parsl.load(config)
-    results = launch_n_random(n)
-    rundir = parsl.dfk().run_dir
-    parsl.dfk().cleanup()
-    parsl.clear()
+    with parsl_configured(tmpd_cwd, checkpoint_mode="task_exit"):
+        checkpoint_files = [os.path.join(parsl.dfk().run_dir, "checkpoint")]
+        results = launch_n_random(n)
 
-    local_config = fresh_config()
-    local_config.checkpoint_files = [os.path.join(rundir, 'checkpoint')]
-    parsl.load(local_config)
+    with parsl_configured(tmpd_cwd, checkpoint_files=checkpoint_files):
+        relaunched = launch_n_random(n)
 
-    relaunched = launch_n_random(n)
     assert len(relaunched) == len(results) == n, "Expected all results to have n items"
-
     for i in range(n):
-        assert relaunched[i] == results[i], "Expected relaunched to contain cached results from first run"
-    parsl.dfk().cleanup()
-    parsl.clear()
+        assert relaunched[i] == results[i], "Expect relaunch to find cached results"


### PR DESCRIPTION
Factor out the boilerplate DFK startup and shutdown to a contextmanager; the key bits of the test&nbsp;&mdash;&nbsp;is the checkpoint *utilized* (i.e., random numbers match second time)&nbsp;&mdash;&nbsp;are more apparent.

Meanwhile, use `tmpd_cwd` to remove another test detritus item.

## Type of change

- Code maintenance/cleanup