### PR TITLE
Use `dict` instead of `Mapping` in #3111

### DIFF
--- a/parsl/dataflow/future_resolution.py
+++ b/parsl/dataflow/future_resolution.py
@@ -1,4 +1,3 @@
-from collections.abc import Mapping
 from concurrent.futures import Future
 from functools import singledispatch
 
@@ -58,7 +57,7 @@ def _(iterable):
     return type_(map(unwrap, iterable))
 
 
-@traverse_to_gather.register(Mapping)
+@traverse_to_gather.register(dict)
 def _(dictionary):
     futures = []
     for key, value in dictionary.items():
@@ -69,7 +68,7 @@ def _(dictionary):
     return futures
 
 
-@traverse_to_unwrap.register(Mapping)
+@traverse_to_unwrap.register(dict)
 def _(dictionary):
     unwrapped_dict = {}
     for key, value in dictionary.items():


### PR DESCRIPTION
# Description

I made sure to use `dict` instead of `Mapping` in the `@traverse_to_gather.register(dict)` and `@traverse_to_unwrap.register(dict)` since we are specifically returning a `dict` in the wrap function. In principle, this could likely be made more general to `Mapping`, but let's start simple for now.