### PR TITLE
Reduce flake8 max-line-length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,7 @@
 # W504: line break after binary operator
 #       (Raised by flake8 even when it is followed)
 ignore = E126, E402, E129, W504
-max-line-length = 147
+max-line-length = 146
 exclude = test_import_fail.py,
   parsl/executors/workqueue/parsl_coprocess.py
 # E741 disallows ambiguous single letter names which look like numbers

--- a/docs/userguide/execution.rst
+++ b/docs/userguide/execution.rst
@@ -39,7 +39,7 @@ parameters include access keys, instance type, and spot bid price
 Parsl currently supports the following providers:
 
 1. `parsl.providers.LocalProvider`: The provider allows you to run locally on your laptop or workstation.
-2. `parsl.providers.CobaltProvider`: This provider allows you to schedule resources via the Cobalt scheduler. **This provider is deprecated and will be removed by 2024.04**.
+2. `parsl.providers.CobaltProvider`: This provider allows you to schedule resources via the Cobalt scheduler. **This Provider is DEPRECATED, and will be removed by 2024.04**.
 3. `parsl.providers.SlurmProvider`: This provider allows you to schedule resources via the Slurm scheduler.
 4. `parsl.providers.CondorProvider`: This provider allows you to schedule resources via the Condor scheduler.
 5. `parsl.providers.GridEngineProvider`: This provider allows you to schedule resources via the GridEngine scheduler.


### PR DESCRIPTION
# Description

Reduce flake8 max-line-length to one less from 147 to 146. 
Updated the wording of the deprecation of the CobaltProvider with more emphasis.

# Changed Behaviour

PEP-8 says the max line length should be 80, but since we aren't able to change it all at once, we have to change it one at a time. 
Warning for users to see that CobaltProvider will be deprecated.

# Fixes

Fixes #3105
Fixes #3143 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
