### PR TITLE
Use DFK in a `with` block in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,6 @@ Parsl lets you chain functions together and will launch each function as inputs 
     import parsl
     from parsl import python_app
 
-    # Start Parsl on a single computer
-    parsl.load()
 
     # Make functions parallel by decorating them
     @python_app
@@ -27,12 +25,14 @@ Parsl lets you chain functions together and will launch each function as inputs 
     def g(x):
         return x * 2
 
-    # These functions now return Futures, and can be chained
-    future = f(1)
-    assert future.result() == 2
+    # Start Parsl on a single computer
+    with parsl.load():
+        # These functions now return Futures, and can be chained
+        future = f(1)
+        assert future.result() == 2
 
-    future = g(f(1))
-    assert future.result() == 4
+        future = g(f(1))
+        assert future.result() == 4
 
 
 Start with the `configuration quickstart <https://parsl.readthedocs.io/en/stable/quickstart.html#getting-started>`_ to learn how to tell Parsl how to use your computing resource,


### PR DESCRIPTION
This functionality was introduced in #3260 and we should be encouraging people to use it in order to clean up nicely, after PR #3165 took away atexit handler cleanup.

## Type of change

- Update to human readable text: Documentation/error messages/comments
