### PR TITLE
Make HTEX default launch_cmd available as a global

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -35,6 +35,23 @@ from parsl.providers import LocalProvider
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_LAUNCH_CMD = ("process_worker_pool.py {debug} {max_workers} "
+                      "-a {addresses} "
+                      "-p {prefetch_capacity} "
+                      "-c {cores_per_worker} "
+                      "-m {mem_per_worker} "
+                      "--poll {poll_period} "
+                      "--task_port={task_port} "
+                      "--result_port={result_port} "
+                      "--cert_dir {cert_dir} "
+                      "--logdir={logdir} "
+                      "--block_id={{block_id}} "
+                      "--hb_period={heartbeat_period} "
+                      "{address_probe_timeout_string} "
+                      "--hb_threshold={heartbeat_threshold} "
+                      "--cpu-affinity {cpu_affinity} "
+                      "--available-accelerators {accelerators}")
+
 
 class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
     """Executor designed for cluster-scale
@@ -265,25 +282,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         self.cert_dir = None
 
         if not launch_cmd:
-            launch_cmd = (
-                "process_worker_pool.py {debug} {max_workers} "
-                "-a {addresses} "
-                "-p {prefetch_capacity} "
-                "-c {cores_per_worker} "
-                "-m {mem_per_worker} "
-                "--poll {poll_period} "
-                "--task_port={task_port} "
-                "--result_port={result_port} "
-                "--cert_dir {cert_dir} "
-                "--logdir={logdir} "
-                "--block_id={{block_id}} "
-                "--hb_period={heartbeat_period} "
-                "{address_probe_timeout_string} "
-                "--hb_threshold={heartbeat_threshold} "
-                "--cpu-affinity {cpu_affinity} "
-                "--available-accelerators {accelerators}"
-            )
-
+            launch_cmd = DEFAULT_LAUNCH_CMD
         self.launch_cmd = launch_cmd
 
     radio_mode = "htex"


### PR DESCRIPTION
This supports the use case where a user wants to launch the regular launch command but inside some kind of wrapper: they can now write

```
  HighThroughputExecutor(
      launch_cmd = "some_wrapper " + HighThroughputExecutor.DEFAULT_LAUNCH_CMD,
      ...
  )
```

which will use the launch command from the current Parsl version.

The alternative is to cut-and-paste the launch command out of the Parsl source code, which is more fragile.

## Type of change

- New feature
