### PR TITLE
Remove old reference to "mock"

### DIFF
--- a/parsl/tests/test_mpi_apps/test_mpi_scheduler.py
+++ b/parsl/tests/test_mpi_apps/test_mpi_scheduler.py
@@ -1,6 +1,6 @@
 import logging
 import os
-import mock
+from unittest import mock
 import pytest
 import pickle
 from parsl.executors.high_throughput.mpi_resource_management import TaskScheduler, MPITaskScheduler

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,8 +4,6 @@ pandas
 pytest>=7.4.0,<8
 pytest-cov
 pytest-random-order
-mock>=1.0.0
-types-mock
 nbsphinx
 sphinx_rtd_theme
 mypy==1.5.1


### PR DESCRIPTION
https://github.com/testing-cabal/mock says:

> mock is now part of the Python standard library,
> available as unittest.mock in Python 3.3 onwards.
