### PR TITLE
Warning log for launching init_blocks less than min_blocks

### DIFF
--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -134,4 +134,8 @@ class JobStatusPoller(Timer):
             if executor.status_polling_interval > 0:
                 logger.debug("Adding executor {}".format(executor.label))
                 self._poll_items.append(PollItem(executor, self.dfk))
+
+            if executor.provider.init_blocks < executor.provider.min_blocks:
+                logger.warning(f"init_blocks is less than min_blocks in {executor.provider} for executor labeled '{executor.label}'."
+                               " No scaling out to min_blocks on zero active tasks.")
         self._strategy.add_executors(executors)

--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -135,7 +135,9 @@ class JobStatusPoller(Timer):
                 logger.debug("Adding executor {}".format(executor.label))
                 self._poll_items.append(PollItem(executor, self.dfk))
 
-            if executor.provider.init_blocks < executor.provider.min_blocks:
-                logger.warning(f"init_blocks is less than min_blocks in {executor.provider} for executor labeled '{executor.label}'."
-                               " No scaling out to min_blocks on zero active tasks.")
+            provider = executor.provider
+            if provider:
+                if  provider.init_blocks < provider.min_blocks:
+                    logger.warning(f"init_blocks is less than min_blocks in {executor.provider} for executor labeled '{executor.label}'."
+                                " No scaling out to min_blocks on zero active tasks.")
         self._strategy.add_executors(executors)

--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -137,7 +137,7 @@ class JobStatusPoller(Timer):
 
             provider = executor.provider
             if provider:
-                if  provider.init_blocks < provider.min_blocks:
+                if provider.init_blocks < provider.min_blocks:
                     logger.warning(f"init_blocks is less than min_blocks in {executor.provider} for executor labeled '{executor.label}'."
-                                " No scaling out to min_blocks on zero active tasks.")
+                                   " No scaling out to min_blocks on zero active tasks.")
         self._strategy.add_executors(executors)


### PR DESCRIPTION
# Description
If init_blocks is less than min_blocks in provider, user expects that system will maintain min_blocks irrespective of init_blocks, but currently parsl doesnt support that. So we will warn the user, that if there are no active tasks, we wont scale out to min_blocks and only way to maintain min_blocks is to add tasks so that it will scale out


# Changed Behaviour

Warns user that current system wont scale out to min_blocks on zero active tasks

# Fixes

Fixes #3071


