### PR TITLE
Remove use of tmp_path fixture.

### DIFF
--- a/parsl/tests/sites/test_concurrent.py
+++ b/parsl/tests/sites/test_concurrent.py
@@ -24,7 +24,7 @@ def make_config():
 
 
 @mark.local
-def test_executor(tmpdir):
+def test_executor():
     my_config = make_config()
 
     with ParslPoolExecutor(my_config) as exc:

--- a/parsl/tests/test_data/test_file_apps.py
+++ b/parsl/tests/test_data/test_file_apps.py
@@ -35,10 +35,10 @@ def increment(inputs=(), outputs=(), stdout=None, stderr=None):
 
 
 @pytest.mark.staging_required
-def test_increment(tmp_path, depth=5):
+def test_increment(tmpd_cwd, depth=5):
     """Test simple pipeline A->B...->N"""
     # Test setup
-    first_fpath = tmp_path / "test0.txt"
+    first_fpath = tmpd_cwd / "test0.txt"
     first_fpath.write_text("0\n")
 
     prev = [File(first_fpath)]
@@ -46,9 +46,9 @@ def test_increment(tmp_path, depth=5):
     for i in range(1, depth):
         f = increment(
             inputs=prev,
-            outputs=[File(tmp_path / f"test{i}.txt")],
-            stdout=tmp_path / f"incr{i}.out",
-            stderr=tmp_path / f"incr{i}.err",
+            outputs=[File(tmpd_cwd / f"test{i}.txt")],
+            stdout=tmpd_cwd / f"incr{i}.out",
+            stderr=tmpd_cwd / f"incr{i}.err",
         )
         prev = f.outputs
         futs.append((i, prev[0]))

--- a/parsl/tests/test_data/test_file_staging.py
+++ b/parsl/tests/test_data/test_file_staging.py
@@ -11,10 +11,10 @@ def cat(inputs=(), outputs=(), stdout=None, stderr=None):
 
 
 @pytest.mark.staging_required
-def test_regression_200(tmp_path):
+def test_regression_200(tmpd_cwd):
     """Regression test for #200. Pickleablility of Files"""
-    opath = tmp_path / "test_output.txt"
-    fpath = tmp_path / "test.txt"
+    opath = tmpd_cwd / "test_output.txt"
+    fpath = tmpd_cwd / "test.txt"
 
     fpath.write_text("Hello World")
     f = cat(inputs=[File(fpath)], outputs=[File(opath)])

--- a/parsl/tests/test_docs/test_kwargs.py
+++ b/parsl/tests/test_docs/test_kwargs.py
@@ -19,7 +19,7 @@ def test_inputs():
     assert reduce_future.result() == 6
 
 
-def test_outputs(tmpdir):
+def test_outputs(tmpd_cwd):
     @python_app()
     def write_app(message, outputs=()):
         """Write a single message to every file in outputs"""
@@ -28,8 +28,8 @@ def test_outputs(tmpdir):
                 print(message, file=fp)
 
     to_write = [
-        File(Path(tmpdir) / 'output-0.txt'),
-        File(Path(tmpdir) / 'output-1.txt')
+        File(Path(tmpd_cwd) / 'output-0.txt'),
+        File(Path(tmpd_cwd) / 'output-1.txt')
     ]
     write_app('Hello!', outputs=to_write).result()
     for path in to_write:

--- a/parsl/tests/test_python_apps/test_futures.py
+++ b/parsl/tests/test_python_apps/test_futures.py
@@ -42,10 +42,10 @@ def test_fut_case_1():
 
 
 @pytest.mark.staging_required
-def test_fut_case_2(tmp_path):
+def test_fut_case_2(tmpd_cwd):
     """Testing the behavior of DataFutures where there are no dependencies
     """
-    output_f = tmp_path / 'test_fut_case_2.txt'
+    output_f = tmpd_cwd / 'test_fut_case_2.txt'
     app_fu = delay_incr(1, delay=0.01, outputs=[File(str(output_f))])
     data_fu = app_fu.outputs[0]
 
@@ -69,13 +69,13 @@ def test_fut_case_3():
 
 
 @pytest.mark.staging_required
-def test_fut_case_4(tmp_path):
+def test_fut_case_4(tmpd_cwd):
     """Testing the behavior of DataFutures where there are dependencies
 
     The first call has a delay, and the second call depends on the first
     """
-    output_f1 = tmp_path / 'test_fut_case_4_f1.txt'
-    output_f2 = tmp_path / 'test_fut_case_4_f2.txt'
+    output_f1 = tmpd_cwd / 'test_fut_case_4_f1.txt'
+    output_f2 = tmpd_cwd / 'test_fut_case_4_f2.txt'
     app_1 = delay_incr(1, delay=0.01, outputs=[File(str(output_f1))])
     app_2 = delay_incr(app_1, delay=0.01, outputs=[File(str(output_f2))])
     data_2 = app_2.outputs[0]


### PR DESCRIPTION
PR #2764 introduced `tmp_path` without understanding of the shared FS expectation for some tests (i.e., those run on site-specific hosts).  PR #2803 fixed this with `tmpd_cwd` which is a temporary directory created inside of the current working directory&nbsp;&mdash;&nbsp;which is assumed to be on a shared FS.

Fixes: #3039

## Type of change

- Bug fix (in tests)