### PR TITLE
PBSProvider to report stdout/err paths when jobs fails

### DIFF
--- a/parsl/providers/pbspro/template.py
+++ b/parsl/providers/pbspro/template.py
@@ -5,8 +5,8 @@ template_string = '''#!/bin/bash
 #PBS -m n
 #PBS -l walltime=$walltime
 #PBS -l select=${nodes_per_block}:ncpus=${ncpus}${select_options}
-#PBS -o ${submit_script_dir}/${jobname}.submit.stdout
-#PBS -e ${submit_script_dir}/${jobname}.submit.stderr
+#PBS -o ${job_stdout_path}
+#PBS -e ${job_stderr_path}
 ${scheduler_options}
 
 ${worker_init}

--- a/parsl/tests/test_providers/test_pbspro_template.py
+++ b/parsl/tests/test_providers/test_pbspro_template.py
@@ -1,0 +1,28 @@
+import random
+
+from unittest import mock
+import pytest
+
+from parsl.channels import LocalChannel
+from parsl.providers import PBSProProvider
+
+
+@pytest.mark.local
+def test_submit_script_basic(tmp_path):
+    """Test slurm resources table"""
+
+    provider = PBSProProvider(
+        queue="debug", channel=LocalChannel(script_dir=tmp_path)
+    )
+    provider.script_dir = tmp_path
+    job_id = str(random.randint(55000, 59000))
+    provider.execute_wait = mock.Mock(spec=PBSProProvider.execute_wait)
+    provider.execute_wait.return_value = (0, job_id, "")
+    result_job_id = provider.submit("test", tasks_per_node=1)
+    assert job_id == result_job_id
+    provider.execute_wait.assert_called()
+    assert job_id in provider.resources
+
+    job_info = provider.resources[job_id]
+    assert "job_stdout_path" in job_info
+    assert "job_stderr_path" in job_info


### PR DESCRIPTION
# Description


This PR adds better support for reporting stdout/err summary when jobs reach a terminal state with the `PBSProvider`.
This is the PBSPro version of the fixes that went in with PR #3091.

* Updated PBSProvider to report job stdout/err via JobStatus when job reaches terminal state
* Adding a simple test to confirm that stdout/err paths are included in internal table
* Removing config for Comet@SDSC which is now retired


# Changed Behaviour

When jobs silently fail, for eg, workers are not able to connect to the login node or workers are unable to start due to bad worker environments, the failure information captured in the job stdout/err is summarized in an exception.
Example error from testing on Polaris@ALCF :

```
(gce) rchard@polaris-login-01:~/src/Parsl/tests/failures> python yadu1.py
Launched task.. waiting
Traceback (most recent call last):
  File "/home/rchard/src/Parsl/tests/failures/yadu1.py", line 60, in <module>
    priming()
  File "/home/rchard/src/Parsl/tests/failures/yadu1.py", line 21, in priming
    print(f"Result : {future.result()}")
  File "/home/rchard/.anaconda3/envs/gce/lib/python3.9/concurrent/futures/_base.py", line 446, in result
    return self.__get_result()
  File "/home/rchard/.anaconda3/envs/gce/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/home/rchard/.anaconda3/envs/gce/lib/python3.9/site-packages/parsl/dataflow/dflow.py", line 302, in handle_exec_update
    res = self._unwrap_remote_exception_wrapper(future)
  File "/home/rchard/.anaconda3/envs/gce/lib/python3.9/site-packages/parsl/dataflow/dflow.py", line 570, in _unwrap_remote_exception_wrapper
    result = future.result()
  File "/home/rchard/.anaconda3/envs/gce/lib/python3.9/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File "/home/rchard/.anaconda3/envs/gce/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
parsl.executors.errors.BadStateException: Executor Polaris-1 failed due to: Error 1:
        Job is marked as MISSING since the workers failed to register to the executor. Check the stdout/stderr logs in the submit_scripts directory for more debug information
        STDOUT: Failed to find a viable address to connect to interchange. Exiting
```
## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix
