### PR TITLE
Remove last usage of `six` Python 2 compatibility layer

### DIFF
--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -6,17 +6,6 @@ from types import TracebackType
 import logging
 from tblib import Traceback
 
-def reraise(tp, value, tb=None):
-    try:
-        if value is None:
-            value = tp()
-        if value.__traceback__ is not tb:
-            raise value.with_traceback(tb)
-        raise value
-    finally:
-        value = None
-        tb = None
-
 from parsl.data_provider.files import File
 from parsl.errors import ParslError
 
@@ -128,7 +117,12 @@ class RemoteExceptionWrapper:
 
         v = self.get_exception()
 
-        reraise(t, v, v.__traceback__)
+        try:
+            if v.__traceback__ is not t:
+                raise v.with_traceback(t)
+            raise v
+        finally:
+            v = None
 
     def get_exception(self) -> BaseException:
         v = self.e_value

--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -6,7 +6,16 @@ from types import TracebackType
 import logging
 from tblib import Traceback
 
-from six import reraise
+def reraise(tp, value, tb=None):
+    try:
+        if value is None:
+            value = tp()
+        if value.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+    finally:
+        value = None
+        tb = None
 
 from parsl.data_provider.files import File
 from parsl.errors import ParslError

--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -107,8 +107,6 @@ class RemoteExceptionWrapper:
 
     def reraise(self) -> None:
 
-        t = self.e_type
-
         # the type is logged here before deserialising v and tb
         # because occasionally there are problems deserialising the
         # value (see #785, #548) and the fix is related to the

--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -118,11 +118,9 @@ class RemoteExceptionWrapper:
         v = self.get_exception()
 
         try:
-            if v.__traceback__ is not t:
-                raise v.with_traceback(t)
             raise v
         finally:
-            v = None
+            pass
 
     def get_exception(self) -> BaseException:
         v = self.e_value

--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -115,10 +115,7 @@ class RemoteExceptionWrapper:
 
         v = self.get_exception()
 
-        try:
-            raise v
-        finally:
-            pass
+        raise v
 
     def get_exception(self) -> BaseException:
         v = self.e_value

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 pyzmq>=17.1.2
 typeguard>=2.10,<3
 typing-extensions>=4.6,<5
-six
 globus-sdk
 dill
 tblib

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,7 +10,6 @@ sphinx_rtd_theme
 mypy==1.5.1
 types-python-dateutil
 types-requests
-types-six
 types-paramiko
 mpi4py
 


### PR DESCRIPTION
https://wiki.debian.org/Python3-six-removal