### PR TITLE
fix code of conduct link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,7 +119,7 @@ Parsl is supported in Python 3.8+. Requirements can be found `here <requirements
 Code of Conduct
 ===============
 
-Parsl seeks to foster an open and welcoming environment - Please see the `Parsl Code of Conduct <https://github.com/Parsl/parsl/blob/master/CoC.md>`_ for more details.
+Parsl seeks to foster an open and welcoming environment - Please see the `Parsl Code of Conduct <https://github.com/Parsl/parsl/blob/master/CODE_OF_CONDUCT.md>`_ for more details.
 
 Contributing
 ============


### PR DESCRIPTION
# Description

The link in the Readme file's code of conduct section was not redirecting properly.

# Changed Behaviour

The link now correctly redirects to the code of conduct.



