### PR TITLE
Add visualization as a dependency for test-viz part of the tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,7 +90,7 @@ jobs:
       run: |
         source .venv/bin/activate
         sudo apt-get install -y graphviz
-        pip install .[monitoring]
+        pip install .[monitoring,visualization]
         parsl/tests/test-viz.sh
 
     - name: make coverage


### PR DESCRIPTION
This is masked on master because of test execution order, but breaks on desc branch at the moment because of re-ordered tests

This broke in PR #2911 which split montoring dependencies into two in setup.py

# Changed Behaviour

Tests should be more resilient to makefile re-ordering.

## Type of change

- Bug fix
