### PR TITLE
Unshare "now" timestamp across executor polls

### DIFF
--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -37,7 +37,8 @@ class PolledExecutorFacade:
     def _should_poll(self, now: float) -> bool:
         return now >= self._last_poll_time + self._executor.status_polling_interval
 
-    def poll(self, now: float) -> None:
+    def poll(self) -> None:
+        now = time.time()
         if self._should_poll(now):
             previous_status = self._status
             self._status = self._executor.status()
@@ -123,9 +124,8 @@ class JobStatusPoller(Timer):
             es.executor.handle_errors(es.status)
 
     def _update_state(self) -> None:
-        now = time.time()
         for item in self._executor_facades:
-            item.poll(now)
+            item.poll()
 
     def add_executors(self, executors: Sequence[BlockProviderExecutor]) -> None:
         for executor in executors:


### PR DESCRIPTION
This PR removes the notion of a shared current time among all polls.

Instead each facade poll looks up the current time individually.

Although executor polls are all launched from the same loop, there's no need for them to act as if they are being polled at the same moment in time, which in the case of multiple executors, will be some time in the past.

This means there is one less variable shared between polls of different executors, which is part of work pushing executor polling deeper into each executor away from the per-DFK JobStatusPoller.


# Changed Behaviour

This will change the cadence of polling: `now` may be measured a bit later, especially in the presence of multiple executors, causing meaning a poll that might have previously skipped to now run, and as a knock on, all subsequent skips/updates will be jiggled around based on that change. This should not have any serious effect on observable behaviour.

## Type of change

- Code maintenance/cleanup
