### PR TITLE
Remove return bool from Channel.close()

### DIFF
--- a/parsl/channels/base.py
+++ b/parsl/channels/base.py
@@ -89,15 +89,8 @@ class Channel(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def close(self) -> bool:
-        ''' Closes the channel. Clean out any auth credentials.
-
-        Args:
-            None
-
-        Returns:
-            Bool
-
+    def close(self) -> None:
+        ''' Closes the channel.
         '''
         pass
 

--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -107,13 +107,10 @@ class LocalChannel(Channel, RepresentationMixin):
     def pull_file(self, remote_source, local_dir):
         return self.push_file(remote_source, local_dir)
 
-    def close(self):
-        ''' There's nothing to close here, and this really doesn't do anything
-
-        Returns:
-             - False, because it really did not "close" this channel.
+    def close(self) -> None:
+        ''' There's nothing to close here, and so this doesn't do anything
         '''
-        return False
+        pass
 
     def isdir(self, path):
         """Return true if the path refers to an existing directory.

--- a/parsl/channels/oauth_ssh/oauth_ssh.py
+++ b/parsl/channels/oauth_ssh/oauth_ssh.py
@@ -106,5 +106,5 @@ class OAuthSSHChannel(SSHChannel):
 
         return exit_status, stdout, stderr
 
-    def close(self):
-        return self.transport.close()
+    def close(self) -> None:
+        self.transport.close()

--- a/parsl/channels/ssh/ssh.py
+++ b/parsl/channels/ssh/ssh.py
@@ -217,9 +217,9 @@ class SSHChannel(Channel, RepresentationMixin):
 
         return local_dest
 
-    def close(self):
+    def close(self) -> None:
         if self._is_connected():
-            return self.ssh_client.close()
+            self.ssh_client.close()
 
     def isdir(self, path):
         """Return true if the path refers to an existing directory.


### PR DESCRIPTION
Theres was no defined meaning to the return bool either in the code or in the human text:

- no code calls close to give an example of interpretation

- it's not success/fail because local channel returns False to indicate that it didn't need to do anything, not that there was a failure.

Other .close() style methods return None and raise an exception if there is a problem. This PR pushes Channel.close() in this direction.

A separate PR will actually invoke this .close() method.

# Changed Behaviour

This is an apparently unused return value so should not affect anything.

## Type of change

- Code maintenance/cleanup
