### PR TITLE
Return None rather than constant True from cluster provider _write_submit_script

### DIFF
--- a/parsl/providers/cluster_provider.py
+++ b/parsl/providers/cluster_provider.py
@@ -91,7 +91,7 @@ class ClusterProvider(ExecutionProvider):
               - configs (dict) : configs that get pushed into the template
 
         Returns:
-              - True: on success
+              - None
 
         Raises:
               SchedulerMissingArgs : If template is missing args
@@ -116,8 +116,6 @@ class ClusterProvider(ExecutionProvider):
             print("Kwargs : ", configs)
             logger.error("Uncategorized error: %s", e)
             raise e
-
-        return True
 
     @abstractmethod
     def _status(self):


### PR DESCRIPTION
# Description

I fixed the issue "parsl.providers.cluster_provider _write_submit_script should return nothing, rather than constant True." I changed return True to having a placeholder of nothing. I also edited it inside of the docstring. 

# Changed Behaviour

With this new change, the return type of _write_submit_script becomes nothing or falls off the end of the method without a return statement at all.

# Fixes

Fixes #3234 

## Type of change

- Bug fix
- Code maintenance/cleanup
