### PR TITLE
Add deprecation warning for the CobaltProvider

### DIFF
--- a/parsl/providers/cobalt/cobalt.py
+++ b/parsl/providers/cobalt/cobalt.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import time
+import warnings
 
 from parsl.providers.errors import ScaleOutFailed
 from parsl.channels import LocalChannel
@@ -23,6 +24,8 @@ translate_table = {
 
 class CobaltProvider(ClusterProvider, RepresentationMixin):
     """ Cobalt Execution Provider
+
+    WARNING: CobaltProvider is deprecated and will be removed by 2024.04
 
     This provider uses cobalt to submit (qsub), obtain the status of (qstat), and cancel (qdel)
     jobs. Theo script to be used is created from a template file in this
@@ -86,6 +89,9 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
         self.queue = queue
         self.scheduler_options = scheduler_options
         self.worker_init = worker_init
+        warnings.warn("CobaltProvider is deprecated; This will be removed after 2024-04",
+                      DeprecationWarning,
+                      stacklevel=2)
 
     def _status(self):
         """Returns the status list for a list of job_ids

--- a/parsl/tests/test_providers/test_cobalt_deprecation_warning.py
+++ b/parsl/tests/test_providers/test_cobalt_deprecation_warning.py
@@ -1,0 +1,16 @@
+import warnings
+import pytest
+from parsl.providers import CobaltProvider
+
+
+@pytest.mark.local
+def test_deprecation_warning():
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+
+        CobaltProvider()
+
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "CobaltProvider" in str(w[-1].message)


### PR DESCRIPTION
# Description

Cobalt scheduler is no longer in use in any of the major ALCF machines. At this point only JLSE uses Cobalt. 
Since we don't know for sure if there are any parsl users on JLSE, I'm adding a deprecation notice with intent to remove the `CobaltProvider` by 2024-04. 


## Type of change

Choose which options apply, and delete the ones which do not apply.

- Update to human readable text: Documentation/error messages/comments
