### PR TITLE
Adding onto #3111: shallow resolution of lists, sets, and tuples

### DIFF
--- a/parsl/dataflow/future_resolution.py
+++ b/parsl/dataflow/future_resolution.py
@@ -1,6 +1,5 @@
 from concurrent.futures import Future
 from functools import singledispatch
-from typing import Union
 
 
 @singledispatch

--- a/parsl/dataflow/future_resolution.py
+++ b/parsl/dataflow/future_resolution.py
@@ -35,8 +35,7 @@ def _(iterable: Union[tuple, list, set]):
     # a "deep" traversal would instead recursively call traverse_to_gather
     # here to inspect whatever is inside the sequence
 
-    type_ = type(iterable)
-    return type_([v for v in iterable if isinstance(v, Future)])
+    return [v for v in iterable if isinstance(v, Future)]
 
 
 @traverse_to_unwrap.register

--- a/parsl/dataflow/future_resolution.py
+++ b/parsl/dataflow/future_resolution.py
@@ -30,17 +30,21 @@ def _(fut: Future):
 # Below is an example of shallow traversal of iterables.
 
 
-@traverse_to_gather.register
-def _(iterable: Union[tuple, list, set]):
+@traverse_to_gather.register(tuple)
+@traverse_to_gather.register(list)
+@traverse_to_gather.register(set)
+def _(iterable):
     # a "deep" traversal would instead recursively call traverse_to_gather
     # here to inspect whatever is inside the sequence
 
     return [v for v in iterable if isinstance(v, Future)]
 
 
-@traverse_to_unwrap.register
+@traverse_to_unwrap.register(tuple)
+@traverse_to_unwrap.register(list)
+@traverse_to_unwrap.register(set)
 @singledispatch
-def _(iterable: Union[tuple, list, set]):
+def _(iterable):
     def unwrap(v):
         if isinstance(v, Future):
             assert (

--- a/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
+++ b/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from threading import Event
-from typing import Iterable, Sequence
+from typing import Sequence
 
 import pytest
 

--- a/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
+++ b/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
@@ -49,7 +49,7 @@ def make_path(s: str):
 
 
 @parsl.python_app
-def append_paths(iterable: Iterable[Path], end_str: str = "end"):
+def append_paths(iterable, end_str: str = "end"):
     type_ = type(iterable)
     return type_([Path(s, end_str) for s in iterable])
 

--- a/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
+++ b/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
@@ -1,10 +1,11 @@
-import parsl
+from pathlib import Path
+from threading import Event
+from typing import Sequence
+
 import pytest
 
+import parsl
 from parsl.tests.configs.local_threads import fresh_config as local_config
-
-from typing import Sequence
-from threading import Event
 
 
 @parsl.python_app
@@ -36,7 +37,33 @@ def b_first(x: Sequence[int]):
 @pytest.mark.local
 def test_tuple_pos_arg():
     e = Event()
-    s = (a(e), )
+    s = (a(e),)
     f_b = b_first(s)
     e.set()
     assert f_b.result() == 8
+
+
+@parsl.python_app
+def make_path(s: str):
+    return Path(s)
+
+
+@parsl.python_app
+def append_paths(seq: Sequence[Path], end_str: str = "end"):
+    return [Path(s, end_str) for s in seq]
+
+
+@pytest.mark.local
+@pytest.mark.parametrize(
+    "type_",
+    [
+        tuple,
+        list,
+        set,
+    ],
+)
+def test_resolving_iterables(type_):
+    output1 = make_path("test1")
+    output2 = make_path("test2")
+    output3 = append_paths(type_([output1, output2]), end_str="end")
+    assert output3.result() == type_([Path("test1", "end"), Path("test2", "end")])

--- a/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
+++ b/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
@@ -30,7 +30,7 @@ def test_simple_pos_arg():
 
 
 @parsl.python_app
-def b_first(x: Sequence[int]):
+def b_first(x: Iterable[int]):
     return x[0] + 1
 
 

--- a/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
+++ b/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from threading import Event
-from typing import Iterable
+from typing import Iterable, Sequence
 
 import pytest
 
@@ -30,7 +30,7 @@ def test_simple_pos_arg():
 
 
 @parsl.python_app
-def b_first(x: Iterable[int]):
+def b_first(x: Sequence[int]):
     return x[0] + 1
 
 

--- a/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
+++ b/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from threading import Event
-from typing import Sequence
+from typing import Iterable
 
 import pytest
 
@@ -49,9 +49,9 @@ def make_path(s: str):
 
 
 @parsl.python_app
-def append_paths(seq: Sequence[Path], end_str: str = "end"):
-    type_ = type(seq)
-    return type_([Path(s, end_str) for s in seq])
+def append_paths(iterable: Iterable[Path], end_str: str = "end"):
+    type_ = type(iterable)
+    return type_([Path(s, end_str) for s in iterable])
 
 
 @pytest.mark.local

--- a/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
+++ b/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
@@ -50,7 +50,8 @@ def make_path(s: str):
 
 @parsl.python_app
 def append_paths(seq: Sequence[Path], end_str: str = "end"):
-    return [Path(s, end_str) for s in seq]
+    type_ = type(seq)
+    return type_([Path(s, end_str) for s in seq])
 
 
 @pytest.mark.local


### PR DESCRIPTION
@benclifford: This PR into #3111 is to augment support for shallow-level `AppFuture` resolution.

A few comments:
1. The newly added tests pass on Python 3.11 for me, but I can't figure out the typing syntax for Python 3.8/3.9. I tried replacing `tuple`, `list`, and `set` with `typing.Tuple`, `typing.List`, and `typing.Set`, but that didn't help matters.
2. I tried to generalize [this line](https://github.com/Parsl/parsl/pull/3118/files#diff-d95e44771f15076748fffdf10ae0a92f25b3aeed06a61c26b4488b0103220b20R44) as being of type `Sequence` or `Iterable` instead of `Union[tuple, list, set]`, but when doing the former, the output of the test has `Path(<mapping>)` objects instead of the expected normal `pathlib.Path("str")` kind of result. So, I stuck with the explicit `Union`.
3. This does not yet address the `dict` type (or, rather, general `Mapping` type). I wanted to solve the above instances first.