### PR TITLE
Allow a few seconds for the end message usage process to work

### DIFF
--- a/parsl/usage_tracking/usage.py
+++ b/parsl/usage_tracking/usage.py
@@ -32,7 +32,7 @@ def async_process(fn: Callable[P, None]) -> Callable[P, None]:
 
 
 @async_process
-def udp_messenger(domain_name: str, UDP_IP: str, UDP_PORT: int, sock_timeout: int, message: str) -> None:
+def udp_messenger(domain_name: str, UDP_PORT: int, sock_timeout: int, message: str) -> None:
     """Send UDP messages to usage tracker asynchronously
 
     This multiprocessing based messenger was written to overcome the limitations
@@ -40,7 +40,6 @@ def udp_messenger(domain_name: str, UDP_IP: str, UDP_PORT: int, sock_timeout: in
 
     Args:
           - domain_name (str) : Domain name string
-          - UDP_IP (str) : IP address YYY.YYY.YYY.YYY
           - UDP_PORT (int) : UDP port to send out on
           - sock_timeout (int) : Socket timeout
     """
@@ -49,15 +48,7 @@ def udp_messenger(domain_name: str, UDP_IP: str, UDP_PORT: int, sock_timeout: in
     try:
         encoded_message = bytes(message, "utf-8")
 
-        if domain_name:
-            try:
-                UDP_IP = socket.gethostbyname(domain_name)
-            except Exception:
-                # (False, "Domain lookup failed, defaulting to {0}".format(UDP_IP))
-                pass
-
-        if UDP_IP is None:
-            raise Exception("UDP_IP is None")
+        UDP_IP = socket.gethostbyname(domain_name)
 
         if UDP_PORT is None:
             raise Exception("UDP_PORT is None")
@@ -84,7 +75,7 @@ class UsageTracker:
 
     """
 
-    def __init__(self, dfk, ip='52.3.111.203', port=50077,
+    def __init__(self, dfk, port=50077,
                  domain_name='tracking.parsl-project.org'):
         """Initialize usage tracking unless the user has opted-out.
 
@@ -99,18 +90,15 @@ class UsageTracker:
              - dfk (DFK object) : Data Flow Kernel object
 
         KWargs:
-             - ip (string) : IP address
              - port (int) : Port number, Default:50077
              - domain_name (string) : Domain name, will override IP
                   Default: tracking.parsl-project.org
         """
 
         self.domain_name = domain_name
-        self.ip = ip
         # The sock timeout will only apply to UDP send and not domain resolution
         self.sock_timeout = 5
         self.UDP_PORT = port
-        self.UDP_IP = None
         self.procs = []
         self.dfk = dfk
         self.config = self.dfk.config
@@ -188,7 +176,7 @@ class UsageTracker:
         """Send UDP message."""
         if self.tracking_enabled:
             try:
-                proc = udp_messenger(self.domain_name, self.UDP_IP, self.UDP_PORT, self.sock_timeout, message)
+                proc = udp_messenger(self.domain_name, self.UDP_PORT, self.sock_timeout, message)
                 self.procs.append(proc)
             except Exception as e:
                 logger.debug("Usage tracking failed: {}".format(e))

--- a/parsl/usage_tracking/usage.py
+++ b/parsl/usage_tracking/usage.py
@@ -192,7 +192,17 @@ class UsageTracker:
 
         self.send_UDP_message(message)
 
-    def close(self) -> None:
-        """We terminate (SIGTERM) the processes added to the self.procs list """
+    def close(self, timeout: float = 10.0) -> None:
+        """First give each process one timeout period to finish what it is
+        doing, then kill it (SIGKILL). There's no softer SIGTERM step,
+        because that adds one join period of delay for what is almost
+        definitely either: going to behave broadly the same as to SIGKILL,
+        or won't respond to SIGTERM.
+        """
+        logger.error("BENC CLOSE1")
         for proc in self.procs:
-            proc.terminate()
+            proc.join(timeout=timeout)
+            if proc.is_alive():
+                logger.info("Usage tracking process did not end itself; sending SIGKILL")
+                proc.kill()
+        logger.error("BENC CLOSE2")

--- a/parsl/usage_tracking/usage.py
+++ b/parsl/usage_tracking/usage.py
@@ -199,10 +199,8 @@ class UsageTracker:
         definitely either: going to behave broadly the same as to SIGKILL,
         or won't respond to SIGTERM.
         """
-        logger.error("BENC CLOSE1")
         for proc in self.procs:
             proc.join(timeout=timeout)
             if proc.is_alive():
                 logger.info("Usage tracking process did not end itself; sending SIGKILL")
                 proc.kill()
-        logger.error("BENC CLOSE2")


### PR DESCRIPTION
Before this PR, the end message process was terminated immediately, which mean that end messages (in all of my tests) were not sent.

This PR waits 10 seconds for termination before forcing a (now stronger) kill, which in practice is enough for the end message to be sent.

Reasons for making that timeout any larger are primarily DNS-resolution-time related - the tracking DNS record has a TTL of only a few hundred seconds, so it's likely to need re-resolving at end time in any non-trivial run.

In practice on a small pytest run on my laptop, with DNS cached, this new close procedure takes 20ms.


# Changed Behaviour

More information is delivered to the usage tracking server - the end message contains different information to the start message

# Fixes

Fixes issue #2532 

## Type of change

- Bug fix
