### PR TITLE
[not for merge] Demo for Logan of Transformation Catalog style behaviour

### DIFF
--- a/parsl/config.py
+++ b/parsl/config.py
@@ -88,6 +88,7 @@ class Config(RepresentationMixin):
                  internal_tasks_max_threads: int = 10,
                  retries: int = 0,
                  retry_handler: Optional[Callable[[Exception, TaskRecord], float]] = None,
+                 tc_logan: Optional[Callable[[TaskRecord], None]] = None,
                  run_dir: str = 'runinfo',
                  strategy: Optional[str] = 'simple',
                  strategy_period: Union[float, int] = 5,
@@ -122,6 +123,7 @@ class Config(RepresentationMixin):
         self.internal_tasks_max_threads = internal_tasks_max_threads
         self.retries = retries
         self.retry_handler = retry_handler
+        self.tc_logan = tc_logan
         self.run_dir = run_dir
         self.strategy = strategy
         self.strategy_period = strategy_period

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1038,6 +1038,12 @@ class DataFlowKernel:
                                                               waiting_message))
 
         app_fu.add_done_callback(partial(self.handle_app_update, task_record))
+
+        if self.config.tc_logan:
+            logger.info(f"Invoking tc_logan with old task record {task_record}")
+            self.config.tc_logan(task_record)
+            logger.info(f"Post-tc_logan task record {task_record}")
+
         self.update_task_state(task_record, States.pending)
         logger.debug("Task {} set to pending state with AppFuture: {}".format(task_id, task_record['app_fu']))
 

--- a/parsl/tests/test_tc_logan.py
+++ b/parsl/tests/test_tc_logan.py
@@ -4,7 +4,7 @@ import pytest
 from parsl.dataflow.taskrecord import TaskRecord
 
 
-def l(t: TaskRecord):
+def some_user_supplied_mutator(t: TaskRecord):
     t['kwargs']['s'] = f"hi, magic value for app {t['func_name']} on executor {t['executor']}"
 
 
@@ -15,7 +15,7 @@ def write(s: str, stdout=parsl.AUTO_LOGNAME):
 
 @pytest.mark.local
 def test_tc_logan():
-    parsl.load(parsl.Config(tc_logan=l))
+    parsl.load(parsl.Config(tc_logan=some_user_supplied_mutator))
     f = write()
     f.result()
     parsl.dfk().cleanup()

--- a/parsl/tests/test_tc_logan.py
+++ b/parsl/tests/test_tc_logan.py
@@ -1,0 +1,21 @@
+import parsl
+import pytest
+
+from parsl.dataflow.taskrecord import TaskRecord
+
+
+def l(t: TaskRecord):
+    t['kwargs']['s'] = f"hi, magic value for app {t['func_name']} on executor {t['executor']}"
+
+
+@parsl.bash_app
+def write(s: str, stdout=parsl.AUTO_LOGNAME):
+    return f"echo {s}"
+
+
+@pytest.mark.local
+def test_tc_logan():
+    parsl.load(parsl.Config(tc_logan=l))
+    f = write()
+    f.result()
+    parsl.dfk().cleanup()


### PR DESCRIPTION
# Description

Logan had some questions that made me think of VDS style Transformation Catalogs: attributes of tasks that are tied neither purely to an app, app invocation or site/executor.

This PR is a quick (at core, 1 line) demo of what that might look like in Parsl: after a task is submitted and some initial processing has happened, a user plugin gets to screw with the task definition as it wants. This single point is deliberately not "per-site" or "per-app" etc - that's specifically the functionality this is trying to avoid.

Instead, the user supplied `tc_logan` can make its own judgements about what should be done, and how. It can mutate the task record however it wants, in the same way as task retry handlers can, but at a different point in task processing.

Basically anything that's happened already in `dfk.submit` you should not mess with.

The supplied demo test case shows adding in a parameter to a function that is a function of both the site name and app name - in the traditional Transformation Catalog, that might be a look up in a 2d-style site/app table.

## Type of change

- demo