### PR TITLE
Fix typo in test invocation that results in skipped DFK cleanup

### DIFF
--- a/parsl/tests/test_checkpointing/test_task_exit.py
+++ b/parsl/tests/test_checkpointing/test_task_exit.py
@@ -15,7 +15,7 @@ def local_setup():
 
 
 def local_teardown():
-    parsl.dfk().cleanup
+    parsl.dfk().cleanup()
     parsl.clear()
 
 


### PR DESCRIPTION
This typo is not a syntax error, although it might superficially look like one: it merely computes the method that if invoked, would clean up the DFK, and then discards the result of that computation rather than invoking it.

This typo resulted in an entire DFK being left behind after the test finishes.

## Type of change

- Bug fix
