### PR TITLE
Demo of hacking in custom registration behaviour into interchange registrations

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -451,6 +451,8 @@ class Interchange:
                 logger.info("Registration info for manager {!r}: {}".format(manager_id, msg))
                 self._send_monitoring_info(hub_channel, m)
 
+                os.system(f"echo HELLO FROM BENC ... heres a command line run on registration of {m['hostname']} >> benc.demo")
+
                 if (msg['python_v'].rsplit(".", 1)[0] != self.current_platform['python_v'].rsplit(".", 1)[0] or
                     msg['parsl_v'] != self.current_platform['parsl_v']):
                     logger.error("Manager {!r} has incompatible version info with the interchange".format(manager_id))


### PR DESCRIPTION
# Description

This is a demo for @cms21 of hacking in custom registration behaviour when a manager registers to an interchange.

(Longer term, I'd like this sort of thing to be possible through configurable monitoring radios, something like PR #3315, allowing people to plug in whatever behaviour they want, throughout parsl, when "interesting things happen")

# Changed Behaviour

you should see a file benc.demo appear in the working directory of the interchange, with a new line appended every time a manager registers

## Type of change

- demo 
