### PR TITLE
Remove ChannelError.__repr__ in favor of __str__

### DIFF
--- a/parsl/channels/errors.py
+++ b/parsl/channels/errors.py
@@ -14,11 +14,8 @@ class ChannelError(ParslError):
         self.e = e
         self.hostname = hostname
 
-    def __repr__(self) -> str:
-        return "Hostname:{0}, Reason:{1}".format(self.hostname, self.reason)
-
     def __str__(self) -> str:
-        return self.__repr__()
+        return "Hostname:{0}, Reason:{1}".format(self.hostname, self.reason)
 
 
 class BadHostKeyException(ChannelError):


### PR DESCRIPTION
See PR #1966 for more context

# Changed Behaviour

Channel error messages which report via repr rather than str will look different - now using repr-style syntax. Error messages which use str will remain the same.

## Type of change

- Code maintenance/cleanup
