### PR TITLE
Only monitor processes when resource_monitoring_interval > 0

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -125,7 +125,10 @@ class MonitoringHub(RepresentationMixin):
              This will include environment information such as start time, hostname and block id,
              along with periodic resource usage of each task. Default: True
         resource_monitoring_interval : float
-             The time interval, in seconds, at which the monitoring records the resource usage of each task. Default: 30 seconds
+             The time interval, in seconds, at which the monitoring records the resource usage of each task.
+             If set to 0, only start and end information will be logged, and no periodic monitoring will
+             be made.
+             Default: 30 seconds
         """
 
         self.logger = logger

--- a/parsl/monitoring/remote.py
+++ b/parsl/monitoring/remote.py
@@ -43,7 +43,7 @@ def monitor_wrapper(f: Any,           # per app
                            radio_mode,
                            run_dir)
 
-        if monitor_resources:
+        if monitor_resources and sleep_dur > 0:
             # create the monitor process and start
             pp = ForkProcess(target=monitor,
                              args=(os.getpid(),


### PR DESCRIPTION
Two kinds of monitoring message originate from workers:

1. task start and end messages which are relatively lightweight, sent by the task thread at the beginning and end of a task.

2. periodic resource usage message which happen periodically while a task is running. These are sent from a forked process which monitors the task process and its descendants. This can be substantially more resource intensive and degrade workflow performance.

Previously configuration only allow disabling both of this kind of message. This PR allows the type 1 messages to continue to be sent, allowing users to see when a task starts executing, without running a per-task periodic monitoring process.

# Changed Behaviour

This only affects behaviour when `resource_monitoring_interval` was set to zero. In that case, previously the resource monitoring loop would have run without delay, monitoring as fast as it can. Now it will not run at all.

## Type of change

- New feature
