### PR TITLE
Repurpose test_scaling/test_scale_down.py for simple strategy

### DIFF
--- a/parsl/tests/test_scaling/test_scale_down.py
+++ b/parsl/tests/test_scaling/test_scale_down.py
@@ -39,7 +39,7 @@ def local_config():
             )
         ],
         max_idletime=0.5,
-        strategy='htex_auto_scale',
+        strategy='simple',
     )
 
 


### PR DESCRIPTION
PR #3097 introduced a more comprehensive test for the htex_auto_scale strategy, based on this test, and prior to this PR, test_scale_down only tested the 'simple' strategy parts of htex_auto_scale.

So, this PR leaves the #3097 test to test the `htex_auto_scale` strategy, and adds coverage for the `simple` strategy.

## Type of change

- Code maintenance/cleanup
