### PR TITLE
Reduce flake8 max-line-length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,7 @@
 # W504: line break after binary operator
 #       (Raised by flake8 even when it is followed)
 ignore = E126, E402, E129, W504
-max-line-length = 149
+max-line-length = 148
 exclude = test_import_fail.py,
   parsl/executors/workqueue/parsl_coprocess.py
 # E741 disallows ambiguous single letter names which look like numbers

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -722,7 +722,10 @@ class DataFlowKernel:
         self._send_task_log_info(task_record)
 
         if hasattr(exec_fu, "parsl_executor_task_id"):
-            logger.info(f"Parsl task {task_id} try {try_id} launched on executor {executor.label} with executor id {exec_fu.parsl_executor_task_id}")
+            logger.info(
+                 f"Parsl task {task_id} try {try_id} launched on executor {executor.label}"
+                 f"with executor id {exec_fu.parsl_executor_task_id}"
+            )
         else:
             logger.info(f"Parsl task {task_id} try {try_id} launched on executor {executor.label}")
 

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -723,7 +723,7 @@ class DataFlowKernel:
 
         if hasattr(exec_fu, "parsl_executor_task_id"):
             logger.info(
-                 f"Parsl task {task_id} try {try_id} launched on executor {executor.label}"
+                 f"Parsl task {task_id} try {try_id} launched on executor {executor.label} "
                  f"with executor id {exec_fu.parsl_executor_task_id}"
             )
         else:

--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -228,7 +228,10 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         # factory logs go with manager logs regardless
         self.factory_config.scratch_dir = self.manager_config.vine_log_dir
         logger.debug(f"Function data directory: {self._function_data_dir}, log directory: {log_dir}")
-        logger.debug(f"TaskVine manager log directory: {self.manager_config.vine_log_dir}, factory log directory: {self.factory_config.scratch_dir}")
+        logger.debug(
+            f"TaskVine manager log directory: {self.manager_config.vine_log_dir},"
+            f"factory log directory: {self.factory_config.scratch_dir}"
+        )
 
     def start(self):
         """Create submit process and collector thread to create, send, and

--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -229,7 +229,7 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         self.factory_config.scratch_dir = self.manager_config.vine_log_dir
         logger.debug(f"Function data directory: {self._function_data_dir}, log directory: {log_dir}")
         logger.debug(
-            f"TaskVine manager log directory: {self.manager_config.vine_log_dir},"
+            f"TaskVine manager log directory: {self.manager_config.vine_log_dir}, "
             f"factory log directory: {self.factory_config.scratch_dir}"
         )
 

--- a/parsl/tests/configs/user_opts.py
+++ b/parsl/tests/configs/user_opts.py
@@ -52,7 +52,11 @@ user_opts = {
     #     'username': MIDWAY_USERNAME,
     #     'script_dir': '/scratch/midway2/{}/parsl_scripts'.format(MIDWAY_USERNAME),
     #     'scheduler_options': "",
-    #     'worker_init': 'cd /scratch/midway2/{}/parsl_scripts; module load Anaconda3/5.1.0; source activate parsl_testing;'.format(MIDWAY_USERNAME),
+    #     'worker_init': (
+    #         'cd /scratch/midway2/{}/parsl_scripts; '
+    #         'module load Anaconda3/5.1.0; '
+    #         'source activate parsl_testing;'
+    #      ).format(MIDWAY_USERNAME),
     # },
     # 'osg': {
     #     'username': OSG_USERNAME,


### PR DESCRIPTION
# Description

Reduce max-length line from 149 to 148 . And making changes to the different files to reduce the line size to run the Make flake8 command successfully 

# Changed Behaviour

These Changes does not change the actual working of the code . And significantly increase code readability

# Fixes

Fixes # (3105)

## Type of change

Choose which options apply, and delete the ones which do not apply.
- Code maintenance/cleanup
