### PR TITLE
SlurmProvider to report stdout/err when job reaches terminal state

### DIFF
--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -188,14 +188,18 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
                 logger.warning(f"Slurm status {slurm_state} is not recognized")
             status = translate_table.get(slurm_state, JobState.UNKNOWN)
             logger.debug("Updating job {} with slurm status {} to parsl state {!s}".format(job_id, slurm_state, status))
-            self.resources[job_id]['status'] = JobStatus(status)
+            self.resources[job_id]['status'] = JobStatus(status,
+                                                         stdout_path=self.resources[job_id]['job_stdout_path'],
+                                                         stderr_path=self.resources[job_id]['job_stderr_path'])
             jobs_missing.remove(job_id)
 
         # squeue does not report on jobs that are not running. So we are filling in the
         # blanks for missing jobs, we might lose some information about why the jobs failed.
         for missing_job in jobs_missing:
             logger.debug("Updating missing job {} to completed status".format(missing_job))
-            self.resources[missing_job]['status'] = JobStatus(JobState.COMPLETED)
+            self.resources[missing_job]['status'] = JobStatus(JobState.COMPLETED,
+                                                              stdout_path=self.resources[missing_job]['job_stdout_path'],
+                                                              stderr_path=self.resources[missing_job]['job_stderr_path'])
 
     def submit(self, command: str, tasks_per_node: int, job_name="parsl.slurm") -> str:
         """Submit the command as a slurm job.
@@ -226,8 +230,10 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
 
         job_name = "{0}.{1}".format(job_name, time.time())
 
-        script_path = "{0}/{1}.submit".format(self.script_dir, job_name)
+        script_path = os.path.join(self.script_dir, job_name)
         script_path = os.path.abspath(script_path)
+        job_stdout_path = script_path + ".stdout"
+        job_stderr_path = script_path + ".stderr"
 
         logger.debug("Requesting one block with {} nodes".format(self.nodes_per_block))
 
@@ -239,6 +245,8 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         job_config["scheduler_options"] = scheduler_options
         job_config["worker_init"] = worker_init
         job_config["user_script"] = command
+        job_config["job_stdout_path"] = job_stdout_path
+        job_config["job_stderr_path"] = job_stderr_path
 
         # Wrap the command
         job_config["user_script"] = self.launcher(command,
@@ -262,7 +270,11 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
                 match = re.match(self.regex_job_id, line)
                 if match:
                     job_id = match.group("id")
-                    self.resources[job_id] = {'job_id': job_id, 'status': JobStatus(JobState.PENDING)}
+                    self.resources[job_id] = {'job_id': job_id,
+                                              'status': JobStatus(JobState.PENDING),
+                                              'job_stdout_path': job_stdout_path,
+                                              'job_stderr_path': job_stderr_path,
+                                              }
                     return job_id
             else:
                 logger.error("Could not read job ID from submit command standard output.")

--- a/parsl/providers/slurm/slurm.py
+++ b/parsl/providers/slurm/slurm.py
@@ -230,6 +230,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
 
         job_name = "{0}.{1}".format(job_name, time.time())
 
+        assert self.script_dir, "Expected script_dir to be set"
         script_path = os.path.join(self.script_dir, job_name)
         script_path = os.path.abspath(script_path)
         job_stdout_path = script_path + ".stdout"

--- a/parsl/providers/slurm/template.py
+++ b/parsl/providers/slurm/template.py
@@ -1,8 +1,8 @@
 template_string = '''#!/bin/bash
 
 #SBATCH --job-name=${jobname}
-#SBATCH --output=${submit_script_dir}/${jobname}.submit.stdout
-#SBATCH --error=${submit_script_dir}/${jobname}.submit.stderr
+#SBATCH --output=${job_stdout_path}
+#SBATCH --error=${job_stderr_path}
 #SBATCH --nodes=${nodes}
 #SBATCH --time=${walltime}
 #SBATCH --ntasks-per-node=${tasks_per_node}

--- a/parsl/tests/test_providers/test_slurm_template.py
+++ b/parsl/tests/test_providers/test_slurm_template.py
@@ -1,0 +1,30 @@
+import logging
+import random
+
+import mock
+import pytest
+
+from parsl.channels import LocalChannel
+from parsl.providers import SlurmProvider
+
+
+@pytest.mark.local
+def test_submit_script_basic(tmp_path):
+    """Test slurm resources table"""
+
+    provider = SlurmProvider(
+        partition="debug", channel=LocalChannel(script_dir=tmp_path)
+    )
+    provider.script_dir = tmp_path
+    job_id = str(random.randint(55000, 59000))
+    provider.execute_wait = mock.MagicMock()
+    provider.execute_wait.return_value = (0, f"Submitted batch job {job_id}", "")
+    result_job_id = provider.submit("test", tasks_per_node=1)
+    assert job_id == result_job_id
+    provider.execute_wait.assert_called()
+    logging.warning(f"Got resources: {provider.resources}")
+    assert job_id in provider.resources
+
+    job_info = provider.resources[job_id]
+    assert "job_stdout_path" in job_info
+    assert "job_stderr_path" in job_info

--- a/parsl/tests/test_providers/test_slurm_template.py
+++ b/parsl/tests/test_providers/test_slurm_template.py
@@ -1,7 +1,7 @@
 import logging
 import random
 
-import mock
+from unittest import mock
 import pytest
 
 from parsl.channels import LocalChannel
@@ -17,12 +17,11 @@ def test_submit_script_basic(tmp_path):
     )
     provider.script_dir = tmp_path
     job_id = str(random.randint(55000, 59000))
-    provider.execute_wait = mock.MagicMock()
+    provider.execute_wait = mock.MagicMock(spec=SlurmProvider.execute_wait)
     provider.execute_wait.return_value = (0, f"Submitted batch job {job_id}", "")
     result_job_id = provider.submit("test", tasks_per_node=1)
     assert job_id == result_job_id
     provider.execute_wait.assert_called()
-    logging.warning(f"Got resources: {provider.resources}")
     assert job_id in provider.resources
 
     job_info = provider.resources[job_id]


### PR DESCRIPTION
# Description

This PR updates the stdout/err paths specified in the Slurm templates and updates the reporting of `JobStatus` at terminal states to include the stdout/err paths. I have tested these changes on Expanse by setting the address to `127.0.0.1`.

# Changed Behaviour

```
parsl.executors.errors.BadStateException: Executor Expanse failed due to: Error 1:
        Job is marked as MISSING since the workers failed to register to the executor. Check the stdout/stderr logs in the submit_scripts directory for more debug information
        STDOUT: Found cores : 128
Found nodes : 1
0: Failed to find a viable address to connect to interchange. Exiting

        STDERR: srun: error: exp-9-55: task 0: Exited with exit code 5
```

# Fixes

Fixes #3058

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix