### PR TITLE
Add type signatures related to add_executors

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1115,7 +1115,7 @@ class DataFlowKernel:
 
         channel.makedirs(channel.script_dir, exist_ok=True)
 
-    def add_executors(self, executors):
+    def add_executors(self, executors: Sequence[ParslExecutor]) -> None:
         for executor in executors:
             executor.run_id = self.run_id
             executor.run_dir = self.run_dir

--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -107,6 +107,16 @@ class ParslExecutor(metaclass=ABCMeta):
         self._run_dir = value
 
     @property
+    def run_id(self) -> Optional[str]:
+        """UUID for the enclosing DFK.
+        """
+        return self._run_id
+
+    @run_id.setter
+    def run_id(self, value: Optional[str]) -> None:
+        self._run_id = value
+
+    @property
     def hub_address(self) -> Optional[str]:
         """Address to the Hub for monitoring.
         """


### PR DESCRIPTION
This PR adds type signatures directly on add_executors, and adds an explicit typed property onto the executor base class that is references from add_executors.

## Type of change

- Code maintenance/cleanup
