### PR TITLE
Constrain pandas to exclude new v2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require = {
         'networkx>=2.5,<2.6',
         'Flask>=1.0.2',
         'flask_sqlalchemy',
-        'pandas<3',
+        'pandas<2.2',
         'plotly',
         'python-daemon'
     ],


### PR DESCRIPTION
Prior to this PR, pandas is constrained with a SemVer-like major-only constraint, `<3`. This aligns with Pandas declared policy of approximate-SemVer: https://pandas.pydata.org/docs/development/policies.html

On 20th January 2024, the latest version of Pandas went from 2.1.4 to 2.2.0 and looks like it introduced changes which break our usage of pandas.

I have not investigated in any depth what those changes are, but CI began to fail with the below stack trace.

This PR introduces a stronger minor-level upper bound, based on the above situation. This is likely to cause some conflict with users wanting to use recent pandas, and some effort should be made to fix it [by whom?].

The stack trace:

```
2024-01-22T16:48:24.7427770Z + wget http://127.0.0.1:8080/ --recursive --no-verbose --page-requisites --level=inf -e robots=off
2024-01-22T16:48:24.7462824Z 127.0.0.1 - - [22/Jan/2024 16:48:24] "GET / HTTP/1.1" 200 -
2024-01-22T16:48:24.7465385Z 2024-01-22 16:48:24 URL:http://127.0.0.1:8080/ [2805/2805] -> "127.0.0.1:8080/index.html" [1]
2024-01-22T16:48:24.7491348Z 127.0.0.1 - - [22/Jan/2024 16:48:24] "GET /static/parsl-monitor.css HTTP/1.1" 200 -
2024-01-22T16:48:24.7494399Z 2024-01-22 16:48:24 URL:http://127.0.0.1:8080/static/parsl-monitor.css [337/337] -> "127.0.0.1:8080/static/parsl-monitor.css" [1]
2024-01-22T16:48:24.7545143Z 127.0.0.1 - - [22/Jan/2024 16:48:24] "GET /static/parsl-logo-white.png HTTP/1.1" 200 -
2024-01-22T16:48:24.7548740Z 2024-01-22 16:48:24 URL:http://127.0.0.1:8080/static/parsl-logo-white.png [14199/14199] -> "127.0.0.1:8080/static/parsl-logo-white.png" [1]
2024-01-22T16:48:24.7574565Z /home/runner/work/parsl/parsl/.venv/lib/python3.11/site-packages/parsl/monitoring/queries/pandas.py:46: UserWarning:
2024-01-22T16:48:24.7575330Z 
2024-01-22T16:48:24.7576201Z pandas only supports SQLAlchemy connectable (engine/connection) or database string URI or sqlite3 DBAPI2 connection. Other DBAPI2 objects are not tested. Please consider using SQLAlchemy.
2024-01-22T16:48:24.7577058Z 
2024-01-22T16:48:24.7621851Z 127.0.0.1 - - [22/Jan/2024 16:48:24] "GET /workflow/e1513bc0-25c0-46f0-9aec-ca8d4568df87/ HTTP/1.1" 500 -
2024-01-22T16:48:24.7623134Z http://127.0.0.1:8080/workflow/e1513bc0-25c0-46f0-9aec-ca8d4568df87/:
2024-01-22T16:48:24.7624112Z 2024-01-22 16:48:24 ERROR 500: INTERNAL SERVER ERROR.
2024-01-22T16:48:24.7624829Z FINISHED --2024-01-22 16:48:24--
2024-01-22T16:48:24.7625339Z Total wall clock time: 0.02s
2024-01-22T16:48:24.7625864Z Downloaded: 3 files, 17K in 0s (170 MB/s)
2024-01-22T16:48:24.7627015Z Traceback (most recent call last):
2024-01-22T16:48:24.7635421Z   File "/home/runner/work/parsl/parsl/.venv/lib/python3.11/site-packages/flask/app.py", line 1488, in __call__
2024-01-22T16:48:24.7636220Z     return self.wsgi_app(environ, start_response)
2024-01-22T16:48:24.7636615Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-01-22T16:48:24.7637489Z   File "/home/runner/work/parsl/parsl/.venv/lib/python3.11/site-packages/flask/app.py", line 1466, in wsgi_app
2024-01-22T16:48:24.7638196Z     response = self.handle_exception(e)
2024-01-22T16:48:24.7638529Z                ^^^^^^^^^^^^^^^^^^^^^^^^
2024-01-22T16:48:24.7639275Z   File "/home/runner/work/parsl/parsl/.venv/lib/python3.11/site-packages/flask/app.py", line 1463, in wsgi_app
2024-01-22T16:48:24.7640158Z     response = self.full_dispatch_request()
2024-01-22T16:48:24.7640573Z                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-01-22T16:48:24.7641453Z   File "/home/runner/work/parsl/parsl/.venv/lib/python3.11/site-packages/flask/app.py", line 872, in full_dispatch_request
2024-01-22T16:48:24.7642182Z     rv = self.handle_user_exception(e)
2024-01-22T16:48:24.7642516Z          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-01-22T16:48:24.7643338Z   File "/home/runner/work/parsl/parsl/.venv/lib/python3.11/site-packages/flask/app.py", line 870, in full_dispatch_request
2024-01-22T16:48:24.7644045Z     rv = self.dispatch_request()
2024-01-22T16:48:24.7644345Z          ^^^^^^^^^^^^^^^^^^^^^^^
2024-01-22T16:48:24.7645532Z   File "/home/runner/work/parsl/parsl/.venv/lib/python3.11/site-packages/flask/app.py", line 855, in dispatch_request
2024-01-22T16:48:24.7646624Z     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
2024-01-22T16:48:24.7647284Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-01-22T16:48:24.7648503Z   File "/home/runner/work/parsl/parsl/.venv/lib/python3.11/site-packages/parsl/monitoring/visualization/views.py", line 61, in workflow
2024-01-22T16:48:24.7649417Z     df_status = queries.status_for_workflow(workflow_id, db.engine)
2024-01-22T16:48:24.7649889Z                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-01-22T16:48:24.7650858Z   File "/home/runner/work/parsl/parsl/.venv/lib/python3.11/site-packages/parsl/monitoring/queries/pandas.py", line 46, in status_for_workflow
2024-01-22T16:48:24.7651664Z     return pd.read_sql_query("""
2024-01-22T16:48:24.7652179Z            ^^^^^^^^^^^^^^^^^^^^^
2024-01-22T16:48:24.7653206Z   File "/home/runner/work/parsl/parsl/.venv/lib/python3.11/site-packages/pandas/io/sql.py", line 526, in read_sql_query
2024-01-22T16:48:24.7653914Z     return pandas_sql.read_query(
2024-01-22T16:48:24.7654481Z            ^^^^^^^^^^^^^^^^^^^^^^
2024-01-22T16:48:24.7655677Z   File "/home/runner/work/parsl/parsl/.venv/lib/python3.11/site-packages/pandas/io/sql.py", line 2739, in read_query
2024-01-22T16:48:24.7656617Z     cursor = self.execute(sql, params)
2024-01-22T16:48:24.7657113Z              ^^^^^^^^^^^^^^^^^^^^^^^^^
2024-01-22T16:48:24.7657921Z   File "/home/runner/work/parsl/parsl/.venv/lib/python3.11/site-packages/pandas/io/sql.py", line 2673, in execute
2024-01-22T16:48:24.7658595Z     cur = self.con.cursor()
2024-01-22T16:48:24.7658873Z           ^^^^^^^^^^^^^^^^^
2024-01-22T16:48:24.7659293Z AttributeError: 'Engine' object has no attribute 'cursor'
```
