### PR TITLE
Make test executors use default staging storage access list

### DIFF
--- a/parsl/tests/configs/htex_local_alternate.py
+++ b/parsl/tests/configs/htex_local_alternate.py
@@ -31,6 +31,7 @@ from parsl.executors import HighThroughputExecutor
 from parsl.data_provider.http import HTTPInTaskStaging
 from parsl.data_provider.ftp import FTPInTaskStaging
 from parsl.data_provider.file_noop import NoOpFileStaging
+from parsl.data_provider.zip import ZipFileStaging
 
 working_dir = os.getcwd() + "/" + "test_htex_alternate"
 
@@ -42,7 +43,7 @@ def fresh_config():
                 address="127.0.0.1",
                 label="htex_Local",
                 working_dir=working_dir,
-                storage_access=[FTPInTaskStaging(), HTTPInTaskStaging(), NoOpFileStaging()],
+                storage_access=[ZipFileStaging(), FTPInTaskStaging(), HTTPInTaskStaging(), NoOpFileStaging()],
                 worker_debug=True,
                 cores_per_worker=1,
                 heartbeat_period=2,

--- a/parsl/tests/configs/taskvine_ex.py
+++ b/parsl/tests/configs/taskvine_ex.py
@@ -9,5 +9,4 @@ from parsl.data_provider.file_noop import NoOpFileStaging
 
 def fresh_config():
     return Config(executors=[TaskVineExecutor(manager_config=TaskVineManagerConfig(port=9000),
-                                              worker_launch_method='factory',
-                                              storage_access=[FTPInTaskStaging(), HTTPInTaskStaging(), NoOpFileStaging()])])
+                                              worker_launch_method='factory')])

--- a/parsl/tests/configs/workqueue_ex.py
+++ b/parsl/tests/configs/workqueue_ex.py
@@ -8,5 +8,4 @@ from parsl.data_provider.file_noop import NoOpFileStaging
 
 def fresh_config():
     return Config(executors=[WorkQueueExecutor(port=9000,
-                                               coprocess=True,
-                                               storage_access=[FTPInTaskStaging(), HTTPInTaskStaging(), NoOpFileStaging()])])
+                                               coprocess=True)])


### PR DESCRIPTION
Aside from htex_local_alternate which is deliberately intended to use complicated option combinations, other test providers should use a minimal configuration and get the default.

This has the immediate effect of making zip: file staging available to future tests on all executors.

# Changed Behaviour

more file staging available by default - no tests make use of this at the moment

## Type of change

- New feature
