### PR TITLE
Scale out to min blocks on no active tasks

### DIFF
--- a/parsl/jobs/strategy.py
+++ b/parsl/jobs/strategy.py
@@ -219,18 +219,27 @@ class Strategy:
             # Case 1
             # No tasks.
             if active_tasks == 0:
-                # Case 1a
                 logger.debug("Strategy case 1: Executor has no active tasks")
 
-                # Fewer blocks that min_blocks
-                if active_blocks <= min_blocks:
-                    logger.debug("Strategy case 1a: Executor has no active tasks and minimum blocks. Taking no action.")
+                # Case 1a
+                # Active blocks == min_blocks
+                if active_blocks == min_blocks:
+                    logger.debug("Strategy case 1a: Executor has no active tasks and minimum blocks is maintained. Taking no action.")
+
                 # Case 1b
+                # Lesser blocks that min_blocks
+                elif active_blocks < min_blocks:
+                    logger.debug("Strategy case 1b: Executor has no active tasks. "
+                                 "minimum blocks is not maintained. "
+                                 "Scaling out by 1 block")
+                    exec_status.scale_out(1)  # scaling out by 1 block
+
+                # Case 1c
                 # More blocks than min_blocks. Scale in
                 else:
                     # We want to make sure that max_idletime is reached
                     # before killing off resources
-                    logger.debug(f"Strategy case 1b: Executor has no active tasks, and more ({active_blocks}) than minimum blocks ({min_blocks})")
+                    logger.debug(f"Strategy case 1c: Executor has no active tasks, and more ({active_blocks}) than minimum blocks ({min_blocks})")
 
                     if not self.executors[executor.label]['idle_since']:
                         logger.debug(f"Starting idle timer for executor. If idle time exceeds {self.max_idletime}s, blocks will be scaled in")

--- a/parsl/tests/test_scaling/test_scale_out_to_min_blocks.py
+++ b/parsl/tests/test_scaling/test_scale_out_to_min_blocks.py
@@ -1,0 +1,52 @@
+import pytest
+import parsl
+import time
+from parsl.executors import HighThroughputExecutor
+from parsl.providers import LocalProvider
+from parsl.launchers import SimpleLauncher
+from parsl.config import Config
+
+
+_init_blocks = 1
+_min_blocks = 3
+
+
+def local_setup():
+    config = Config(
+        executors=[
+            HighThroughputExecutor(
+                label="HTEX",
+                heartbeat_period=1,
+                heartbeat_threshold=2,
+                poll_period=100,
+                address="127.0.0.1",
+                max_workers_per_node=1,
+                provider=LocalProvider(
+                    init_blocks=_init_blocks,
+                    max_blocks=4,
+                    min_blocks=_min_blocks,
+                    launcher=SimpleLauncher()
+                ),
+            )
+        ],
+        max_idletime=0.5,
+        strategy='simple',
+    )
+    parsl.load(config)
+
+
+def local_teardown():
+    parsl.dfk().cleanup()
+    parsl.clear()
+
+
+@pytest.mark.local
+def test_scaling_out():
+    # status_polling_interval for LocalProvider is 5s
+    # sleeping >10 will scale out to min blocks
+
+    assert len(parsl.dfk().executors["HTEX"].connected_managers()) != _min_blocks
+
+    time.sleep(15)
+
+    assert len(parsl.dfk().executors["HTEX"].connected_managers()) == _min_blocks


### PR DESCRIPTION
# Description

Scaling out to minimum blocks when active blocks is less than minimum blocks. It is indicated that there should be some number of minimum blocks should be maintained but in current system, whenever the active blocks are lesser than minimum blocks, we just ignore and taking no action. Is it really the intended behaviour? NO. User might've wanted the minimum blocks to be certain amount and launched some initial blocks less than that and expected the system to scale it out as mentioned in the documentation but that's not what happening here. So how are we fixing this,  so we know at every poll period, the system will check the current resources and compare with the required resources and take decisions to scale in or out, so at that point, if there are no active tasks and our active blocks is less than minimum blocks mentioned by the user, we will scale out by 1 block until we reach the minimum blocks. Now the question arises? why maintaining when there is no tasks?

1. we might think anyway we have to maintain minimum blocks then why not scale out to minimum blocks at start when init_blocks provided is less than minimum blocks? if we go that way, then there wont be any actual difference between initial blocks and minimum blocks, its simply like launching minimum blocks at start, so we lose the importance or need of the initial_blocks.

2. why not scaling out when there are active tasks? the answer is there might be a possibility that from active tasks, the minimum blocks can be maintained. consider the case of user requested 1 init_block and 3 min_blocks. and he has 3 active tasks at launch, so without our interruption, by normal scaling, the minimum blocks will be obtained.

I feel like scaling out or scaling in to min blocks when there is no active tasks is nice as its more like maintaining the system after all the storm (all the active tasks) and it can be maintained as user requested.

# Changed Behaviour

After this PR, whenever the active blocks are lesser than min blocks, it will scale one by one until it maintains the min_blocks

# Fixes

Fixes #3071 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix
