### PR TITLE
Treat stdout and stderr as stageable Files

### DIFF
--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -5,6 +5,7 @@ import logging
 
 from parsl.app.errors import wrap_error
 from parsl.app.app import AppBase
+from parsl.data_provider.files import File
 from parsl.dataflow.dflow import DataFlowKernelLoader
 
 logger = logging.getLogger(__name__)
@@ -54,7 +55,12 @@ def remote_side_bash_executor(func, *args, **kwargs):
         if stdfspec is None:
             return None
 
-        fname, mode = get_std_fname_mode(fdname, stdfspec)
+        if isinstance(stdfspec, File):
+            fname = str(stdfspec)
+            mode = "w"
+        else:
+            fname, mode = get_std_fname_mode(fdname, stdfspec)
+
         try:
             if os.path.dirname(fname):
                 os.makedirs(os.path.dirname(fname), exist_ok=True)

--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -56,7 +56,9 @@ def remote_side_bash_executor(func, *args, **kwargs):
             return None
 
         if isinstance(stdfspec, File):
-            fname = str(stdfspec)
+            # a File is an os.PathLike and so we can use it directly for
+            # the subsequent file operations
+            fname = stdfspec
             mode = "w"
         else:
             fname, mode = get_std_fname_mode(fdname, stdfspec)
@@ -66,7 +68,7 @@ def remote_side_bash_executor(func, *args, **kwargs):
                 os.makedirs(os.path.dirname(fname), exist_ok=True)
             fd = open(fname, mode)
         except Exception as e:
-            raise pe.BadStdStreamFile(fname) from e
+            raise pe.BadStdStreamFile(str(fname)) from e
         return fd
 
     std_out = open_std_fd('stdout')

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -831,11 +831,11 @@ class DataFlowKernel:
             func, outputs[idx], o = stageout_one_file(file, func)
             app_fut._outputs.append(o)
 
-        file = kwargs.get('stdout', None)
+        file = kwargs.get('stdout')
         if isinstance(file, File):
             func, kwargs['stdout'], app_fut._stdout_future = stageout_one_file(file, func)
 
-        file = kwargs.get('stderr', None)
+        file = kwargs.get('stderr')
         if isinstance(file, File):
             func, kwargs['stderr'], app_fut._stderr_future = stageout_one_file(file, func)
 

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -794,7 +794,7 @@ class DataFlowKernel:
         # and for each of those, perform possible stage-out. This can result in:
         # a DataFuture to be exposed in app_fut to represent the completion of
         # that stageout (sometimes backed by a new sub-workflow for separate-task
-        # stageout), a replacement # for the function to be executed (intended to
+        # stageout), a replacement for the function to be executed (intended to
         # be the original function wrapped with an in-task stageout wrapper), a
         # rewritten File object to be passed to task to be executed
 

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1391,10 +1391,20 @@ class DataFlowKernel:
 
     @staticmethod
     def _log_std_streams(task_record: TaskRecord) -> None:
-        if task_record['app_fu'].stdout is not None:
-            logger.info("Standard output for task {} available at {}".format(task_record['id'], task_record['app_fu'].stdout))
-        if task_record['app_fu'].stderr is not None:
-            logger.info("Standard error for task {} available at {}".format(task_record['id'], task_record['app_fu'].stderr))
+        tid = task_record['id']
+
+        def log_std_stream(name: str, target) -> None:
+            if target is None:
+                logger.info(f"{name} for task {tid} will not be redirected.")
+            elif isinstance(target, str):
+                logger.info(f"{name} for task {tid} will be redirected to {target}")
+            elif isinstance(target, tuple) and len(target) == 2:
+                logger.info(f"{name} for task {tid} will be redirected to {target[0]} with mode {target[1]}")
+            else:
+                logger.error(f"{name} for task {tid} has unknown specification: {target!r}")
+
+        log_std_stream("Standard out", task_record['app_fu'].stdout)
+        log_std_stream("Standard error", task_record['app_fu'].stderr)
 
 
 class DataFlowKernelLoader:

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -260,32 +260,29 @@ class DataFlowKernel:
 
         if stdout_spec is None:
             stdout_name = ""
-        else:  # TODO
+        elif isinstance(stdout_spec, File):
+            stdout_name = stdout_spec.url
+        else:
+            # fallthrough case is various str, os.PathLike, tuple modes that
+            # can be interpreted by get_std_fname_mode.
             try:
                 stdout_name, _ = get_std_fname_mode('stdout', stdout_spec)
             except Exception:
                 logger.exception("Could not parse stdout specification {} for task {}".format(stdout_spec, task_record['id']))
                 stdout_name = ""
 
-        # TODO: this needs to become per-case, not per-anti-case
-        # with all cases addressed.
         if stderr_spec is None:
             stderr_name = ""
+        elif isinstance(stderr_spec, File):
+            stderr_name = stderr_spec.url
         else:
-            reveal_type(stderr_spec)
+            # fallthrough case is various str, os.PathLike, tuple modes that
+            # can be interpreted by get_std_fname_mode.
             try:
                 stderr_name, _ = get_std_fname_mode('stderr', stderr_spec)
-                reveal_type(stderr_spec)
-                reveal_type(get_std_fname_mode)
             except Exception:
                 logger.exception("Could not parse stderr specification {} for task {}".format(stderr_spec, task_record['id']))
                 stderr_name = ""
-            # TODO:
-            # When stdout_spec is a File, the above fails, but we can't then use str, because str for a File
-            # gives the localpath, which doesn't exist on the submit side for a non-file: File object.
-            # Reporting the stderr path here probably should be done differently for File objects, perhaps
-            # reporting the URL without using get_std_fname_mode which only makes sense in the case of
-            # shared filesystem stdout/stderrs?
 
         task_log_info['task_stdout'] = stdout_name
         task_log_info['task_stderr'] = stderr_name

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -780,8 +780,8 @@ class DataFlowKernel:
             (inputs[idx], func) = self.data_manager.optionally_stage_in(f, func, executor)
 
         for kwarg, f in kwargs.items():
-            # stdout and stderr files should not be staging in (they should be staged *out*
-            # in _add_output_deps
+            # stdout and stderr files should not be staging in (they will be staged *out*
+            # in _add_output_deps)
             if kwarg in ['stdout', 'stderr']:
                 continue
             (kwargs[kwarg], func) = self.data_manager.optionally_stage_in(f, func, executor)

--- a/parsl/dataflow/futures.py
+++ b/parsl/dataflow/futures.py
@@ -78,7 +78,8 @@ class AppFuture(Future):
         """Return app stdout. If stdout was specified as a string, then this
         property will return that string. If stdout was specified as a File,
         then this property will return a DataFuture representing that file
-        stageout."""
+        stageout.
+        TODO: this can be a tuple too I think?"""
         if self._stdout_future:
             return self._stdout_future
         else:
@@ -90,7 +91,8 @@ class AppFuture(Future):
         """Return app stderr. If stdout was specified as a string, then this
         property will return that string. If stdout was specified as a File,
         then this property will return a DataFuture representing that file
-        stageout."""
+        stageout.
+        TODO: this can be a tuple too I think?"""
         if self._stderr_future:
             return self._stderr_future
         else:

--- a/parsl/tests/test_bash_apps/test_basic.py
+++ b/parsl/tests/test_bash_apps/test_basic.py
@@ -50,6 +50,8 @@ def test_auto_log_filename_format(caplog):
         foo_future.result())
 
     log_fpath = foo_future.stdout
+    assert isinstance(log_fpath, str)
+
     log_pattern = fr".*/task_\d+_foo_{app_label}"
     assert re.match(log_pattern, log_fpath), 'Output file "{0}" does not match pattern "{1}"'.format(
         log_fpath, log_pattern)

--- a/parsl/tests/test_staging/test_staging_stdout.py
+++ b/parsl/tests/test_staging/test_staging_stdout.py
@@ -1,0 +1,61 @@
+import logging
+import os
+import parsl
+import pytest
+import zipfile
+
+from parsl.app.futures import DataFuture
+from parsl.tests.configs.htex_local import fresh_config as local_config
+from parsl.data_provider.files import File
+
+
+@parsl.bash_app
+def output_to_stds(*, stdout=parsl.AUTO_LOGNAME, stderr=parsl.AUTO_LOGNAME):
+    return "echo hello ; echo goodbye >&2"
+
+
+def test_stdout_staging_file(tmpd_cwd, caplog):
+    basename = str(tmpd_cwd) + "/stdout.txt"
+    stdout_file = File("file://" + basename)
+
+    app_future = output_to_stds(stdout=stdout_file)
+
+    assert isinstance(app_future.stdout, DataFuture)
+    app_future.stdout.result()
+
+    assert os.path.exists(basename)
+
+    for record in caplog.records:
+        assert record.levelno < logging.ERROR
+
+
+def test_stdout_stderr_staging_zip(tmpd_cwd, caplog):
+    zipfile_name = str(tmpd_cwd) + "/staging.zip"
+    stdout_relative_path = "somewhere/test-out.txt"
+    stdout_file = File("zip:" + zipfile_name + "/" + stdout_relative_path)
+
+    stderr_relative_path = "somewhere/test-error.txt"
+    stderr_file = File("zip:" + zipfile_name + "/" + stderr_relative_path)
+
+    app_future = output_to_stds(stdout=stdout_file, stderr=stderr_file)
+
+    assert isinstance(app_future.stdout, DataFuture)
+    app_future.stdout.result()
+
+    # check the file exists as soon as possible
+    assert os.path.exists(zipfile_name)
+    with zipfile.ZipFile(zipfile_name) as z:
+        with z.open(stdout_relative_path) as f:
+            assert f.readlines() == [b'hello\n']
+
+    assert isinstance(app_future.stderr, DataFuture)
+    app_future.stderr.result()
+    with zipfile.ZipFile(zipfile_name) as z:
+        with z.open(stderr_relative_path) as f:
+            # The last line of stderr should be goodbye, but Parsl will write
+            # other Parsl-specific into to stderr before that, so only assert
+            # the behaviour of the final line.
+            assert f.readlines()[-1] == b'goodbye\n'
+
+    for record in caplog.records:
+        assert record.levelno < logging.ERROR


### PR DESCRIPTION
Prior to this PR, stdout and stderr were treated as string pathnames interpreted in an executor specific context: for example, htex treats them as paths on the worker filesystem; Task Vine treats these paths as names of files that should be staged to the submitting system.

This is/was different to the treatment of files placed in the outputs kwarg of an app using File objects. Those file objects can be staged out arbitrarily using Parsl file staging.

This PR allows File objects to be specified for bash_app stdout and stderr kwargs, and stages those files out in the same way as outputs-kwarg files are staged.

This PR preserves the previous str-based behaviour without staging. This is inconsistent with the data staging mechanism, which only accepts Files, but preserves backwards compatibility, which is important here because stdout and stderr kwargs are used by users a lot.

When this new staging mechanism is used, DataFutures for stdout/err Files are made available to the user via app_future.stdout and app_future.stderr. This properties existed previously, and when using strings for stdout/err, retain their previous behaviour of returning those strings.

This mode is incompatible with tuple-based stdout/err specifications, which allow opening stdout/err with specific file modes, and rely on the user to manage those files outwith Parsl: that concept is not compatible with the file staging model of "write a file once, don't ever modify it".

Fixes issue #363

# Changed Behaviour

Things using the existing stdout/err behaviour should behave the same - this PR should turn some previously invalid stdout/err specifications into valid ones.

## Type of change

- New feature
