### PR TITLE
Rewrite htex scale_in docstring

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -634,7 +634,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
 
         Returns
         -------
-        List of job_ids marked for termination
+        List of block IDs scaled in
         """
         logger.debug(f"Scale in called, blocks={blocks}, block_ids={block_ids}")
         if block_ids:


### PR DESCRIPTION
scale_in returns block IDs, not provider job ids - that was changed in PR #1952

scale_in does not mark blocks for termination - it uses the provider mechanism to terminate blocks directly.

## Type of change

- Update to human readable text: Documentation/error messages/comments
