### PR TITLE
Remove duplicated parsl.providers.GridEngineProvider

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -113,7 +113,6 @@ Providers
     parsl.providers.GridEngineProvider
     parsl.providers.LocalProvider
     parsl.providers.LSFProvider
-    parsl.providers.GridEngineProvider
     parsl.providers.SlurmProvider
     parsl.providers.TorqueProvider
     parsl.providers.KubernetesProvider


### PR DESCRIPTION
# Description

Remove duplicated `parsl.providers.GridEngineProvider`from docs

# Changed Behaviour

N.A.

# Fixes

N.A.

## Type of change

- Update to human readable text: Documentation
