### PR TITLE
Update JobStatusPoller to not require DFK

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -177,7 +177,9 @@ class DataFlowKernel:
 
         # this must be set before executors are added since add_executors calls
         # job_status_poller.add_executors.
-        self.job_status_poller = JobStatusPoller(self)
+        self.job_status_poller = JobStatusPoller(strategy=self.config.strategy,
+                                                 max_idletime=self.config.max_idletime,
+                                                 dfk=self)
 
         self.executors: Dict[str, ParslExecutor] = {}
 

--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -2,7 +2,7 @@ import logging
 import parsl
 import time
 import zmq
-from typing import Dict, List, Sequence
+from typing import Dict, List, Sequence, Optional
 
 from parsl.jobs.states import JobStatus, JobState
 from parsl.jobs.strategy import Strategy
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class PollItem:
-    def __init__(self, executor: BlockProviderExecutor, dfk: "parsl.dataflow.dflow.DataFlowKernel"):
+    def __init__(self, executor: BlockProviderExecutor, dfk: Optional["parsl.dataflow.dflow.DataFlowKernel"] = None):
         self._executor = executor
         self._dfk = dfk
         self._interval = executor.status_polling_interval
@@ -26,7 +26,7 @@ class PollItem:
 
         # Create a ZMQ channel to send poll status to monitoring
         self.monitoring_enabled = False
-        if self._dfk.monitoring is not None:
+        if self._dfk and self._dfk.monitoring is not None:
             self.monitoring_enabled = True
             hub_address = self._dfk.hub_address
             hub_port = self._dfk.hub_interchange_port
@@ -100,11 +100,12 @@ class PollItem:
 
 
 class JobStatusPoller(Timer):
-    def __init__(self, dfk: "parsl.dataflow.dflow.DataFlowKernel") -> None:
+    def __init__(self, strategy: Optional[str] = None, max_idletime: float = 0.0,
+                 dfk: Optional["parsl.dataflow.dflow.DataFlowKernel"] = None) -> None:
         self._poll_items = []  # type: List[PollItem]
         self.dfk = dfk
-        self._strategy = Strategy(strategy=dfk.config.strategy,
-                                  max_idletime=dfk.config.max_idletime)
+        self._strategy = Strategy(strategy=strategy,
+                                  max_idletime=max_idletime)
         super().__init__(self.poll, interval=5, name="JobStatusPoller")
 
     def poll(self) -> None:


### PR DESCRIPTION
# Description

Currently, the `JobStatusPoller` and `PollItem` both take the `DataFlowKernel` as an argument, when in reality there's very little dependence for these on the `DFK`. `PollItem` uses the DKF to get to the monitoring component, which is again optional. This PR converts the DFK to an optional argument. 

This PR is primarily to simplify integrating Parsl scaling logic directly with individual executors without involving the DFK which is the direction globus-compute is taking with it's execution engines.

# Changed Behaviour

No user-facing changes are expected.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
