### PR TITLE
Move 'first' field into strategy state

### DIFF
--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -23,7 +23,6 @@ class PolledExecutorFacade:
         self._interval = executor.status_polling_interval
         self._last_poll_time = 0.0
         self._status = {}  # type: Dict[str, JobStatus]
-        self.first = True
 
         # Create a ZMQ channel to send poll status to monitoring
         self.monitoring_enabled = False

--- a/parsl/jobs/strategy.py
+++ b/parsl/jobs/strategy.py
@@ -27,7 +27,7 @@ class ExecutorState(TypedDict):
     """
 
     first: bool
-    """Is this the first poll for this executor?
+    """True if this executor has not yet had a strategy poll.
     """
 
 


### PR DESCRIPTION
This is part of work to move JobStatusPoller facade state into other classes, as part of job handling rearrangements in PR #3293

This should not change behaviour: each executor has a single PolledExecutorFacade and a single strategy.ExecutorState, and this PR moves the 'first' field from one to the other.

parsl/tests/test_monitoring/test_htex_init_blocks_vs_monitoring.py tests that init_blocks handling still fires properly - that's what is switched by this 'first' field.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
