### PR TITLE
Change API usage to explict start/end style

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -95,7 +95,7 @@ class DataFlowKernel:
         self.checkpoint_lock = threading.Lock()
 
         self.usage_tracker = UsageTracker(self)
-        self.usage_tracker.send_message()
+        self.usage_tracker.send_start_message()
 
         self.task_state_counts_lock = threading.Lock()
         self.task_state_counts = {state: 0 for state in States}
@@ -1205,7 +1205,7 @@ class DataFlowKernel:
                 self._checkpoint_timer.close()
 
         # Send final stats
-        self.usage_tracker.send_message()
+        self.usage_tracker.send_end_message()
         self.usage_tracker.close()
 
         logger.info("Closing job status poller")

--- a/parsl/usage_tracking/usage.py
+++ b/parsl/usage_tracking/usage.py
@@ -109,7 +109,6 @@ class UsageTracker:
                                                 sys.version_info.micro)
         self.tracking_enabled = self.check_tracking_enabled()
         logger.debug("Tracking status: {}".format(self.tracking_enabled))
-        self.initialized = False  # Once first message is sent this will be True
 
     def check_tracking_enabled(self):
         """Check if tracking is enabled.
@@ -176,15 +175,12 @@ class UsageTracker:
             except Exception as e:
                 logger.debug("Usage tracking failed: {}".format(e))
 
-    def send_message(self) -> None:
-        """Send message over UDP.
-        """
-        if not self.initialized:
-            message = self.construct_start_message()
-            self.initialized = True
-        else:
-            message = self.construct_end_message()
+    def send_start_message(self) -> None:
+        message = self.construct_start_message()
+        self.send_UDP_message(message)
 
+    def send_end_message(self) -> None:
+        message = self.construct_end_message()
         self.send_UDP_message(message)
 
     def close(self, timeout: float = 10.0) -> None:


### PR DESCRIPTION
Previously the message format was driven by a small "invoke me repeatedly, I'll change my behaviour based on how many times you've invoked me" state machine.

This PR removes that state machine and relies on the DFK knowing whether it is starting up or shutting down - that information is available statically inside the DFK code.

# Changed Behaviour

This should not change any behaviour

## Type of change

- Code maintenance/cleanup
