### PR TITLE
Exit monitoring router exit on multiprocessing event, not exit message

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1227,8 +1227,7 @@ class DataFlowKernel:
                                   'tasks_completed_count': self.task_state_counts[States.exec_done],
                                   "time_began": self.time_began,
                                   'time_completed': self.time_completed,
-                                  'run_id': self.run_id, 'rundir': self.run_dir,
-                                  'exit_now': True})
+                                  'run_id': self.run_id, 'rundir': self.run_dir})
 
             logger.info("Terminating monitoring")
             self.monitoring.close()


### PR DESCRIPTION
Prior to this PR, the monitoring router exited due to receiving a WORKFLOW_INFO message with an exit_now field set to True, but only if that message was received through a specific path.

This PR removes that exit_now field, and makes the monitoring router exit on a multiprocessing event. This removes the need for the exit message to arrive through that specific path into the router, which makes message handling more consistent, and opens up opportunities to feed messages into monitoring through different paths.

Slowly ongoing work has been trying to make all the different monitoring message paths behave the same with a goal of eliminating some of them, and this change also works towards that.

# Changed Behaviour

Exiting might behave slightly differently: before this PR, the exit message was sent a bit before calling `DFK.monitoring.close()`, and the exit event is set a bit later than that; and the alternation between checking UDP, checking ZMQ and checking exit status will be a bit peturbed.

## Type of change

- Code maintenance/cleanup
