### PR TITLE
Propagate SLURM submission errors as exceptions, not `None`

### DIFF
--- a/parsl/providers/errors.py
+++ b/parsl/providers/errors.py
@@ -51,11 +51,12 @@ class SubmitException(ExecutionProviderException):
     '''Raised by the submit() method of a provider if there is an error in launching a job.
     '''
 
-    def __init__(self, job_name, message, stdout=None, stderr=None):
+    def __init__(self, job_name, message, stdout=None, stderr=None, retcode=None):
         self.job_name = job_name
         self.message = message
         self.stdout = stdout
         self.stderr = stderr
+        self.retcode = retcode
 
     @property
     def task_name(self) -> str:
@@ -64,7 +65,4 @@ class SubmitException(ExecutionProviderException):
 
     def __str__(self):
         # TODO: make this more user-friendly
-        return "Cannot launch job {0}: {1}; stdout={2}, stderr={3}".format(self.job_name,
-                                                                           self.message,
-                                                                           self.stdout,
-                                                                           self.stderr)
+        return f"Cannot launch job {self.job_name}: {self.messsage}; recode={self.retcode}, stdout={self.stdout}, stderr={self.stderr}"

--- a/parsl/providers/errors.py
+++ b/parsl/providers/errors.py
@@ -63,6 +63,6 @@ class SubmitException(ExecutionProviderException):
         warnings.warn("task_name is deprecated; use .job_name instead. This will be removed after 2024-06.", DeprecationWarning)
         return self.job_name
 
-    def __str__(self):
+    def __str__(self) -> str:
         # TODO: make this more user-friendly
-        return f"Cannot launch job {self.job_name}: {self.messsage}; recode={self.retcode}, stdout={self.stdout}, stderr={self.stderr}"
+        return f"Cannot launch job {self.job_name}: {self.message}; recode={self.retcode}, stdout={self.stdout}, stderr={self.stderr}"


### PR DESCRIPTION
# Description

This PR moves the SLURM provider towards the tighter provider.submit API described in issue #2949 which requires that submission failures are indicated by an exception, rather than by a `None` value.

In this PR, instead of a relatively uninformative `None` value, a richer SubmitException is returned with more information about the submission failure.

I tested this on perlmutter by setting scheduler_options=`#SBATCH --nonsense`.

Before this PR, execution fails with this exception:

```
parsl.executors.errors.BadStateException: Executor PM_HTEX_multinode failed due to: Error 1:
        Failed to start block 0: Executor PM_HTEX_multinode failed to scale due to: Attempt to provision nodes did not return a job ID
```

After this PR, the same failure results in this exception:

```
parsl.executors.errors.BadStateException: Executor PM_HTEX_multinode failed due to: Error 1:
        Failed to start block 0: Cannot launch job parsl.PM_HTEX_multinode.block-0.1706699269.6424484: Could not read job ID from submit command standard output; recode=255, stdout=, stderr=sbatch: unrecognized option '--nonsense'
```

This propagates the `sbatch` error message into the exception stack, hopefully leading the user more directly to their problem.

This PR also adds a retcode parameter to SubmitException, to go alongside the existing stderr and stdout parameters to represent the return state of a unix process.

This PR removes the incorrect docstring that a slurmprovider.submit error occurs because the queue is at capacity - as the above example demostrates, that is not the only cause of a slurmprovider.submit error.

This work comes from the ongoing `benc-mypy` project.

# Changed Behaviour

Richer AppFuture exceptions and log messages when batch submission fails.

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
