### PR TITLE
Add more cases for std stream logging

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1391,10 +1391,20 @@ class DataFlowKernel:
 
     @staticmethod
     def _log_std_streams(task_record: TaskRecord) -> None:
-        if task_record['app_fu'].stdout is not None:
-            logger.info("Standard output for task {} available at {}".format(task_record['id'], task_record['app_fu'].stdout))
-        if task_record['app_fu'].stderr is not None:
-            logger.info("Standard error for task {} available at {}".format(task_record['id'], task_record['app_fu'].stderr))
+        tid = task_record['id']
+
+        def log_std_stream(name: str, target) -> None:
+            if target is None:
+                logger.info(f"{name} for task {tid} will not be redirected.")
+            elif isinstance(target, str):
+                logger.info(f"{name} for task {tid} will be redirected to {target}")
+            elif isinstance(target, tuple) and len(target) == 2:
+                logger.info(f"{name} for task {tid} will be redirected to {target[0]} with mode {target[1]}")
+            else:
+                logger.error(f"{name} for task {tid} has unknown specification: {target!r}")
+
+        log_std_stream("Standard out", task_record['app_fu'].stdout)
+        log_std_stream("Standard error", task_record['app_fu'].stderr)
 
 
 class DataFlowKernelLoader:


### PR DESCRIPTION
Previously, stdout/err logs no output if the streams were not set (i.e. defaulting to None) and logged with the entire stream target if set.

This PR adds more cases here with case specific logging: if stdout/err is not redirected, that is now logged. If tuple mode is used, the tuple is unpacked and logged as separate fields. If an unknown format is specified an error is logged (but no exception is raised - it is not the job of this code to validate the stdout/err specifications)

This PR is in preparation for a new case to be added in an upcoming PR which requires more serious formatting that was not accomodated by the previous implementation.

# Changed Behaviour

log messages - including a new error log

## Type of change

- Update to human readable text: Documentation/error messages/comments
