### PR TITLE
Add exception type to task failed log messages

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -302,7 +302,7 @@ class DataFlowKernel:
             res = self._unwrap_remote_exception_wrapper(future)
 
         except Exception as e:
-            logger.debug("Task {} try {} failed".format(task_id, task_record['try_id']))
+            logger.info(f"Task {task_id} try {task_record['try_id']} failed with exception of type {type(e).__name__}")
             # We keep the history separately, since the future itself could be
             # tossed.
             task_record['fail_history'].append(repr(e))

--- a/parsl/tests/configs/htex_local_alternate.py
+++ b/parsl/tests/configs/htex_local_alternate.py
@@ -39,7 +39,7 @@ def fresh_config():
     return Config(
         executors=[
             HighThroughputExecutor(
-                address="localhost",
+                address="127.0.0.1",
                 label="htex_Local",
                 working_dir=working_dir,
                 storage_access=[FTPInTaskStaging(), HTTPInTaskStaging(), NoOpFileStaging()],

--- a/parsl/tests/configs/htex_local_alternate.py
+++ b/parsl/tests/configs/htex_local_alternate.py
@@ -39,7 +39,7 @@ def fresh_config():
     return Config(
         executors=[
             HighThroughputExecutor(
-                address="127.0.0.1",
+                address="localhost",
                 label="htex_Local",
                 working_dir=working_dir,
                 storage_access=[FTPInTaskStaging(), HTTPInTaskStaging(), NoOpFileStaging()],


### PR DESCRIPTION
This arises from a user interaction where it was unclear that some tasks were failing and retrying due to an application error; and others were failing due to lost managers.

The exception is recorded in the monitoring database, if that is used, and when retries have run out, is returned to the user in the relevant AppFuture but the exception class was not previously recorded in the log file for live investigation while a run is still proceeding.

Before:

1706696631.320572 2024-01-31 10:23:51 MainProcess-4072 HTEX-Queue-Management-Thread-139622759765696 parsl.dataflow.dflow:305 handle_exec_update DEBUG: Task 9 try 0 failed

After:

1706696578.454484 2024-01-31 10:22:58 MainProcess-3792 HTEX-Queue-Management-Thread-140175535478464 parsl.dataflow.dflow:305 handle_exec_update INFO: Task 9 try 0 failed with exception of type AppTimeout

# Changed Behaviour

Human readable log message has more stuff in it. Anyone attempting regexpy parsing of log files will break.
INFO-level logs will be slightly more verbose in the presence of failures, as this PR changes the log level for this message from DEBUG to INFO

## Type of change

- Update to human readable text: Documentation/error messages/comments
