### PR TITLE
Return DFK in context manager

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -207,7 +207,7 @@ class DataFlowKernel:
         atexit.register(self.atexit_cleanup)
 
     def __enter__(self):
-       return self
+        return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         logger.debug("Exiting the context manager, calling cleanup for DFK")

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -207,7 +207,7 @@ class DataFlowKernel:
         atexit.register(self.atexit_cleanup)
 
     def __enter__(self):
-        pass
+       return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         logger.debug("Exiting the context manager, calling cleanup for DFK")

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras_require = {
     'workqueue': ['work_queue'],
     'flux': ['pyyaml', 'cffi', 'jsonschema'],
     'proxystore': ['proxystore'],
-    'radical-pilot': ['radical.pilot'],
+    'radical-pilot': ['radical.pilot==1.47'],
     # Disabling psi-j since github direct links are not allowed by pypi
     # 'psij': ['psi-j-parsl@git+https://github.com/ExaWorks/psi-j-parsl']
 }


### PR DESCRIPTION
# Description

When attempting to use the with statement with `parsl.load()` to manage a DataFlowKernel object (dfk). Currently, the context manager protocol does not correctly assign the loaded DataFlowKernel to dfk, resulting in dfk being `None`. The desired solution is to ensure that `with parsl.load() as dfk`: That assigns the loaded DataFlowKernel object to dfk

# Changed Behaviour

now the DFK context manager should return DFK

# Fixes

Fixes # (https://github.com/Parsl/parsl/issues/3292)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature

