### PR TITLE
Replace Comet with Expanse@SDSC in configuration section

### DIFF
--- a/docs/userguide/configuring.rst
+++ b/docs/userguide/configuring.rst
@@ -519,16 +519,16 @@ visit the `CCTools documentation online <https://cctools.readthedocs.io/en/lates
 
 .. literalinclude::  ../../parsl/configs/wqex_local.py
 
-Comet (SDSC)
-------------
+Expanse (SDSC)
+--------------
 
-.. image:: https://ucsdnews.ucsd.edu/news_uploads/comet-logo.jpg
+.. image:: https://www.hpcwire.com/wp-content/uploads/2019/07/SDSC-Expanse-graphic-cropped.jpg
 
 The following snippet shows an example configuration for executing remotely on San Diego Supercomputer
-Center's **Comet** supercomputer. The example is designed to be executed on the login nodes, using the
+Center's **Expanse** supercomputer. The example is designed to be executed on the login nodes, using the
 `parsl.providers.SlurmProvider` to interface with the Slurm scheduler used by Comet and the `parsl.launchers.SrunLauncher` to launch workers.
 
-.. literalinclude:: ../../parsl/configs/comet.py
+.. literalinclude:: ../../parsl/configs/expanse.py
 
 
 Cooley (ALCF)

--- a/parsl/configs/expanse.py
+++ b/parsl/configs/expanse.py
@@ -1,0 +1,29 @@
+from parsl.config import Config
+from parsl.launchers import SrunLauncher
+from parsl.providers import SlurmProvider
+from parsl.executors import HighThroughputExecutor
+
+
+config = Config(
+    executors=[
+        HighThroughputExecutor(
+            label='Expanse_CPU_Multinode',
+            max_workers=32,
+            provider=SlurmProvider(
+                'compute',
+                account='YOUR_ALLOCATION_ON_EXPANSE',
+                launcher=SrunLauncher(),
+                # string to prepend to #SBATCH blocks in the submit
+                # script to the scheduler
+                scheduler_options='',
+                # Command to be run before starting a worker, such as:
+                # 'module load Anaconda; source activate parsl_env'.
+                worker_init='',
+                walltime='01:00:00',
+                init_blocks=1,
+                max_blocks=1,
+                nodes_per_block=2,
+            ),
+        )
+    ]
+)


### PR DESCRIPTION
# Description

Comet@SDSC is retired and is now replaced by Expanse. This PR adds expanse to the configuration section.
PS. I'm not deleting the comet from the configs. 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Update to human readable text: Documentation/error messages/comments
