### PR TITLE
Fix broken test that cannot be run multiple times in same environment.

### DIFF
--- a/parsl/tests/test_python_apps/test_context_manager.py
+++ b/parsl/tests/test_python_apps/test_context_manager.py
@@ -24,15 +24,15 @@ def local_teardown():
 
 
 @pytest.mark.local
-def test_within_context_manger():
+def test_within_context_manger(tmpd_cwd):
     config = fresh_config()
     with parsl.load(config=config) as dfk:
         assert isinstance(dfk, DataFlowKernel)
 
-        bash_future = foo(1)
+        bash_future = foo(1, stdout=tmpd_cwd / 'foo.stdout')
         assert bash_future.result() == 0
 
-        with open('foo.stdout', 'r') as f:
+        with open(tmpd_cwd / 'foo.stdout', 'r') as f:
             assert f.read() == "2\n"
 
     with pytest.raises(NoDataFlowKernelError) as excinfo:


### PR DESCRIPTION
This test used to re-use a temporary intermediate file by appending to it. When run multiple times, it failed with errors like this as the results from previous runs are also observed by the test:

```
E               AssertionError: assert '2\n2\n2\n2\n' == '2\n'
```

This PR uses `tmpd_cwd` to avoid that behaviour.

## Type of change

- Code maintenance/cleanup