### PR TITLE
Remove expensive typeguard call from file staging closure

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -798,7 +798,6 @@ class DataFlowKernel:
         # be the original function wrapped with an in-task stageout wrapper), a
         # rewritten File object to be passed to task to be executed
 
-        @typechecked
         def stageout_one_file(file: File, rewritable_func: Callable):
             if not self.check_staging_inhibited(kwargs):
                 # replace a File with a DataFuture - either completing when the stageout


### PR DESCRIPTION
Prior to this PR, the closure stageout_one_file is redecorated by typeguard on every invocation, so once per task that is using files, and instruments that closure each time with internal type checking code. This was introduced incidentally as part of PR #3348.

This PR removes that runtime type-checking. In general, parsl-internal calls should be checked statically by mypy if possible, not by typeguard, which should be reserved for the interface with users.

Prior to this PR, parsl-perf modified to use a File stdout on my laptop ran at median 2176 tasks per second. After this PR, median 2627 tasks per second.

@svandenhaute experienced a much starker difference on a psiflow test case, with one test case that takes 40 seconds reduced to 9 seconds by this PR, the same performance as before PR #3348.

## Type of change

- Bug fix
