### PR TITLE
removing permit_multiple_nodes argument in simpleLauncher 

### DIFF
--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -18,6 +18,10 @@ class SimpleLauncher(Launcher):
         - task_block (string) : bash evaluated string.
 
         """
+        if nodes_per_block > 1:
+            logger.warning('Simple Launcher only supports single node per block. '
+                           f'Requested nodes: {nodes_per_block}. '
+                           'You may be getting fewer workers than expected')
         return command
 
 


### PR DESCRIPTION
# Description

As of now, when nodes per block requested is greater than 1 in simpleLauncher , warning log with indicating to set permit multiple nodes to be True for multiple nodes per block, but it is not simpleLauncher supports at the moment even if permit multiple nodes set to be true on call. So it gives the user a false promise.

# Changed Behaviour

After this pr, whenever there is a request of multiple nodes per block , we just simply log a warning stating simpleLauncher only supports single node per block
. 

# Fixes

Fixes #3161 



