### PR TITLE
Add a new line in the execution.rst file

### DIFF
--- a/docs/userguide/execution.rst
+++ b/docs/userguide/execution.rst
@@ -39,7 +39,7 @@ parameters include access keys, instance type, and spot bid price
 Parsl currently supports the following providers:
 
 1. `parsl.providers.LocalProvider`: The provider allows you to run locally on your laptop or workstation.
-2. `parsl.providers.CobaltProvider`: This provider allows you to schedule resources via the Cobalt scheduler. **This provider is deprecated and will be removed by 2024.04**.
+2. `parsl.providers.CobaltProvider`: This provider allows you to schedule resources via the Cobalt scheduler. **Please note that the CobaltProvider is DEPRECATED and will be removed by 2024.04**.
 3. `parsl.providers.SlurmProvider`: This provider allows you to schedule resources via the Slurm scheduler.
 4. `parsl.providers.CondorProvider`: This provider allows you to schedule resources via the Condor scheduler.
 5. `parsl.providers.GridEngineProvider`: This provider allows you to schedule resources via the GridEngine scheduler.


### PR DESCRIPTION
# Description

This PR adds a line to the documentation regarding the CobaltProvider, indicating that it is deprecated and will be removed by 2024.04. This change provides clarity and ensures users are aware of the deprecation timeline.

# Changed Behaviour

After this PR, users accessing the documentation will be informed about the deprecation of the CobaltProvider and its planned removal by 2024.04. This may prompt users to migrate to alternative providers.

# Fixes

N/A

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Update to human readable text: Documentation/error messages/comments

