### PR TITLE
Clearing the active DFK on cleaning

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1254,6 +1254,8 @@ class DataFlowKernel:
             logger.info("Terminated monitoring")
 
         logger.info("DFK cleanup complete")
+        logger.info("Removing the reference of cleaned DFK")
+        DataFlowKernelLoader.clear()
 
     def checkpoint(self, tasks: Optional[Sequence[TaskRecord]] = None) -> str:
         """Checkpoint the dfk incrementally to a checkpoint file.


### PR DESCRIPTION
# Description

Currently now, on cleaning the Active DFK ( dfk.cleanup ), It releases all the resources and cleans the DFK, but it doesnt remove the reference of the cleaned dfk from the KernelLoader, It makes the user to run .clear() one more time to remove the reference of the DFK, and there are no things can be done with cleaned up dfk , even cant load a new config, So its better to clear the reference as well at cleanup, so that user can directly load another config to work on

# Changed Behaviour
After this pr, at cleanup of dfk , reference of the cleaned dfk will be removed


# Fixes

Fixes #3263 

## Type of change

- New feature

