### PR TITLE
Preserve argument defaults to Sphinx documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -371,3 +371,4 @@ autodoc_default_options = {
     'members': True,
     'undoc-members': True
 }
+autodoc_preserve_defaults = True


### PR DESCRIPTION
# Description

This change improves Sphinx documentation reproducibility by preserving argument defaults.

Indeed, James Addison noted that:
> the hostname of the build host appears in some of the documentation built by Sphinx and the autodoc extension.  The hostname is evaluated from a class attribute that calls the Python `socket.gethostname` method.

> In more detail:
> 
> The `TaskVineManagerConfig` dataclass includes an `address` attribute that is set to the value of `socket.gethostname()` when the class is loaded.
> 
> Meanwhile, the `TaskVineExecutor.__init__` method `manager_config` argument has a default value of a no-args constructed `TaskVineManagerConfig` instance.
> 
> When Sphinx builds documentation, by default it will emit a Python `repr()` of the `manager_config` argument, causing the hostname of the build host to be included.
> 
> We can solve that by instructing the Sphinx autodoc extension to retain the textual representation of argument lists as they are found in the source code, instead of evaluated and repr'd equivalents.

# Changed Behaviour

From James:
> [The patch] resolves the problem by enabling the Sphinx autodoc extension `autodoc_preserve_defaults` configuration setting.  Please note that this does affect other output in the documentation.

I thus must highlight, that if you prefer documentation with results of interpretation instead of the raw variable names, and if you are uninterested in reproducible artifacts building, then you may want to reject the present merge request.

# Fixes

This patch has originally been written to address the [Debian bug #1063542].  James originally planned to forward the patch, but I haven't seen it in the set of open or closed pull requests, so I guess they may have been busy on other fronts.

[Debian bug #1063542]: https://bugs.debian.org/1063542

## Type of change

- Bug fix
- Update to human readable text: Documentation

Have a nice day,  :)
Étienne.