### PR TITLE
Shutdown multiprocessing queues at TaskVine shutdown

### DIFF
--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -644,6 +644,12 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
             logger.debug("Joining on factory process")
             self._factory_process.join()
 
+        # Shutdown multiprocessing queues
+        self._ready_task_queue.close()
+        self._ready_task_queue.join_thread()
+        self._finished_task_queue.close()
+        self._finished_task_queue.join_thread()
+
         self._is_shutdown = True
         logger.debug("TaskVine shutdown completed")
 


### PR DESCRIPTION
This frees up some threads and file descriptors.

cc @tphung3 @colinthomas-z80 etc

## Type of change

- Code maintenance/cleanup
