### PR TITLE
Fix srun scripts location

### DIFF
--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -327,12 +327,12 @@ WORKERCOUNT={task_blocks}
 
 path_cmd=$(dirname $SLURM_JOB_STDOUT)
 
-cat << SLURM_EOF > ${path_cmd}/cmd_$SLURM_JOB_NAME.sh
+cat << SLURM_EOF > $path_cmd/cmd_$SLURM_JOB_NAME.sh
 {command}
 SLURM_EOF
-chmod a+x ${path_cmd}/cmd_$SLURM_JOB_NAME.sh
+chmod a+x $path_cmd/cmd_$SLURM_JOB_NAME.sh
 
-srun --ntasks {task_blocks} -l {overrides} bash ${path_cmd}/cmd_$SLURM_JOB_NAME.sh
+srun --ntasks {task_blocks} -l {overrides} bash $path_cmd/cmd_$SLURM_JOB_NAME.sh
 
 [[ "{debug}" == "1" ]] && echo "Done"
 '''.format(command=command,

--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -325,12 +325,14 @@ export NODES=$SLURM_JOB_NUM_NODES
 [[ "{debug}" == "1" ]] && echo "Found nodes : $NODES"
 WORKERCOUNT={task_blocks}
 
-cat << SLURM_EOF > cmd_$SLURM_JOB_NAME.sh
+path_cmd=$(dirname $SLURM_JOB_STDOUT)
+
+cat << SLURM_EOF > ${path_cmd}/cmd_$SLURM_JOB_NAME.sh
 {command}
 SLURM_EOF
-chmod a+x cmd_$SLURM_JOB_NAME.sh
+chmod a+x ${path_cmd}/cmd_$SLURM_JOB_NAME.sh
 
-srun --ntasks {task_blocks} -l {overrides} bash cmd_$SLURM_JOB_NAME.sh
+srun --ntasks {task_blocks} -l {overrides} bash ${path_cmd}/cmd_$SLURM_JOB_NAME.sh
 
 [[ "{debug}" == "1" ]] && echo "Done"
 '''.format(command=command,


### PR DESCRIPTION
Fixes #3067  for the specific case of `SrunLauncher`, because in that case it is guaranteed that the block submission script exposes a shared directory in which intermediate helper files created by the launcher can be placed. In particular, the SLURM stderr/stdout location.
