### PR TITLE
Reduce flake8 max-line-length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,7 @@
 # W504: line break after binary operator
 #       (Raised by flake8 even when it is followed)
 ignore = E126, E402, E129, W504
-max-line-length = 152
+max-line-length = 151
 exclude = test_import_fail.py,
   parsl/executors/workqueue/parsl_coprocess.py
 # E741 disallows ambiguous single letter names which look like numbers

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -518,7 +518,8 @@ class DatabaseManager:
                                 reprocessable_first_resource_messages.append(msg)
                             else:
                                 if task_try_id in deferred_resource_messages:
-                                    logger.error("Task {} already has a deferred resource message. Discarding previous message.".format(msg['task_id']))
+                                    logger.error("Task {} already has a deferred resource message. "
+                                                 "Discarding previous message.".format(msg['task_id']))
                                 deferred_resource_messages[task_try_id] = msg
                         elif msg['last_msg']:
                             # This assumes that the primary key has been added


### PR DESCRIPTION
# Description

This change makes pass through flake8 test when new max-line-length value set.
More specifically error refers to parsl/monitoring/db_manager.py:521:152: E501 line too long (152 > 151 characters), so corresponding changes have been made in this file to make it work with new value.

# Changed Behaviour

This PR doesn't affect any existing user workflows or functionality.

# Fixes

Fixes #3105 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
