### PR TITLE
Better support in HTEX for reporting jobs that fail without connecting

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -547,6 +547,10 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         """
         return self.command_client.run("MANAGERS")
 
+    def connected_blocks(self) -> List[str]:
+        """List of connected block ids"""
+        return self.command_client.run("CONNECTED_BLOCKS")
+
     def _hold_block(self, block_id):
         """ Sends hold command to all managers which are in a specific block
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -731,6 +731,12 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
             job_info = job_status[job_id]
             if job_info.terminal and job_id not in connected_blocks:
                 job_status[job_id].state = JobState.MISSING
+                if job_status[job_id].message is None:
+                    job_status[job_id].message = (
+                        "Job is marked as MISSING since the workers failed to register"
+                        "to the executor. Check the stdout/stderr logs in the submit_scripts"
+                        "directory for more debug information"
+                    )
         return job_status
 
     def shutdown(self):

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -733,8 +733,8 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
                 job_status[job_id].state = JobState.MISSING
                 if job_status[job_id].message is None:
                     job_status[job_id].message = (
-                        "Job is marked as MISSING since the workers failed to register"
-                        "to the executor. Check the stdout/stderr logs in the submit_scripts"
+                        "Job is marked as MISSING since the workers failed to register "
+                        "to the executor. Check the stdout/stderr logs in the submit_scripts "
                         "directory for more debug information"
                     )
         return job_status

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -14,7 +14,7 @@ import queue
 import threading
 import json
 
-from typing import cast, Any, Dict, NoReturn, Sequence, Set, Optional, Tuple
+from typing import cast, Any, Dict, NoReturn, Sequence, Set, Optional, Tuple, List
 
 from parsl import curvezmq
 from parsl.utils import setproctitle
@@ -184,6 +184,7 @@ class Interchange:
             self.worker_task_port, self.worker_result_port))
 
         self._ready_managers: Dict[bytes, ManagerRecord] = {}
+        self.connected_block_history: List[str] = []
 
         self.heartbeat_threshold = heartbeat_threshold
 
@@ -285,6 +286,9 @@ class Interchange:
                     for manager in self._ready_managers.values():
                         outstanding += len(manager['tasks'])
                     reply = outstanding
+
+                elif command_req == "CONNECTED_BLOCKS":
+                    reply = self.connected_block_history
 
                 elif command_req == "WORKERS":
                     num_workers = 0
@@ -416,6 +420,7 @@ class Interchange:
                                                         'worker_count': 0,
                                                         'active': True,
                                                         'tasks': []}
+                    self.connected_block_history.append(msg['block_id'])
                 if reg_flag is True:
                     interesting_managers.add(manager_id)
                     logger.info("Adding manager: {!r} to ready queue".format(manager_id))

--- a/parsl/jobs/error_handlers.py
+++ b/parsl/jobs/error_handlers.py
@@ -33,7 +33,7 @@ def _count_jobs(status: Dict[str, JobStatus]) -> Tuple[int, int]:
     failed = 0
     for js in status.values():
         total += 1
-        if js.state == JobState.FAILED:
+        if js.state == JobState.FAILED or js.state == JobState.MISSING:
             failed += 1
     return total, failed
 

--- a/parsl/jobs/states.py
+++ b/parsl/jobs/states.py
@@ -39,12 +39,19 @@ class JobState(IntEnum):
     HELD = 7
     """This job is held/suspended in the batch system"""
 
+    MISSING = 8
+    """This job has reached a terminal state without the resources(managers/workers)
+    launched in the job connecting back to the Executor. This state is set by HTEX
+    when it is able to infer that the block failed to start workers for eg due to
+    bad worker environment or network connectivity issues.
+    """
+
     def __str__(self) -> str:
         return self.__class__.__name__ + "." + self.name
 
 
 TERMINAL_STATES = [JobState.CANCELLED, JobState.COMPLETED, JobState.FAILED,
-                   JobState.TIMEOUT]
+                   JobState.TIMEOUT, JobState.MISSING]
 
 
 class JobStatus:

--- a/parsl/tests/test_htex/test_connected_blocks.py
+++ b/parsl/tests/test_htex/test_connected_blocks.py
@@ -1,0 +1,61 @@
+import parsl
+import pytest
+from parsl.executors import HighThroughputExecutor
+from parsl import Config
+from parsl.providers import LocalProvider
+
+
+def local_config():
+    return Config(
+        executors=[
+            HighThroughputExecutor(
+                label="HTEX",
+                heartbeat_period=1,
+                heartbeat_threshold=2,
+                poll_period=100,
+                address="127.0.0.1",
+                max_workers=1,
+                provider=LocalProvider(
+                    init_blocks=0,
+                    max_blocks=2,
+                    min_blocks=0,
+                ),
+            )
+        ],
+        max_idletime=0.5,
+        strategy='htex_auto_scale',
+    )
+
+
+@parsl.python_app
+def double(x):
+    return x * 2
+
+
+@pytest.mark.local
+def test_get_connected_blocks():
+    """Test reporting of connected blocks from HTEX"""
+    dfk = parsl.dfk()
+    executor = dfk.executors["HTEX"]
+
+    connected_blocks = executor.connected_blocks()
+    assert not connected_blocks, "Expected 0 blocks"
+
+    blocking_task = double(5).result()
+    assert blocking_task == 10
+
+    connected_blocks = executor.connected_blocks()
+    assert len(connected_blocks) == 1, "Expected 1 block"
+
+    executor.scale_in(1)
+
+    connected_blocks = executor.connected_blocks()
+    assert len(connected_blocks) == 1, "Expected 1 block"
+
+    blocking_task = double(5).result()
+    assert blocking_task == 10
+
+    # With the first block scaled_in there should be reporting
+    # 2 blocks including the older one.
+    connected_blocks = executor.connected_blocks()
+    assert len(connected_blocks) == 2, "Expected 2 blocks"

--- a/parsl/tests/test_htex/test_disconnected_blocks.py
+++ b/parsl/tests/test_htex/test_disconnected_blocks.py
@@ -1,0 +1,64 @@
+import logging
+import parsl
+import pytest
+from parsl.executors import HighThroughputExecutor
+from parsl import Config
+from parsl.providers import LocalProvider
+from parsl.executors.errors import BadStateException
+from parsl.jobs.states import JobStatus, JobState
+
+
+def local_config():
+    """Config to simulate failing blocks without connecting"""
+    return Config(
+        executors=[
+            HighThroughputExecutor(
+                label="HTEX",
+                heartbeat_period=1,
+                heartbeat_threshold=2,
+                poll_period=100,
+                max_workers=1,
+                provider=LocalProvider(
+                    worker_init="conda deactivate; export PATH=''; which python; exit 0",
+                    init_blocks=0,
+                    max_blocks=2,
+                    min_blocks=0,
+                ),
+            )
+        ],
+        run_dir="/tmp/test_htex",
+        max_idletime=0.5,
+        strategy='htex_auto_scale',
+    )
+
+
+@parsl.python_app
+def double(x):
+    return x * 2
+
+
+@pytest.mark.local
+def test_disconnected_blocks():
+    """Test reporting of blocks that fail to connect from HTEX"""
+    dfk = parsl.dfk()
+    executor = dfk.executors["HTEX"]
+
+    connected_blocks = executor.connected_blocks()
+    assert not connected_blocks, "Expected 0 blocks"
+
+    future = double(5)
+    with pytest.raises(BadStateException):
+        future.result()
+
+    assert isinstance(future.exception(), BadStateException)
+    exception_body = str(future.exception())
+    assert "EXIT CODE: 0" in exception_body
+
+    status_dict = executor.status()
+    assert len(status_dict) == 1, "Expected only 1 block"
+    for status in status_dict.values():
+        assert isinstance(status, JobStatus)
+        assert status.state == JobState.MISSING
+
+    connected_blocks = executor.connected_blocks()
+    assert not connected_blocks, "Expected 0 blocks"

--- a/parsl/tests/test_htex/test_multiple_disconnected_blocks.py
+++ b/parsl/tests/test_htex/test_multiple_disconnected_blocks.py
@@ -1,0 +1,67 @@
+import logging
+import parsl
+import pytest
+from parsl.executors import HighThroughputExecutor
+from parsl import Config
+from parsl.providers import LocalProvider
+from parsl.executors.errors import BadStateException
+from parsl.jobs.states import JobStatus, JobState
+
+
+def local_config():
+    """Config to simulate failing blocks without connecting"""
+    return Config(
+        executors=[
+            HighThroughputExecutor(
+                label="HTEX",
+                heartbeat_period=1,
+                heartbeat_threshold=2,
+                poll_period=100,
+                max_workers=1,
+                provider=LocalProvider(
+                    worker_init="conda deactivate; export PATH=''; which python; exit 0",
+                    init_blocks=2,
+                    max_blocks=4,
+                    min_blocks=0,
+                ),
+            )
+        ],
+        run_dir="/tmp/test_htex",
+        max_idletime=0.5,
+        strategy='htex_auto_scale',
+    )
+
+
+@parsl.python_app
+def double(x):
+    return x * 2
+
+
+@pytest.mark.local
+def test_multiple_disconnected_blocks():
+    """Test reporting of blocks that fail to connect from HTEX
+    When init_blocks == N, error handling expects N failures before
+    the run is cancelled
+    """
+    dfk = parsl.dfk()
+    executor = dfk.executors["HTEX"]
+
+    connected_blocks = executor.connected_blocks()
+    assert not connected_blocks, "Expected 0 blocks"
+
+    future = double(5)
+    with pytest.raises(BadStateException):
+        future.result()
+
+    assert isinstance(future.exception(), BadStateException)
+    exception_body = str(future.exception())
+    assert "EXIT CODE: 0" in exception_body
+
+    status_dict = executor.status()
+    assert len(status_dict) == 2, "Expected 2 blocks"
+    for status in status_dict.values():
+        assert isinstance(status, JobStatus)
+        assert status.state == JobState.MISSING
+
+    connected_blocks = executor.connected_blocks()
+    assert not connected_blocks, "Expected 0 blocks"


### PR DESCRIPTION
# Description

When it comes to an executor using a provider like SlurmProvider to provision resources, there are a few different failure modes that are not well supported.

1. Job fails to submit -> Reported as a provider failure
2. Job starts, workers fail to start with an non-zero exit code reported (LocalProvider) -> Reported as a provider failure
3. Job starts, but workers fail to start (bad env/network config) -> Silently ignored
4. Job starts, but terminates later due to reaching walltime -> Not a failure. 

In case3, when the batch system deems a task as completed/failed, the provider may not see further info reported from the queue. In such a situation the provider marks the job as `JobState.COMPLETED` instead of `JobState.FAILED`. However, this leads to a situation where Parsl would repeatedly attempt provisioning jobs when it should shut down.

# Changed Behaviour

This PR introduces a new `JobState.MISSING` which is set by the `HighThroughputExecutor` when it detects that a job reported by the provider to have reached a terminal state did not connect. 


Fixes # (issue)

## Type of change

- Bug fix