### PR TITLE
Reduce flake8 max-line-lenth

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,7 @@
 # W504: line break after binary operator
 #       (Raised by flake8 even when it is followed)
 ignore = E126, E402, E129, W504
-max-line-length = 157
+max-line-length = 156
 exclude = test_import_fail.py,
   parsl/executors/workqueue/parsl_coprocess.py
 # E741 disallows ambiguous single letter names which look like numbers


### PR DESCRIPTION
# Description

I'm pulling a merge request for Outreachy contribution period. I changed max-line-length = 157 to 156.

# Changed Behaviour

PEP-8 says the max line length should be 80 but we can't change it all at once.

# Fixes

Issue #3105 

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
