### PR TITLE
SimpleLauncher should help the user understand why they are not getting multiple nodes #3161

### DIFF
--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -8,8 +8,13 @@ logger = logging.getLogger(__name__)
 class SimpleLauncher(Launcher):
     """ Does no wrapping. Just returns the command as-is
     """
-    def __init_(self, debug: bool = True) -> None:
-        super().__init__(debug=debug)
+
+    def __init__(self, nodes_per_block=1, permit_multiple_nodes=False):
+        self.nodes_per_block = nodes_per_block
+        self.permit_multiple_nodes = permit_multiple_nodes
+
+        if not self.permit_multiple_nodes and self.nodes_per_block != 1:
+            raise Exception("SimpleLauncher only supports 1 node per block by default.")
 
     def __call__(self, command: str, tasks_per_node: int, nodes_per_block: int) -> str:
         """
@@ -19,6 +24,27 @@ class SimpleLauncher(Launcher):
 
         """
         return command
+# Tests for SimpleLauncher class
+def test_single_node_per_block():
+    launcher = SimpleLauncher(nodes_per_block=1)
+    assert launcher.nodes_per_block == 1
+
+def test_exception_raised_for_multiple_nodes_per_block():
+    try:
+        launcher = SimpleLauncher(nodes_per_block=64)
+    except Exception as e:
+        assert str(e) == "SimpleLauncher only supports 1 node per block by default."
+    else:
+        assert False, "Expected an exception but none was raised."
+
+
+def test_permit_multiple_nodes():
+    try:
+        launcher = SimpleLauncher(nodes_per_block=64, permit_multiple_nodes=True)
+    except Exception as e:
+        assert False, f"Expected no exception but got: {str(e)}"
+    else:
+        assert launcher.nodes_per_block == 64
 
 
 class WrappedLauncher(Launcher):

--- a/parsl/launchers/test_launcher.py
+++ b/parsl/launchers/test_launcher.py
@@ -1,0 +1,22 @@
+# test_launcher.py
+from parsl.launchers import SimpleLauncher
+
+def test_single_node_per_block():
+    launcher = SimpleLauncher(nodes_per_block=1)
+    assert launcher.nodes_per_block == 1
+
+def test_exception_raised_for_multiple_nodes_per_block():
+    try:
+        launcher = SimpleLauncher(nodes_per_block=64)
+    except Exception as e:
+        assert str(e) == "SimpleLauncher only supports 1 node per block by default."
+    else:
+        assert False, "Expected an exception but none was raised."
+
+def test_permit_multiple_nodes():
+    try:
+        launcher = SimpleLauncher(nodes_per_block=64, permit_multiple_nodes=True)
+    except Exception as e:
+        assert False, f"Expected no exception but got: {str(e)}"
+    else:
+        assert launcher.nodes_per_block == 64


### PR DESCRIPTION
# Description

Please include a summary of the change and (optionally) which issue is fixed. Please also include
relevant motivation and context.

Test cases for: 

- test that the launcher works with one node per block specified
- test that the launcher raises an exception with some other number of nodes per block, for example 64 nodes per block
- test that advanced users can disable the exception when using 64 nodes per block but setting permit_multiple_nodes=True

# Changed Behaviour

Which existing user workflows or functionality will behave differently after this PR?

# Fixes

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix
- New feature
- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
