### PR TITLE
WQExecutor + TVExecutor: Automatic cleanup by adding their own atexit handlers.

### DIFF
--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -250,7 +250,7 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         """Create submit process and collector thread to create, send, and
         retrieve Parsl tasks within the TaskVine system.
         """
-        
+
         # Mark this executor object as started
         self._started = True
 

--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -4,6 +4,7 @@ high-throughput system for delegating Parsl tasks to thousands of remote machine
 """
 
 # Import Python built-in libraries
+import atexit
 import threading
 import multiprocessing
 import logging
@@ -178,6 +179,13 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
             self._poncho_available = False
         else:
             self._poncho_available = True
+
+        # register atexit handler to cleanup when Python shuts down
+        atexit.register(self.atexit_cleanup)
+
+    def atexit_cleanup(self):
+        # Calls this executor's shutdown method upon Python exiting the process.
+        self.shutdown()
 
     def _get_launch_command(self, block_id):
         # Implements BlockProviderExecutor's abstract method.


### PR DESCRIPTION
# Description

Previously these executors don't exit on their own but wait for the DFK to call their shutdown methods from the DFK's atexit handler. Now the call is removed so these executors add their own atexit handlers to clean themselves up, otherwise a Parsl program using these executors will hang at the end of the program.

These handlers never spawn new threads or processes so they should be safe according to Python3.12's atexit standard.

# Changed Behaviour

TaskVineExecutor and WorkQueueExecutor.


## Type of change
- Bug fix
- New feature