### PR TITLE
Annotate scale_in and scale_out with types in JobStatusPoller

### DIFF
--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -72,7 +72,7 @@ class PollItem:
     def executor(self) -> BlockProviderExecutor:
         return self._executor
 
-    def scale_in(self, n, max_idletime=None):
+    def scale_in(self, n: int, max_idletime: Optional[float] = None) -> List[str]:
 
         if max_idletime is None:
             block_ids = self._executor.scale_in(n)
@@ -82,7 +82,7 @@ class PollItem:
             # scale_in method really does come from HighThroughputExecutor,
             # and so does have an extra max_idletime parameter not present
             # in the executor interface.
-            block_ids = self._executor.scale_in(n, max_idletime=max_idletime)
+            block_ids = self._executor.scale_in(n, max_idletime=max_idletime)  # type: ignore[call-arg]
         if block_ids is not None:
             new_status = {}
             for block_id in block_ids:
@@ -91,7 +91,7 @@ class PollItem:
             self.send_monitoring_info(new_status)
         return block_ids
 
-    def scale_out(self, n):
+    def scale_out(self, n: int) -> List[str]:
         block_ids = self._executor.scale_out(n)
         if block_ids is not None:
             new_status = {}


### PR DESCRIPTION
These types align with the scale_in and scale_out types defined on BlockProviderExecutor.

## Type of change

- Code maintenance/cleanup
