### PR TITLE
Update Sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,7 +93,7 @@ release = parsl.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,12 @@ extras_require = {
     'aws' : ['boto3'],
     'kubernetes' : ['kubernetes'],
     'oauth_ssh' : ['oauth-ssh>=0.9'],
-    'docs' : ['nbsphinx', 'sphinx_rtd_theme', 'ipython<=8.6.0'],
+    'docs' : [
+        'ipython<=8.6.0',
+        'nbsphinx',
+        'sphinx>=7.1,<7.2',  # 7.2 requires python 3.9+
+        'sphinx_rtd_theme'
+    ],
     'google_cloud' : ['google-auth', 'google-api-python-client'],
     'gssapi' : ['python-gssapi'],
     'azure' : ['azure<=4', 'msrestazure'],


### PR DESCRIPTION
A recent requirement update is incompatible with Sphinx 4.5.0.  Take the opportunity to update to Sphinx 7.2.

## Type of change

- Code maintenance/cleanup