### PR TITLE
Remove (unused?) PolledExecutorFacade __repr__

### DIFF
--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -100,9 +100,6 @@ class PolledExecutorFacade:
             self._status.update(new_status)
         return block_ids
 
-    def __repr__(self) -> str:
-        return self._status.__repr__()
-
 
 class JobStatusPoller(Timer):
     def __init__(self, *, strategy: Optional[str], max_idletime: float,


### PR DESCRIPTION
I can't find anywhere this is used: I think PolledExecutorFacades are never referenced outside of job_status_poller.py and strategy.py; and in both of those files, I cannot see anywhere that a PolledExecutorFacade is repr'd.

# Changed Behaviour

This PR should not change any behaviour.

## Type of change

- Code maintenance/cleanup
