### PR TITLE
`isort` on the test code

### DIFF
--- a/parsl/tests/__init__.py
+++ b/parsl/tests/__init__.py
@@ -1,5 +1,5 @@
-from parsl.dataflow.memoization import id_for_memo
 from parsl.data_provider.files import File
+from parsl.dataflow.memoization import id_for_memo
 
 
 @id_for_memo.register(File)

--- a/parsl/tests/configs/ad_hoc_cluster_htex.py
+++ b/parsl/tests/configs/ad_hoc_cluster_htex.py
@@ -1,9 +1,9 @@
-from parsl.providers import AdHocProvider
-from parsl.channels import SSHChannel
-from parsl.executors import HighThroughputExecutor
-from parsl.config import Config
-
 from typing import Any, Dict
+
+from parsl.channels import SSHChannel
+from parsl.config import Config
+from parsl.executors import HighThroughputExecutor
+from parsl.providers import AdHocProvider
 
 user_opts = {'adhoc':
              {'username': 'YOUR_USERNAME',

--- a/parsl/tests/configs/azure_single_node.py
+++ b/parsl/tests/configs/azure_single_node.py
@@ -1,14 +1,12 @@
 """Config for Azure"""
-from parsl.providers import AzureProvider
-
-from parsl.config import Config
-from parsl.executors import HighThroughputExecutor
-from parsl.data_provider.http import HTTPInTaskStaging
-from parsl.data_provider.ftp import FTPInTaskStaging
-from parsl.data_provider.rsync import RSyncStaging
-
 import getpass
 
+from parsl.config import Config
+from parsl.data_provider.ftp import FTPInTaskStaging
+from parsl.data_provider.http import HTTPInTaskStaging
+from parsl.data_provider.rsync import RSyncStaging
+from parsl.executors import HighThroughputExecutor
+from parsl.providers import AzureProvider
 # If you are a developer running tests, make sure to update parsl/tests/configs/user_opts.py
 # If you are a user copying-and-pasting this as an example, make sure to either
 #       1) create a local `user_opts.py`, or

--- a/parsl/tests/configs/bridges.py
+++ b/parsl/tests/configs/bridges.py
@@ -1,7 +1,8 @@
 from parsl.config import Config
-from parsl.providers import SlurmProvider
-from parsl.launchers import SrunLauncher
 from parsl.executors import HighThroughputExecutor
+from parsl.launchers import SrunLauncher
+from parsl.providers import SlurmProvider
+
 from .user_opts import user_opts
 
 

--- a/parsl/tests/configs/cc_in2p3.py
+++ b/parsl/tests/configs/cc_in2p3.py
@@ -1,7 +1,7 @@
-from parsl.config import Config
 from parsl.channels import LocalChannel
-from parsl.providers import GridEngineProvider
+from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
+from parsl.providers import GridEngineProvider
 
 from .user_opts import user_opts
 

--- a/parsl/tests/configs/comet.py
+++ b/parsl/tests/configs/comet.py
@@ -1,7 +1,8 @@
 from parsl.config import Config
+from parsl.executors import HighThroughputExecutor
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
-from parsl.executors import HighThroughputExecutor
+
 from .user_opts import user_opts
 
 

--- a/parsl/tests/configs/ec2_single_node.py
+++ b/parsl/tests/configs/ec2_single_node.py
@@ -11,11 +11,9 @@ Block {Min:0, init:1, Max:1}
 ==================
 
 """
-from parsl.providers import AWSProvider
-
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
-
+from parsl.providers import AWSProvider
 # If you are a developer running tests, make sure to update parsl/tests/configs/user_opts.py
 # If you are a user copying-and-pasting this as an example, make sure to either
 #       1) create a local `user_opts.py`, or

--- a/parsl/tests/configs/ec2_spot.py
+++ b/parsl/tests/configs/ec2_spot.py
@@ -1,8 +1,6 @@
-from parsl.providers import AWSProvider
-
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
-
+from parsl.providers import AWSProvider
 # If you are a developer running tests, make sure to update parsl/tests/configs/user_opts.py
 # If you are a user copying-and-pasting this as an example, make sure to either
 #       1) create a local `user_opts.py`, or

--- a/parsl/tests/configs/frontera.py
+++ b/parsl/tests/configs/frontera.py
@@ -1,10 +1,11 @@
-from parsl.config import Config
 from parsl.channels import LocalChannel
-from parsl.providers import SlurmProvider
+from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.launchers import SrunLauncher
+from parsl.providers import SlurmProvider
 
 from .user_opts import user_opts
+
 """ This config assumes that it is used to launch parsl tasks from the login nodes
 of Frontera at TACC. Each job submitted to the scheduler will request 2 nodes for 10 minutes.
 """

--- a/parsl/tests/configs/htex_ad_hoc_cluster.py
+++ b/parsl/tests/configs/htex_ad_hoc_cluster.py
@@ -1,9 +1,7 @@
-from parsl.providers import AdHocProvider
 from parsl.channels import SSHChannel
-from parsl.executors import HighThroughputExecutor
-
 from parsl.config import Config
-
+from parsl.executors import HighThroughputExecutor
+from parsl.providers import AdHocProvider
 from parsl.tests.configs.user_opts import user_opts
 
 config = Config(

--- a/parsl/tests/configs/htex_local.py
+++ b/parsl/tests/configs/htex_local.py
@@ -1,9 +1,8 @@
-from parsl.providers import LocalProvider
 from parsl.channels import LocalChannel
-from parsl.launchers import SimpleLauncher
-
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
+from parsl.launchers import SimpleLauncher
+from parsl.providers import LocalProvider
 
 
 def fresh_config():

--- a/parsl/tests/configs/htex_local_alternate.py
+++ b/parsl/tests/configs/htex_local_alternate.py
@@ -15,22 +15,18 @@ will cause substantially different behaviour on whatever
 those timing parameters control.
 """
 
-# imports for monitoring:
-from parsl.monitoring import MonitoringHub
-
 import os
 
-from parsl.providers import LocalProvider
 from parsl.channels import LocalChannel
-from parsl.launchers import SingleNodeLauncher
-
 from parsl.config import Config
-from parsl.executors import HighThroughputExecutor
-
-
-from parsl.data_provider.http import HTTPInTaskStaging
-from parsl.data_provider.ftp import FTPInTaskStaging
 from parsl.data_provider.file_noop import NoOpFileStaging
+from parsl.data_provider.ftp import FTPInTaskStaging
+from parsl.data_provider.http import HTTPInTaskStaging
+from parsl.executors import HighThroughputExecutor
+from parsl.launchers import SingleNodeLauncher
+# imports for monitoring:
+from parsl.monitoring import MonitoringHub
+from parsl.providers import LocalProvider
 
 working_dir = os.getcwd() + "/" + "test_htex_alternate"
 

--- a/parsl/tests/configs/htex_local_intask_staging.py
+++ b/parsl/tests/configs/htex_local_intask_staging.py
@@ -1,13 +1,11 @@
-from parsl.providers import LocalProvider
 from parsl.channels import LocalChannel
-from parsl.launchers import SimpleLauncher
-
-from parsl.data_provider.http import HTTPInTaskStaging
-from parsl.data_provider.ftp import FTPInTaskStaging
-from parsl.data_provider.file_noop import NoOpFileStaging
-
 from parsl.config import Config
+from parsl.data_provider.file_noop import NoOpFileStaging
+from parsl.data_provider.ftp import FTPInTaskStaging
+from parsl.data_provider.http import HTTPInTaskStaging
 from parsl.executors import HighThroughputExecutor
+from parsl.launchers import SimpleLauncher
+from parsl.providers import LocalProvider
 
 config = Config(
     executors=[

--- a/parsl/tests/configs/htex_local_rsync_staging.py
+++ b/parsl/tests/configs/htex_local_rsync_staging.py
@@ -1,13 +1,11 @@
-from parsl.providers import LocalProvider
 from parsl.channels import LocalChannel
-from parsl.launchers import SimpleLauncher
-
-from parsl.data_provider.http import HTTPInTaskStaging
-from parsl.data_provider.ftp import FTPInTaskStaging
-from parsl.data_provider.rsync import RSyncStaging
-
 from parsl.config import Config
+from parsl.data_provider.ftp import FTPInTaskStaging
+from parsl.data_provider.http import HTTPInTaskStaging
+from parsl.data_provider.rsync import RSyncStaging
 from parsl.executors import HighThroughputExecutor
+from parsl.launchers import SimpleLauncher
+from parsl.providers import LocalProvider
 
 config = Config(
     executors=[

--- a/parsl/tests/configs/local_adhoc.py
+++ b/parsl/tests/configs/local_adhoc.py
@@ -1,5 +1,5 @@
-from parsl.config import Config
 from parsl.channels import LocalChannel
+from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.providers import AdHocProvider
 

--- a/parsl/tests/configs/local_radical.py
+++ b/parsl/tests/configs/local_radical.py
@@ -1,9 +1,7 @@
 import os
 
 from parsl.config import Config
-from parsl.executors.radical import RadicalPilotExecutor
-from parsl.executors.radical import ResourceConfig
-
+from parsl.executors.radical import RadicalPilotExecutor, ResourceConfig
 
 rpex_cfg = ResourceConfig()
 

--- a/parsl/tests/configs/local_radical_mpi.py
+++ b/parsl/tests/configs/local_radical_mpi.py
@@ -1,10 +1,10 @@
 import os
+
 from parsl.config import Config
 
 
 def fresh_config():
-    from parsl.executors.radical import ResourceConfig
-    from parsl.executors.radical import RadicalPilotExecutor
+    from parsl.executors.radical import RadicalPilotExecutor, ResourceConfig
 
     rpex_cfg = ResourceConfig()
     rpex_cfg.worker_type = "MPI"

--- a/parsl/tests/configs/midway.py
+++ b/parsl/tests/configs/midway.py
@@ -1,7 +1,7 @@
 from parsl.config import Config
-from parsl.providers import SlurmProvider
-from parsl.launchers import SrunLauncher
 from parsl.executors import HighThroughputExecutor
+from parsl.launchers import SrunLauncher
+from parsl.providers import SlurmProvider
 
 from .user_opts import user_opts
 

--- a/parsl/tests/configs/nscc_singapore.py
+++ b/parsl/tests/configs/nscc_singapore.py
@@ -1,8 +1,8 @@
-from parsl.providers import PBSProProvider
-from parsl.executors import HighThroughputExecutor
-from parsl.launchers import MpiRunLauncher
 from parsl.addresses import address_by_interface
 from parsl.config import Config
+from parsl.executors import HighThroughputExecutor
+from parsl.launchers import MpiRunLauncher
+from parsl.providers import PBSProProvider
 
 from .user_opts import user_opts
 

--- a/parsl/tests/configs/osg_htex.py
+++ b/parsl/tests/configs/osg_htex.py
@@ -1,6 +1,6 @@
 from parsl.config import Config
-from parsl.providers import CondorProvider
 from parsl.executors import HighThroughputExecutor
+from parsl.providers import CondorProvider
 
 # If you are a developer running tests, make sure to update parsl/tests/configs/user_opts.py
 # If you are a user copying-and-pasting this as an example, make sure to either

--- a/parsl/tests/configs/petrelkube.py
+++ b/parsl/tests/configs/petrelkube.py
@@ -1,10 +1,11 @@
+import os
+
+from parsl.addresses import address_by_route
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.providers import KubernetesProvider
-from parsl.addresses import address_by_route
 
 from .user_opts import user_opts
-import os
 
 
 def fresh_config():

--- a/parsl/tests/configs/summit.py
+++ b/parsl/tests/configs/summit.py
@@ -4,6 +4,7 @@ from parsl.launchers import JsrunLauncher
 from parsl.providers import LSFProvider
 
 from .user_opts import user_opts
+
 """ This config assumes that it is used to launch parsl tasks from the login nodes
 of Frontera at TACC. Each job submitted to the scheduler will request 2 nodes for 10 minutes.
 """

--- a/parsl/tests/configs/swan_htex.py
+++ b/parsl/tests/configs/swan_htex.py
@@ -8,10 +8,10 @@
 ==================
 """
 from parsl.channels import SSHChannel
-from parsl.launchers import AprunLauncher
-from parsl.providers import TorqueProvider
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
+from parsl.launchers import AprunLauncher
+from parsl.providers import TorqueProvider
 
 # If you are a developer running tests, make sure to update parsl/tests/configs/user_opts.py
 # If you are a user copying-and-pasting this as an example, make sure to either

--- a/parsl/tests/configs/taskvine_ex.py
+++ b/parsl/tests/configs/taskvine_ex.py
@@ -1,10 +1,8 @@
 from parsl.config import Config
-from parsl.executors.taskvine import TaskVineExecutor
-from parsl.executors.taskvine import TaskVineManagerConfig
-
-from parsl.data_provider.http import HTTPInTaskStaging
-from parsl.data_provider.ftp import FTPInTaskStaging
 from parsl.data_provider.file_noop import NoOpFileStaging
+from parsl.data_provider.ftp import FTPInTaskStaging
+from parsl.data_provider.http import HTTPInTaskStaging
+from parsl.executors.taskvine import TaskVineExecutor, TaskVineManagerConfig
 
 
 def fresh_config():

--- a/parsl/tests/configs/theta.py
+++ b/parsl/tests/configs/theta.py
@@ -1,7 +1,7 @@
 from parsl.config import Config
-from parsl.providers import CobaltProvider
-from parsl.launchers import AprunLauncher
 from parsl.executors import HighThroughputExecutor
+from parsl.launchers import AprunLauncher
+from parsl.providers import CobaltProvider
 
 from .user_opts import user_opts
 

--- a/parsl/tests/configs/workqueue_ex.py
+++ b/parsl/tests/configs/workqueue_ex.py
@@ -1,9 +1,8 @@
 from parsl.config import Config
-from parsl.executors import WorkQueueExecutor
-
-from parsl.data_provider.http import HTTPInTaskStaging
-from parsl.data_provider.ftp import FTPInTaskStaging
 from parsl.data_provider.file_noop import NoOpFileStaging
+from parsl.data_provider.ftp import FTPInTaskStaging
+from parsl.data_provider.http import HTTPInTaskStaging
+from parsl.executors import WorkQueueExecutor
 
 
 def fresh_config():

--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -5,20 +5,20 @@ import os
 import pathlib
 import re
 import shutil
-import time
-import types
 import signal
 import sys
 import tempfile
 import threading
+import time
 import traceback
+import types
 import typing as t
 from datetime import datetime
 from glob import glob
 from itertools import chain
 
-import pytest
 import _pytest.runner as runner
+import pytest
 
 import parsl
 from parsl.dataflow.dflow import DataFlowKernelLoader

--- a/parsl/tests/integration/test_channels/test_ssh_errors.py
+++ b/parsl/tests/integration/test_channels/test_ssh_errors.py
@@ -1,4 +1,4 @@
-from parsl.channels.errors import SSHException, BadHostKeyException
+from parsl.channels.errors import BadHostKeyException, SSHException
 from parsl.channels.ssh.ssh import SSHChannel as SSH
 
 

--- a/parsl/tests/integration/test_stress/test_python_simple.py
+++ b/parsl/tests/integration/test_stress/test_python_simple.py
@@ -1,10 +1,9 @@
+import argparse
+import time
+
 import parsl
 from parsl import python_app
 from parsl.configs.htex_local import config
-# from parsl.configs.local_threads import config
-
-import time
-import argparse
 
 
 @python_app

--- a/parsl/tests/integration/test_stress/test_python_threads.py
+++ b/parsl/tests/integration/test_stress/test_python_threads.py
@@ -1,13 +1,11 @@
 ''' Testing bash apps
 '''
+import argparse
+import time
+
 import parsl
 from parsl import python_app
-
-import time
-import argparse
-
 from parsl.tests.configs.local_threads import config
-
 
 local_config = config
 

--- a/parsl/tests/manual_tests/htex_local.py
+++ b/parsl/tests/manual_tests/htex_local.py
@@ -1,10 +1,9 @@
-from parsl.providers import LocalProvider
 from parsl.channels import LocalChannel
-# from parsl.launchers import SimpleLauncher
-from parsl.launchers import SingleNodeLauncher
-
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
+# from parsl.launchers import SimpleLauncher
+from parsl.launchers import SingleNodeLauncher
+from parsl.providers import LocalProvider
 
 config = Config(
     executors=[

--- a/parsl/tests/manual_tests/test_ad_hoc_htex.py
+++ b/parsl/tests/manual_tests/test_ad_hoc_htex.py
@@ -1,11 +1,12 @@
 import parsl
 from parsl import python_app
+
 parsl.set_stream_logger()
 
-from parsl.providers import AdHocProvider
 from parsl.channels import SSHChannel
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
+from parsl.providers import AdHocProvider
 
 remotes = ['midway2-login2.rcc.uchicago.edu', 'midway2-login1.rcc.uchicago.edu']
 

--- a/parsl/tests/manual_tests/test_basic.py
+++ b/parsl/tests/manual_tests/test_basic.py
@@ -2,6 +2,7 @@ import argparse
 import time
 
 import parsl
+
 # Tested. Confirmed. Local X Local X SingleNodeLauncher
 # from parsl.tests.configs.local_ipp import config
 

--- a/parsl/tests/manual_tests/test_fan_in_out_htex_remote.py
+++ b/parsl/tests/manual_tests/test_fan_in_out_htex_remote.py
@@ -1,12 +1,12 @@
+import logging
+
 import parsl
-from parsl.monitoring.monitoring import MonitoringHub
+from parsl.app.app import python_app
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.launchers import AprunLauncher
+from parsl.monitoring.monitoring import MonitoringHub
 from parsl.providers import CobaltProvider
-
-import logging
-from parsl.app.app import python_app
 
 
 def local_setup():

--- a/parsl/tests/manual_tests/test_log_filter.py
+++ b/parsl/tests/manual_tests/test_log_filter.py
@@ -1,6 +1,8 @@
 import argparse
-import parsl
 import logging
+
+import parsl
+
 parsl.load()
 
 from parsl import python_app

--- a/parsl/tests/manual_tests/test_memory_limits.py
+++ b/parsl/tests/manual_tests/test_memory_limits.py
@@ -1,15 +1,15 @@
 import argparse
-import parsl
-import psutil
 import multiprocessing
 
-from parsl.providers import LocalProvider
+import psutil
+
+import parsl
+from parsl.app.app import python_app  # , bash_app
 from parsl.channels import LocalChannel
-from parsl.launchers import SingleNodeLauncher
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
-
-from parsl.app.app import python_app  # , bash_app
+from parsl.launchers import SingleNodeLauncher
+from parsl.providers import LocalProvider
 
 
 @python_app

--- a/parsl/tests/manual_tests/test_regression_220.py
+++ b/parsl/tests/manual_tests/test_regression_220.py
@@ -1,7 +1,8 @@
+import time
+
 import pytest
 
 from parsl import DataFlowKernel, set_stream_logger
-import time
 from parsl.tests.configs.local_threads import config
 
 

--- a/parsl/tests/manual_tests/test_udp_simple.py
+++ b/parsl/tests/manual_tests/test_udp_simple.py
@@ -1,9 +1,10 @@
+import logging
+
+import parsl
 from parsl import python_app
-from parsl.monitoring.monitoring import MonitoringHub
 from parsl.config import Config
 from parsl.executors import ThreadPoolExecutor
-import parsl
-import logging
+from parsl.monitoring.monitoring import MonitoringHub
 
 
 def local_setup():

--- a/parsl/tests/manual_tests/test_worker_count.py
+++ b/parsl/tests/manual_tests/test_worker_count.py
@@ -1,7 +1,7 @@
 import argparse
-import time
 import math
 import multiprocessing
+import time
 
 import parsl
 
@@ -10,10 +10,10 @@ CORES_PER_WORKER = 1
 EXPECTED_WORKERS = math.floor(CORES / CORES_PER_WORKER)
 
 
+from parsl.executors import HighThroughputExecutor
 # from parsl.tests.configs.htex_local import config
 from parsl.tests.manual_tests.htex_local import config
 
-from parsl.executors import HighThroughputExecutor
 assert isinstance(config.executors[0], HighThroughputExecutor)
 config.executors[0].cores_per_worker = CORES_PER_WORKER
 config.executors[0].provider.init_blocks = 1

--- a/parsl/tests/scaling_tests/htex_local.py
+++ b/parsl/tests/scaling_tests/htex_local.py
@@ -1,8 +1,8 @@
-from parsl.providers import LocalProvider
 from parsl.channels import LocalChannel
-
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
+from parsl.providers import LocalProvider
+
 # import os
 config = Config(
     executors=[

--- a/parsl/tests/scaling_tests/test_scale.py
+++ b/parsl/tests/scaling_tests/test_scale.py
@@ -1,19 +1,8 @@
-#!/usr/bin/env python3
-
 import argparse
 import time
 
 import parsl
-
-# from parsl.tests.configs.htex_local import config
-# from htex_local import config
-# from parsl.configs.local_threads import config
-# from parsl.configs.local_ipp import config
-
-# parsl.set_stream_logger()
-# config.executors[0].provider.tasks_per_node = 4
-# parsl.load(config)
-from parsl.app.app import python_app  # , bash_app
+from parsl.app.app import python_app
 
 
 @python_app
@@ -29,8 +18,6 @@ def echo(x, string, stdout=None):
 
 @python_app
 def import_echo(x, string, stdout=None):
-    # from time import sleep
-    # sleep(0)
     print(string)
     return x * 5
 

--- a/parsl/tests/scaling_tests/vineex_condor.py
+++ b/parsl/tests/scaling_tests/vineex_condor.py
@@ -1,6 +1,5 @@
 from parsl.config import Config
-from parsl.executors.taskvine import TaskVineExecutor
-from parsl.executors.taskvine import TaskVineManagerConfig
+from parsl.executors.taskvine import TaskVineExecutor, TaskVineManagerConfig
 from parsl.providers import CondorProvider
 
 config = Config(

--- a/parsl/tests/scaling_tests/vineex_local.py
+++ b/parsl/tests/scaling_tests/vineex_local.py
@@ -1,6 +1,5 @@
 from parsl.config import Config
-from parsl.executors.taskvine import TaskVineExecutor
-from parsl.executors.taskvine import TaskVineManagerConfig
+from parsl.executors.taskvine import TaskVineExecutor, TaskVineManagerConfig
 from parsl.providers import LocalProvider
 
 config = Config(

--- a/parsl/tests/site_tests/test_provider.py
+++ b/parsl/tests/site_tests/test_provider.py
@@ -1,8 +1,10 @@
 import argparse
 import logging
-import pytest
-import parsl
 import time
+
+import pytest
+
+import parsl
 from parsl.app.app import python_app  # , bash_app
 from parsl.jobs.states import JobState
 from parsl.tests.site_tests.site_config_selector import fresh_config

--- a/parsl/tests/site_tests/test_site.py
+++ b/parsl/tests/site_tests/test_site.py
@@ -1,5 +1,7 @@
 import argparse
+
 import pytest
+
 import parsl
 from parsl.app.app import python_app  # , bash_app
 from parsl.tests.site_tests.site_config_selector import fresh_config

--- a/parsl/tests/sites/test_affinity.py
+++ b/parsl/tests/sites/test_affinity.py
@@ -1,12 +1,14 @@
 """Tests related to assigning workers to specific compute units"""
 
-from parsl.providers import LocalProvider
+import os
+
+import pytest
+
+from parsl import python_app
 from parsl.channels import LocalChannel
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
-from parsl import python_app
-import pytest
-import os
+from parsl.providers import LocalProvider
 
 
 def local_config():
@@ -32,8 +34,8 @@ def local_config():
 
 @python_app
 def get_worker_info():
-    from time import sleep
     import os
+    from time import sleep
     rank = int(os.environ['PARSL_WORKER_RANK'])
     aff = os.sched_getaffinity(0)
     device = os.environ.get('CUDA_VISIBLE_DEVICES')

--- a/parsl/tests/sites/test_dynamic_executor.py
+++ b/parsl/tests/sites/test_dynamic_executor.py
@@ -1,10 +1,10 @@
+import pytest
+
 import parsl
+from parsl.app.app import python_app
 from parsl.executors import HighThroughputExecutor
 from parsl.executors.threads import ThreadPoolExecutor
 from parsl.providers import LocalProvider
-from parsl.app.app import python_app
-
-import pytest
 
 
 @python_app(executors=['threads'])

--- a/parsl/tests/sites/test_ec2.py
+++ b/parsl/tests/sites/test_ec2.py
@@ -1,10 +1,11 @@
-import parsl
+import logging
+
 import pytest
 
+import parsl
 from parsl.app.app import python_app
 from parsl.tests.configs.ec2_single_node import config
 
-import logging
 logger = logging.getLogger(__name__)
 
 local_config = config

--- a/parsl/tests/sites/test_local_adhoc.py
+++ b/parsl/tests/sites/test_local_adhoc.py
@@ -1,9 +1,10 @@
+import logging
+
 import pytest
 
 from parsl import python_app
 from parsl.tests.configs.local_adhoc import fresh_config as local_config
 
-import logging
 logger = logging.getLogger(__name__)
 
 

--- a/parsl/tests/sites/test_worker_info.py
+++ b/parsl/tests/sites/test_worker_info.py
@@ -1,11 +1,12 @@
 """Tests related to Parsl workers being able to access their worker ID"""
 
-from parsl.providers import LocalProvider
+import pytest
+
+from parsl import python_app
 from parsl.channels import LocalChannel
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
-from parsl import python_app
-import pytest
+from parsl.providers import LocalProvider
 
 
 def local_config():

--- a/parsl/tests/test_aalst_patterns.py
+++ b/parsl/tests/test_aalst_patterns.py
@@ -6,7 +6,6 @@ import pytest
 from parsl.app.app import python_app
 from parsl.tests.configs.local_threads import config
 
-
 pytestmark = pytest.mark.skip('not asserting anything')
 
 

--- a/parsl/tests/test_bash_apps/test_apptimeout.py
+++ b/parsl/tests/test_bash_apps/test_apptimeout.py
@@ -1,9 +1,9 @@
-import parsl
 import pytest
 
+import parsl
 from parsl.app.app import bash_app
-from parsl.tests.configs.local_threads import config
 from parsl.app.errors import AppTimeout
+from parsl.tests.configs.local_threads import config
 
 
 @bash_app

--- a/parsl/tests/test_bash_apps/test_error_codes.py
+++ b/parsl/tests/test_bash_apps/test_error_codes.py
@@ -4,12 +4,9 @@ import os
 import pytest
 
 import parsl
-from parsl.app.app import bash_app
 import parsl.app.errors as pe
-
-
+from parsl.app.app import bash_app
 from parsl.app.errors import BashExitFailure
-
 from parsl.tests.configs.local_threads import fresh_config as local_config
 
 

--- a/parsl/tests/test_bash_apps/test_memoize_ignore_args.py
+++ b/parsl/tests/test_bash_apps/test_memoize_ignore_args.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 import parsl

--- a/parsl/tests/test_bash_apps/test_memoize_ignore_args_regr.py
+++ b/parsl/tests/test_bash_apps/test_memoize_ignore_args_regr.py
@@ -1,8 +1,8 @@
 import copy
 import os
-import pytest
-
 from typing import List
+
+import pytest
 
 import parsl
 from parsl.app.app import bash_app

--- a/parsl/tests/test_bash_apps/test_pipeline.py
+++ b/parsl/tests/test_bash_apps/test_pipeline.py
@@ -1,8 +1,8 @@
 import pytest
 
 from parsl.app.app import bash_app
-from parsl.data_provider.files import File
 from parsl.app.futures import DataFuture
+from parsl.data_provider.files import File
 
 
 @bash_app

--- a/parsl/tests/test_callables.py
+++ b/parsl/tests/test_callables.py
@@ -5,9 +5,9 @@
 
 import importlib
 import pathlib
-import parsl
-
 from functools import partial
+
+import parsl
 
 
 @parsl.python_app

--- a/parsl/tests/test_checkpointing/test_python_checkpoint_1.py
+++ b/parsl/tests/test_checkpointing/test_python_checkpoint_1.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 import parsl

--- a/parsl/tests/test_checkpointing/test_python_checkpoint_2.py
+++ b/parsl/tests/test_checkpointing/test_python_checkpoint_2.py
@@ -1,9 +1,10 @@
 import contextlib
 import os
+
 import pytest
+
 import parsl
 from parsl import python_app
-
 from parsl.tests.configs.local_threads_checkpoint import fresh_config
 
 

--- a/parsl/tests/test_checkpointing/test_regression_239.py
+++ b/parsl/tests/test_checkpointing/test_regression_239.py
@@ -2,7 +2,7 @@ import pickle
 
 import pytest
 
-from parsl import python_app, DataFlowKernel
+from parsl import DataFlowKernel, python_app
 from parsl.utils import time_limited_open
 
 

--- a/parsl/tests/test_checkpointing/test_task_exit.py
+++ b/parsl/tests/test_checkpointing/test_task_exit.py
@@ -5,8 +5,8 @@ import pytest
 
 import parsl
 from parsl.app.app import python_app
-from parsl.utils import time_limited_open
 from parsl.tests.configs.local_threads_checkpoint_task_exit import config
+from parsl.utils import time_limited_open
 
 
 def local_setup():

--- a/parsl/tests/test_docs/test_from_slides.py
+++ b/parsl/tests/test_docs/test_from_slides.py
@@ -1,7 +1,7 @@
+import os
+
 from parsl.app.app import bash_app, python_app
 from parsl.data_provider.files import File
-
-import os
 
 
 @bash_app

--- a/parsl/tests/test_docs/test_kwargs.py
+++ b/parsl/tests/test_docs/test_kwargs.py
@@ -1,7 +1,7 @@
 """Functions used to explain kwargs"""
 from pathlib import Path
 
-from parsl import python_app, File
+from parsl import File, python_app
 
 
 def test_inputs():

--- a/parsl/tests/test_docs/test_tutorial_1.py
+++ b/parsl/tests/test_docs/test_tutorial_1.py
@@ -1,11 +1,10 @@
 import argparse
-import parsl
 
 import pytest
 
+import parsl
 from parsl.app.app import bash_app
 from parsl.tests.configs.local_threads import config
-
 
 local_config = config
 

--- a/parsl/tests/test_docs/test_workflow1.py
+++ b/parsl/tests/test_docs/test_workflow1.py
@@ -1,11 +1,11 @@
 import os
-import pytest
-import parsl
 
+import pytest
+
+import parsl
 from parsl.app.app import bash_app, python_app
 from parsl.data_provider.files import File
 from parsl.tests.configs.local_threads import config
-
 
 # parsl.set_stream_logger()
 

--- a/parsl/tests/test_docs/test_workflow2.py
+++ b/parsl/tests/test_docs/test_workflow2.py
@@ -5,7 +5,6 @@ import pytest
 from parsl.app.app import python_app
 from parsl.tests.configs.local_threads import config
 
-
 local_config = config
 
 

--- a/parsl/tests/test_error_handling/test_rand_fail.py
+++ b/parsl/tests/test_error_handling/test_rand_fail.py
@@ -15,8 +15,8 @@ def local_config():
 
 @python_app
 def sleep_fail(sleep_dur, sleep_rand_max, fail_prob, inputs=[]):
-    import time
     import random
+    import time
 
     s = sleep_dur + random.randint(-sleep_rand_max, sleep_rand_max)
 
@@ -144,8 +144,8 @@ def test_deps(numtasks=10):
 
 @python_app
 def sleep_then_fail(sleep_dur=0.1):
-    import time
     import math
+    import time
     time.sleep(sleep_dur)
     math.ceil("Trigger TypeError")
     return 0

--- a/parsl/tests/test_error_handling/test_resource_spec.py
+++ b/parsl/tests/test_error_handling/test_resource_spec.py
@@ -1,9 +1,10 @@
 import parsl
 from parsl.app.app import python_app
-from parsl.executors.errors import UnsupportedFeatureError, ExecutorError
 from parsl.executors import WorkQueueExecutor
-from parsl.executors.high_throughput.mpi_prefix_composer import InvalidResourceSpecification
+from parsl.executors.errors import ExecutorError, UnsupportedFeatureError
 from parsl.executors.high_throughput.executor import HighThroughputExecutor
+from parsl.executors.high_throughput.mpi_prefix_composer import \
+    InvalidResourceSpecification
 
 
 @python_app

--- a/parsl/tests/test_error_handling/test_retries.py
+++ b/parsl/tests/test_error_handling/test_retries.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+
 import pytest
 
 import parsl
@@ -15,8 +16,8 @@ def local_config():
 
 @python_app
 def sleep_then_fail(inputs=[], sleep_dur=0.1):
-    import time
     import math
+    import time
     time.sleep(sleep_dur)
     math.ceil("Trigger TypeError")
     return 0

--- a/parsl/tests/test_error_handling/test_retry_handler.py
+++ b/parsl/tests/test_error_handling/test_retry_handler.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 import parsl

--- a/parsl/tests/test_error_handling/test_retry_handler_failure.py
+++ b/parsl/tests/test_error_handling/test_retry_handler_failure.py
@@ -1,5 +1,6 @@
-import parsl
 import pytest
+
+import parsl
 
 
 @parsl.python_app

--- a/parsl/tests/test_error_handling/test_serialization_fail.py
+++ b/parsl/tests/test_error_handling/test_serialization_fail.py
@@ -1,8 +1,8 @@
 import pytest
 
 from parsl import python_app
-from parsl.tests.configs.htex_local import fresh_config
 from parsl.serialize.errors import SerializationError
+from parsl.tests.configs.htex_local import fresh_config
 
 
 def local_config():

--- a/parsl/tests/test_error_handling/test_wrap_with_logs.py
+++ b/parsl/tests/test_error_handling/test_wrap_with_logs.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from parsl.process_loggers import wrap_with_logs

--- a/parsl/tests/test_flux.py
+++ b/parsl/tests/test_flux.py
@@ -1,14 +1,11 @@
-import os
 import concurrent.futures as cf
+import os
 
 import pytest
 
 from parsl.app.errors import AppException
-from parsl.executors.flux.executor import (
-    FluxExecutor,
-    FluxFutureWrapper,
-    _complete_future,
-)
+from parsl.executors.flux.executor import (FluxExecutor, FluxFutureWrapper,
+                                           _complete_future)
 
 try:
     import flux.job.executor  # noqa: F401

--- a/parsl/tests/test_htex/test_connected_blocks.py
+++ b/parsl/tests/test_htex/test_connected_blocks.py
@@ -1,7 +1,8 @@
-import parsl
 import pytest
-from parsl.executors import HighThroughputExecutor
+
+import parsl
 from parsl import Config
+from parsl.executors import HighThroughputExecutor
 from parsl.providers import LocalProvider
 
 

--- a/parsl/tests/test_htex/test_cpu_affinity_explicit.py
+++ b/parsl/tests/test_htex/test_cpu_affinity_explicit.py
@@ -1,8 +1,10 @@
 import logging
 import os
-import parsl
-import pytest
 import random
+
+import pytest
+
+import parsl
 from parsl.tests.configs.htex_local import fresh_config
 
 logger = logging.getLogger(__name__)

--- a/parsl/tests/test_htex/test_disconnected_blocks.py
+++ b/parsl/tests/test_htex/test_disconnected_blocks.py
@@ -1,11 +1,13 @@
 import logging
-import parsl
+
 import pytest
-from parsl.executors import HighThroughputExecutor
+
+import parsl
 from parsl import Config
-from parsl.providers import LocalProvider
+from parsl.executors import HighThroughputExecutor
 from parsl.executors.errors import BadStateException
-from parsl.jobs.states import JobStatus, JobState
+from parsl.jobs.states import JobState, JobStatus
+from parsl.providers import LocalProvider
 
 
 def local_config():

--- a/parsl/tests/test_htex/test_htex.py
+++ b/parsl/tests/test_htex/test_htex.py
@@ -3,8 +3,7 @@ from unittest import mock
 
 import pytest
 
-from parsl import curvezmq
-from parsl import HighThroughputExecutor
+from parsl import HighThroughputExecutor, curvezmq
 from parsl.multiprocessing import ForkProcess
 
 _MOCK_BASE = "parsl.executors.high_throughput.executor"

--- a/parsl/tests/test_htex/test_multiple_disconnected_blocks.py
+++ b/parsl/tests/test_htex/test_multiple_disconnected_blocks.py
@@ -1,11 +1,13 @@
 import logging
-import parsl
+
 import pytest
-from parsl.executors import HighThroughputExecutor
+
+import parsl
 from parsl import Config
-from parsl.providers import LocalProvider
+from parsl.executors import HighThroughputExecutor
 from parsl.executors.errors import BadStateException
-from parsl.jobs.states import JobStatus, JobState
+from parsl.jobs.states import JobState, JobStatus
+from parsl.providers import LocalProvider
 
 
 def local_config():

--- a/parsl/tests/test_monitoring/test_basic.py
+++ b/parsl/tests/test_monitoring/test_basic.py
@@ -1,8 +1,10 @@
 import logging
 import os
-import parsl
-import pytest
 import time
+
+import pytest
+
+import parsl
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +28,7 @@ def test_row_counts():
     # run.
     import sqlalchemy
     from sqlalchemy import text
+
     from parsl.tests.configs.htex_local_alternate import fresh_config
 
     if os.path.exists("runinfo/monitoring.db"):

--- a/parsl/tests/test_monitoring/test_db_locks.py
+++ b/parsl/tests/test_monitoring/test_db_locks.py
@@ -1,8 +1,10 @@
 import logging
 import os
-import parsl
-import pytest
 import time
+
+import pytest
+
+import parsl
 
 logger = logging.getLogger(__name__)
 
@@ -14,9 +16,10 @@ def this_app():
 
 @pytest.mark.local
 def test_row_counts():
-    from parsl.tests.configs.htex_local_alternate import fresh_config
     import sqlalchemy
     from sqlalchemy import text
+
+    from parsl.tests.configs.htex_local_alternate import fresh_config
     if os.path.exists("runinfo/monitoring.db"):
         logger.info("Monitoring database already exists - deleting")
         os.remove("runinfo/monitoring.db")

--- a/parsl/tests/test_monitoring/test_fuzz_zmq.py
+++ b/parsl/tests/test_monitoring/test_fuzz_zmq.py
@@ -1,9 +1,11 @@
 import logging
 import os
-import parsl
-import pytest
 import socket
 import time
+
+import pytest
+
+import parsl
 
 logger = logging.getLogger(__name__)
 
@@ -15,9 +17,10 @@ def this_app():
 
 @pytest.mark.local
 def test_row_counts():
-    from parsl.tests.configs.htex_local_alternate import fresh_config
     import sqlalchemy
     from sqlalchemy import text
+
+    from parsl.tests.configs.htex_local_alternate import fresh_config
 
     if os.path.exists("runinfo/monitoring.db"):
         logger.info("Monitoring database already exists - deleting")

--- a/parsl/tests/test_monitoring/test_incomplete_futures.py
+++ b/parsl/tests/test_monitoring/test_incomplete_futures.py
@@ -1,10 +1,11 @@
 import logging
 import os
-import parsl
-import pytest
 import random
-
 from concurrent.futures import Future
+
+import pytest
+
+import parsl
 
 
 @parsl.python_app
@@ -16,6 +17,7 @@ def this_app(inputs=()):
 def test_future_representation(tmpd_cwd):
     import sqlalchemy
     from sqlalchemy import text
+
     from parsl.tests.configs.htex_local_alternate import fresh_config
 
     monitoring_db = str(tmpd_cwd / "monitoring.db")

--- a/parsl/tests/test_monitoring/test_memoization_representation.py
+++ b/parsl/tests/test_monitoring/test_memoization_representation.py
@@ -1,8 +1,10 @@
 
 import logging
 import os
-import parsl
+
 import pytest
+
+import parsl
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +18,7 @@ def this_app(x):
 def test_hashsum():
     import sqlalchemy
     from sqlalchemy import text
+
     from parsl.tests.configs.htex_local_alternate import fresh_config
 
     if os.path.exists("runinfo/monitoring.db"):

--- a/parsl/tests/test_monitoring/test_viz_colouring.py
+++ b/parsl/tests/test_monitoring/test_viz_colouring.py
@@ -1,4 +1,5 @@
 import pytest
+
 from parsl.dataflow.states import States
 
 

--- a/parsl/tests/test_mpi_apps/test_bad_mpi_config.py
+++ b/parsl/tests/test_mpi_apps/test_bad_mpi_config.py
@@ -2,7 +2,8 @@ import pytest
 
 from parsl import Config
 from parsl.executors import HighThroughputExecutor
-from parsl.launchers import SrunLauncher, SingleNodeLauncher, SimpleLauncher, AprunLauncher
+from parsl.launchers import (AprunLauncher, SimpleLauncher, SingleNodeLauncher,
+                             SrunLauncher)
 from parsl.providers import SlurmProvider
 
 

--- a/parsl/tests/test_mpi_apps/test_mpi_mode_disabled.py
+++ b/parsl/tests/test_mpi_apps/test_mpi_mode_disabled.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Dict
+
 import pytest
+
 import parsl
 from parsl import python_app
 from parsl.tests.configs.htex_local import fresh_config

--- a/parsl/tests/test_mpi_apps/test_mpi_mode_enabled.py
+++ b/parsl/tests/test_mpi_apps/test_mpi_mode_enabled.py
@@ -1,12 +1,13 @@
 import logging
+import os
 import random
 from typing import Dict
-import pytest
-import parsl
-from parsl import python_app, bash_app
-from parsl.tests.configs.htex_local import fresh_config
 
-import os
+import pytest
+
+import parsl
+from parsl import bash_app, python_app
+from parsl.tests.configs.htex_local import fresh_config
 
 EXECUTOR_LABEL = "MPI_TEST"
 

--- a/parsl/tests/test_mpi_apps/test_mpi_prefix.py
+++ b/parsl/tests/test_mpi_apps/test_mpi_prefix.py
@@ -1,14 +1,11 @@
 import logging
+
 import pytest
 
-from parsl.executors.high_throughput.mpi_resource_management import Scheduler
 from parsl.executors.high_throughput.mpi_prefix_composer import (
-    compose_srun_launch_cmd,
-    compose_aprun_launch_cmd,
-    compose_mpiexec_launch_cmd,
-    compose_all,
-)
-
+    compose_all, compose_aprun_launch_cmd, compose_mpiexec_launch_cmd,
+    compose_srun_launch_cmd)
+from parsl.executors.high_throughput.mpi_resource_management import Scheduler
 
 resource_spec = {"num_nodes": 2,
                  "num_ranks": 8,

--- a/parsl/tests/test_mpi_apps/test_mpi_scheduler.py
+++ b/parsl/tests/test_mpi_apps/test_mpi_scheduler.py
@@ -1,11 +1,15 @@
 import logging
 import os
-from unittest import mock
-import pytest
 import pickle
-from parsl.executors.high_throughput.mpi_resource_management import TaskScheduler, MPITaskScheduler
+from unittest import mock
+
+import pytest
+
+from parsl.executors.high_throughput.mpi_resource_management import (
+    MPITaskScheduler, TaskScheduler)
 from parsl.multiprocessing import SpawnContext
-from parsl.serialize import pack_res_spec_apply_message, unpack_res_spec_apply_message
+from parsl.serialize import (pack_res_spec_apply_message,
+                             unpack_res_spec_apply_message)
 
 
 @pytest.fixture(autouse=True)

--- a/parsl/tests/test_mpi_apps/test_resource_spec.py
+++ b/parsl/tests/test_mpi_apps/test_resource_spec.py
@@ -2,25 +2,19 @@ import contextlib
 import logging
 import os
 import typing
-
+import unittest
+from typing import Dict
 
 import pytest
-import unittest
 
 import parsl
 from parsl.app.app import python_app
-from parsl.tests.configs.htex_local import fresh_config
-from typing import Dict
-from parsl.executors.high_throughput.mpi_resource_management import (
-    get_pbs_hosts_list,
-    get_slurm_hosts_list,
-    get_nodes_in_batchjob,
-    identify_scheduler,
-)
 from parsl.executors.high_throughput.mpi_prefix_composer import (
-    validate_resource_spec,
-    InvalidResourceSpecification
-)
+    InvalidResourceSpecification, validate_resource_spec)
+from parsl.executors.high_throughput.mpi_resource_management import (
+    get_nodes_in_batchjob, get_pbs_hosts_list, get_slurm_hosts_list,
+    identify_scheduler)
+from parsl.tests.configs.htex_local import fresh_config
 
 EXECUTOR_LABEL = "MPI_TEST"
 

--- a/parsl/tests/test_providers/test_cobalt_deprecation_warning.py
+++ b/parsl/tests/test_providers/test_cobalt_deprecation_warning.py
@@ -1,5 +1,7 @@
 import warnings
+
 import pytest
+
 from parsl.providers import CobaltProvider
 
 

--- a/parsl/tests/test_providers/test_local_provider.py
+++ b/parsl/tests/test_providers/test_local_provider.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import pathlib
-import pytest
 import random
 import shutil
 import socket
@@ -9,6 +8,8 @@ import subprocess
 import tempfile
 import threading
 import time
+
+import pytest
 
 from parsl.channels import LocalChannel, SSHChannel
 from parsl.jobs.states import JobState

--- a/parsl/tests/test_providers/test_pbspro_template.py
+++ b/parsl/tests/test_providers/test_pbspro_template.py
@@ -1,6 +1,6 @@
 import random
-
 from unittest import mock
+
 import pytest
 
 from parsl.channels import LocalChannel

--- a/parsl/tests/test_providers/test_slurm_template.py
+++ b/parsl/tests/test_providers/test_slurm_template.py
@@ -1,7 +1,7 @@
 import logging
 import random
-
 from unittest import mock
+
 import pytest
 
 from parsl.channels import LocalChannel

--- a/parsl/tests/test_providers/test_submiterror_deprecation.py
+++ b/parsl/tests/test_providers/test_submiterror_deprecation.py
@@ -1,6 +1,7 @@
-import pytest
 import random
 import string
+
+import pytest
 
 from parsl.providers.errors import SubmitException
 

--- a/parsl/tests/test_python_apps/test_dep_standard_futures.py
+++ b/parsl/tests/test_python_apps/test_dep_standard_futures.py
@@ -1,6 +1,7 @@
+from concurrent.futures import Future
+
 import parsl
 from parsl.dataflow.errors import DependencyError
-from concurrent.futures import Future
 
 
 @parsl.python_app

--- a/parsl/tests/test_python_apps/test_futures.py
+++ b/parsl/tests/test_python_apps/test_futures.py
@@ -11,8 +11,9 @@ Same applies to datafutures, and we need to know the behavior wrt.
 2. done() called on 1, vs 2
 
 """
-import pytest
 from os.path import basename
+
+import pytest
 
 from parsl.app.app import python_app
 from parsl.data_provider.files import File

--- a/parsl/tests/test_python_apps/test_join.py
+++ b/parsl/tests/test_python_apps/test_join.py
@@ -3,7 +3,6 @@ import pytest
 from parsl import join_app, python_app
 from parsl.dataflow.errors import JoinError
 
-
 RESULT_CONSTANT = 3
 
 

--- a/parsl/tests/test_python_apps/test_lifted.py
+++ b/parsl/tests/test_python_apps/test_lifted.py
@@ -1,6 +1,7 @@
+from concurrent.futures import Future
+
 import pytest
 
-from concurrent.futures import Future
 from parsl import python_app
 
 

--- a/parsl/tests/test_python_apps/test_memoize_2.py
+++ b/parsl/tests/test_python_apps/test_memoize_2.py
@@ -4,7 +4,8 @@ import pytest
 
 import parsl
 from parsl.app.app import python_app
-from parsl.tests.configs.local_threads_no_cache import fresh_config as local_config
+from parsl.tests.configs.local_threads_no_cache import \
+    fresh_config as local_config
 
 
 @python_app

--- a/parsl/tests/test_python_apps/test_memoize_bad_id_for_memo.py
+++ b/parsl/tests/test_python_apps/test_memoize_bad_id_for_memo.py
@@ -1,4 +1,5 @@
 import pytest
+
 from parsl import python_app
 from parsl.dataflow.memoization import id_for_memo
 

--- a/parsl/tests/test_radical/test_mpi_funcs.py
+++ b/parsl/tests/test_radical/test_mpi_funcs.py
@@ -1,6 +1,6 @@
-import parsl
 import pytest
 
+import parsl
 from parsl.tests.configs.local_radical_mpi import fresh_config as local_config
 
 

--- a/parsl/tests/test_regression/test_1480.py
+++ b/parsl/tests/test_regression/test_1480.py
@@ -1,5 +1,6 @@
-from parsl import python_app
 import pytest
+
+from parsl import python_app
 from parsl.tests.configs.htex_local import fresh_config as local_config
 
 

--- a/parsl/tests/test_regression/test_1653.py
+++ b/parsl/tests/test_regression/test_1653.py
@@ -1,5 +1,6 @@
-from parsl import python_app
 import pytest
+
+from parsl import python_app
 from parsl.tests.configs.htex_local import fresh_config as local_config
 
 

--- a/parsl/tests/test_regression/test_2652.py
+++ b/parsl/tests/test_regression/test_2652.py
@@ -1,4 +1,5 @@
 import pytest
+
 from parsl.jobs.states import JobState
 
 

--- a/parsl/tests/test_regression/test_69a.py
+++ b/parsl/tests/test_regression/test_69a.py
@@ -6,7 +6,6 @@ import pytest
 from parsl.app.app import bash_app, python_app
 from parsl.tests.configs.local_threads import config
 
-
 local_config = config
 
 

--- a/parsl/tests/test_regression/test_854.py
+++ b/parsl/tests/test_regression/test_854.py
@@ -1,8 +1,10 @@
-import time
 import multiprocessing
-import pytest
-from parsl.multiprocessing import MacSafeQueue
 import random
+import time
+
+import pytest
+
+from parsl.multiprocessing import MacSafeQueue
 
 
 def consumer(in_q, out_q, delay=0):

--- a/parsl/tests/test_regression/test_97_parallelism_0.py
+++ b/parsl/tests/test_regression/test_97_parallelism_0.py
@@ -1,11 +1,10 @@
 import pytest
 
 import parsl
-
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
-from parsl.providers import LocalProvider
 from parsl.launchers import SimpleLauncher
+from parsl.providers import LocalProvider
 
 
 def local_config() -> Config:

--- a/parsl/tests/test_regression/test_98.py
+++ b/parsl/tests/test_regression/test_98.py
@@ -6,7 +6,6 @@ import argparse
 import pytest
 
 import parsl
-
 from parsl.dataflow.dflow import DataFlowKernel
 from parsl.tests.configs.local_threads import config
 

--- a/parsl/tests/test_scaling/test_block_error_handler.py
+++ b/parsl/tests/test_scaling/test_block_error_handler.py
@@ -1,11 +1,14 @@
+from functools import partial
+from unittest.mock import Mock
+
 import pytest
 
 from parsl.executors import HighThroughputExecutor
+from parsl.jobs.error_handlers import (noop_error_handler,
+                                       simple_error_handler,
+                                       windowed_error_handler)
+from parsl.jobs.states import JobState, JobStatus
 from parsl.providers import LocalProvider
-from unittest.mock import Mock
-from parsl.jobs.states import JobStatus, JobState
-from parsl.jobs.error_handlers import simple_error_handler, windowed_error_handler, noop_error_handler
-from functools import partial
 
 
 @pytest.mark.local

--- a/parsl/tests/test_scaling/test_scale_down.py
+++ b/parsl/tests/test_scaling/test_scale_down.py
@@ -4,13 +4,12 @@ import time
 import pytest
 
 import parsl
-
 from parsl import File, python_app
-from parsl.providers import LocalProvider
 from parsl.channels import LocalChannel
-from parsl.launchers import SingleNodeLauncher
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
+from parsl.launchers import SingleNodeLauncher
+from parsl.providers import LocalProvider
 
 logger = logging.getLogger(__name__)
 

--- a/parsl/tests/test_serialization/test_2555_caching_deserializer.py
+++ b/parsl/tests/test_serialization/test_2555_caching_deserializer.py
@@ -1,6 +1,6 @@
-import parsl
 import pytest
 
+import parsl
 from parsl.tests.configs.htex_local import fresh_config as local_config
 
 

--- a/parsl/tests/test_serialization/test_basic.py
+++ b/parsl/tests/test_serialization/test_basic.py
@@ -1,5 +1,6 @@
 import pytest
-from parsl.serialize import serialize, deserialize
+
+from parsl.serialize import deserialize, serialize
 from parsl.serialize.concretes import DillSerializer, PickleSerializer
 
 

--- a/parsl/tests/test_serialization/test_htex_code_cache.py
+++ b/parsl/tests/test_serialization/test_htex_code_cache.py
@@ -1,10 +1,9 @@
-import parsl
-import pytest
-
 from typing import Any
 
-from parsl.serialize.facade import methods_for_code
+import pytest
 
+import parsl
+from parsl.serialize.facade import methods_for_code
 from parsl.tests.configs.htex_local import fresh_config as local_config
 
 

--- a/parsl/tests/test_serialization/test_pack_resource_spec.py
+++ b/parsl/tests/test_serialization/test_pack_resource_spec.py
@@ -1,5 +1,7 @@
 import pytest
-from parsl.serialize import unpack_res_spec_apply_message, pack_res_spec_apply_message
+
+from parsl.serialize import (pack_res_spec_apply_message,
+                             unpack_res_spec_apply_message)
 
 
 def double(x: int, y: int = 2) -> int:

--- a/parsl/tests/test_serialization/test_proxystore_configured.py
+++ b/parsl/tests/test_serialization/test_proxystore_configured.py
@@ -1,19 +1,21 @@
 import logging
-import pytest
 import uuid
 
-import parsl
-from parsl.serialize.facade import additional_methods_for_deserialization, methods_for_data, register_method_for_data
-from parsl.tests.configs.htex_local import fresh_config
+import pytest
 
+import parsl
+from parsl.serialize.facade import (additional_methods_for_deserialization,
+                                    methods_for_data, register_method_for_data)
+from parsl.tests.configs.htex_local import fresh_config
 
 logger = logging.getLogger(__name__)
 
 
 def local_setup():
-    from parsl.serialize.proxystore import ProxyStoreSerializer
-    from proxystore.store import Store, register_store
     from proxystore.connectors.file import FileConnector
+    from proxystore.store import Store, register_store
+
+    from parsl.serialize.proxystore import ProxyStoreSerializer
 
     parsl.load(fresh_config())
 

--- a/parsl/tests/test_serialization/test_proxystore_impl.py
+++ b/parsl/tests/test_serialization/test_proxystore_impl.py
@@ -1,5 +1,6 @@
-import pytest
 import uuid
+
+import pytest
 
 
 def policy_example(o):
@@ -13,10 +14,11 @@ def test_proxystore_nonglobal():
     """
     # import in function, because proxystore is not importable in base parsl
     # installation.
-    from parsl.serialize.proxystore import ProxyStoreSerializer
+    from proxystore.connectors.file import FileConnector
     from proxystore.proxy import Proxy
     from proxystore.store import Store, register_store
-    from proxystore.connectors.file import FileConnector
+
+    from parsl.serialize.proxystore import ProxyStoreSerializer
 
     store = Store(name='parsl_store_' + str(uuid.uuid4()), connector=FileConnector(store_dir="/tmp"))
     register_store(store)

--- a/parsl/tests/test_staging/staging_provider.py
+++ b/parsl/tests/test_staging/staging_provider.py
@@ -62,8 +62,8 @@ def make_stage_out_app(executor, dfk):
 
 
 def stage_out_noop(app_fu, inputs=[], _parsl_staging_inhibit=True):
-    import time
     import logging
+    import time
     logger = logging.getLogger(__name__)
     logger.info("stage_out_noop")
     time.sleep(1)
@@ -75,8 +75,8 @@ def make_stage_in_app(executor, dfk):
 
 
 def stage_in_noop(parent_fut=None, outputs=[], _parsl_staging_inhibit=True):
-    import time
     import logging
+    import time
     logger = logging.getLogger(__name__)
     logger.info("stage_in_noop")
     time.sleep(1)

--- a/parsl/tests/test_staging/test_1316.py
+++ b/parsl/tests/test_staging/test_1316.py
@@ -1,8 +1,9 @@
+import time
+
 import pytest
 
 import parsl
-import time
-from parsl import python_app, ThreadPoolExecutor
+from parsl import ThreadPoolExecutor, python_app
 from parsl.config import Config
 from parsl.data_provider.files import File
 from parsl.data_provider.staging import Staging

--- a/parsl/tests/test_staging/test_docs_1.py
+++ b/parsl/tests/test_staging/test_docs_1.py
@@ -1,6 +1,6 @@
 import pytest
 
-from parsl import python_app, File
+from parsl import File, python_app
 
 
 @python_app

--- a/parsl/tests/test_staging/test_docs_2.py
+++ b/parsl/tests/test_staging/test_docs_2.py
@@ -1,5 +1,6 @@
 import pytest
-from parsl import bash_app, File
+
+from parsl import File, bash_app
 from parsl.tests.configs.local_threads import fresh_config as local_config
 
 

--- a/parsl/tests/test_staging/test_elaborate_noop_file.py
+++ b/parsl/tests/test_staging/test_elaborate_noop_file.py
@@ -6,15 +6,16 @@
 # of the globus staging provider
 
 import logging
+
 import pytest
 
 import parsl
-
 from parsl import bash_app, python_app
 from parsl.config import Config
 from parsl.data_provider.files import File
 from parsl.executors.threads import ThreadPoolExecutor
-from parsl.tests.test_staging.staging_provider import NoOpTestingFileStaging, NoOpError
+from parsl.tests.test_staging.staging_provider import (NoOpError,
+                                                       NoOpTestingFileStaging)
 
 logger = logging.getLogger(__name__)
 

--- a/parsl/tests/test_staging/test_staging_ftp_in_task.py
+++ b/parsl/tests/test_staging/test_staging_ftp_in_task.py
@@ -2,7 +2,8 @@ import pytest
 
 from parsl.app.app import python_app
 from parsl.data_provider.files import File
-from parsl.tests.configs.local_threads_ftp_in_task import fresh_config as local_config
+from parsl.tests.configs.local_threads_ftp_in_task import \
+    fresh_config as local_config
 
 
 @python_app

--- a/parsl/tests/test_staging/test_staging_https.py
+++ b/parsl/tests/test_staging/test_staging_https.py
@@ -1,9 +1,8 @@
+import pytest
+
 import parsl
 from parsl.app.app import python_app
 from parsl.data_provider.files import File
-
-import pytest
-
 # This config is for the local test which will adding an executor.
 # Most tests in this file should be non-local and use the configuration
 # specificed with --config, not this one.

--- a/parsl/tests/test_summary.py
+++ b/parsl/tests/test_summary.py
@@ -1,5 +1,6 @@
-import parsl
 import pytest
+
+import parsl
 from parsl.tests.configs.local_threads import fresh_config
 
 

--- a/parsl/tests/test_thread_parallelism.py
+++ b/parsl/tests/test_thread_parallelism.py
@@ -5,7 +5,6 @@ import pytest
 from parsl.app.app import bash_app, python_app
 from parsl.tests.configs.local_threads import config
 
-
 local_config = config
 
 

--- a/parsl/tests/test_threads/test_configs.py
+++ b/parsl/tests/test_threads/test_configs.py
@@ -7,9 +7,9 @@ from parsl.tests.configs.local_threads import fresh_config
 
 @python_app
 def worker_identify(x, sleep_dur=0.2):
-    import time
     import os
     import threading
+    import time
     time.sleep(sleep_dur)
     return {"pid": os.getpid(),
             "tid": threading.current_thread()}

--- a/parsl/tests/test_threads/test_lazy_errors.py
+++ b/parsl/tests/test_threads/test_lazy_errors.py
@@ -1,5 +1,6 @@
-import parsl
 import pytest
+
+import parsl
 from parsl import python_app
 from parsl.tests.configs.local_threads import fresh_config
 


### PR DESCRIPTION

# Description

`isort` **should** only resort import statements and add white spaces to separate different categories of imports.
This PR should not introduce any functional changes. I wanted to get some feedback before sticking isort on the rest of the codebase. If folks like the changes, I'd like to add this to the linter scripts.

# Changed Behaviour

No functional changes.


## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
