### PR TITLE
Renaming parsl_resource_spefication options for MPI Mode

### DIFF
--- a/docs/userguide/mpi_apps.rst
+++ b/docs/userguide/mpi_apps.rst
@@ -39,8 +39,9 @@ The broad strokes of a complete solution involves the following components:
     # Resources in terms of nodes and how ranks are to be distributed are set on a per app
     # basis via the resource_spec dictionary.
     resource_spec = {
-        "NUM_NODES" = 2,
-        "RANKS_PER_NODE" = 2,
+        "num_nodes" = 2,
+        "ranks_per_node" = 2,
+        "num_ranks" = 4,
     }
     future = lammps_mpi_application(File('in.file'), resource_specification=resource_spec)
 
@@ -179,12 +180,13 @@ However, the following options are **required** for MPI applications :
 .. code-block:: python
 
     resource_specification = {
-      'NUM_NODES': <int>,        # Number of nodes required for the application instance
-      'RANKS_PER_NODE': <int>,   # Number of Ranks / application elements to be launched per node
+      'num_nodes': <int>,        # Number of nodes required for the application instance
+      'ranks_per_node': <int>,   # Number of ranks / application elements to be launched per node
+      'num_ranks': <int>,        # Number of ranks in total
     }
 
     # The above are made available in the worker env vars:
-    # echo $PARSL_NUM_NODES, $PARSL_RANKS_PER_NODE
+    # echo $PARSL_NUM_NODES, $PARSL_RANKS_PER_NODE, $PARSL_NUM_RANKS
 
 When the above are supplied, the following launch command prefixes are set:
 
@@ -283,7 +285,7 @@ Next we define the CosmicTagger MPI application. TODO: Ask Khalid for help.
                       stdout=parsl.AUTO_LOGNAME,
                       stderr=parsl.AUTO_LOGNAME,
                       parsl_resource_specification:Dict={}):
-        NRANKS = parsl_resource_specification['NUM_NODES'] * parsl_resource_specification['RANKS_PER_NODE']
+        NRANKS = parsl_resource_specification['num_ranks']
 
         return f"""
         module purge
@@ -315,8 +317,9 @@ while launching the application over 2-4 nodes.
         for num_nodes in [2, 4]:
             for batchsize in [2, 4, 8]:
 
-                parsl_res_spec = {"NUM_NODES": num_nodes,
-                                  "RANKS_PER_NODE": 4}
+                parsl_res_spec = {"num_nodes": num_nodes,
+                                  "num_tasks": num_nodes * 4,
+                                  "ranks_per_node": 4}
                 future = cosmic_tagger(workdir="/home/yadunand/CosmicTagger",
                                        datatype="float32",
                                        batchsize=str(batchsize),

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -191,7 +191,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
         list of supported MPI launchers = ("srun", "aprun", "mpiexec").
         default: "mpiexec"
 
-   encrypted : bool
+    encrypted : bool
         Flag to enable/disable encryption (CurveZMQ). Default is False.
     """
 

--- a/parsl/executors/high_throughput/mpi_resource_management.py
+++ b/parsl/executors/high_throughput/mpi_resource_management.py
@@ -177,7 +177,7 @@ class MPITaskScheduler(TaskScheduler):
             task_package["buffer"], user_ns, copy=False
         )
 
-        nodes_needed = resource_spec.get("NUM_NODES")
+        nodes_needed = resource_spec.get("num_nodes")
         if nodes_needed:
             try:
                 allocated_nodes = self._get_nodes(nodes_needed)

--- a/parsl/tests/test_mpi_apps/test_mpi_mode_disabled.py
+++ b/parsl/tests/test_mpi_apps/test_mpi_mode_disabled.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Dict
 import pytest
 import parsl
@@ -36,8 +37,8 @@ def test_only_resource_specs_set():
     """Confirm that resource_spec env vars are set while launch prefixes are not
     when enable_mpi_mode = False"""
     resource_spec = {
-        "NUM_NODES": 4,
-        "RANKS_PER_NODE": 2,
+        "num_nodes": 4,
+        "ranks_per_node": 2,
     }
 
     future = get_env_vars(parsl_resource_specification=resource_spec)
@@ -46,5 +47,5 @@ def test_only_resource_specs_set():
     assert isinstance(result, Dict)
     assert "PARSL_DEFAULT_PREFIX" not in result
     assert "PARSL_SRUN_PREFIX" not in result
-    assert result["PARSL_NUM_NODES"] == str(resource_spec["NUM_NODES"])
-    assert result["PARSL_RANKS_PER_NODE"] == str(resource_spec["RANKS_PER_NODE"])
+    assert result["PARSL_NUM_NODES"] == str(resource_spec["num_nodes"])
+    assert result["PARSL_RANKS_PER_NODE"] == str(resource_spec["ranks_per_node"])

--- a/parsl/tests/test_mpi_apps/test_mpi_prefix.py
+++ b/parsl/tests/test_mpi_apps/test_mpi_prefix.py
@@ -10,9 +10,13 @@ from parsl.executors.high_throughput.mpi_prefix_composer import (
 )
 
 
+resource_spec = {"num_nodes": 2,
+                 "num_ranks": 8,
+                 "ranks_per_node": 4}
+
+
 @pytest.mark.local
 def test_srun_launch_cmd():
-    resource_spec = {"NUM_NODES": 2, "RANKS_PER_NODE": 4}
     prefix_name, composed_prefix = compose_srun_launch_cmd(
         resource_spec=resource_spec, node_hostnames=["node1", "node2"]
     )
@@ -24,7 +28,6 @@ def test_srun_launch_cmd():
 
 @pytest.mark.local
 def test_aprun_launch_cmd():
-    resource_spec = {"NUM_NODES": 2, "RANKS_PER_NODE": 4}
     prefix_name, composed_prefix = compose_aprun_launch_cmd(
         resource_spec=resource_spec, node_hostnames=["node1", "node2"]
     )
@@ -35,7 +38,6 @@ def test_aprun_launch_cmd():
 
 @pytest.mark.local
 def test_mpiexec_launch_cmd():
-    resource_spec = {"NUM_NODES": 2, "RANKS_PER_NODE": 4}
     prefix_name, composed_prefix = compose_mpiexec_launch_cmd(
         resource_spec=resource_spec, node_hostnames=["node1", "node2"]
     )
@@ -46,7 +48,6 @@ def test_mpiexec_launch_cmd():
 
 @pytest.mark.local
 def test_slurm_launch_cmd():
-    resource_spec = {"NUM_NODES": 2, "RANKS_PER_NODE": 4}
     table = compose_all(
         mpi_launcher="srun",
         resource_spec=resource_spec,
@@ -59,7 +60,6 @@ def test_slurm_launch_cmd():
 
 @pytest.mark.local
 def test_default_launch_cmd():
-    resource_spec = {"NUM_NODES": 2, "RANKS_PER_NODE": 4}
     table = compose_all(
         mpi_launcher="srun",
         resource_spec=resource_spec,

--- a/parsl/tests/test_mpi_apps/test_mpi_scheduler.py
+++ b/parsl/tests/test_mpi_apps/test_mpi_scheduler.py
@@ -40,8 +40,8 @@ def test_MPISched_put_task():
     mock_task_buffer = pack_res_spec_apply_message("func",
                                                    "args",
                                                    "kwargs",
-                                                   resource_specification={"NUM_NODES": 2,
-                                                                           "RANKS_PER_NODE": 2})
+                                                   resource_specification={"num_nodes": 2,
+                                                                           "ranks_per_node": 2})
     task_package = {"task_id": 1, "buffer": mock_task_buffer}
     scheduler.put_task(task_package)
 
@@ -83,8 +83,8 @@ def test_MPISched_roundtrip():
         mock_task_buffer = pack_res_spec_apply_message("func",
                                                        "args",
                                                        "kwargs",
-                                                       resource_specification={"NUM_NODES": round,
-                                                                               "RANKS_PER_NODE": 2})
+                                                       resource_specification={"num_nodes": round,
+                                                                               "ranks_per_node": 2})
         task_package = {"task_id": round, "buffer": mock_task_buffer}
         scheduler.put_task(task_package)
 
@@ -113,8 +113,8 @@ def test_MPISched_contention():
                                                    "args",
                                                    "kwargs",
                                                    resource_specification={
-                                                       "NUM_NODES": 8,
-                                                       "RANKS_PER_NODE": 2
+                                                       "num_nodes": 8,
+                                                       "ranks_per_node": 2
                                                    })
     task_package = {"task_id": 1, "buffer": mock_task_buffer}
     scheduler.put_task(task_package)
@@ -126,8 +126,8 @@ def test_MPISched_contention():
                                                    "args",
                                                    "kwargs",
                                                    resource_specification={
-                                                       "NUM_NODES": 8,
-                                                       "RANKS_PER_NODE": 2
+                                                       "num_nodes": 8,
+                                                       "ranks_per_node": 2
                                                    })
     task_package = {"task_id": 2, "buffer": mock_task_buffer}
     scheduler.put_task(task_package)

--- a/parsl/tests/test_mpi_apps/test_resource_spec.py
+++ b/parsl/tests/test_mpi_apps/test_resource_spec.py
@@ -57,8 +57,8 @@ def get_env_vars(parsl_resource_specification: Dict = {}) -> Dict:
 @pytest.mark.local
 def test_resource_spec_env_vars():
     resource_spec = {
-        "NUM_NODES": 4,
-        "RANKS_PER_NODE": 2,
+        "num_nodes": 4,
+        "ranks_per_node": 2,
     }
 
     assert double(5).result() == 10
@@ -67,8 +67,8 @@ def test_resource_spec_env_vars():
 
     result = future.result()
     assert isinstance(result, Dict)
-    assert result["PARSL_NUM_NODES"] == str(resource_spec["NUM_NODES"])
-    assert result["PARSL_RANKS_PER_NODE"] == str(resource_spec["RANKS_PER_NODE"])
+    assert result["PARSL_NUM_NODES"] == str(resource_spec["num_nodes"])
+    assert result["PARSL_RANKS_PER_NODE"] == str(resource_spec["ranks_per_node"])
 
 
 @pytest.mark.local
@@ -130,9 +130,9 @@ def test_top_level():
 @pytest.mark.parametrize(
     "resource_spec, exception",
     (
-        ({"NUM_NODES": 2, "RANKS_PER_NODE": 1}, None),
-        ({"LAUNCHER_OPTIONS": "--debug_foo"}, None),
-        ({"NUM_NODES": 2, "BAD_OPT": 1}, InvalidResourceSpecification),
+        ({"num_nodes": 2, "ranks_per_node": 1}, None),
+        ({"launcher_options": "--debug_foo"}, None),
+        ({"num_nodes": 2, "BAD_OPT": 1}, InvalidResourceSpecification),
         ({}, None),
     )
 )


### PR DESCRIPTION
# Description

This PR adds the following renaming changes to the `parsl_resource_specification` options defined in the #3016 

* `NUM_NODES` -> `num_nodes`
* `LAUNCHER_OPTIONS` -> `launcher_options`
* `RANKS_PER_NODE` -> `ranks_per_node`
* New kwarg `num_tasks`


Which existing user workflows or functionality will behave differently after this PR?

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
