### PR TITLE
Reduce flake8 max-line-length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,7 @@
 # W504: line break after binary operator
 #       (Raised by flake8 even when it is followed)
 ignore = E126, E402, E129, W504
-max-line-length = 151
+max-line-length = 150
 exclude = test_import_fail.py,
   parsl/executors/workqueue/parsl_coprocess.py
 # E741 disallows ambiguous single letter names which look like numbers


### PR DESCRIPTION
# Description
Reduce flake8 max-line-length
When I set up the project, the max line length was 152 and I decreased it by one.

# Changed Behaviour
max line length is reduced by 1 and creates an error when we run this command
`make flake8`

# Fixes
Reduce flake8 max-line-length

Fixes # (issue)
[#3105](https://github.com/Parsl/parsl/issues/3105)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
