### PR TITLE
.close() interchange process to release more fds

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -818,4 +818,6 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin):
             logger.info("Unable to terminate Interchange process; sending SIGKILL")
             self.interchange_proc.kill()
 
+        self.interchange_proc.close()
+
         logger.info("Finished HighThroughputExecutor shutdown attempt")

--- a/parsl/tests/test_htex/test_missing_worker.py
+++ b/parsl/tests/test_htex/test_missing_worker.py
@@ -37,7 +37,3 @@ def test_that_it_fails():
         raise Exception("The app somehow ran without a valid worker")
 
     assert parsl.dfk().config.executors[0]._executor_bad_state.is_set()
-
-    # htex needs shutting down explicitly because dfk.cleanup() will not
-    # do that, as it is in bad state
-    parsl.dfk().config.executors[0].shutdown()


### PR DESCRIPTION
This releases two fds in the workflow process used to communicate with the interchange process, and is part of work to release more resources explicitly at shutdown rather than leaving them until process end.

One test was making an out-of-API shutdown of HTEX on the basis that the DFK would not shutdown this executor when a bad state was set. That used to be true, but PR #2855, which re-arranged some shutdown behaviour, (accidentally?) changed shutdown to always happen. That is, I think, the right shutdown behaviour: if an executor wants to suppress parts of its own shutdown based on internal state, that's the business of the executor, not the DFK.

This PR removes that out-of-API shutdown.

# Changed Behaviour

As exposed by the changed test, shutdown behaviour is a bit peturbed: for example, situations where executor.shutdown was called multiple times that worked before might no longer work.

## Type of change

- Code maintenance/cleanup
