### PR TITLE
Move provider status caching closer to providers

### DIFF
--- a/parsl/tests/test_scaling/test_status_cache.py
+++ b/parsl/tests/test_scaling/test_status_cache.py
@@ -2,10 +2,8 @@ import parsl
 import pytest
 import time
 
-from parsl.channels import LocalChannel
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
-from parsl.launchers import SimpleLauncher
 from parsl.providers import LocalProvider
 
 T = 0.25  # time constant to adjust timings throughout this test, seconds

--- a/parsl/tests/test_scaling/test_status_cache.py
+++ b/parsl/tests/test_scaling/test_status_cache.py
@@ -1,0 +1,73 @@
+import parsl
+import pytest
+import time
+
+from parsl.providers import LocalProvider
+from parsl.tests.configs.htex_local import fresh_config
+
+T = 0.25  # time constant to adjust timings throughout this test, seconds
+
+CACHE_PERIOD = T*3
+
+
+class TestProvider(LocalProvider):
+
+    def __init__(self):
+        self.count = 0
+        super().__init__(init_blocks=1, min_blocks=1, max_blocks=1)
+
+    @property
+    def status_polling_interval(self):
+        return CACHE_PERIOD
+
+    def status(self, *args, **kwargs):
+        self.count += 1
+        return super().status(*args, **kwargs)
+
+
+def local_setup():
+    config = fresh_config()  # TODO: explicit parsl config here rather than so many modifications
+    config.strategy = 'simple'
+    config.strategy_period = T
+    config.executors[0].poll_period = 1
+    config.executors[0].max_workers_per_node = 1
+    config.executors[0]._provider = TestProvider()
+
+    dfk = parsl.load(config)
+
+
+def local_teardown():
+    parsl.dfk().cleanup()
+    parsl.clear()
+
+
+@parsl.python_app
+def noop():
+    pass
+
+
+# test a few ways:
+@pytest.mark.local
+def test_cache():
+
+    # This is how many times the cache period we will wait
+    # for scaling/provider caching activity to happen.
+    # It doesn't matter too much what this number is as long
+    # as its an integer bigger than one. Later in the test,
+    # we'll count that cache refresh from the provider only
+    # happened K-ish times.
+    K = 4
+
+    provider = parsl.dfk().config.executors[0].provider
+
+    c1 = provider.count
+
+    time.sleep(CACHE_PERIOD*K)
+
+    c2 = provider.count
+
+    # check that the provider was refreshed either K or K-1
+    # times - it might be K-1 because over overlap/non-alignment
+    # of the above time.sleep vs polling periods.
+    assert c2 - c1 <= K, "Provider status was requested too many times"
+    assert c2 - c1 >= K-1, "Provider status was requested too few times"

--- a/parsl/tests/test_scaling/test_status_cache.py
+++ b/parsl/tests/test_scaling/test_status_cache.py
@@ -7,7 +7,7 @@ from parsl.tests.configs.htex_local import fresh_config
 
 T = 0.25  # time constant to adjust timings throughout this test, seconds
 
-CACHE_PERIOD = T*3
+CACHE_PERIOD = T * 3
 
 
 class TestProvider(LocalProvider):
@@ -33,7 +33,7 @@ def local_setup():
     config.executors[0].max_workers_per_node = 1
     config.executors[0]._provider = TestProvider()
 
-    dfk = parsl.load(config)
+    parsl.load(config)
 
 
 def local_teardown():
@@ -62,7 +62,7 @@ def test_cache():
 
     c1 = provider.count
 
-    time.sleep(CACHE_PERIOD*K)
+    time.sleep(CACHE_PERIOD * K)
 
     c2 = provider.count
 
@@ -70,4 +70,4 @@ def test_cache():
     # times - it might be K-1 because over overlap/non-alignment
     # of the above time.sleep vs polling periods.
     assert c2 - c1 <= K, "Provider status was requested too many times"
-    assert c2 - c1 >= K-1, "Provider status was requested too few times"
+    assert c2 - c1 >= K - 1, "Provider status was requested too few times"

--- a/parsl/tests/test_scaling/test_status_cache.py
+++ b/parsl/tests/test_scaling/test_status_cache.py
@@ -2,8 +2,11 @@ import parsl
 import pytest
 import time
 
+from parsl.channels import LocalChannel
+from parsl.config import Config
+from parsl.executors import HighThroughputExecutor
+from parsl.launchers import SimpleLauncher
 from parsl.providers import LocalProvider
-from parsl.tests.configs.htex_local import fresh_config
 
 T = 0.25  # time constant to adjust timings throughout this test, seconds
 
@@ -26,12 +29,19 @@ class TestProvider(LocalProvider):
 
 
 def local_setup():
-    config = fresh_config()  # TODO: explicit parsl config here rather than so many modifications
-    config.strategy = 'simple'
-    config.strategy_period = T
-    config.executors[0].poll_period = 1
-    config.executors[0].max_workers_per_node = 1
-    config.executors[0]._provider = TestProvider()
+
+    config = Config(
+            executors=[
+                HighThroughputExecutor(
+                    max_workers_per_node=1,
+                    label="htex_local",
+                    poll_period=1,
+                    provider=TestProvider(),
+                    worker_debug=True,
+                )
+            ],
+            strategy='simple',
+            strategy_period=T)
 
     parsl.load(config)
 


### PR DESCRIPTION
parsl.provider.* status() calls can be expensive, in the sense that they do things like execute batch system commands which system administrators dislike being run automatically and periodically, and even in some situations ban that behavior.

So, Parsl tries to not do those calls too often - providers can define a status_polling_interval (which returns an interval in seconds) and the strategy code will call (through a chain of calls) the provider status method at most every status_polling_interval.

Prior to this PR, this was implemented in the job status poller code, which makes the following chain of calls at most every status polling interval

poller/strategy iterator =>
  poll_item.poll (runs "often" - eg every 5 seconds driven by job status poller?)
    => determine if the rest of this stack should run, or otherwise use data cached as poll item._status attribute
      => executor.status()
        => provider.status()
          => (in the case of cluster provider, provider._status and LRM command line callout)

There are a couple of issues related to this call stack:

* #3235 - slow update of jobs that failed to submit - when a job fails to submit, at present it is recorded in a separate table, the _simulated_status dictionary, in BlockProviderExecutor. Entries added to that are not exposed to the scaling code until executor.status() is called, which may be many strategy iterations later. In that time, the scaling strategy make make the wrong decisions, based on incomplete information. That is the core of issue #3235

* #2627 - htex scale in needs to be aware of job status. Scale in code is not always driven in by the poller/strategy code; for example it executes at shutdown driven by the DataFlowKernel. That scale in code then is not in a position to make use of the cached data inside poll_item and it is more natural to call executor.status() to determine status - see PR #3232. That results in calls to provider.status() without any status_polling_interval rate limiting/caching.

This current PR moves that rate limit/cache deeper into the stack to the BlockProviderExecutor.

The job status poller code now polls the executor on every iteration, relying on the executor to perform rate limiting and caching.

That has the effect of exposing simulated statuses to the scaling strategy code on each iteration, so that the delays in issue #3235 will not be experienced.

This change also means that PR #3232 can safely call executor.status() without exceeding the rate limit.

This PR changes when provider status gets called, because it is now a cache that refreshes whenever status is called past the expiry time, rather than more explicitly driven in a loop. That might change scaling behaviour, but I think not in any significant way.

This PR changes the decision of when an executor is to be polled for status: previously non-positive values of status_polling_interval were used as magic values to inhibit provider status polling. Now, any executor with a provider will be polled.

This PR makes the call stack above provider.status a little more data driven and less effectful (the effect being load on the LRM), which might make refactoring this stack a bit easier. However, it will also make that a bit more computation heavy - I think not much because usually there are not many blocks in existence.

This PR adds a test that repeatedly calling BlockProviderExecutor.status does not result in an excessive number of calls to the provider status method but still updates eventually.

# Changed Behaviour

LRM interactions might be substantially different, and scaling behaviour may be different while still fitting within the broad descriptions of what scaling is meant to do.

## Type of change

- Code maintenance/cleanup
