### PR TITLE
Add `cd` command to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,7 @@ For Developers
 
 2. Build and Test::
 
+    $ cd Parsl # navigate to the root directoty of the project
     $ make   # show all available makefile targets
     $ make virtualenv # create a virtual environment
     $ source .venv/bin/activate # activate the virtual environment

--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ For Developers
 
 2. Build and Test::
 
-    $ cd Parsl # navigate to the root directoty of the project
+    $ cd parsl # navigate to the root directory of the project
     $ make   # show all available makefile targets
     $ make virtualenv # create a virtual environment
     $ source .venv/bin/activate # activate the virtual environment


### PR DESCRIPTION
# Description

Added instruction to README: "To prevent errors when running the 'make' command immediately after cloning, remind users to navigate to the root directory by using the command 'cd Parsl' first."

## Type of change

- Update to human readable text: Documentation/error messages/comments

