### PR TITLE
Inline PolledExecutorFacade._should_poll_now

### DIFF
--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -37,12 +37,9 @@ class PolledExecutorFacade:
         else:
             self.hub_channel = None
 
-    def _should_poll(self, now: float) -> bool:
-        return now >= self._last_poll_time + self._executor.status_polling_interval
-
     def poll(self) -> None:
         now = time.time()
-        if self._should_poll(now):
+        if now >= self._last_poll_time + self._executor.status_polling_interval:
             previous_status = self._status
             self._status = self._executor.status()
             self._last_poll_time = now


### PR DESCRIPTION
It was used once, a couple of lines below.


# Changed Behaviour

This PR should not change behaviour.

## Type of change

- Code maintenance/cleanup
