### PR TITLE
Reduce WorkQueue CPU time at expense of more latency in complex submission patterns

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -849,7 +849,7 @@ def _work_queue_submit_wait(*,
             break
 
         # Submit tasks
-        while task_queue.qsize() > 0 and not should_stop.value:
+        while task_queue.qsize() > 0 or q.empty() and not should_stop.value:
             # Obtain task from task_queue
             try:
                 task = task_queue.get(timeout=1)


### PR DESCRIPTION
# Description
After #2984 was merged it was observed that the work queue send/retrieve loop consumes CPU when there is no work to be done. This PR suspends execution waiting on the task input queue when both queues are empty. 

## Type of change

- Bug fix
- Code maintenance/cleanup
