### PR TITLE
Replace problematic chars in test dir name

### DIFF
--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -83,8 +83,9 @@ def tmpd_cwd_session(pytestconfig):
 
 
 @pytest.fixture
-def tmpd_cwd(tmpd_cwd_session, request):
-    prefix = f"{request.node.name}-"
+def tmpd_cwd(tmpd_cwd_session, request: pytest.FixtureRequest):
+    node_name = re.sub(r'[^\w\s-]', '_', request.node.name)
+    prefix = f"{node_name}-"
     tmpd = tempfile.mkdtemp(dir=tmpd_cwd_session, prefix=prefix)
     yield pathlib.Path(tmpd)
 


### PR DESCRIPTION
## Description

The pytest node names encapsulate test parameters in square brackets, which can be problematic when used in a dir name. To avoid issues, we ensure that the test dir name only includes word characters, whitespace, hyphens and underscores.

## Type of change

- Code maintenance/cleanup
