### PR TITLE
Remove "anonymous" in relation to usage tracking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ To run the Parsl tutorial notebooks you will need to install Jupyter::
 
 Detailed information about setting up Jupyter with Python is available `here <https://jupyter.readthedocs.io/en/latest/install.html>`_
 
-Note: Parsl uses an opt-in model to collect anonymous usage statistics for reporting and improvement purposes. To understand what stats are collected and enable collection please refer to the `usage tracking guide <http://parsl.readthedocs.io/en/stable/userguide/usage_tracking.html>`__
+Note: Parsl uses an opt-in model to collect usage statistics for reporting and improvement purposes. To understand what stats are collected and enable collection please refer to the `usage tracking guide <http://parsl.readthedocs.io/en/stable/userguide/usage_tracking.html>`__
 
 Documentation
 =============

--- a/docs/userguide/usage_tracking.rst
+++ b/docs/userguide/usage_tracking.rst
@@ -3,7 +3,7 @@
 Usage statistics collection
 ===========================
 
-Parsl uses an **Opt-in** model to send anonymized usage statistics back to the Parsl development team to
+Parsl uses an **Opt-in** model to send usage statistics back to the Parsl development team to
 measure worldwide usage and improve reliability and usability. The usage statistics are used only for
 improvements and reporting. They are not shared in raw form outside of the Parsl team.
 
@@ -21,7 +21,7 @@ it is important that we provide aggregate usage data about such things as the fo
 * Parsl exit codes
 
 By participating in this project, you help justify continuing support for the software on which you rely.
-The data sent is as generic as possible and is anonymized (see :ref:`What is sent? <what-is-sent>` below).
+(see :ref:`What is sent? <what-is-sent>` below).
 
 Opt-In
 ------
@@ -40,11 +40,9 @@ If you wish to opt in to usage reporting, set ``PARSL_TRACKING=true`` in your en
 What is sent?
 -------------
 
-* Anonymized user ID
-* Anonymized hostname
-* Anonymized Parsl script ID
+* IP address
+* Run UUID
 * Start and end times
-* Parsl exit code
 * Number of executors used
 * Number of failures
 * Parsl and Python version


### PR DESCRIPTION
While this and similar words have been used repeatedly in sellling usage tracking to end users, the user's IP address (regarded as at least possibly identifying information under e.g. GDPR, CCPA and HIPAA) is clearly logged on the receiving side, and for at least that reason it is likely incorrect to be calling this information collection anonymous.

https://github.com/Parsl/parsl_tracking/blob/2c9e11e991e38100126d28b18a57f52a0cc01aa0/tracking_listener.py#L38

Until PR #2666, an easily reversible encoding of username was also transmitted, suggesting a general culture of insincerity or naivety around anonymisation, and the onus should now be on the Parsl team to demonstrate a more serious approach before using this kind of phrasing again.

## Type of change

- Update to human readable text: Documentation/error messages/comments
