### PR TITLE
Tidy up htex worker pool start time recording

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -140,7 +140,9 @@ class Manager:
             Path to the certificate directory.
         """
 
-        logger.info("Manager started")
+        logger.info("Manager initializing")
+
+        self._start_time = time.time()
 
         try:
             ix_address = probe_addresses(addresses.split(','), task_port, timeout=address_probe_timeout)
@@ -454,7 +456,6 @@ class Manager:
 
         TODO: Move task receiving to a thread
         """
-        start = time.time()
         self._kill_event = threading.Event()
         self._tasks_in_progress = self._mp_manager.dict()
 
@@ -504,7 +505,7 @@ class Manager:
         self.task_incoming.close()
         self.result_outgoing.close()
         self.zmq_context.term()
-        delta = time.time() - start
+        delta = time.time() - self._start_time
         logger.info("process_worker_pool ran for {} seconds".format(delta))
         return
 


### PR DESCRIPTION
The start time is needed as part of upcoming work on walltime-based worker draining (so this PR makes it into an instance attribute)...

... and it can be made more accurate than the previous implementation by measuring it earlier (most especially, prior to invoking the often expensive probe_addresses call)

This PR rephrases a nearby log line which uses the word "starting" despite being not in the start() procedure of the manager, to reduce ambiguity when reading the code vs logs.

# Changed Behaviour

Users who pay attention to this log line:

>         logger.info("process_worker_pool ran for {} seconds".format(delta))

might notice a slight increase in the seconds count for "the same" duration runs.

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
