### PR TITLE
Do not store DFK in PolledExecutorFacade

### DIFF
--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -19,17 +19,16 @@ logger = logging.getLogger(__name__)
 class PolledExecutorFacade:
     def __init__(self, executor: BlockProviderExecutor, dfk: Optional["parsl.dataflow.dflow.DataFlowKernel"] = None):
         self._executor = executor
-        self._dfk = dfk
         self._interval = executor.status_polling_interval
         self._last_poll_time = 0.0
         self._status = {}  # type: Dict[str, JobStatus]
 
         # Create a ZMQ channel to send poll status to monitoring
         self.monitoring_enabled = False
-        if self._dfk and self._dfk.monitoring is not None:
+        if dfk and dfk.monitoring is not None:
             self.monitoring_enabled = True
-            hub_address = self._dfk.hub_address
-            hub_port = self._dfk.hub_zmq_port
+            hub_address = dfk.hub_address
+            hub_port = dfk.hub_zmq_port
             context = zmq.Context()
             self.hub_channel = context.socket(zmq.DEALER)
             self.hub_channel.set_hwm(0)


### PR DESCRIPTION
The DFK is only used to initialise monitoring, in `__init__`, and is not used after that. The object that lives beyond `__init__` is `self.hub_channel`.

This is part of work to move `JobStatusPoller` facade state into other classes, as part of job handling rearrangements in PR #3293

# Changed Behaviour

This PR should not change behaviour.

## Type of change

- Code maintenance/cleanup
