### PR TITLE
Update mpi_apps.rst

### DIFF
--- a/docs/userguide/mpi_apps.rst
+++ b/docs/userguide/mpi_apps.rst
@@ -146,7 +146,7 @@ Writing MPI-Compatible Apps
 ++++++++++++++++++++++++++++
 
 In MPI mode, the :class:`~parsl.executors.high_throughput.executor.HighThroughputExecutor` can execute both Python or Bash Apps which invokes the MPI application.
-However, it is important to not that Python Apps that directly use ``mpi4py`` is not supported.
+However, it is important to note that Python Apps that directly use ``mpi4py`` is not supported.
 
 For multi-node MPI applications, especially when running multiple applications within a single batch job,
 it is important to specify the resource requirements for the app so that the Parsl worker can provision


### PR DESCRIPTION
fixed type note

# Description

docs/userguide/mpi_apps.rst contains this typo of the word "note":

However, it is important to not that Python Apps that directly use mpi4py is not supported.
It should be important to note

# Changed Behaviour
No typos

Which existing user workflows or functionality will behave differently after this PR?

# Fixes

Fixes #3158


## Type of change

Choose which options apply, and delete the ones which do not apply.
- Update to human readable text: Documentation/error messages/comments

