### PR TITLE
Unabstract executor.create_monitoring_info

### DIFF
--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -1,9 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from concurrent.futures import Future
-from typing import Any, Callable, Dict, Optional, List
+from typing import Any, Callable, Dict, Optional
 from typing_extensions import Literal, Self
-
-from parsl.jobs.states import JobStatus
 
 
 class ParslExecutor(metaclass=ABCMeta):
@@ -78,13 +76,6 @@ class ParslExecutor(metaclass=ABCMeta):
         This includes all attached resources such as workers and controllers.
         """
         pass
-
-    def create_monitoring_info(self, status: Dict[str, JobStatus]) -> List[object]:
-        """Create a monitoring message for each block based on the poll status.
-
-        :return: a list of dictionaries mapping to the info of each block
-        """
-        return []
 
     def monitor_resources(self) -> bool:
         """Should resource monitoring happen for tasks on running on this executor?

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -5,7 +5,6 @@ import typeguard
 import logging
 import threading
 import queue
-import datetime
 import pickle
 from dataclasses import dataclass
 from multiprocessing import Process, Queue
@@ -676,22 +675,6 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
 
         # Return the future
         return fut
-
-    def create_monitoring_info(self, status):
-        """ Create a msg for monitoring based on the poll status
-
-        """
-        msg = []
-        for bid, s in status.items():
-            d = {}
-            d['run_id'] = self.run_id
-            d['status'] = s.status_name
-            d['timestamp'] = datetime.datetime.now()
-            d['executor_label'] = self.label
-            d['job_id'] = self.blocks_to_job_id.get(bid, None)
-            d['block_id'] = bid
-            msg.append(d)
-        return msg
 
     @property
     def workers_per_node(self) -> Union[int, float]:

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
+import datetime
 import logging
 import threading
 from itertools import compress
 from abc import abstractmethod, abstractproperty
 from concurrent.futures import Future
-from typing import List, Any, Dict, Optional, Tuple, Union, Callable
+from typing import List, Any, Dict, Optional, Sequence, Tuple, Union, Callable
 
 from parsl.executors.base import ParslExecutor
 from parsl.executors.errors import BadStateException, ScalingFailed
@@ -234,3 +235,18 @@ class BlockProviderExecutor(ParslExecutor):
     @abstractproperty
     def workers_per_node(self) -> Union[int, float]:
         pass
+
+    def create_monitoring_info(self, status: Dict[str, JobStatus]) -> Sequence[object]:
+        """Create a monitoring message for each block based on the poll status.
+        """
+        msg = []
+        for bid, s in status.items():
+            d: Dict[str, Any] = {}
+            d['run_id'] = self.run_id
+            d['status'] = s.status_name
+            d['timestamp'] = datetime.datetime.now()
+            d['executor_label'] = self.label
+            d['job_id'] = self.blocks_to_job_id.get(bid, None)
+            d['block_id'] = bid
+            msg.append(d)
+        return msg


### PR DESCRIPTION
This method makes sense for `BlockProviderExecutors`, where it is used by the `JobStatusPoller`. It does not make sense for Parsl Executors in general and is not otherwise used. So remove from the `ParslExecutor` base class, which removes the dependency of `parsl.executors.base` on `parsl.jobs.*`, a cleaner separation of concerns.

This method is implemented in `HighThroughputExecutor`, but the information generated only uses `BlockProviderExecutor` information and would make sense for other BlockProviderExecutors (Work Queue, Task Vine and the erstwhile IPP and Extreme Scale executors). Using this implementation has been prototyped in the desc branch of parsl since 2021. So move that implementation out of `HighThroughputExecutor` and into `BlockProviderExecutor`.

This should not change any behaviour when using `HighThroughputExecutor`. When using Work Queue or Task Vine, this change will bring block monitoring support to those executors. As noted above, this has been used successfully with Work Queue since 2021 in the desc branch. This PR modifies the basic monitoring test to test against those executors in addition to the `HighThroughputExecutor`.

This PR modifies the type annotations of `create_monitoring_info` to type check properly - the previous htex implementation was not type-checked. The return type is modified to a sequence, because `List` is invariant on its parameter type, which is incompatible with adding `Dict[str, Any]` to it.

# Changed Behaviour

see main description

## Type of change

- New feature