### PR TITLE
Reduce flake8 max-line-length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,7 @@
 # W504: line break after binary operator
 #       (Raised by flake8 even when it is followed)
 ignore = E126, E402, E129, W504
-max-line-length = 150
+max-line-length = 149
 exclude = test_import_fail.py,
   parsl/executors/workqueue/parsl_coprocess.py
 # E741 disallows ambiguous single letter names which look like numbers

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -583,8 +583,10 @@ class DatabaseManager:
                     self._dispatch_to_internal(x)
                 elif queue_tag == 'resource':
                     assert isinstance(x, tuple), "_migrate_logs_to_internal was expecting a tuple, got {}".format(x)
-                    assert x[0] == MessageType.RESOURCE_INFO, \
-                        "_migrate_logs_to_internal can only migrate RESOURCE_INFO message from resource queue, got tag {}, message {}".format(x[0], x)
+                    assert x[0] == MessageType.RESOURCE_INFO, (
+                        "_migrate_logs_to_internal can only migrate RESOURCE_INFO message from resource queue, "
+                        "got tag {}, message {}".format(x[0], x)
+                    )
                     self._dispatch_to_internal(x)
                 elif queue_tag == 'node':
                     assert len(x) == 2, "expected message tuple to have exactly two elements"

--- a/parsl/tests/test_scaling/test_scale_down_htex_auto_scale.py
+++ b/parsl/tests/test_scaling/test_scale_down_htex_auto_scale.py
@@ -98,7 +98,8 @@ def test_scale_out(tmpd_cwd, try_assert):
 
     assert dfk.executors['htex_local'].outstanding == 0
 
-    # now we can launch one "long" task - and what should happen is that the connected_managers count "eventually" (?) converges to 1 and stays there.
+    # now we can launch one "long" task -
+    # and what should happen is that the connected_managers count "eventually" (?) converges to 1 and stays there.
 
     finish_path = tmpd_cwd / "stage2_workers_may_continue"
 


### PR DESCRIPTION
# Description

Reduce max-length line from 150 to 149. To make make flake8 run successfully as reducing max-length voilates the code functionality, So to ensure it fits within the new maximum line length limit of 149 characters i splits it into multiple lines

# Changed Behaviour

It doesn't change flow of code

# Fixes

Fixes [#3105](https://github.com/Parsl/parsl/issues/3105)

## Type of change

- Code maintenance/cleanup
