### PR TITLE
Address flaky tmp test dir cleanup

### DIFF
--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -48,6 +48,12 @@ def pytest_sessionstart(session):
 
 @pytest.fixture(scope="session")
 def tmpd_cwd_session(pytestconfig):
+    def _chmod(path: pathlib.Path, mode: int):
+        try:
+            path.lchmod(mode)  # support BSD and derivatives
+        except NotImplementedError:
+            path.chmod(mode)
+
     config = re.sub(r"[^A-z0-9_-]+", "_", pytestconfig.getoption('config')[0])
     cwd = pathlib.Path(os.getcwd())
     pytest_dir = cwd / ".pytest"
@@ -76,9 +82,9 @@ def tmpd_cwd_session(pytestconfig):
         for root, subdirnames, fnames in os.walk(run_to_remove):
             rpath = pathlib.Path(root)
             for d in subdirnames:
-                (rpath / d).lchmod(0o700)
+                _chmod(rpath / d, 0o700)
             for f in fnames:
-                (rpath / f).lchmod(0o600)
+                _chmod(rpath / f, 0o600)
         shutil.rmtree(run_to_remove)
 
 


### PR DESCRIPTION
A conflation of OS's internally initially led to use of `lchmod`.  It's still the correct call "for robustness" on platforms that support it, but for those that don't, fallback to regular `chmod`.

## Type of change

- Code maintenance/cleanup