### PR TITLE
Fix two CI-rot breakages

### DIFF
--- a/parsl/tests/test_htex/test_zmq_binding.py
+++ b/parsl/tests/test_htex/test_zmq_binding.py
@@ -53,6 +53,7 @@ def test_interchange_binding_with_address(cert_dir: Optional[str]):
     assert ix.interchange_address == address
 
 
+@pytest.mark.skip("This behaviour is possibly unexpected. See issue #3037")
 @pytest.mark.local
 @pytest.mark.parametrize("encrypted", (True, False), indirect=True)
 def test_interchange_binding_with_non_ipv4_address(cert_dir: Optional[str]):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras_require = {
     'workqueue': ['work_queue'],
     'flux': ['pyyaml', 'cffi', 'jsonschema'],
     'proxystore': ['proxystore'],
-    'radical-pilot': ['radical.pilot==1.47'],
+    'radical-pilot': ['radical.pilot==1.52.1'],
     # Disabling psi-j since github direct links are not allowed by pypi
     # 'psij': ['psi-j-parsl@git+https://github.com/ExaWorks/psi-j-parsl']
 }


### PR DESCRIPTION
# Description

Two simultaneous CI-rot breakages have happened and this PR fixes them simultaneously - they cannot be fixed individually because neither fix is sufficient to pass CI.

RADICAL-Pilot installation broke recently in CI, through some change outside of the Parsl repository, and even with a pinned RADICAL-Pilot version. More recent radical-pilot will install OK, and this PR advances the pin to that more recent version. This might be something to do with this fix introduced in https://github.com/radical-cybertools/radical.pilot/pull/3169 but I'm not completely clear.

Issue #3037 started happening in CI. That issue is that a test checks a property that it might not actually be reasonable to expect to hold. This PR skips that issue, leaving further work for whoever adopts issue #3037.

## Type of change

- Bug fix
