### PR TITLE
WQ + TV Executors: Making their shutdown methods idempotent

### DIFF
--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -623,7 +623,7 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         if not self._is_started:
             # Don't shutdown if the executor never starts.
             return
-        
+
         if self._is_shutdown:
             # Don't shutdown this executor again.
             return
@@ -645,7 +645,7 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         if self.worker_launch_method == 'factory':
             logger.debug("Joining on factory process")
             self._factory_process.join()
-        
+
         self._is_shutdown = True
         logger.debug("TaskVine shutdown completed")
 

--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -186,7 +186,13 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         # Attribute indicating whether this executor was started to shut it down properly.
         # This safeguards cases where an object of this executor is created but
         # the executor never starts, so it shouldn't be shutdowned.
-        self._started = False
+        self._is_started = False
+
+        # Attribute indicating whether this executor was shutdown before.
+        # This safeguards cases where this object is automatically shut down (e.g.,
+        # via atexit) and the user also explicitly calls shut down. While this is
+        # permitted, the effect of an executor shutdown should happen only once.
+        self._is_shutdown = False
 
     def atexit_cleanup(self):
         # Calls this executor's shutdown method upon Python exiting the process.
@@ -252,7 +258,7 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         """
 
         # Mark this executor object as started
-        self._started = True
+        self._is_started = True
 
         # Synchronize connection and communication settings between the manager and factory
         self.__synchronize_manager_factory_comm_settings()
@@ -614,8 +620,12 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         """Shutdown the executor. Sets flag to cancel the submit process and
         collector thread, which shuts down the TaskVine system submission.
         """
-        if not self._started:
+        if not self._is_started:
             # Don't shutdown if the executor never starts.
+            return
+        
+        if self._is_shutdown:
+            # Don't shutdown this executor again.
             return
 
         logger.debug("TaskVine shutdown started")
@@ -635,7 +645,8 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         if self.worker_launch_method == 'factory':
             logger.debug("Joining on factory process")
             self._factory_process.join()
-
+        
+        self._is_shutdown = True
         logger.debug("TaskVine shutdown completed")
 
     @wrap_with_logs

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -305,7 +305,13 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         # Attribute indicating whether this executor was started to shut it down properly.
         # This safeguards cases where an object of this executor is created but
         # the executor never starts, so it shouldn't be shutdowned.
-        self.started = False
+        self.is_started = False
+
+        # Attribute indicating whether this executor was shutdown before.
+        # This safeguards cases where this object is automatically shut down (e.g.,
+        # via atexit) and the user also explicitly calls shut down. While this is
+        # permitted, the effect of an executor shutdown should happen only once.
+        self.is_shutdown = False
 
     def atexit_cleanup(self):
         # Calls this executor's shutdown method upon Python exiting the process.
@@ -321,7 +327,7 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         retrieve Parsl tasks within the Work Queue system.
         """
         # Mark this executor object as started
-        self.started = True
+        self.is_started = True
         self.tasks_lock = threading.Lock()
 
         # Create directories for data and results
@@ -710,8 +716,12 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         """Shutdown the executor. Sets flag to cancel the submit process and
         collector thread, which shuts down the Work Queue system submission.
         """
-        if not self.started:
+        if not self.is_started:
             # Don't shutdown if the executor never starts.
+            return
+
+        if self.is_shutdown:
+            # Don't shutdown this executor again.
             return
 
         logger.debug("Work Queue shutdown started")
@@ -728,6 +738,7 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         logger.debug("Joining on collector thread")
         self.collector_thread.join()
 
+        self.is_shutdown = True
         logger.debug("Work Queue shutdown completed")
 
     @wrap_with_logs


### PR DESCRIPTION
# Description

Previously, WQ and TV Executors can be shut down twice, one by the registration of `shutdown` to atexit, one by the user explicitly calling `parsl.dfk().cleanup()`. This PR makes the effect of these executors shutdown happen only once. Note that previously the shutdown methods don't create bugs as they only call process joins and a python process can be joined many times, but future bugs might come.

# Changed Behaviour

WQ and TV Executors

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
