### PR TITLE
Remove unused 'noci' pytest marker.

### DIFF
--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -135,12 +135,11 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         'markers',
-        'noci: mark test to be unsuitable for running during automated tests'
+        'cleannet: Enable tests that require a clean network connection (such as for testing FTP)'
     )
-
     config.addinivalue_line(
         'markers',
-        'cleannet: Enable tests that require a clean network connection (such as for testing FTP)'
+        'issue363: Marks tests that require a shared filesystem for stdout/stderr - see issue #363'
     )
     config.addinivalue_line(
         'markers',

--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -143,10 +143,6 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         'markers',
-        'issue363: Marks tests that require a shared filesystem for stdout/stderr - see issue #363'
-    )
-    config.addinivalue_line(
-        'markers',
         'staging_required: Marks tests that require a staging provider, when there is no sharedFS)'
     )
     config.addinivalue_line(


### PR DESCRIPTION
Not-running-tests-in-CI is achieved by more subtle means, such as topic and issue specific test markers.

## Type of change

- Code maintenance/cleanup
