### PR TITLE
Add ZipFileStaging to archive outputs into a zip file

### DIFF
--- a/parsl/data_provider/data_manager.py
+++ b/parsl/data_provider/data_manager.py
@@ -7,6 +7,7 @@ from parsl.data_provider.files import File
 from parsl.data_provider.file_noop import NoOpFileStaging
 from parsl.data_provider.ftp import FTPSeparateTaskStaging
 from parsl.data_provider.http import HTTPSeparateTaskStaging
+from parsl.data_provider.zip import ZipFileStaging
 from parsl.data_provider.staging import Staging
 
 if TYPE_CHECKING:
@@ -17,7 +18,7 @@ logger = logging.getLogger(__name__)
 # these will be shared between all executors that do not explicitly
 # override, so should not contain executor-specific state
 default_staging: List[Staging]
-default_staging = [NoOpFileStaging(), FTPSeparateTaskStaging(), HTTPSeparateTaskStaging()]
+default_staging = [NoOpFileStaging(), FTPSeparateTaskStaging(), HTTPSeparateTaskStaging(), ZipFileStaging()]
 
 
 class DataManager:

--- a/parsl/data_provider/zip.py
+++ b/parsl/data_provider/zip.py
@@ -1,0 +1,84 @@
+import filelock
+import logging
+import os
+import parsl
+import zipfile
+
+from typing import Tuple
+
+from parsl.data_provider.staging import Staging
+from parsl.data_provider.files import File
+
+
+logger = logging.getLogger(__name__)
+
+
+class ZipFileStaging(Staging):
+    """A stage-out provider for zip files.
+
+    This provider will stage out files by writing them into the specified zip
+    file.
+
+    The filename of both the zip file and the file contained in that zip are
+    specified using a zip: URL, like this:
+
+    zip:/tmp/foo/this.zip/inside/here.txt
+
+    This URL names a zip file ``/tmp/foo/this.zip`` containing a file
+    ``inside/here.txt``.
+
+    The provider will use the Python filelock package to lock the zip file so
+    that it does not conflict with other instances of itself. This lock will
+    not protect against other modifications to the zip file.
+    """
+
+    def can_stage_out(self, file: File) -> bool:
+        logger.debug("archive provider checking File {}".format(repr(file)))
+        return file.scheme == 'zip'
+
+    def stage_out(self, dm, executor, file, parent_fut):
+        assert file.scheme == 'zip'
+
+        zip_path, inside_path = zip_path_split(file.path)
+
+        working_dir = dm.dfk.executors[executor].working_dir
+
+        if working_dir:
+            file.local_path = os.path.join(working_dir, inside_path)
+
+            # TODO: I think its the right behaviour that a staging out provider should create the directory structure
+            # for the file to be placed in?
+            os.makedirs(os.path.dirname(file.local_path), exist_ok=True)
+        else:
+            raise RuntimeError("zip file staging requires a working_dir to be specified")
+
+        stage_out_app = _zip_stage_out_app(dm)
+        app_fut = stage_out_app(zip_path, inside_path, working_dir, inputs=[file], _parsl_staging_inhibit=True, parent_fut=parent_fut)
+        return app_fut
+
+
+def _zip_stage_out(zip_file, inside_path, working_dir, parent_fut=None, inputs=[], _parsl_staging_inhibit=True):
+    file = inputs[0]
+
+    os.makedirs(os.path.dirname(zip_file), exist_ok=True)
+
+    with filelock.FileLock(zip_file + ".lock"):
+        with zipfile.ZipFile(zip_file, mode='a', compression=zipfile.ZIP_DEFLATED) as z:
+            z.write(file, arcname=inside_path)
+
+    os.remove(file)
+
+
+def _zip_stage_out_app(dm):
+    return parsl.python_app(executors=['_parsl_internal'], data_flow_kernel=dm.dfk)(_zip_stage_out)
+
+
+def zip_path_split(path: str) -> Tuple[str, str]:
+    """Split zip: path into a zipfile name and a contained-file name.
+    """
+    index = path.find(".zip/")
+
+    zip_path = path[:index + 4]
+    inside_path = path[index + 5:]
+
+    return (zip_path, inside_path)

--- a/parsl/tests/test_staging/test_zip_out.py
+++ b/parsl/tests/test_staging/test_zip_out.py
@@ -4,7 +4,7 @@ import zipfile
 
 from parsl.data_provider.files import File
 from parsl.data_provider.data_manager import default_staging
-from parsl.data_provider.zip import ZipFileStaging
+from parsl.data_provider.zip import ZipAuthorityError, ZipFileStaging
 
 from parsl.providers import LocalProvider
 from parsl.channels import LocalChannel
@@ -97,3 +97,17 @@ def test_zip_out_multi(tmpd_cwd):
         assert len(z.namelist()) == 1
         with z.open(relative_file_path_3) as f:
             assert f.readlines() == [b'2\n']
+
+
+@pytest.mark.local
+def test_zip_bad_authority(tmpd_cwd):
+    # tests that there's an exception when staging a ZIP url with an authority
+    # section specified, rather than silently ignoring it. This simulates a
+    # user who misunderstands what that piece of what a zip: URL means.
+
+    zip_path = tmpd_cwd / "container.zip"
+    file_base = "data.txt"
+    of = File(f"zip://someauthority/{zip_path / file_base}")
+
+    with pytest.raises(ZipAuthorityError):
+        output_something(outputs=[of])

--- a/parsl/tests/test_staging/test_zip_out.py
+++ b/parsl/tests/test_staging/test_zip_out.py
@@ -1,0 +1,99 @@
+import parsl
+import pytest
+import zipfile
+
+from parsl.data_provider.files import File
+from parsl.data_provider.data_manager import default_staging
+from parsl.data_provider.zip import ZipFileStaging
+
+from parsl.providers import LocalProvider
+from parsl.channels import LocalChannel
+from parsl.launchers import SimpleLauncher
+
+from parsl.config import Config
+from parsl.executors import HighThroughputExecutor
+
+from parsl.tests.configs.htex_local import fresh_config as local_config
+
+
+@pytest.mark.local
+def test_zip_path_split():
+    from parsl.data_provider.zip import zip_path_split
+    assert zip_path_split("/tmp/foo/this.zip/inside/here.txt") == ("/tmp/foo/this.zip", "inside/here.txt")
+
+
+@parsl.bash_app
+def output_something(outputs=()):
+    """This should output something into every specified output file:
+    the position in the output sequence will be written into the
+    corresponding output file.
+    """
+    cmds = []
+    for n in range(len(outputs)):
+        cmds.append(f"echo {n} > {outputs[n]}")
+
+    return "; ".join(cmds)
+
+
+@pytest.mark.local
+def test_zip_out(tmpd_cwd):
+    # basic test of zip file stage-out
+    zip_path = str(tmpd_cwd) + "container.zip"
+    file_base = "data.txt"
+    of = File("zip:" + zip_path + "/" + file_base)
+
+    app_future = output_something(outputs=[of])
+    output_file_future = app_future.outputs[0]
+
+    app_future.result()
+    output_file_future.result()
+
+    assert zipfile.is_zipfile(zip_path)
+
+    with zipfile.ZipFile(zip_path) as z:
+        assert file_base in z.namelist()
+        assert len(z.namelist()) == 1
+        with z.open(file_base) as f:
+            assert f.readlines() == [b'0\n']
+
+
+@pytest.mark.local
+def test_zip_out_multi(tmpd_cwd):
+    # tests multiple files, multiple zip files and multiple
+    # sub-paths
+
+    zip_path_1 = str(tmpd_cwd) + "container1.zip"
+    zip_path_2 = str(tmpd_cwd) + "container2.zip"
+
+    relative_file_path_1 = "a/b/c/data.txt"
+    relative_file_path_2 = "something.txt"
+    relative_file_path_3 = "a/d/other.txt"
+    of1 = File("zip:" + zip_path_1 + "/" + relative_file_path_1)
+    of2 = File("zip:" + zip_path_1 + "/" + relative_file_path_2)
+    of3 = File("zip:" + zip_path_2 + "/" + relative_file_path_3)
+
+    app_future = output_something(outputs=[of1, of2, of3])
+
+    for f in app_future.outputs:
+        f.result()
+
+    app_future.result()
+
+    assert zipfile.is_zipfile(zip_path_1)
+
+    with zipfile.ZipFile(zip_path_1) as z:
+        assert relative_file_path_1 in z.namelist()
+        assert relative_file_path_2 in z.namelist()
+        assert len(z.namelist()) == 2
+        with z.open(relative_file_path_1) as f:
+            assert f.readlines() == [b'0\n']
+        with z.open(relative_file_path_2) as f:
+            assert f.readlines() == [b'1\n']
+
+    assert zipfile.is_zipfile(zip_path_2)
+
+    with zipfile.ZipFile(zip_path_2) as z:
+        assert relative_file_path_3 in z.namelist()
+        assert len(z.namelist()) == 1
+        with z.open(relative_file_path_3) as f:
+            assert f.readlines() == [b'2\n']

--- a/parsl/tests/test_staging/test_zip_out.py
+++ b/parsl/tests/test_staging/test_zip_out.py
@@ -38,9 +38,9 @@ def output_something(outputs=()):
 @pytest.mark.local
 def test_zip_out(tmpd_cwd):
     # basic test of zip file stage-out
-    zip_path = str(tmpd_cwd) + "container.zip"
+    zip_path = tmpd_cwd / "container.zip"
     file_base = "data.txt"
-    of = File("zip:" + zip_path + "/" + file_base)
+    of = File(f"zip:{zip_path / file_base}")
 
     app_future = output_something(outputs=[of])
     output_file_future = app_future.outputs[0]
@@ -62,15 +62,15 @@ def test_zip_out_multi(tmpd_cwd):
     # tests multiple files, multiple zip files and multiple
     # sub-paths
 
-    zip_path_1 = str(tmpd_cwd) + "container1.zip"
-    zip_path_2 = str(tmpd_cwd) + "container2.zip"
+    zip_path_1 = tmpd_cwd / "container1.zip"
+    zip_path_2 = tmpd_cwd / "container2.zip"
 
     relative_file_path_1 = "a/b/c/data.txt"
     relative_file_path_2 = "something.txt"
     relative_file_path_3 = "a/d/other.txt"
-    of1 = File("zip:" + zip_path_1 + "/" + relative_file_path_1)
-    of2 = File("zip:" + zip_path_1 + "/" + relative_file_path_2)
-    of3 = File("zip:" + zip_path_2 + "/" + relative_file_path_3)
+    of1 = File(f"zip:{zip_path_1 / relative_file_path_1}")
+    of2 = File(f"zip:{zip_path_1 / relative_file_path_2}")
+    of3 = File(f"zip:{zip_path_2 / relative_file_path_3}")
 
     app_future = output_something(outputs=[of1, of2, of3])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ requests
 paramiko
 psutil>=5.5.1
 setproctitle
+filelock>=3.13,<4


### PR DESCRIPTION
# Description

This output file staging mechanism provides a zip: URL scheme, naming
a file inside a zip file; output files from apps can be staged out into
this location. Input staging is not supported.
    
The use-case for this is as part of a sequence of PRs separating
PR #3306, leading to stdout staging into zipfiles.

# Changed Behaviour

This is new functionality only activated by use of the `zip:` URL scheme, which previously would have raised an error.

## Type of change

- New feature
