### PR TITLE
Rename PollItem to reflect its current role as a facade on executor

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1215,19 +1215,19 @@ class DataFlowKernel:
 
         logger.info("Scaling in and shutting down executors")
 
-        for pi in self.job_status_poller._poll_items:
-            if not pi.executor.bad_state_is_set:
-                logger.info(f"Scaling in executor {pi.executor.label}")
+        for ef in self.job_status_poller._executor_facades:
+            if not ef.executor.bad_state_is_set:
+                logger.info(f"Scaling in executor {ef.executor.label}")
 
                 # this code needs to be at least as many blocks as need
                 # cancelling, but it is safe to be more, as the scaling
                 # code will cope with being asked to cancel more blocks
                 # than exist.
-                block_count = len(pi.status)
-                pi.scale_in(block_count)
+                block_count = len(ef.status)
+                ef.scale_in(block_count)
 
             else:  # and bad_state_is_set
-                logger.warning(f"Not scaling in executor {pi.executor.label} because it is in bad state")
+                logger.warning(f"Not scaling in executor {ef.executor.label} because it is in bad state")
 
         for executor in self.executors.values():
             logger.info(f"Shutting down executor {executor.label}")


### PR DESCRIPTION
This should not change behaviour, but should make the behaviour of this class a bit more understandable for human readers.

The history here was PollItem used to be two classes, PollItem and ExecutorStatus. Those two classes were merged, leaving only PollItem; and the combo gained more facade-like behaviour, rather than being a only status cache.

# Changed Behaviour

none

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
