### PR TITLE
Fix and tighten large argument debug line

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -594,8 +594,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
 
         # handle people sending blobs gracefully
         if logger.getEffectiveLevel() <= logging.DEBUG:
-            arg_repr = repr(arg)
-            args_to_print = tuple([arg if len(arg_repr) < 100 else (arg_repr[:100] + '...') for arg in args])
+            args_to_print = tuple([ar if len(ar := repr(arg)) < 100 else (ar[:100] + '...') for arg in args])
             logger.debug("Pushing function {} to queue with args {}".format(func, args_to_print))
 
         fut = Future()

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -593,10 +593,10 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         task_id = self._task_counter
 
         # handle people sending blobs gracefully
-        args_to_print = args
-        if logger.getEffectiveLevel() >= logging.DEBUG:
-            args_to_print = tuple([arg if len(repr(arg)) < 100 else (repr(arg)[:100] + '...') for arg in args])
-        logger.debug("Pushing function {} to queue with args {}".format(func, args_to_print))
+        if logger.getEffectiveLevel() <= logging.DEBUG:
+            arg_repr = repr(arg)
+            args_to_print = tuple([arg if len(arg_repr) < 100 else (arg_repr[:100] + '...') for arg in args])
+            logger.debug("Pushing function {} to queue with args {}".format(func, args_to_print))
 
         fut = Future()
         fut.parsl_executor_task_id = task_id


### PR DESCRIPTION
This `if` statement had its inequality the wrong way round and would only truncate arguments when the effective log level was DEBUG or higher:

If the effective log level was exactly DEBUG, then the = part of the inequality fired, and the log message was truncated correctly.

If the effective log level was less than DEBUG (for example, imagine a user-defined TRACE level) then the log message was not truncated, and an unrestricted length log message was output.

If the effective log level was more than DEBUG (for example, WARNING, the default if initialize_logging=False), then the expense of truncation would be incurred, but the result would be discarded by being logged at DEBUG level.

This PR flips that inequality round to correct the behaviour.

It moves all of the log message processing into the `if` statement so that it all only happens if the log level is DEBUG or lower.

The possibly expensive conversion of each argument to a string via `repr` is factored into a variable using the `:=` walrus operator which has been available since Python 3.8 became our lower bound.

# Changed Behaviour

Logging should be a bit more efficient. Users who were relying on this log line outputting the full repr at low log levels will be disappointed. That's an obscure use case though.

## Type of change

- Bug fix
- Update to human readable text: Documentation/error messages/comments
