### PR TITLE
Permit both typeguard 2.x and 4.x

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -171,7 +171,10 @@ class MonitoringHub(RepresentationMixin):
         self.logger.debug("Initializing ZMQ Pipes to client")
         self.monitoring_hub_active = True
 
-        comm_q: Queue[Union[Tuple[int, int], str]]
+        # This annotation is incompatible with typeguard 4.x instrumentation
+        # of local variables, because Queue is not a type: it's a method on
+        # multiprocessing.context.DefaultContext.
+        # comm_q: Queue[Union[Tuple[int, int], str]]
         comm_q = SizedQueue(maxsize=10)
 
         self.exception_q: Queue[Tuple[str, str]]

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -23,7 +23,7 @@ from parsl.serialize import deserialize
 
 from parsl.monitoring.message_type import MessageType
 from parsl.monitoring.types import AddressedMonitoringMessage, TaggedMonitoringMessage
-from typing import cast, Any, Callable, Dict, Optional, Sequence, Tuple, Union
+from typing import cast, Any, Callable, Dict, Optional, Sequence, Tuple, Union, TYPE_CHECKING
 
 _db_manager_excepts: Optional[Exception]
 
@@ -177,10 +177,15 @@ class MonitoringHub(RepresentationMixin):
         # This annotation is incompatible with typeguard 4.x instrumentation
         # of local variables: Queue is not subscriptable at runtime, as far
         # as typeguard is concerned. The more general Queue annotation works,
-        # but does not restrict the contents of the Queue.
+        # but does not restrict the contents of the Queue. Using TYPE_CHECKING
+        # here allows the stricter definition to be seen by mypy, and the
+        # simpler definition to be seen by typeguard. Hopefully at some point
+        # in the future, Queue will allow runtime subscripts.
 
-        # comm_q: Queue[Union[Tuple[int, int], str]]
-        comm_q: Queue
+        if TYPE_CHECKING:
+            comm_q: Queue[Union[Tuple[int, int], str]]
+        else:
+            comm_q: Queue
 
         comm_q = SizedQueue(maxsize=10)
 

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import socket
 import time
@@ -11,7 +13,8 @@ import queue
 import parsl.monitoring.remote
 
 from parsl.multiprocessing import ForkProcess, SizedQueue
-from multiprocessing import Process, Queue
+from multiprocessing import Process
+from multiprocessing.queues import Queue
 from parsl.utils import RepresentationMixin
 from parsl.process_loggers import wrap_with_logs
 from parsl.utils import setproctitle
@@ -172,9 +175,13 @@ class MonitoringHub(RepresentationMixin):
         self.monitoring_hub_active = True
 
         # This annotation is incompatible with typeguard 4.x instrumentation
-        # of local variables, because Queue is not a type: it's a method on
-        # multiprocessing.context.DefaultContext.
+        # of local variables: Queue is not subscriptable at runtime, as far
+        # as typeguard is concerned. The more general Queue annotation works,
+        # but does not restrict the contents of the Queue.
+
         # comm_q: Queue[Union[Tuple[int, int], str]]
+        comm_q: Queue
+
         comm_q = SizedQueue(maxsize=10)
 
         self.exception_q: Queue[Tuple[str, str]]

--- a/parsl/tests/test_bash_apps/test_stdout.py
+++ b/parsl/tests/test_bash_apps/test_stdout.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+import typeguard
 
 import parsl.app.errors as perror
 from parsl.app.app import bash_app
@@ -44,7 +45,11 @@ def test_bad_stdout_specs(spec):
     try:
         fn.result()
     except Exception as e:
-        assert isinstance(e, TypeError) or isinstance(e, perror.BadStdStreamFile), "Exception is wrong type"
+        # This tests for TypeCheckError by string matching on the type name
+        # because that class does not exist in typeguard 2.x - it is new in
+        # typeguard 4.x. When typeguard 2.x support is dropped, this test can
+        # become an isinstance check.
+        assert "TypeCheckError" in str(type(e)) or isinstance(e, TypeError) or isinstance(e, perror.BadStdStreamFile), "Exception is wrong type"
     else:
         assert False, "Did not raise expected exception"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,12 @@
 pyzmq>=17.1.2
-typeguard>=2.10,<3
+
+# typeguard uses semantic versioning.
+# major v3 was a shortlived version that was rapidly replaced by major v4,
+# so this specification excludes it.
+# v2 and v4 are both seen in the wild with users in complex deployments.
+typeguard>=2.10,!=3.*,<5
+
+
 typing-extensions>=4.6,<5
 globus-sdk
 dill


### PR DESCRIPTION
This PR loosens some type checking to accomodate both typeguard 2.x and 4.x as large parsl users (eg. LSST DESC) still package version 2.x but other users want the latest - 4.x

In typeguard 4.x, local variables are instrumented for type-checking, which is incompatible with using multiprocessing.Queue: multiprocessing.Queue is not a type as far as typeguard is concerned, so a single use of that, in MonitoringHub, is commented out by this PR.

Typeguard 2.x and 4.x have different type error classes, so explicit type checking of exception classes cannot happen in tests as the typeguard 4.x TypeCheckError class does not exist when typeguard 2.x is installed. This PR makes that type-check of type-checking errors happen using string matching of the name of the type-check error class in test_bash_apps/test_stdout.py

See for example issue #3017

This PR is ugly but attempts to be pragmatic about user packaging needs.

# Changed Behaviour

different exceptions on user type errors

# Fixes

Fixes #3017

## Type of change

- Code maintenance/cleanup
