### PR TITLE
Fix stdout/err log errors introduced by PR #3347

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1426,8 +1426,12 @@ class DataFlowKernel:
                 logger.info(f"{name} for task {tid} will not be redirected.")
             elif isinstance(target, str):
                 logger.info(f"{name} for task {tid} will be redirected to {target}")
-            elif isinstance(target, tuple) and len(target) == 2:
+            elif isinstance(target, os.PathLike):
+                logger.info(f"{name} for task {tid} will be redirected to {os.fspath(target)}")
+            elif isinstance(target, tuple) and len(target) == 2 and isinstance(target[0], str):
                 logger.info(f"{name} for task {tid} will be redirected to {target[0]} with mode {target[1]}")
+            elif isinstance(target, tuple) and len(target) == 2 and isinstance(target[0], os.PathLike):
+                logger.info(f"{name} for task {tid} will be redirected to {os.fspath(target[0])} with mode {target[1]}")
             elif isinstance(target, DataFuture):
                 logger.info(f"{name} for task {tid} will staged to {target.file_obj.url}")
             else:

--- a/parsl/tests/test_monitoring/test_stdouterr.py
+++ b/parsl/tests/test_monitoring/test_stdouterr.py
@@ -1,6 +1,7 @@
 """Tests monitoring records app name under various decoration patterns.
 """
 
+import logging
 import os
 import parsl
 import pytest
@@ -55,7 +56,7 @@ class ArbitraryStaging(Staging):
                           (File("file:///tmp/pl5"), "file:///tmp/pl5"),
                           ])
 @pytest.mark.parametrize('stream', ['stdout', 'stderr'])
-def test_stdstream_to_monitoring(stdx, expected_stdx, stream, tmpd_cwd):
+def test_stdstream_to_monitoring(stdx, expected_stdx, stream, tmpd_cwd, caplog):
     """This tests that various forms of stdout/err specification are
        represented in monitoring correctly. The stderr and stdout codepaths
        are generally duplicated, rather than factorised, and so this test
@@ -106,3 +107,6 @@ def test_stdstream_to_monitoring(stdx, expected_stdx, stream, tmpd_cwd):
             assert expected_stdx(c)
         else:
             raise RuntimeError("Bad expected_stdx value")
+
+    for record in caplog.records:
+        assert record.levelno < logging.ERROR


### PR DESCRIPTION
PR #3347 attempted to do case-based logging of all the different kinds of stdout/err specification.

It failed to capture some of the cases involving os.PathLike, and so after PR #3347, those cases would log an ERROR that the specification was unknown. This new behavior is only a new ERROR logging message - PR #3347 did not change other behaviour.

This PR also amends a rich test of stdout/err specification types introduced in PR #3363 to check that no ERROR messages are logged during these tests.

## Type of change

- Bug fix
