### PR TITLE
Remove 'not issue363' markers from Work Queue and Task Vine tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,11 @@ $(CCTOOLS_INSTALL):	#CCtools contains both taskvine and workqueue so install onl
 
 .PHONY: vineex_local_test
 vineex_local_test: $(CCTOOLS_INSTALL)  ## run all tests with taskvine_ex config
-	PYTHONPATH=/tmp/cctools/lib/python3.8/site-packages  pytest parsl/tests/ -k "not cleannet and not issue363" --config parsl/tests/configs/taskvine_ex.py --random-order --durations 10
+	PYTHONPATH=/tmp/cctools/lib/python3.8/site-packages  pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/taskvine_ex.py --random-order --durations 10
 
 .PHONY: wqex_local_test
 wqex_local_test: $(CCTOOLS_INSTALL)  ## run all tests with workqueue_ex config
-	PYTHONPATH=/tmp/cctools/lib/python3.8/site-packages  pytest parsl/tests/ -k "not cleannet and not issue363" --config parsl/tests/configs/workqueue_ex.py --random-order --durations 10
+	PYTHONPATH=/tmp/cctools/lib/python3.8/site-packages  pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/workqueue_ex.py --random-order --durations 10
 
 .PHONY: radical_local_test
 radical_local_test:


### PR DESCRIPTION
These tests all pass with Work Queue and Task Vine in CI and on my laptop.

Some of these used to fail, but PR #2803 changed the stdout/stderr paths from relative paths to absolute paths (to move files into a per-test working directory). This then causes a different codepath for std* behaviour to be followed in Task Vine and Work Queue: when give absolute paths, those executors assume a shared file system without staging.

For example, test_stdout_truncate in parsl/tests/test_bash_apps/test_stdout.py work as currently written, but fails if this change from PR #2803 is reverted:

```
  def test_stdout_append(tmpd_cwd):

-    out = str('t1.out')
+    out = str(tmpd_cwd / 't1.out')
```

Making a more formal model of how Work Queue and Task Vine should handle relative vs absolute paths as a signal to stage or not stage is beyond the scope of this pull request. Instead this PR seeks to enable tests that are not failing (and no longer expected to fail).

## Type of change

- Code maintenance/cleanup
