### PR TITLE
Updated simpleLauncher Function 

### DIFF
--- a/docs/userguide/execution.rst
+++ b/docs/userguide/execution.rst
@@ -39,7 +39,7 @@ parameters include access keys, instance type, and spot bid price
 Parsl currently supports the following providers:
 
 1. `parsl.providers.LocalProvider`: The provider allows you to run locally on your laptop or workstation.
-2. `parsl.providers.CobaltProvider`: This provider allows you to schedule resources via the Cobalt scheduler.
+2. `parsl.providers.CobaltProvider: This provider allows you to schedule resources via the Cobalt scheduler. Please note that the CobaltProvider is deprecated and will be removed by 2024.04.
 3. `parsl.providers.SlurmProvider`: This provider allows you to schedule resources via the Slurm scheduler.
 4. `parsl.providers.CondorProvider`: This provider allows you to schedule resources via the Condor scheduler.
 5. `parsl.providers.GridEngineProvider`: This provider allows you to schedule resources via the GridEngine scheduler.

--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -8,8 +8,9 @@ logger = logging.getLogger(__name__)
 class SimpleLauncher(Launcher):
     """ Does no wrapping. Just returns the command as-is
     """
-    def __init_(self, debug: bool = True) -> None:
+    def __init__(self, permit_multiple_nodes=False, debug: bool = True) -> None:
         super().__init__(debug=debug)
+        self.permit_multiple_nodes = permit_multiple_nodes
 
     def __call__(self, command: str, tasks_per_node: int, nodes_per_block: int) -> str:
         """
@@ -18,6 +19,8 @@ class SimpleLauncher(Launcher):
         - task_block (string) : bash evaluated string.
 
         """
+        if not self.permit_multiple_nodes and nodes_per_block > 1:
+            raise ValueError("SimpleLauncher only supports one node per block.")
         return command
 
 

--- a/parsl/tests/sites/test_launchers.py
+++ b/parsl/tests/sites/test_launchers.py
@@ -9,3 +9,19 @@ def test_wrapped_launcher(caplog):
     w('test', 2, 2)
     assert 'tasks per node' in caplog.text
     assert 'nodes per block' in caplog.text
+    
+def test_simple_launcher_one_node_per_block():
+    # Test that SimpleLauncher works with one node per block specified
+    launcher = SimpleLauncher()
+    assert launcher("", 1, 1) == ""
+
+def test_simple_launcher_exception():
+    # Test that SimpleLauncher raises an exception with some other number of nodes per block
+    launcher = SimpleLauncher()
+    with pytest.raises(ValueError):
+        launcher("", 1, 64)
+
+def test_advanced_users_permit_multiple_nodes():
+    # Test that advanced users can disable the exception when using multiple nodes per block
+    launcher = SimpleLauncher(permit_multiple_nodes=True)
+    assert launcher("", 1, 64) == ""

--- a/parsl/tests/sites/test_launchers.py
+++ b/parsl/tests/sites/test_launchers.py
@@ -9,19 +9,3 @@ def test_wrapped_launcher(caplog):
     w('test', 2, 2)
     assert 'tasks per node' in caplog.text
     assert 'nodes per block' in caplog.text
-    
-def test_simple_launcher_one_node_per_block():
-    # Test that SimpleLauncher works with one node per block specified
-    launcher = SimpleLauncher()
-    assert launcher("", 1, 1) == ""
-
-def test_simple_launcher_exception():
-    # Test that SimpleLauncher raises an exception with some other number of nodes per block
-    launcher = SimpleLauncher()
-    with pytest.raises(ValueError):
-        launcher("", 1, 64)
-
-def test_advanced_users_permit_multiple_nodes():
-    # Test that advanced users can disable the exception when using multiple nodes per block
-    launcher = SimpleLauncher(permit_multiple_nodes=True)
-    assert launcher("", 1, 64) == ""


### PR DESCRIPTION
# Description

The SimpleLauncher class has been updated to raise an exception when users attempt to use it with multiple nodes per block without specifying the `permit_multiple_nodes` parameter. Additionally, the __init__ method of SimpleLauncher now includes a new parameter `permit_multiple_nodes` to allow advanced users to disable this exception and use multiple nodes per block if needed.

# Changed Behaviour

After this change, users attempting to use SimpleLauncher with multiple nodes per block without setting `permit_multiple_nodes=True` will receive an exception. This behavior ensures that users are aware of the limitations of SimpleLauncher and can make informed decisions when specifying launcher options.


# Fixes

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix
- New feature
- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
