### PR TITLE
Make JobStatusPoller parameters mandatory and remove defaults

### DIFF
--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -106,7 +106,7 @@ class PollItem:
 
 
 class JobStatusPoller(Timer):
-    def __init__(self, strategy: Optional[str] = None, max_idletime: float = 0.0,
+    def __init__(self, *, strategy: Optional[str], max_idletime: float,
                  dfk: Optional["parsl.dataflow.dflow.DataFlowKernel"] = None) -> None:
         self._poll_items = []  # type: List[PollItem]
         self.dfk = dfk


### PR DESCRIPTION
Making the parameters mandatory and without defaults helps in debuggability and in code understanding.

Defaults come from closer to the user, and so the defaults removed here are never used.

To support Parsl users using JobStatusPoller as part of a DFK-free environment (for example, Globus Compute), this PR leaves the dfk parameter to have a meaningful default.

# Changed Behaviour

Runtime behaviour should not be changed, as this only removes unused defaults and requires parameters that were already supplied.

## Type of change

- Code maintenance/cleanup
