### PR TITLE
Use strategy_period in test, instead of custom thread

### DIFF
--- a/parsl/tests/test_scaling/test_regression_1621.py
+++ b/parsl/tests/test_scaling/test_regression_1621.py
@@ -9,6 +9,14 @@ from parsl.executors import HighThroughputExecutor
 from parsl.launchers import SimpleLauncher
 from parsl.providers import LocalProvider
 
+# Timing notes:
+# The configured strategy_period must be much smaller than the delay in
+# app() so that multiple iterations of the strategy have had a chance
+# to (mis)behave.
+# The status polling interval in OneShotLocalProvider must be much bigger
+# than the above times, so that the job status cached from the provider
+# will not be updated while the single invocation of app() runs.
+
 
 @parsl.python_app
 def app():
@@ -55,20 +63,12 @@ def test_one_block(tmpd_cwd):
             )
         ],
         strategy='simple',
+        strategy_period=0.1
     )
 
-    parsl.load(config)
-    dfk = parsl.dfk()
+    with parsl.load(config):
+        app().result()
 
-    def poller():
-        import time
-        while True:
-            dfk.job_status_poller.poll()
-            time.sleep(0.1)
-
-    threading.Thread(target=poller, daemon=True).start()
-    app().result()
-    parsl.dfk().cleanup()
     parsl.clear()
 
     assert oneshot_provider.recorded_submits == 1


### PR DESCRIPTION
PR #2816 introduced a workaround in the polling API by adding a new thread to call job status poller poll() method more frequently than the JobStatusPoller invokes that method.

PR #3246 introduced general configurability of the JobStatusPoller poll period.

This PR replaces the thread from #2816 with the configuration option from #3246.

This PR removes one thread left running at the end of this test case, in --config local tests.

## Type of change

- Code maintenance/cleanup
