### PR TITLE
Fixed the bug for linkcode_resolve function

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,8 +52,24 @@ def linkcode_resolve(domain, info):
         return None
     if not info['module']:
         return None
-    filename = info['module'].replace('.', '/')
-    return "http://github.com/Parsl/parsl/blob/master/{}.py".format(filename)
+    
+    module = info['module']
+    fullname = info['fullname']
+    obj = sys.modules.get(module)
+    if obj is None:
+        return None
+
+    # Handle re-exported module names
+    if module.startswith('parsl.provider'):
+        module = 'parsl.provider.provider'
+
+    # Adjust module path if necessary
+    module = module.replace('.', '/')
+
+    # Construct GitHub URL
+    github_url = f"https://github.com/Parsl/parsl/blob/master/{module}.py"
+
+    return github_url
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
# Description

This change adjusts the linkcode_resolve function in the conf.py file to properly handle the mapping of module names to their corresponding GitHub URLs. Specifically, it addresses the issue where the assumption about the source code location for CondorProvider is incorrect.

# Changed Behaviour

After this change, when generating documentation, the links to the source code on GitHub for modules like parsl.provider.CondorProvider will correctly point to the appropriate location, ensuring accurate reference to the source code.

# Fixes

Fixes # (#2604 )

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix
