### PR TITLE
Pin radical-pilot to version 1.47

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras_require = {
     'workqueue': ['work_queue'],
     'flux': ['pyyaml', 'cffi', 'jsonschema'],
     'proxystore': ['proxystore'],
-    'radical-pilot': ['radical.pilot'],
+    'radical-pilot': ['radical.pilot==1.47'],
     # Disabling psi-j since github direct links are not allowed by pypi
     # 'psij': ['psi-j-parsl@git+https://github.com/ExaWorks/psi-j-parsl']
 }


### PR DESCRIPTION
A recently released version, 1.48, doesn't work with this executor, so this PR aggressively constrains the version to what was passing in Parsl GitHub Actions over the last few weeks.

For further contex, see
https://github.com/radical-cybertools/radical.saga/issues/885#issuecomment-2017520999

## Type of change

- Code maintenance/cleanup
