### PR TITLE
Use .pytest rundir hook for disconnection test

### DIFF
--- a/parsl/tests/test_htex/test_disconnected_blocks.py
+++ b/parsl/tests/test_htex/test_disconnected_blocks.py
@@ -26,7 +26,6 @@ def local_config():
                 ),
             )
         ],
-        run_dir="/tmp/test_htex",
         max_idletime=0.5,
         strategy='htex_auto_scale',
     )


### PR DESCRIPTION
By leaving the test config's rundir as default, parsl/tests/conftest.py will reassign that attribute to a dynamically generated directory under .pytest/parsltest-current

## Type of change

- Code maintenance/cleanup
