### PR TITLE
Added deprecated warning in CobaltProvider line

### DIFF
--- a/docs/userguide/execution.rst
+++ b/docs/userguide/execution.rst
@@ -39,7 +39,7 @@ parameters include access keys, instance type, and spot bid price
 Parsl currently supports the following providers:
 
 1. `parsl.providers.LocalProvider`: The provider allows you to run locally on your laptop or workstation.
-2. `parsl.providers.CobaltProvider`: This provider allows you to schedule resources via the Cobalt scheduler. This provider is DEPRECATED and will be removed by 2024.04
+2. `parsl.providers.CobaltProvider`: This provider allows you to schedule resources via the Cobalt scheduler. This provider is DEPRECATED, and will be removed by 2024.04
 3. `parsl.providers.SlurmProvider`: This provider allows you to schedule resources via the Slurm scheduler.
 4. `parsl.providers.CondorProvider`: This provider allows you to schedule resources via the Condor scheduler.
 5. `parsl.providers.GridEngineProvider`: This provider allows you to schedule resources via the GridEngine scheduler.

--- a/docs/userguide/execution.rst
+++ b/docs/userguide/execution.rst
@@ -39,7 +39,7 @@ parameters include access keys, instance type, and spot bid price
 Parsl currently supports the following providers:
 
 1. `parsl.providers.LocalProvider`: The provider allows you to run locally on your laptop or workstation.
-2. `parsl.providers.CobaltProvider`: This provider allows you to schedule resources via the Cobalt scheduler. This provider is DEPRECATED, and will be removed by 2024.04
+2. `parsl.providers.CobaltProvider`: This provider allows you to schedule resources via the Cobalt scheduler. This provider is DEPRECATED and will be removed by 2024.04
 3. `parsl.providers.SlurmProvider`: This provider allows you to schedule resources via the Slurm scheduler.
 4. `parsl.providers.CondorProvider`: This provider allows you to schedule resources via the Condor scheduler.
 5. `parsl.providers.GridEngineProvider`: This provider allows you to schedule resources via the GridEngine scheduler.

--- a/docs/userguide/execution.rst
+++ b/docs/userguide/execution.rst
@@ -39,7 +39,7 @@ parameters include access keys, instance type, and spot bid price
 Parsl currently supports the following providers:
 
 1. `parsl.providers.LocalProvider`: The provider allows you to run locally on your laptop or workstation.
-2. `parsl.providers.CobaltProvider`: This provider allows you to schedule resources via the Cobalt scheduler. **This provider is deprecated and will be removed by 2024.04**.
+2. `parsl.providers.CobaltProvider`: This provider allows you to schedule resources via the Cobalt scheduler. This provider is DEPRECATED and will be removed by 2024.04
 3. `parsl.providers.SlurmProvider`: This provider allows you to schedule resources via the Slurm scheduler.
 4. `parsl.providers.CondorProvider`: This provider allows you to schedule resources via the Condor scheduler.
 5. `parsl.providers.GridEngineProvider`: This provider allows you to schedule resources via the GridEngine scheduler.


### PR DESCRIPTION
# Description

Added a DEPRECATED warning infront of CobaltProvider line in Execution Provider document i.e. https://parsl.readthedocs.io/en/stable/userguide/execution.html#execution-providers%3E

# Changed Behaviour

It will not change any code flow

# Fixes

Fixes #[ (3143)](https://github.com/Parsl/parsl/issues/3143)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Documentation

