### PR TITLE
Add support for dicts in future-resolution-plugin (#3111)

### DIFF
--- a/parsl/dataflow/errors.py
+++ b/parsl/dataflow/errors.py
@@ -1,11 +1,6 @@
 from parsl.errors import ParslError
 from typing import Optional, Sequence, Tuple
 
-import logging
-
-
-logger = logging.getLogger(__name__)
-
 
 class DataFlowException(ParslError):
     """Base class for all exceptions.

--- a/parsl/dataflow/future_resolution.py
+++ b/parsl/dataflow/future_resolution.py
@@ -1,6 +1,6 @@
+from collections.abc import Mapping
 from concurrent.futures import Future
 from functools import singledispatch
-from collections.abc import Mapping
 
 
 @singledispatch

--- a/parsl/dataflow/future_resolution.py
+++ b/parsl/dataflow/future_resolution.py
@@ -55,3 +55,28 @@ def _(iterable):
 
     type_ = type(iterable)
     return type_(map(unwrap, iterable))
+
+
+@traverse_to_gather.register(dict)
+def _(dictionary):
+    futures = []
+    for key, value in dictionary.items():
+        if isinstance(key, Future):
+            futures.append(key)
+        if isinstance(value, Future):
+            futures.append(value)
+    return futures
+
+
+@traverse_to_unwrap.register(dict)
+def _(dictionary):
+    unwrapped_dict = {}
+    for key, value in dictionary.items():
+        if isinstance(key, Future):
+            assert key.done(), "key future should be done by now"
+            key = key.result()
+        if isinstance(value, Future):
+            assert value.done(), "value future should be done by now"
+            value = value.result()
+        unwrapped_dict[key] = value
+    return unwrapped_dict

--- a/parsl/dataflow/future_resolution.py
+++ b/parsl/dataflow/future_resolution.py
@@ -1,5 +1,6 @@
 from concurrent.futures import Future
 from functools import singledispatch
+from collections.abc import Mapping
 
 
 @singledispatch
@@ -57,7 +58,7 @@ def _(iterable):
     return type_(map(unwrap, iterable))
 
 
-@traverse_to_gather.register(dict)
+@traverse_to_gather.register(Mapping)
 def _(dictionary):
     futures = []
     for key, value in dictionary.items():
@@ -68,7 +69,7 @@ def _(dictionary):
     return futures
 
 
-@traverse_to_unwrap.register(dict)
+@traverse_to_unwrap.register(Mapping)
 def _(dictionary):
     unwrapped_dict = {}
     for key, value in dictionary.items():

--- a/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
+++ b/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
@@ -68,3 +68,16 @@ def test_resolving_iterables(type_):
     output2 = make_path("test2")
     output3 = append_paths(type_([output1, output2]), end_str="end")
     assert output3.result() == type_([Path("test1", "end"), Path("test2", "end")])
+
+
+@parsl.python_app
+def append_paths_dict(iterable: dict, end_str: str = "end"):
+    return {Path(k, end_str): Path(v, end_str) for k, v in iterable.items()}
+
+
+@pytest.mark.local
+def test_resolving_dict():
+    output1 = make_path("test1")
+    output2 = make_path("test2")
+    output3 = append_paths_dict({output1: output2}, end_str="end")
+    assert output3.result() == {Path("test1", "end"): Path("test2", "end")}


### PR DESCRIPTION
# Description

Adds support for shallow resolution of Futures in `dict` types for #3111.

Thoughts, @benclifford? This takes care of key futures. It also takes care of value futures, but in this spirit of "shallow" future resolution, it only does so if it `isinstance(value, Future)` and won't (yet) handle more complex cases like a dictionary where the value is a `list` containing a future.