### PR TITLE
Delete duplicate misplaced DFK docstring on random executors

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -674,14 +674,6 @@ class DataFlowKernel:
     def launch_task(self, task_record: TaskRecord) -> Future:
         """Handle the actual submission of the task to the executor layer.
 
-        If the app task has the executors attributes not set (default=='all')
-        the task is launched on a randomly selected executor from the
-        list of executors. This behavior could later be updated to support
-        binding to executors based on user specified criteria.
-
-        If the app task specifies a particular set of executors, it will be
-        targeted at those specific executors.
-
         Args:
             task_record : The task record
 


### PR DESCRIPTION
This text is already present on a more appropriate method, `submit`, where executor selection actually takes place. The deleted text was on the launch_task method, which runs long after executor selection has happened.

## Type of change

- Update to human readable text: Documentation/error messages/comments
