### PR TITLE
Replace proc_id with human words in LocalProvider debug log

### DIFF
--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -266,7 +266,7 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
         for job in job_ids:
             job_dict = self.resources[job]
             job_dict['cancelled'] = True
-            logger.debug("Terminating job/proc_id: {0}".format(job))
+            logger.debug("Terminating job/process ID: {0}".format(job))
             cmd = "kill -- -$(ps -o pgid= {} | grep -o '[0-9]*')".format(job_dict['remote_pid'])
             retcode, stdout, stderr = self.channel.execute_wait(cmd, self.cmd_timeout)
             if retcode != 0:


### PR DESCRIPTION
Before this PR, `proc_id` was used in log messages as if its a symbol such as a local variable or function parameter. It is not.

This PR replaces `proc_id` with human words.

## Type of change

- Update to human readable text: Documentation/error messages/comments
