### PR TITLE
Upadate SimpleLauncher class to warn user 

### DIFF
--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -8,10 +8,15 @@ logger = logging.getLogger(__name__)
 class SimpleLauncher(Launcher):
     """ Does no wrapping. Just returns the command as-is
     """
-    def __init_(self, debug: bool = True) -> None:
+    def __init_(self, debug: bool = True, permit_multiple_nodes: bool = False) -> None:
         super().__init__(debug=debug)
+        self.permit_multiple_nodes = permit_multiple_nodes
 
     def __call__(self, command: str, tasks_per_node: int, nodes_per_block: int) -> str:
+        advanced_user_permit_multiple_nodes = self.permit_multiple_nodes
+        if not advanced_user_permit_multiple_nodes and nodes_per_block > 1:
+            logger.warning("You can only use SimpleLauncher with 1 node per block")
+
         """
         Args:
         - command (string): The command string to be launched

--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -15,7 +15,8 @@ class SimpleLauncher(Launcher):
     def __call__(self, command: str, tasks_per_node: int, nodes_per_block: int) -> str:
         advanced_user_permit_multiple_nodes = self.permit_multiple_nodes
         if not advanced_user_permit_multiple_nodes and nodes_per_block > 1:
-            logger.warning("You can only use SimpleLauncher with 1 node per block")
+            logger.warning("SimpleLauncher supports only 1 node per block. "
+                           "To allow multiple nodes per block set permit_multiple_nodes=True ")
 
         """
         Args:


### PR DESCRIPTION


# Description

Please include a summary of the change and (optionally) which issue is fixed. Please also include
relevant motivation and context.

Updated the SimpleLauncher class to throw a warning when a user tries to use more than one node per block. Advanced users do not get a warning if they set  permit_multiple_nodes=True. This PR fixes issue #3161 


# Changed Behaviour

Which existing user workflows or functionality will behave differently after this PR?

Users who are not advanced users will now get a warning when they try to use more than one node per block. Advanced users will not get a warning if they set permit_multiple_nodes=True.

# Fixes

Fixes # (issue)
#3161 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix
- New feature


