### PR TITLE
 Upadated the SimpleLauncher Class

### DIFF
--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 class SimpleLauncher(Launcher):
     """ Does no wrapping. Just returns the command as-is
     """
-    def __init_(self, debug: bool = True) -> None
+    def __init_(self, debug: bool = True) -> None:
         super().__init__(debug=debug)
 
     def __call__(self, command: str, tasks_per_node: int, nodes_per_block: int) -> str:

--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -8,16 +8,19 @@ logger = logging.getLogger(__name__)
 class SimpleLauncher(Launcher):
     """ Does no wrapping. Just returns the command as-is
     """
-    def __init_(self, debug: bool = True) -> None:
+    def __init__(self, debug: bool = True) -> None:
         super().__init__(debug=debug)
 
-    def __call__(self, command: str, tasks_per_node: int, nodes_per_block: int) -> str:
+    def __call__(self, command: str, tasks_per_node: int, nodes_per_block: int, permit_multiple_nodes: bool = False) -> str:
         """
         Args:
         - command (string): The command string to be launched
-        - task_block (string) : bash evaluated string.
-
+        - tasks_per_node (int): Number of tasks to launch per node
+        - nodes_per_block (int): Number of nodes per block
+        - permit_multiple_nodes (bool): Whether to allow multiple nodes per block
         """
+        if nodes_per_block > 1 and not permit_multiple_nodes:
+            raise ValueError("SimpleLauncher only supports 1 node per block. Set permit_multiple_nodes=True to allow multiple nodes per block.")
         return command
 
 

--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 class SimpleLauncher(Launcher):
     """ Does no wrapping. Just returns the command as-is
     """
-    def __init_(self, debug: bool = True) -> None:
+    def __init_(self, debug: bool = True) -> None
         super().__init__(debug=debug)
 
     def __call__(self, command: str, tasks_per_node: int, nodes_per_block: int) -> str:


### PR DESCRIPTION
# Description

This pull request enhances the behavior of the SimpleLauncher class in the Parsl library. It addresses the issue where users could inadvertently attempt to use the SimpleLauncher with multiple nodes per block, which could lead to confusion and unexpected behavior. This enhancement ensures that an exception is raised when users try to use the SimpleLauncher with more than one node per block, unless explicitly permitted.

# Changed Behaviour

After this PR, if users attempt to use the SimpleLauncher with multiple nodes per block without explicitly permitting it, an exception will be raised. This helps clarify the behavior of the SimpleLauncher and prevents potential confusion for users.

# Fixes

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix

