### PR TITLE
Remove docstring talk of scaling coroutines

### DIFF
--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -211,10 +211,6 @@ class BlockProviderExecutor(ParslExecutor):
 
         Cause the executor to reduce the number of blocks by count.
 
-        We should have the scale in method simply take resource object
-        which will have the scaling methods, scale_in itself should be a coroutine, since
-        scaling tasks can be slow.
-
         :return: A list of block ids corresponding to the blocks that were removed.
         """
         pass


### PR DESCRIPTION
This dates from 2017, bfd4045b05f3ae9abd554a841e2ab73fb1213a5a and reflects a possible scaling model that is not what ended up being implemented in the subsequent 7 years.

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
