### PR TITLE
Add shebang to exec_parsl_function.py

### DIFF
--- a/parsl/executors/workqueue/exec_parsl_function.py
+++ b/parsl/executors/workqueue/exec_parsl_function.py
@@ -1,3 +1,4 @@
+#! /usr/bin/env python3
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.data_provider.files import File
 from parsl.utils import get_std_fname_mode


### PR DESCRIPTION
# Description

This change add a shebang to exec_parsl_function.py.

The script is flagged for installation in setup.py, so end users may expect to be able to run it straight from their PATH, without having to specify the interpreter and the full path to the script.  While the shebang is missing, the operating system can barely guess what interpreter to use for running the script in such conditions, and thus would not be able to run exec_parsl_function.py.

# Changed Behaviour

It will be possible to invoke exec_parsl_function.py as a regular executable without having to call python3 explicitly.

# Fixes

No relevant issue has been identified in relation to this change.

## Type of change

- Bug fix
- Code maintenance/cleanup

Have a nice day,  :)
Étienne.