### PR TITLE
Set Executor attributes in super class constructor

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1140,8 +1140,6 @@ class DataFlowKernel:
             executor.hub_port = self.hub_zmq_port
             if self.monitoring:
                 executor.monitoring_radio = self.monitoring.radio
-            else:
-                executor.monitoring_radio = None
             if hasattr(executor, 'provider'):
                 if hasattr(executor.provider, 'script_dir'):
                     executor.provider.script_dir = os.path.join(self.run_dir, 'submit_scripts')

--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -1,3 +1,4 @@
+import os
 from abc import ABCMeta, abstractmethod
 from concurrent.futures import Future
 from typing import Any, Callable, Dict, Optional
@@ -44,6 +45,21 @@ class ParslExecutor(metaclass=ABCMeta):
 
     label: str = "undefined"
     radio_mode: str = "udp"
+
+    def __init__(
+        self,
+        *,
+        hub_address: Optional[str] = None,
+        hub_port: Optional[int] = None,
+        monitoring_radio: Optional[MonitoringRadio] = None,
+        run_dir: str = ".",
+        run_id: Optional[str] = None,
+    ):
+        self.hub_address = hub_address
+        self.hub_port = hub_port
+        self.monitoring_radio = monitoring_radio
+        self.run_dir = os.path.abspath(run_dir)
+        self.run_id = run_id
 
     def __enter__(self) -> Self:
         return self


### PR DESCRIPTION
# Description

Setting these attributes in the constructor makes reasoning about later use less complicated.  If an Executor is instantiated these exist.  Whether or not they've been set to a non-default value is another question.

# Changed Behaviour

Functionally for users, this should represent no change.  These attributes are nominally already set by the rest of Parsl's infrastructure.  For developers, this change simply makes reasoning about the state of Executors a little easier.

## Type of change

- Code maintenance/cleanup