### PR TITLE
Remove nested exception from BadStdStreamFile exception

### DIFF
--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -60,7 +60,7 @@ def remote_side_bash_executor(func, *args, **kwargs):
                 os.makedirs(os.path.dirname(fname), exist_ok=True)
             fd = open(fname, mode)
         except Exception as e:
-            raise pe.BadStdStreamFile(fname, e)
+            raise pe.BadStdStreamFile(fname) from e
         return fd
 
     std_out = open_std_fd('stdout')

--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -78,16 +78,14 @@ class BadStdStreamFile(ParslError):
 
     Contains:
        reason(string)
-       exception object
     """
 
-    def __init__(self, reason: str, exception: Exception) -> None:
-        super().__init__(reason, exception)
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
         self._reason = reason
-        self._exception = exception
 
     def __repr__(self) -> str:
-        return "Bad Stream File: {} Exception: {}".format(self._reason, self._exception)
+        return "Bad Stream File: {}".format(self._reason)
 
     def __str__(self) -> str:
         return self.__repr__()

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -121,7 +121,7 @@ def get_std_fname_mode(
         if len(stdfspec) != 2:
             msg = (f"std descriptor {fdname} has incorrect tuple length "
                    f"{len(stdfspec)}")
-            raise pe.BadStdStreamFile(msg, TypeError('Bad Tuple Length'))
+            raise pe.BadStdStreamFile(msg)
         fname, mode = stdfspec
     return str(fname), mode
 


### PR DESCRIPTION
Prior to this PR, this exception class had a mandatory nested exception attibute.

This PR removes that exception, because Python already has some nesting mechanisms for exceptions which would serve well enough here: https://docs.python.org/3/tutorial/errors.html#exception-chaining

This change allows exceptions to be optionally chained like any other Python exception; or not chained at all, simplifying one use of BadStdStreamFile where a contrived TypeError was constructed to fill the slot.

# Changed Behaviour

Any user code catching BadStdStreamFile exceptions and extracting the chained exception will have to be adapted to live without that chained exception.

## Type of change

- Code maintenance/cleanup
