### PR TITLE
Use incluster config fallback for KubernetesProvider

### DIFF
--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -105,7 +105,10 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         if not _kubernetes_enabled:
             raise OptionalModuleMissing(['kubernetes'],
                                         "Kubernetes provider requires kubernetes module and config.")
-        config.load_kube_config()
+        try:
+            config.load_kube_config()
+        except:
+            config.load_incluster_config()
 
         self.namespace = namespace
         self.image = image

--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -107,7 +107,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
                                         "Kubernetes provider requires kubernetes module and config.")
         try:
             config.load_kube_config()
-        except:
+        except config.config_exception.ConfigException:
             config.load_incluster_config()
 
         self.namespace = namespace

--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -121,10 +121,9 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
             # Based on: https://github.com/kubernetes-client/python/issues/1005
             try:
                 config.load_incluster_config()
-            except Exception as incluster_config_exception:
-                raise ExceptionGroup(
-                    "Encountered errors loading kubernetes cluster configuration",
-                    [kube_config_exception, incluster_config_exception],
+            except config.config_exception.ConfigException:
+                raise config.config_exception.ConfigException(
+                    "Failed to load both kube-config file and in-cluster configuration."
                 )
 
 

--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -107,7 +107,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
                                         "Kubernetes provider requires kubernetes module and config.")
         try:
             config.load_kube_config()
-        except config.config_exception.ConfigException as kube_config_exception:
+        except config.config_exception.ConfigException:
             # `load_kube_config` assumes a local kube-config file, and fails if not
             # present, raising:
             #
@@ -125,7 +125,6 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
                 raise config.config_exception.ConfigException(
                     "Failed to load both kube-config file and in-cluster configuration."
                 )
-
 
         self.namespace = namespace
         self.image = image


### PR DESCRIPTION
# Description

This PR supersedes https://github.com/Parsl/parsl/pull/2503

See https://github.com/kubernetes-client/python/issues/1005 for a good description of the issue.  

# Changed Behaviour

The `KubernetesProvider` now falls back to loading config in-cluster if a kube-config file is not found. This allows in-cluster submission of parsl jobs.

# Fixes

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix
