### PR TITLE
Remove outdated parsl.dataflow.futures docstring

### DIFF
--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -1,10 +1,3 @@
-"""This module implements the AppFutures.
-
-We have two basic types of futures:
-    1. DataFutures which represent data objects
-    2. AppFutures which represent the futures on App/Leaf tasks.
-
-"""
 from __future__ import annotations
 
 from concurrent.futures import Future


### PR DESCRIPTION
This refers to DataFutures which do not live in this module. AppFutures are already described in the AppFuture docstring.

## Type of change

- Update to human readable text: Documentation/error messages/comments
