### PR TITLE
Scale in unregistered htex blocks

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -17,7 +17,7 @@ import parsl.launchers
 from parsl.serialize import pack_res_spec_apply_message, deserialize
 from parsl.serialize.errors import SerializationError, DeserializationError
 from parsl.app.errors import RemoteExceptionWrapper
-from parsl.jobs.states import JobStatus, JobState
+from parsl.jobs.states import JobStatus, JobState, TERMINAL_STATES
 from parsl.executors.high_throughput import zmq_pipes
 from parsl.executors.high_throughput import interchange
 from parsl.executors.errors import (
@@ -730,6 +730,26 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
 
         managers = self.connected_managers()
         block_info: Dict[str, BlockInfo] = {}
+
+        # First populate the list of blocks with blocks known to the provider
+        # mechanism. Then update that list with information from the
+        # interchange which will include idle times and task counts. Blocks
+        # with no interchange registration (for example because they are still
+        # in a batch queue) will be regarded as idle for a long time (so will
+        # be preferred when killing most idle blocks) in preference to any
+        # blocks which have already registered.
+
+        provider_blocks = self.status()
+        for (b_id, job_status) in provider_blocks.items():
+
+            # skip blocks that have already finished...
+            if job_status.state in TERMINAL_STATES:
+                continue
+
+            if b_id not in block_info:
+                block_info[b_id] = BlockInfo(tasks=0, idle=float('inf'))
+
+        managers = self.connected_managers()
         for manager in managers:
             if not manager['active']:
                 continue

--- a/parsl/tests/test_scaling/test_scale_down_htex_unregistered.py
+++ b/parsl/tests/test_scaling/test_scale_down_htex_unregistered.py
@@ -1,0 +1,70 @@
+import logging
+import time
+
+import pytest
+
+import parsl
+
+from parsl import File, python_app
+from parsl.jobs.states import JobState, TERMINAL_STATES
+from parsl.providers import LocalProvider
+from parsl.channels import LocalChannel
+from parsl.launchers import SingleNodeLauncher
+from parsl.config import Config
+from parsl.executors import HighThroughputExecutor
+
+logger = logging.getLogger(__name__)
+
+_max_blocks = 1
+_min_blocks = 0
+
+
+def local_config():
+    return Config(
+        executors=[
+            HighThroughputExecutor(
+                heartbeat_period=1,
+                heartbeat_threshold=2,
+                poll_period=100,
+                label="htex_local",
+                address="127.0.0.1",
+                max_workers=1,
+                encrypted=True,
+                launch_cmd="sleep inf",
+                provider=LocalProvider(
+                    channel=LocalChannel(),
+                    init_blocks=1,
+                    max_blocks=_max_blocks,
+                    min_blocks=_min_blocks,
+                    launcher=SingleNodeLauncher(),
+                ),
+            )
+        ],
+        max_idletime=0.5,
+        strategy='htex_auto_scale',
+    )
+
+
+# see issue #1885 for details of failures of this test.
+# at the time of issue #1885 this test was failing frequently
+# in CI.
+@pytest.mark.local
+def test_scaledown_with_register(try_assert):
+    dfk = parsl.dfk()
+    htex = dfk.executors['htex_local']
+
+    num_managers = len(htex.connected_managers())
+    assert num_managers == 0, "Expected 0 managers at start"
+    s = htex.status()
+    assert len(s) == 1, "Expected 1 block at start"
+    assert s['0'].state == JobState.RUNNING, "Expected block to be in RUNNING"
+
+    def check_zero_blocks():
+        s = htex.status()
+        return len(s) == 1 and s['0'].state in TERMINAL_STATES
+
+    try_assert(
+        check_zero_blocks,
+        fail_msg="Expected 0 blocks after idle scaledown",
+        timeout_ms=15000,
+    )


### PR DESCRIPTION
This PR will make the htex scale-in code consider blocks which have been launched through the provider mechanism but have not registered to the interchange. This is especially relevant at shutdown time, when previous blocks still waiting in the queue (and so, not registered) would be abandoned by parsl shutdown.

[first commit on this PR is a test that should break; when that happens, I'll push the rest; this is to get a demonstrated failure of test in CI]

# Changed Behaviour

More blocks scaling in. Tidier shutdown.

# Fixes

Fixes #2627 

## Type of change

- Bug fix
