### PR TITLE
Add psij-python dependency for radical to avoid radical.saga layer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ extras_require = {
     'workqueue': ['work_queue'],
     'flux': ['pyyaml', 'cffi', 'jsonschema'],
     'proxystore': ['proxystore'],
-    'radical-pilot': ['radical.pilot'],
-    # Disabling psi-j since github direct links are not allowed by pypi
+    'radical-pilot': ['radical.pilot', 'psij-python==0.9.3'],
+    # Disabling psi-j-parsl since github direct links are not allowed by pypi
     # 'psij': ['psi-j-parsl@git+https://github.com/ExaWorks/psi-j-parsl']
 }
 extras_require['all'] = sum(extras_require.values(), [])


### PR DESCRIPTION
See https://github.com/radical-cybertools/radical.saga/issues/885 which repeatedly recommends avoiding the radical SAGA layer, and the corresponding Parsl issue #3029

# Changed Behaviour

Job submission in the RadicalPilotExecutor will happen with a different codebase: psij-python, not radical.saga which will swap out radical.saga behavioural quirks for any psij-python ones.

# Fixes

attempts to fix #3029

## Type of change

- Bug fix
