### PR TITLE
taskvine: fix tracking of output files/data futures

### DIFF
--- a/parsl/executors/taskvine/manager.py
+++ b/parsl/executors/taskvine/manager.py
@@ -376,6 +376,7 @@ def _taskvine_submit_wait(ready_task_queue=None,
                             task_out_file = parsl_file_name_to_vine_file[spec.parsl_name]
                         else:
                             task_out_file = m.declare_file(spec.parsl_name, cache=spec.cache, peer_transfer=True)
+                            parsl_file_name_to_vine_file[spec.parsl_name] = task_out_file
                         t.add_output(task_out_file, spec.parsl_name)
 
             # Submit the task to the TaskVine object


### PR DESCRIPTION
# Description
Before this PR, output files and data futures using the taskvine executor were being duplicated, omitting the benefits of caching and peer transfers

# Changed Behaviour

taskvine workflows will be able to effectively cache and manage output file data

## Type of change

- Bug fix

