### PR TITLE
Skip two tests that are blocking CI with hangs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,8 @@ perf_test:
 	parsl-perf --time 5 --config parsl/tests/configs/local_threads.py
 
 .PHONY: test ## run all tests with all config types
-test: clean_coverage lint flake8 mypy local_thread_test htex_local_test htex_local_alternate_test wqex_local_test vineex_local_test radical_local_test config_local_test perf_test ## run all tests
+test: clean_coverage lint flake8 mypy local_thread_test htex_local_test htex_local_alternate_test wqex_local_test radical_local_test config_local_test perf_test ## run all tests
+# vineex_local_test removed from this test: target - waiting for resolution of issue #3089
 
 .PHONY: tag
 tag: ## create a tag in git. to run, do a 'make VERSION="version string" tag

--- a/parsl/tests/test_radical/test_mpi_funcs.py
+++ b/parsl/tests/test_radical/test_mpi_funcs.py
@@ -16,6 +16,7 @@ def some_mpi_func(msg, sleep, comm=None, parsl_resource_specification={}):
 apps = []
 
 
+@pytest.mark.skip("hangs in CI - waiting for resolution of issue #3029")
 @pytest.mark.local
 @pytest.mark.radical
 def test_radical_mpi(n=7):


### PR DESCRIPTION
These tests are highlighting issues raised in issue #3029 and #3089, and should be re-instated as part of resolving those issues.

Between them, the hangs of these tests meant that it was becoming hard, and in some cases apparently impossible, to merge new PRs.

# Changed Behaviour

This PR reduces test coverage, which leads to increased unreliability in the codebase.

## Type of change

- Code maintenance/cleanup
