### PR TITLE
Split out `make test` into a matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,12 +7,54 @@ on:
       - synchronize
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - name: Install requirements (...txt)
+        run: |
+          # libpython3.5: make workqueue binary installer happy
+          # mpich: required by radical executor
+          sudo apt-get update -q
+          sudo apt-get install -qy libpython3.5 mpich
+
+          make virtualenv
+          source .venv/bin/activate
+          python -m pip install -U pip
+          make deps
+      - name: Check for missing __init__ files
+        run: |
+          source .venv/bin/activate
+          make lint
+      - name: flake8
+        run: |
+          source .venv/bin/activate
+          make flake8
+      - name: mypy
+        run: |
+          source .venv/bin/activate
+          make mypy
+
   main-test-suite:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        test-name: [
+            "local_thread_test",
+            "htex_local_test",
+            "htex_local_alternate_test",
+            "wqex_local_test",
+            "vineex_local_test",
+            "radical_local_test",
+            "config_local_test",
+            "perf_test"
+        ]
     runs-on: ubuntu-20.04
-    timeout-minutes: 60
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@master
@@ -41,32 +83,57 @@ jobs:
         sudo apt-get update -q
         sudo apt-get install -qy libpython3.5 mpich
 
-    - name: setup virtual env
+    - name: Install requirements (...txt)
       run: |
         make virtualenv
         source .venv/bin/activate
-
-    - name: make deps clean_coverage
-      run: |
-        source .venv/bin/activate
+        python -m pip install -U pip
         make deps
-        make clean_coverage
+        python -m pip install .
+        python -m pip install .[monitoring,radical-pilot,visualization,proxystore]
 
-    - name: make test
+    - name: make ${{ matrix.test-name }}
       run: |
         source .venv/bin/activate
-
-        # temporary; until test-matrixification
-        export PARSL_TEST_PRESERVE_NUM_RUNS=7
-
-        make test
+        make ${{ matrix.test-name }}
         ln -s .pytest/parsltest-current test_runinfo
+        find . -name "monitoring.db"
 
+    - name: Checking parsl-visualize
+      run: |
+        if find . -type f -name "monitoring.db" | grep -q monitoring.db; then
+          source .venv/bin/activate
+          sudo apt-get install -qy graphviz
+          parsl/tests/test-viz.sh
+        fi
+
+    - name: Archive runinfo logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: runinfo-${{ matrix.python-version }}-${{ matrix.test-name }}-${{ steps.job-info.outputs.as-ascii }}-${{ github.sha }}
+        path: |
+          runinfo/
+          test_runinfo/
+          ci_job_info.txt
+        compression-level: 9
+
+  documentation-checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
     - name: Documentation checks
       run: |
+        sudo apt-get update -q
+        sudo apt-get install -qy pandoc
+        make virtualenv
         source .venv/bin/activate
-        pip install .[docs]
-        sudo apt-get install -y pandoc
+        python -m pip install -U pip
+        python -m pip install .[docs]
+
         cd docs
 
         test ! -e stubs
@@ -82,29 +149,3 @@ jobs:
         # in the absence of that, this is a dirty way to check.
         bash -c '! grep ERROR .pytest/parsltest-current/runinfo*/*/database_manager.log'
         bash -c '! grep ERROR .pytest/parsltest-current/runinfo*/*/monitoring_router.log'
-
-        # temporary; until test-matrixification
-        rm -f .pytest/parsltest-current test_runinfo
-
-    - name: Checking parsl-visualize
-      run: |
-        source .venv/bin/activate
-        sudo apt-get install -y graphviz
-        pip install .[monitoring]
-        parsl/tests/test-viz.sh
-
-    - name: make coverage
-      run: |
-        source .venv/bin/activate
-        make coverage
-
-    - name: Archive runinfo logs
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: runinfo-${{ matrix.python-version }}-${{ steps.job-info.outputs.as-ascii }}-${{ github.sha }}
-        path: |
-          runinfo/
-          .pytest/
-          ci_job_info.txt
-        compression-level: 9

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,7 +93,7 @@ release = parsl.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/parsl/executors/taskvine/install-taskvine.sh
+++ b/parsl/executors/taskvine/install-taskvine.sh
@@ -12,7 +12,7 @@ TARBALL="cctools-$CCTOOLS_VERSION-x86_64-ubuntu20.04.tar.gz"
 
 # If stderr is *not* a TTY, then disable progress bar and show HTTP response headers
 [[ ! -t 1 ]] && NO_VERBOSE="--no-verbose" SHOW_HEADERS="-S"
-wget "$NO_VERBOSE" "$SHOW_HEADERS" -O /tmp/cctools.tar.gz "https://github.com/cooperative-computing-lab/cctools/releases/download/release/$CCTOOLS_VERSION/$TARBALL"
+wget -c "$NO_VERBOSE" "$SHOW_HEADERS" -O /tmp/cctools.tar.gz "https://github.com/cooperative-computing-lab/cctools/releases/download/release/$CCTOOLS_VERSION/$TARBALL" || true
 
 mkdir -p /tmp/cctools
 tar -C /tmp/cctools -zxf /tmp/cctools.tar.gz --strip-components=1

--- a/parsl/tests/test-viz.sh
+++ b/parsl/tests/test-viz.sh
@@ -6,7 +6,7 @@
 
 killall --wait parsl-visualize || echo No previous parsl-visualize to kill
 
-if  [ -n "$1" ]; then
+if [[ -n $1 ]]; then
   rm -f runinfo/monitoring.db
   pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/htex_local_alternate.py --cov=parsl --cov-append --cov-report= --random-order
 fi


### PR DESCRIPTION
Parallelize the tests by using GH's matrix.  There's no need to execute the tests serially.

This reduces CI build time to ~11m, with the vineex test being the bottleneck. Accordingly, reduce timeout limit from 60m to 15m, with the expectation that if tests take longer than that, the *tests* need to be addressed.  In the semi-rare case of downloads taking too long, the developer in question can run another attempt in GH's CI UI.

N.B. Marking as a draft PR because it will fail until Issue #3013 is addressed.

## Type of change

- Code maintenance/cleanup