### PR TITLE
Fix with context manager

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -206,6 +206,14 @@ class DataFlowKernel:
 
         atexit.register(self.atexit_cleanup)
 
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # clean up the dfk on exiting the resource block
+        logger.debug("Calling cleanup for DFK")
+        self.cleanup()
+
     def _send_task_log_info(self, task_record: TaskRecord) -> None:
         if self.monitoring:
             task_log_info = self._create_task_log_info(task_record)

--- a/parsl/tests/manual_tests/test_with_context_manager.py
+++ b/parsl/tests/manual_tests/test_with_context_manager.py
@@ -1,0 +1,34 @@
+import parsl
+from parsl.tests.configs.local_threads import config
+import pytest
+from parsl.errors import NoDataFlowKernelError
+
+
+@parsl.python_app
+def square(x):
+    return x * x
+
+
+@parsl.bash_app
+def foo(x, y, z=30, stdout='foo.stdout', label=None):
+    return f"echo {x} {y} {z}"
+
+
+def test_within_context_manger():
+    with parsl.load(config=config):
+        py_future = square(2)
+        assert py_future.result() == 4
+
+        bash_future = foo(10, 20)
+        assert bash_future.result() == 0
+
+        with open('foo.stdout', 'r') as f:
+            assert f.read() == "10 20 30\n"
+
+    with pytest.raises(NoDataFlowKernelError) as excinfo:
+        square(2).result()
+    assert str(excinfo.value) == "Cannot submit to a DFK that has been cleaned up"
+
+
+if __name__ == '__main__':
+    test_within_context_manger()


### PR DESCRIPTION
# Description

The goal is to address this issue by enabling the use of DFKs within context managers, which would allow for easier cleanup of resources associated with the DFK when exiting the context manager. By implicitly handling the cleanup 

# Changed Behaviour

Users can seamlessly utilize the DFK within context managers such as with. There's no need for users to manually trigger the cleanup process.

# Fixes

Fixes # (https://github.com/Parsl/parsl/issues/3258)

## Type of change

- New Feature

