### PR TITLE
Turn on type checking for all of parsl.jobs.*

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -54,6 +54,9 @@ disallow_untyped_defs = True
 disallow_any_expr = True
 disallow_any_decorated = True
 
+[mypy-parsl.jobs.*]
+disallow_untyped_defs = True
+
 [mypy-parsl.providers.base.*]
 disallow_untyped_decorators = True
 check_untyped_defs = True

--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -131,8 +131,8 @@ class JobStatusPoller(Timer):
                 self._executor_facades.append(PolledExecutorFacade(executor, self.dfk))
         self._strategy.add_executors(executors)
 
-    def close(self):
-        super().close()
+    def close(self, timeout: Optional[float] = None) -> None:
+        super().close(timeout)
         for ef in self._executor_facades:
             if not ef.executor.bad_state_is_set:
                 logger.info(f"Scaling in executor {ef.executor.label}")


### PR DESCRIPTION
This reveals one type error, that JobStatusPoller does not properly implement the .close() method signature. This PR fixes that and passes the new timeout parameter to the superclass which can make use of it.

# Changed Behaviour

should be none - JobStatusPoller.close() is only called in the codebase without this new parameter.

## Type of change

- Code maintenance/cleanup
