### PR TITLE
Reduce test sleep()

### DIFF
--- a/parsl/tests/configs/local_threads_checkpoint_periodic.py
+++ b/parsl/tests/configs/local_threads_checkpoint_periodic.py
@@ -1,13 +1,11 @@
 from parsl.config import Config
 from parsl.executors.threads import ThreadPoolExecutor
 
-config = Config(
-    executors=[
-        ThreadPoolExecutor(
-            label='local_threads_checkpoint_periodic',
-            max_threads=1
-        )
-    ],
-    checkpoint_mode='periodic',
-    checkpoint_period='00:00:05'
-)
+
+def fresh_config():
+    tpe = ThreadPoolExecutor(label='local_threads_checkpoint_periodic', max_threads=1)
+    return Config(
+        executors=[tpe],
+        checkpoint_mode='periodic',
+        checkpoint_period='00:00:02'
+    )

--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -245,6 +245,7 @@ def load_dfk_local_module(request, pytestconfig, tmpd_cwd_session):
 
         if callable(local_teardown):
             local_teardown()
+            assert DataFlowKernelLoader._dfk is None, "Expected teardown to clear DFK"
 
         if local_config:
             if parsl.dfk() != dfk:


### PR DESCRIPTION
# Description

The checkpoint is the threshold of interest, so rather than waiting for an inordinate amount of time, dynamically ascertain what the checkpoint wait time is.  Add 1 second to that value for good measure.

Test time reduced from ~20s locally to ~4s.

## Type of change

- Code maintenance/cleanup