### PR TITLE
Add .pytest/ to runinfo artifact collection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,17 +22,24 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Collect Job Information
+      id: job-info
+      run: |
+        echo "Python Version: ${{ matrix.python-version }}" >> ci_job_info.txt
+        echo "CI Triggering Event: ${{ github.event_name }}" >> ci_job_info.txt
+        echo "Triggering Git Ref: ${{ github.ref }}" >> ci_job_info.txt
+        echo "Triggering Git SHA: ${{ github.sha }}" >> ci_job_info.txt
+        echo "Workflow Run: ${{ github.run_number }}" >> ci_job_info.txt
+        echo "Workflow Attempt: ${{ github.run_attempt }}" >> ci_job_info.txt
+        as_ascii="$(echo "${{ github.ref_name }}" | perl -pe "s/[^A-z0-9-]+/-/g; s/^-+|-+\$//g; s/--+/-/g;")"
+        echo "as-ascii=$as_ascii" >> $GITHUB_OUTPUT
+
     - name: Non-requirements based install
       run: |
+        # libpython3.5: make workqueue binary installer happy
+        # mpich: required by radical executor
         sudo apt-get update -q
-        python --version
-
-        # this is to make the workqueue binary installer happy
-        sudo apt-get install -y libpython3.5
-
-
-        # mpi is required by the radical executor
-        sudo apt install -y mpich
+        sudo apt-get install -qy libpython3.5 mpich
 
     - name: setup virtual env
       run: |
@@ -48,7 +55,12 @@ jobs:
     - name: make test
       run: |
         source .venv/bin/activate
+
+        # temporary; until test-matrixification
+        export PARSL_TEST_PRESERVE_NUM_RUNS=7
+
         make test
+        ln -s .pytest/parsltest-current test_runinfo
 
     - name: Documentation checks
       run: |
@@ -68,8 +80,11 @@ jobs:
         # database manager log file or monitoring router log file. It would be better if
         # the tests themselves failed immediately when there was a monitoring error, but
         # in the absence of that, this is a dirty way to check.
-        bash -c '! grep ERROR runinfo*/*/database_manager.log'
-        bash -c '! grep ERROR runinfo*/*/monitoring_router.log'
+        bash -c '! grep ERROR .pytest/parsltest-current/runinfo*/*/database_manager.log'
+        bash -c '! grep ERROR .pytest/parsltest-current/runinfo*/*/monitoring_router.log'
+
+        # temporary; until test-matrixification
+        rm -f .pytest/parsltest-current test_runinfo
 
     - name: Checking parsl-visualize
       run: |
@@ -85,7 +100,11 @@ jobs:
 
     - name: Archive runinfo logs
       if: ${{ always() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: runinfo-${{ matrix.python-version }}
-        path: runinfo/
+        name: runinfo-${{ matrix.python-version }}-${{ steps.job-info.outputs.as-ascii }}-${{ github.sha }}
+        path: |
+          runinfo/
+          .pytest/
+          ci_job_info.txt
+        compression-level: 9

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ htmlcov/
 coverage.xml
 *.cover
 .hypothesis/
+/.pytest/
 
 # Translations
 *.mo


### PR DESCRIPTION
# Description

Recent efforts to clean up the test detritus left in the developer's source directory were unaware of the fact that the `runinfo/` directory is saved in CI.  To accommodate both goals, refactor the `tmpd_cwd_session` fixture to preserve the last `N` test runs.  If not specified, default to keeping the last 3 runs.

Meanwhile, tell the upload-artifact step to preserve both directories for the time being.

(In response to [observation in PR #3003](https://github.com/Parsl/parsl/pull/3003#issuecomment-1875746026).).

## Type of change

- Code maintenance/cleanup
