### PR TITLE
Add logs around usage tracker shutdown

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1245,8 +1245,10 @@ class DataFlowKernel:
                 self._checkpoint_timer.close()
 
         # Send final stats
+        logger.info("Sending end message for usage tracking")
         self.usage_tracker.send_end_message()
         self.usage_tracker.close()
+        logger.info("Closed usage tracking")
 
         logger.info("Closing job status poller")
         self.job_status_poller.close()


### PR DESCRIPTION
Parsl shutdown logs are deliberately rich at shutdown time because this is an incredibly hang prone part of the code-base.
See https://github.com/Parsl/parsl/labels/safe-exit

This PR adds logs bracketing the shutdown of the usage tracker, in line with later shutdowns of the job status poller, executors and monitoring.

# Changed Behaviour

two more log lines at shutdown

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
