### PR TITLE
Stop DFK cleanup in atexit, because this doesn't work in Python >3.12"

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,7 @@
 # W504: line break after binary operator
 #       (Raised by flake8 even when it is followed)
 ignore = E126, E402, E129, W504
-max-line-length = 153
+max-line-length = 152
 exclude = test_import_fail.py,
   parsl/executors/workqueue/parsl_coprocess.py
 # E741 disallows ambiguous single letter names which look like numbers

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1143,8 +1143,7 @@ class DataFlowKernel:
 
     def atexit_cleanup(self) -> None:
         if not self.cleanup_called:
-            logger.info("DFK cleanup because python process is exiting")
-            self.cleanup()
+            logger.warning("Parsl wasn't cleaned up. You should call parsl.dfk().cleanup() before exiting.")
         else:
             logger.info("python process is exiting, but DFK has already been cleaned up")
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -327,7 +327,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
     def _warn_deprecated(self, old: str, new: str):
         warnings.warn(
             f"{old} is deprecated and will be removed in a future release. "
-            "Please use {new} instead.",
+            f"Please use {new} instead.",
             DeprecationWarning,
             stacklevel=2
         )

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -290,8 +290,12 @@ class MonitoringHub(RepresentationMixin):
             self._dfk_channel.close()
             if exception_msgs:
                 for exception_msg in exception_msgs:
-                    self.logger.error("{} process delivered an exception: {}. Terminating all monitoring processes immediately.".format(exception_msg[0],
-                                      exception_msg[1]))
+                    self.logger.error(
+                        "{} process delivered an exception: {}. Terminating all monitoring processes immediately.".format(
+                            exception_msg[0],
+                            exception_msg[1]
+                        )
+                    )
                 self.router_proc.terminate()
                 self.dbm_proc.terminate()
                 self.filesystem_proc.terminate()


### PR DESCRIPTION
# Description

atexit handlers work differently in the latest version of Python (version 3.12) and it is not safe to automatically call cleanup any more in Python 3.12

# Changed Behaviour

Instead of cleaning up, the code will now emit a WARNING log message to help users understand the change.

# Fixes

Fixes # (https://github.com/Parsl/parsl/issues/3104)

## Type of change

- Bug fix
