### PR TITLE
Move monitoring radio reference from JobStatusPoller to BlockProviderExecutor

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1125,6 +1125,10 @@ class DataFlowKernel:
             executor.run_dir = self.run_dir
             executor.hub_address = self.hub_address
             executor.hub_port = self.hub_zmq_port
+            if self.monitoring:
+                executor.monitoring_radio = self.monitoring.radio
+            else:
+                executor.monitoring_radio = None
             if hasattr(executor, 'provider'):
                 if hasattr(executor.provider, 'script_dir'):
                     executor.provider.script_dir = os.path.join(self.run_dir, 'submit_scripts')

--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -3,6 +3,8 @@ from concurrent.futures import Future
 from typing import Any, Callable, Dict, Optional
 from typing_extensions import Literal, Self
 
+from parsl.monitoring.radios import MonitoringRadio
+
 
 class ParslExecutor(metaclass=ABCMeta):
     """Executors are abstractions that represent available compute resources
@@ -126,3 +128,13 @@ class ParslExecutor(metaclass=ABCMeta):
     @hub_port.setter
     def hub_port(self, value: Optional[int]) -> None:
         self._hub_port = value
+
+    @property
+    def monitoring_radio(self) -> Optional[MonitoringRadio]:
+        """Local radio for sending monitoring messages
+        """
+        return self._monitoring_radio
+
+    @monitoring_radio.setter
+    def monitoring_radio(self, value: Optional[MonitoringRadio]) -> None:
+        self._monitoring_radio = value


### PR DESCRIPTION
This is a step in consolidating responsibility for BLOCK monitoring into the BlockProviderExecutor.

Before this PR, executors were already configured ad-hoc with a lot of monitoring information. This PR adds another attribute to that collection for the local monitoring radio.

This PR removes some more state from the PolledExecutorFacade class.

# Changed Behaviour

This PR should not change behaviour - it changes the code path by which the job poller's monitoring radio is found.

## Type of change

- Code maintenance/cleanup
