### PR TITLE
Verify Interchange terminates on HTEX shutdown

### DIFF
--- a/parsl/multiprocessing.py
+++ b/parsl/multiprocessing.py
@@ -5,17 +5,16 @@ import logging
 import multiprocessing
 import multiprocessing.queues
 import platform
+from multiprocessing.context import ForkProcess as ForkProcessType
 
-from typing import Callable, Type
+from typing import Callable
 
 logger = logging.getLogger(__name__)
 
 ForkContext = multiprocessing.get_context("fork")
 SpawnContext = multiprocessing.get_context("spawn")
 
-# maybe ForkProcess should be: Callable[..., Process] so as to make
-# it clear that it returns a Process always to the type checker?
-ForkProcess: Type = ForkContext.Process
+ForkProcess: Callable[..., ForkProcessType] = ForkContext.Process
 
 
 class MacSafeQueue(multiprocessing.queues.Queue):

--- a/parsl/tests/test_htex/test_htex.py
+++ b/parsl/tests/test_htex/test_htex.py
@@ -1,9 +1,13 @@
 import pathlib
+from unittest import mock
 
 import pytest
 
 from parsl import curvezmq
 from parsl import HighThroughputExecutor
+from parsl.multiprocessing import ForkProcess
+
+_MOCK_BASE = "parsl.executors.high_throughput.executor"
 
 
 @pytest.mark.local
@@ -44,3 +48,42 @@ def test_htex_start_encrypted(
         assert htex.outgoing_q.zmq_context.cert_dir is None
         assert htex.incoming_q.zmq_context.cert_dir is None
         assert htex.command_client.zmq_context.cert_dir is None
+
+
+@pytest.mark.local
+@pytest.mark.parametrize("started", (True, False))
+@pytest.mark.parametrize("timeout_expires", (True, False))
+@mock.patch(f"{_MOCK_BASE}.logger")
+def test_htex_shutdown(
+    mock_logger: mock.MagicMock, started: bool, timeout_expires: bool
+):
+    htex = HighThroughputExecutor()
+    mock_ix_proc = mock.Mock(spec=ForkProcess)
+
+    if started:
+        htex.interchange_proc = mock_ix_proc
+        mock_ix_proc.is_alive.return_value = True
+
+    if not timeout_expires:
+        # Simulate termination of the Interchange process
+        def kill_interchange(*args, **kwargs):
+            mock_ix_proc.is_alive.return_value = False
+
+        mock_ix_proc.terminate.side_effect = kill_interchange
+
+    htex.shutdown()
+
+    mock_logs = mock_logger.info.call_args_list
+    if started:
+        assert mock_ix_proc.terminate.called
+        assert mock_ix_proc.join.called
+        assert {"timeout": 10} == mock_ix_proc.join.call_args[1]
+        if timeout_expires:
+            assert "Unable to terminate Interchange" in mock_logs[1][0][0]
+            assert mock_ix_proc.kill.called
+        assert "Attempting" in mock_logs[0][0][0]
+        assert "Finished" in mock_logs[-1][0][0]
+    else:
+        assert not mock_ix_proc.terminate.called
+        assert not mock_ix_proc.join.called
+        assert "has not started" in mock_logs[0][0][0]


### PR DESCRIPTION
## Description

We give the Interchange process 10 seconds to terminate when calling the HTEX `shutdown()` method. If it doesn't terminate after 10 seconds, we'll add an informative log to notify the user of the stuck process, and then continue.

I've also updated the tests in `test_htex.py` to ensure we call `htex.shutdown()` at the end of each test.

Fixes #3080 

## Type of change

- Bug fix
- Code maintenance/cleanup
