### PR TITLE
Correct code-formatting oversight in docs

### DIFF
--- a/docs/userguide/checkpoints.rst
+++ b/docs/userguide/checkpoints.rst
@@ -161,17 +161,20 @@ Parsl provides four checkpointing modes:
    (after retries if enabled). This mode minimizes the risk of losing information
    from completed tasks.
 
-   from parsl.configs.local_threads import config
-   config.checkpoint_mode = 'task_exit'
+   .. code-block:: python
 
+      from parsl.configs.local_threads import config
+      config.checkpoint_mode = 'task_exit'
 
 2. ``periodic``: a checkpoint is created periodically using a user-specified
    checkpointing interval. Results will be saved to the checkpoint file for
    all tasks that have completed during this period.
 
-   from parsl.configs.local_threads import config
-   config.checkpoint_mode = 'periodic'
-   config.checkpoint_period = "01:00:00"
+   .. code-block:: python
+
+      from parsl.configs.local_threads import config
+      config.checkpoint_mode = 'periodic'
+      config.checkpoint_period = "01:00:00"
 
 3. ``dfk_exit``: checkpoints are created when Parsl is
    about to exit. This reduces the risk of losing results due to
@@ -179,19 +182,22 @@ Parsl provides four checkpointing modes:
    it is still possible that information might be lost if the program is
    terminated abruptly (machine failure, SIGKILL, etc.)
 
-   from parsl.configs.local_threads import config
-   config.checkpoint_mode = 'dfk_exit'
+   .. code-block:: python
+
+      from parsl.configs.local_threads import config
+      config.checkpoint_mode = 'dfk_exit'
 
 4. ``manual``: in addition to these automated checkpointing modes, it is also possible
    to manually initiate a checkpoint by calling ``DataFlowKernel.checkpoint()`` in the
    Parsl program code.
 
+   .. code-block:: python
 
-   import parsl
-   from parsl.configs.local_threads import config
-   dfk = parsl.load(config)
-   ....
-   dfk.checkpoint()
+      import parsl
+      from parsl.configs.local_threads import config
+      dfk = parsl.load(config)
+      ....
+      dfk.checkpoint()
 
 In all cases the checkpoint file is written out to the ``runinfo/RUN_ID/checkpoint/`` directory.
 


### PR DESCRIPTION
Simple code-block addition to the checkpoints documentation page.

## Before to After

### Before
<img src="https://github.com/Parsl/parsl/assets/99676336/bfa92f55-827c-4e6c-ae59-650897a84343" width="500" title="Checkpoints documentation with missing code block formatting">

### After

<img src="https://github.com/Parsl/parsl/assets/99676336/1f466740-4555-469d-88d6-8c8141180608" width="500" title="Checkpoints documentation with pre-formatted and syntax highlighted code blocks">

## Type of change

- Update to human readable text: Documentation/error messages/comments
