### PR TITLE
Fix TypeError race condition in htex draining code

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -335,13 +335,16 @@ class Manager:
                 self.heartbeat_to_incoming()
                 last_beat = time.time()
 
-            if self.drain_time and time.time() > self.drain_time:
+            if time.time() > self.drain_time:
                 logger.info("Requesting drain")
                 self.drain_to_incoming()
-                self.drain_time = None
                 # This will start the pool draining...
                 # Drained exit behaviour does not happen here. It will be
                 # driven by the interchange sending a DRAINED_CODE message.
+
+                # now set drain time to the far future so we don't send a drain
+                # message every iteration.
+                self.drain_time = float('inf')
 
             poll_duration_s = max(0, next_interesting_event_time - time.time())
             socks = dict(poller.poll(timeout=poll_duration_s * 1000))


### PR DESCRIPTION
Before this PR, sometimes draining would fail with this error message:

```python
Traceback (most recent call last):
  File ".../lib/python3.10/site-packages/parsl/process_loggers.py", line 27, in wrapped
    r = func(*args, **kwargs)
  File ".../bin/process_worker_pool.py", line 322, in pull_tasks
    next_interesting_event_time = min(last_beat + self.heartbeat_period,
TypeError: '<' not supported between instances of 'NoneType' and 'float'
```
because the code incorrectly sets drain time to `None` to indicate that further draining messages should not be sent.  An earlier version of the drain code used `None` in that situation, but this was changed to +inf in the version that was actually merged.

This error is statically detectable by mypy, if you turn on mypy checking for pull_tasks, although it also raises other type errors.

## Type of change

- Bug fix
