### PR TITLE
Update Execution Providers section of Quickstart Guide

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -134,8 +134,10 @@ Execution Providers
 
 Resource providers allow Parsl to gain access to computing power.
 For supercomputers, gaining resources often requires requesting them from a scheduler (e.g., Slurm).
-Parsl Providers write the requests to requisition **"Blocks"** (e.g., supercomputer nodes) on your behalf.
-Parsl comes pre-packaged with Providers compatible with most supercomputers and some cloud computing services.
+Parsl Providers manage the process of requesting **"Blocks"** on your behalf, which, in the context of Slurm, 
+are equivalent to separate Slurm allocations. Each **"Block"** represents an individual allocation of resources, 
+such as supercomputer nodes. Parsl comes pre-packaged with Providers compatible with most supercomputers and 
+some cloud computing services.
 
 Another key role of Providers is defining how to start an Executor on a remote computer.
 Often, this simply involves specifying the correct Python environment and


### PR DESCRIPTION
# Description

Updates the wording in the Execution Providers section of Quickstart Guide

# Fixes

Fixes #3183 ("Blocks" in the quickstart guide could be more accurately described)

## Type of change

- Update to human readable text: Documentation/error messages/comments
