### PR TITLE
Update style of scaling test File usage

### DIFF
--- a/parsl/tests/test_scaling/test_scale_down.py
+++ b/parsl/tests/test_scaling/test_scale_down.py
@@ -44,16 +44,16 @@ def local_config():
 
 
 @python_app
-def waiting_app(ident: int, inputs=()):
+def waiting_app(ident: int, inputs=(), outputs=()):
     import pathlib
     import time
 
     # Approximate an Event by writing to files; the test logic will poll this file
-    with open(inputs[0], "a") as f:
+    with open(outputs[0], "a") as f:
         f.write(f"Ready: {ident}\n")
 
     # Similarly, use Event approximation (file check!) by polling.
-    may_finish_file = pathlib.Path(inputs[1])
+    may_finish_file = pathlib.Path(inputs[0])
     while not may_finish_file.exists():
         time.sleep(0.01)
 
@@ -74,9 +74,10 @@ def test_scale_out(tmpd_cwd, try_assert):
     ready_path = tmpd_cwd / "workers_ready"
     finish_path = tmpd_cwd / "workers_may_continue"
     ready_path.touch()
-    inputs = [File(str(ready_path)), File(str(finish_path))]
+    inputs = [File(finish_path)]
+    outputs = [File(ready_path)]
 
-    futs = [waiting_app(i, inputs=inputs) for i in range(ntasks)]
+    futs = [waiting_app(i, outputs=outputs, inputs=inputs) for i in range(ntasks)]
 
     while ready_path.read_text().count("\n") < _max_blocks:
         time.sleep(0.5)


### PR DESCRIPTION
In this particular test configuration, this doesn't really matter: all that is being passed around is a path wrapped in an object; no staging happens; and if staging was configured, this test would usually not work... so it's arguable even that File shouldn't be used here at all and just pass around paths.

It is also not necessary to cast an os.PathLike to a str before constructing a File around it.

# Changed Behaviour

Neither of these changes should change the behaviour of this test, but its probably better that they are in the right style in case someone looks at them.

## Type of change

- Code maintenance/cleanup
