### PR TITLE
Fix broken stdstream handling for bytes and arbitrary os.PathLike objects; test harder.

### DIFF
--- a/parsl/tests/test_monitoring/test_stdouterr.py
+++ b/parsl/tests/test_monitoring/test_stdouterr.py
@@ -4,7 +4,10 @@
 import os
 import parsl
 import pytest
+import re
 import time
+
+from typing import Union
 
 from parsl.tests.configs.htex_local_alternate import fresh_config
 
@@ -15,11 +18,11 @@ def stdapp(stdout=None, stderr=None):
 
 
 class ArbitraryPathLike(os.PathLike):
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: Union[str, bytes]) -> None:
         self.path = path
 
-    def __fspath__(self) -> str:
-        return path
+    def __fspath__(self) -> Union[str, bytes]:
+        return self.path
 
 
 @pytest.mark.local
@@ -30,8 +33,9 @@ class ArbitraryPathLike(os.PathLike):
                           (ArbitraryPathLike('pl.txt'), 'pl.txt'),
                           (ArbitraryPathLike(b'pl2.txt'), 'pl2.txt'),
                           ((ArbitraryPathLike('pl3.txt'), 'w'), 'pl3.txt'),
-                          ((ArbitraryPathLike(b'pl4.txt'), 'w'), 'pl4.txt')
-                          ])  # TODO: how to test the result of PARSL_AUTO here? is it by using a predicate not a string?
+                          ((ArbitraryPathLike(b'pl4.txt'), 'w'), 'pl4.txt'),
+                          (parsl.AUTO_LOGNAME, lambda p: isinstance(p, str) and os.path.isabs(p) and re.match("^.*/task_0000_stdapp\\.std...$", p))
+                          ])
 @pytest.mark.parametrize('stream', ['stdout', 'stderr'])
 def test_stdstream_to_monitoring(stdx, expected_stdx, stream, tmpd_cwd):
     """This tests that various forms of stdout/err specification are
@@ -75,4 +79,10 @@ def test_stdstream_to_monitoring(stdx, expected_stdx, stream, tmpd_cwd):
         # ... and has the expected name.
         result = connection.execute(f"SELECT task_{stream} FROM task")
         (c, ) = result.first()
-        assert c == expected_stdx
+
+        if isinstance(expected_stdx, str):
+            assert c == expected_stdx
+        elif callable(expected_stdx):
+            assert expected_stdx(c)
+        else:
+            raise RuntimeError("Bad expected_stdx value")

--- a/parsl/tests/test_monitoring/test_stdouterr.py
+++ b/parsl/tests/test_monitoring/test_stdouterr.py
@@ -1,0 +1,66 @@
+"""Tests monitoring records app name under various decoration patterns.
+"""
+
+import os
+import parsl
+import pytest
+import time
+
+from parsl.tests.configs.htex_local_alternate import fresh_config
+
+
+@parsl.python_app
+def stdapp(stdout=None, stderr=None):
+    pass
+
+
+@pytest.mark.local
+@pytest.mark.parametrize("stdx,expected_stdx",
+                         [("hello.txt", "hello.txt"),
+                          (None, ""),
+                          (("tuple.txt", "w"), "tuple.txt")
+                          ])  # TODO: how to test the result of PARSL_AUTO here? is it by using a predicate not a string?
+@pytest.mark.parametrize("stream", ["stdout", "stderr"])
+def test_stdstream_to_monitoring(stdx, expected_stdx, stream, tmpd_cwd):
+    """This tests that various forms of stdout/err specification are
+       represented in monitoring correctly. The stderr and stdout codepaths
+       are generally duplicated, rather than factorised, and so this test
+       runs the same tests on both stdout and stderr.
+    """
+
+    # this is imported here rather than at module level because
+    # it isn't available in a plain parsl install, so this module
+    # would otherwise fail to import and break even a basic test
+    # run.
+    import sqlalchemy
+
+    c = fresh_config()
+    c.run_dir = tmpd_cwd
+    c.monitoring.logging_endpoint = f"sqlite:///{tmpd_cwd}/monitoring.db"
+    with parsl.load(c):
+        kwargs = {stream: stdx}
+        stdapp(**kwargs).result()
+
+    parsl.clear()
+
+    engine = sqlalchemy.create_engine(c.monitoring.logging_endpoint)
+    with engine.begin() as connection:
+
+        def count_rows(table: str):
+            result = connection.execute(f"SELECT COUNT(*) FROM {table}")
+            (c, ) = result.first()
+            return c
+
+        # one workflow...
+        assert count_rows("workflow") == 1
+
+        # ... with one task ...
+        assert count_rows("task") == 1
+
+        # ... that was tried once ...
+        assert count_rows("try") == 1
+
+        # ... and has the expected name.
+        result = connection.execute(f"SELECT task_{stream} FROM task")
+        (c, ) = result.first()
+        assert c == expected_stdx

--- a/parsl/tests/test_monitoring/test_stdouterr.py
+++ b/parsl/tests/test_monitoring/test_stdouterr.py
@@ -34,7 +34,11 @@ class ArbitraryPathLike(os.PathLike):
                           (ArbitraryPathLike(b'pl2.txt'), 'pl2.txt'),
                           ((ArbitraryPathLike('pl3.txt'), 'w'), 'pl3.txt'),
                           ((ArbitraryPathLike(b'pl4.txt'), 'w'), 'pl4.txt'),
-                          (parsl.AUTO_LOGNAME, lambda p: isinstance(p, str) and os.path.isabs(p) and re.match("^.*/task_0000_stdapp\\.std...$", p))
+                          (parsl.AUTO_LOGNAME,
+                              lambda p:
+                              isinstance(p, str) and
+                              os.path.isabs(p) and
+                              re.match("^.*/task_0000_stdapp\\.std...$", p))
                           ])
 @pytest.mark.parametrize('stream', ['stdout', 'stderr'])
 def test_stdstream_to_monitoring(stdx, expected_stdx, stream, tmpd_cwd):

--- a/parsl/tests/test_monitoring/test_stdouterr.py
+++ b/parsl/tests/test_monitoring/test_stdouterr.py
@@ -14,13 +14,25 @@ def stdapp(stdout=None, stderr=None):
     pass
 
 
+class ArbitraryPathLike(os.PathLike):
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+    def __fspath__(self) -> str:
+        return path
+
+
 @pytest.mark.local
-@pytest.mark.parametrize("stdx,expected_stdx",
-                         [("hello.txt", "hello.txt"),
-                          (None, ""),
-                          (("tuple.txt", "w"), "tuple.txt")
+@pytest.mark.parametrize('stdx,expected_stdx',
+                         [('hello.txt', 'hello.txt'),
+                          (None, ''),
+                          (('tuple.txt', 'w'), 'tuple.txt'),
+                          (ArbitraryPathLike('pl.txt'), 'pl.txt'),
+                          (ArbitraryPathLike(b'pl2.txt'), 'pl2.txt'),
+                          ((ArbitraryPathLike('pl3.txt'), 'w'), 'pl3.txt'),
+                          ((ArbitraryPathLike(b'pl4.txt'), 'w'), 'pl4.txt')
                           ])  # TODO: how to test the result of PARSL_AUTO here? is it by using a predicate not a string?
-@pytest.mark.parametrize("stream", ["stdout", "stderr"])
+@pytest.mark.parametrize('stream', ['stdout', 'stderr'])
 def test_stdstream_to_monitoring(stdx, expected_stdx, stream, tmpd_cwd):
     """This tests that various forms of stdout/err specification are
        represented in monitoring correctly. The stderr and stdout codepaths

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -131,7 +131,7 @@ def get_std_fname_mode(
     elif isinstance(fname, bytes):
         return fname.decode(), mode
     else:
-        raise ParslError(f"fname had invalid type {type(fname)}")
+        raise BadStdStreamFile(f"fname has invalid type {type(fname)}")
 
 
 @contextmanager

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -13,6 +13,7 @@ import typeguard
 from typing_extensions import Type
 
 import parsl
+from parsl.app.errors import BadStdStreamFile
 from parsl.version import VERSION
 
 
@@ -124,14 +125,14 @@ def get_std_fname_mode(
             raise pe.BadStdStreamFile(msg)
         fname, mode = stdfspec
 
-    fname = os.fspath(fname)
+    path = os.fspath(fname)
 
-    if isinstance(fname, str):
-        return fname, mode
-    elif isinstance(fname, bytes):
-        return fname.decode(), mode
+    if isinstance(path, str):
+        return path, mode
+    elif isinstance(path, bytes):
+        return path.decode(), mode
     else:
-        raise BadStdStreamFile(f"fname has invalid type {type(fname)}")
+        raise BadStdStreamFile(f"fname has invalid type {type(path)}")
 
 
 @contextmanager

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -123,7 +123,15 @@ def get_std_fname_mode(
                    f"{len(stdfspec)}")
             raise pe.BadStdStreamFile(msg, TypeError('Bad Tuple Length'))
         fname, mode = stdfspec
-    return str(fname), mode
+
+    fname = os.fspath(fname)
+
+    if isinstance(fname, str):
+        return fname, mode
+    elif isinstance(fname, bytes):
+        return fname.decode(), mode
+    else:
+        raise ParslError(f"fname had invalid type {type(fname)}")
 
 
 @contextmanager


### PR DESCRIPTION
# Description

Prior to this PR, an arbitrary os.PathLike was rendered to monitoring using that PathLike's str method. What should be appearing in the monitoring database should be a string representation of the path. This is an issue in (rare in practice?) cases where `__str__` and `__fspath__` return different things. This PR changes rendering to use `fspath` rather than `str`.

os.PathLike objects can also render as `bytes`, not `str`. This PR decodes those bytes using `.decode()`.

This PR adds tests for various valid data types going from app stdout/err parameters to the corresponding column in the monitoring database, including test cases that drove the above fixes.

# Changed Behaviour

This will change how some stdout/stderr paths are rendered to the monitoring database, hopefully for the better.

## Type of change

- Bug fix
