### PR TITLE
Return None rather than raise an exception for Gantt chart of 0 tasks

### DIFF
--- a/parsl/monitoring/visualization/plots/default/workflow_plots.py
+++ b/parsl/monitoring/visualization/plots/default/workflow_plots.py
@@ -27,6 +27,9 @@ gantt_colors = {'unsched': 'rgb(240, 240, 240)',
 
 def task_gantt_plot(df_task, df_status, time_completed=None):
 
+    if df_task.empty:
+        return None
+
     # if the workflow is not recorded as completed, then assume
     # that tasks should continue in their last state until now,
     # rather than the workflow end time.


### PR DESCRIPTION
Prior to this PR, visualizing a workflow with no tasks in it would cause an HTTP 500 server error, caused by an exception raised in the gantt generation code.

However, a workflow with no tasks is a legitimate workflow.

This PR makes task_gantt_plot return None, rather than attempting a plot, which then places no Gantt chart in workflow visualization, rather than breaking.

This bug was exposed through PR #3121 which sometimes (as a legitimate part of that test) results in a monitoring DB with a workflow with no tasks (but not always - that test is testing shutdown behaviour, not database contents).

## Type of change
- Bug fix
