### PR TITLE
DFK return in context managers

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -207,7 +207,10 @@ class DataFlowKernel:
         atexit.register(self.atexit_cleanup)
 
     def __enter__(self):
-        pass
+        """
+        Return the Loaded DataFlowKernel
+        """
+        return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         logger.debug("Exiting the context manager, calling cleanup for DFK")

--- a/parsl/tests/test_python_apps/test_context_manager.py
+++ b/parsl/tests/test_python_apps/test_context_manager.py
@@ -2,6 +2,7 @@ import parsl
 from parsl.tests.configs.local_threads import fresh_config
 import pytest
 from parsl.errors import NoDataFlowKernelError
+from parsl.dataflow.dflow import DataFlowKernel
 
 
 @parsl.python_app
@@ -25,7 +26,8 @@ def local_teardown():
 @pytest.mark.local
 def test_within_context_manger():
     config = fresh_config()
-    with parsl.load(config=config):
+    with parsl.load(config=config) as dfk:
+        assert isinstance(dfk, DataFlowKernel)
         py_future = square(2)
         assert py_future.result() == 4
 


### PR DESCRIPTION
# Description

After PR #3260 , DFK can be loaded in context manager to implicitly cleanup when exiting the context manager. So, its natural for users to write `with parsl.load() as dfk:` but it doesn't return instance of DataFlowKernel but rather None. So this PR fixes it by returning the loaded DFK.

# Changed Behaviour

After this PR, on loading a config within context managers , user can get the underlying DFK on entering the context manager rather than using  `DataFlowKernelLoader.dfk()`  inside.

# Fixes

Fixes #3292

## Type of change  
- New feature

