### PR TITLE
Make manager->interchange tasks_output protocol always JSON objects

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -27,7 +27,6 @@ from parsl.monitoring.message_type import MessageType
 from parsl.process_loggers import wrap_with_logs
 
 
-HEARTBEAT_CODE = (2 ** 32) - 1
 PKL_HEARTBEAT_CODE = pickle.dumps((2 ** 32) - 1)
 
 LOGGER_NAME = "interchange"
@@ -394,70 +393,79 @@ class Interchange:
         logger.warning("Exiting")
 
     def process_task_outgoing_incoming(self, interesting_managers: Set[bytes], hub_channel: Optional[zmq.Socket], kill_event: threading.Event) -> None:
-        # Listen for registrations and heartbeats
+        """Process one message from manager on the task_outgoing channel.
+        Note that this message flow is in contradiction to the name of the
+        channel - it is not an outgoing message and it is not a task.
+        """
         if self.task_outgoing in self.socks and self.socks[self.task_outgoing] == zmq.POLLIN:
             logger.debug("starting task_outgoing section")
             message = self.task_outgoing.recv_multipart()
             manager_id = message[0]
 
-            if manager_id not in self._ready_managers:
-                reg_flag = False
+            try:
+                msg = json.loads(message[1].decode('utf-8'))
+            except Exception:
+                logger.warning("Got Exception reading message from manager: {!r}".format(
+                    manager_id), exc_info=True)
+                logger.debug("Message: \n{!r}\n".format(message[1]))
+                return
 
-                try:
-                    msg = json.loads(message[1].decode('utf-8'))
-                    reg_flag = True
-                except Exception:
-                    logger.warning("Got Exception reading registration message from manager: {!r}".format(
-                        manager_id), exc_info=True)
-                    logger.debug("Message: \n{!r}\n".format(message[1]))
+            # perform a bit of validation on the structure of the deserialized
+            # object, at least enough to behave like a deserialization error
+            # in obviously malformed cases
+            if not isinstance(msg, dict) or 'type' not in msg:
+                logger.error(f"JSON message was not correctly formatted from manager: {manager_id!r}")
+                logger.debug("Message: \n{!r}\n".format(message[1]))
+                return
+
+            if msg['type'] == 'registration':
+                # We set up an entry only if registration works correctly
+                self._ready_managers[manager_id] = {'last_heartbeat': time.time(),
+                                                    'idle_since': time.time(),
+                                                    'block_id': None,
+                                                    'max_capacity': 0,
+                                                    'worker_count': 0,
+                                                    'active': True,
+                                                    'tasks': []}
+                self.connected_block_history.append(msg['block_id'])
+
+                interesting_managers.add(manager_id)
+                logger.info("Adding manager: {!r} to ready queue".format(manager_id))
+                m = self._ready_managers[manager_id]
+
+                # m is a ManagerRecord, but msg is a dict[Any,Any] and so can
+                # contain arbitrary fields beyond those in ManagerRecord (and
+                # indeed does - for example, python_v) which are then ignored
+                # later.
+                m.update(msg)  # type: ignore[typeddict-item]
+
+                logger.info("Registration info for manager {!r}: {}".format(manager_id, msg))
+                self._send_monitoring_info(hub_channel, m)
+
+                if (msg['python_v'].rsplit(".", 1)[0] != self.current_platform['python_v'].rsplit(".", 1)[0] or
+                    msg['parsl_v'] != self.current_platform['parsl_v']):
+                    logger.error("Manager {!r} has incompatible version info with the interchange".format(manager_id))
+                    logger.debug("Setting kill event")
+                    kill_event.set()
+                    e = VersionMismatch("py.v={} parsl.v={}".format(self.current_platform['python_v'].rsplit(".", 1)[0],
+                                                                    self.current_platform['parsl_v']),
+                                        "py.v={} parsl.v={}".format(msg['python_v'].rsplit(".", 1)[0],
+                                                                    msg['parsl_v'])
+                                        )
+                    result_package = {'type': 'result', 'task_id': -1, 'exception': serialize_object(e)}
+                    pkl_package = pickle.dumps(result_package)
+                    self.results_outgoing.send(pkl_package)
+                    logger.error("Sent failure reports, shutting down interchange")
                 else:
-                    # We set up an entry only if registration works correctly
-                    self._ready_managers[manager_id] = {'last_heartbeat': time.time(),
-                                                        'idle_since': time.time(),
-                                                        'block_id': None,
-                                                        'max_capacity': 0,
-                                                        'worker_count': 0,
-                                                        'active': True,
-                                                        'tasks': []}
-                    self.connected_block_history.append(msg['block_id'])
-                if reg_flag is True:
-                    interesting_managers.add(manager_id)
-                    logger.info("Adding manager: {!r} to ready queue".format(manager_id))
-                    m = self._ready_managers[manager_id]
-                    m.update(msg)
-                    logger.info("Registration info for manager {!r}: {}".format(manager_id, msg))
-                    self._send_monitoring_info(hub_channel, m)
-
-                    if (msg['python_v'].rsplit(".", 1)[0] != self.current_platform['python_v'].rsplit(".", 1)[0] or
-                        msg['parsl_v'] != self.current_platform['parsl_v']):
-                        logger.error("Manager {!r} has incompatible version info with the interchange".format(manager_id))
-                        logger.debug("Setting kill event")
-                        kill_event.set()
-                        e = VersionMismatch("py.v={} parsl.v={}".format(self.current_platform['python_v'].rsplit(".", 1)[0],
-                                                                        self.current_platform['parsl_v']),
-                                            "py.v={} parsl.v={}".format(msg['python_v'].rsplit(".", 1)[0],
-                                                                        msg['parsl_v'])
-                                            )
-                        result_package = {'type': 'result', 'task_id': -1, 'exception': serialize_object(e)}
-                        pkl_package = pickle.dumps(result_package)
-                        self.results_outgoing.send(pkl_package)
-                        logger.error("Sent failure reports, shutting down interchange")
-                    else:
-                        logger.info("Manager {!r} has compatible Parsl version {}".format(manager_id, msg['parsl_v']))
-                        logger.info("Manager {!r} has compatible Python version {}".format(manager_id,
-                                                                                           msg['python_v'].rsplit(".", 1)[0]))
-                else:
-                    # Registration has failed.
-                    logger.debug("Suppressing bad registration from manager: {!r}".format(manager_id))
-
-            else:
-                heartbeat = int.from_bytes(message[1], "little")
+                    logger.info("Manager {!r} has compatible Parsl version {}".format(manager_id, msg['parsl_v']))
+                    logger.info("Manager {!r} has compatible Python version {}".format(manager_id,
+                                                                                       msg['python_v'].rsplit(".", 1)[0]))
+            elif msg['type'] == 'heartbeat':
                 self._ready_managers[manager_id]['last_heartbeat'] = time.time()
-                if heartbeat == HEARTBEAT_CODE:
-                    logger.debug("Manager {!r} sent heartbeat via tasks connection".format(manager_id))
-                    self.task_outgoing.send_multipart([manager_id, b'', PKL_HEARTBEAT_CODE])
-                else:
-                    logger.error("Unexpected non-heartbeat message received from manager {}")
+                logger.debug("Manager {!r} sent heartbeat via tasks connection".format(manager_id))
+                self.task_outgoing.send_multipart([manager_id, b'', PKL_HEARTBEAT_CODE])
+            else:
+                logger.error(f"Unexpected message type received from manager: {msg['type']}")
             logger.debug("leaving task_outgoing section")
 
     def process_tasks_to_send(self, interesting_managers: Set[bytes]) -> None:

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -237,7 +237,8 @@ class Manager:
     def create_reg_message(self):
         """ Creates a registration message to identify the worker to the interchange
         """
-        msg = {'parsl_v': PARSL_VERSION,
+        msg = {'type': 'registration',
+               'parsl_v': PARSL_VERSION,
                'python_v': "{}.{}.{}".format(sys.version_info.major,
                                              sys.version_info.minor,
                                              sys.version_info.micro),
@@ -258,8 +259,9 @@ class Manager:
     def heartbeat_to_incoming(self):
         """ Send heartbeat to the incoming task queue
         """
-        heartbeat = (HEARTBEAT_CODE).to_bytes(4, "little")
-        self.task_incoming.send(heartbeat)
+        msg = {'type': 'heartbeat'}
+        b_msg = json.dumps(msg).encode('utf-8')
+        self.task_incoming.send(b_msg)
         logger.debug("Sent heartbeat")
 
     @wrap_with_logs


### PR DESCRIPTION
This is to permit imminent changes to this protocol to allow quenching of task delivery as part of work to drain workers near the end of their walltime.

Prior to this PR, the protocol used two formats: the first message in the worker->interchange task_output pipe was a JSON object, the "registration message".

Subsequent messages were not JSON, but an integer encoded as a byte sequence. This integer was historically used for two purposes: as a heartbeat (with value HEARTBEAT_CODE = (2 ** 32) - 1) and as a count of tasks to request from the interchange.

This latter use was removed in PRs #2588 and #3062, leaving only the heartbeat use case.

To allow this channel to be used for richer messages, this PR switches the messages on this stream to always be JSON object, with a 'type' entry: currently 'registration' or 'heartbeat'.

This is in line with the 'result_package' format used on the manager->interchange results_outgoing channel, and so aligns with issue #3022 which talks about unifying those two channels.

Code paths:

This PR removes the reg_flag variable used in registration code, which was redundant and only used to route control flow from a try block into an immediately following code block: that second block is merged upwards.

That try block protected/protects json decoding, and is moved higher up because there is now no need to have a separate path for "expecting JSON" and "expecting encoded int".

Type checking: This PR adds some additional checking for JSON structure to report a more useful error when the message is not a dictionary; this drives mypy to specialise the type of `msg` to dict[Any, Any] which can then not be used to update a ManagerRecord. This PR adds a # type: ignore with commentary to address that.

Testing: while registration is implicitly tested by htex tests successfully running tasks, there isn't any automated testing of manager->interchange heartbeats, so human review should pay special attention there.

# Changed Behaviour

The wire protocol is changed: anyone pretending they can use different versions of Parsl on worker and interchange (#2957) sides will encounter breakage (likely a hang).

## Type of change

- New feature
