### PR TITLE
Use parsl.utils log helpers for monitoring, rather than own variant

### DIFF
--- a/parsl/log_utils.py
+++ b/parsl/log_utils.py
@@ -28,7 +28,7 @@ DEFAULT_FORMAT = (
 def set_stream_logger(name: str = 'parsl',
                       level: int = logging.DEBUG,
                       format_string: Optional[str] = None,
-                      stream: Optional[io.TextIOWrapper] = None) -> None:
+                      stream: Optional[io.TextIOWrapper] = None) -> logging.Logger:
     """Add a stream log handler.
 
     Args:
@@ -39,7 +39,7 @@ def set_stream_logger(name: str = 'parsl',
             If not specified, the default stream for logging.StreamHandler is used.
 
     Returns:
-         - None
+         - logger for specified name
     """
     if format_string is None:
         # format_string = "%(asctime)s %(name)s [%(levelname)s] Thread:%(thread)d %(message)s"
@@ -59,12 +59,14 @@ def set_stream_logger(name: str = 'parsl',
     futures_logger = logging.getLogger("concurrent.futures")
     futures_logger.addHandler(handler)
 
+    return logger
+
 
 @typeguard.typechecked
 def set_file_logger(filename: str,
                     name: str = 'parsl',
                     level: int = logging.DEBUG,
-                    format_string: Optional[str] = None) -> None:
+                    format_string: Optional[str] = None) -> logging.Logger:
     """Add a file log handler.
 
     Args:
@@ -74,7 +76,7 @@ def set_file_logger(filename: str,
         - format_string (string): Set the format string
 
     Returns:
-       -  None
+       - logger for specified name
     """
     if format_string is None:
         format_string = DEFAULT_FORMAT
@@ -91,3 +93,5 @@ def set_file_logger(filename: str,
     # concurrent.futures
     futures_logger = logging.getLogger("concurrent.futures")
     futures_logger.addHandler(handler)
+
+    return logger

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -15,6 +15,7 @@ import parsl.monitoring.remote
 from parsl.multiprocessing import ForkProcess, SizedQueue
 from multiprocessing import Process
 from multiprocessing.queues import Queue
+from parsl.log_utils import set_file_logger
 from parsl.utils import RepresentationMixin
 from parsl.process_loggers import wrap_with_logs
 from parsl.utils import setproctitle
@@ -36,40 +37,6 @@ else:
     _db_manager_excepts = None
 
 logger = logging.getLogger(__name__)
-
-
-def start_file_logger(filename: str, name: str = 'monitoring', level: int = logging.DEBUG, format_string: Optional[str] = None) -> logging.Logger:
-    """Add a stream log handler.
-
-    Parameters
-    ---------
-
-    filename: string
-        Name of the file to write logs to. Required.
-    name: string
-        Logger name.
-    level: logging.LEVEL
-        Set the logging level. Default=logging.DEBUG
-        - format_string (string): Set the format string
-    format_string: string
-        Format string to use.
-
-    Returns
-    -------
-        None.
-    """
-    if format_string is None:
-        format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s]  %(message)s"
-
-    logger = logging.getLogger(name)
-    logger.setLevel(level)
-    logger.propagate = False
-    handler = logging.FileHandler(filename)
-    handler.setLevel(level)
-    formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    return logger
 
 
 @typeguard.typechecked
@@ -337,9 +304,9 @@ class MonitoringHub(RepresentationMixin):
 
 @wrap_with_logs
 def filesystem_receiver(logdir: str, q: "queue.Queue[AddressedMonitoringMessage]", run_dir: str) -> None:
-    logger = start_file_logger("{}/monitoring_filesystem_radio.log".format(logdir),
-                               name="monitoring_filesystem_radio",
-                               level=logging.INFO)
+    logger = set_file_logger("{}/monitoring_filesystem_radio.log".format(logdir),
+                             name="monitoring_filesystem_radio",
+                             level=logging.INFO)
 
     logger.info("Starting filesystem radio receiver")
     setproctitle("parsl: monitoring filesystem receiver")
@@ -405,9 +372,9 @@ class MonitoringRouter:
 
         """
         os.makedirs(logdir, exist_ok=True)
-        self.logger = start_file_logger("{}/monitoring_router.log".format(logdir),
-                                        name="monitoring_router",
-                                        level=logging_level)
+        self.logger = set_file_logger("{}/monitoring_router.log".format(logdir),
+                                      name="monitoring_router",
+                                      level=logging_level)
         self.logger.debug("Monitoring router starting")
 
         self.hub_address = hub_address


### PR DESCRIPTION
This PR removes start_file_logger which was similar, but not the same as parsl.utils.set_file_logger. It makes set_file_logger return the chosen root logger, which was the main difference between start_file_logger and set_file_logger.


# Changed Behaviour

After this PR, monitoring logs will now use the verbose log format used by parsl.log, instead of their own more terse format.

## Type of change

- Code maintenance/cleanup
