### PR TITLE
TaskVineExecutor: remove atexit handler

### DIFF
--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -4,7 +4,6 @@ high-throughput system for delegating Parsl tasks to thousands of remote machine
 """
 
 # Import Python built-in libraries
-import atexit
 import threading
 import multiprocessing
 import logging
@@ -180,24 +179,6 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         else:
             self._poncho_available = True
 
-        # Register atexit handler to cleanup when Python shuts down
-        atexit.register(self.atexit_cleanup)
-
-        # Attribute indicating whether this executor was started to shut it down properly.
-        # This safeguards cases where an object of this executor is created but
-        # the executor never starts, so it shouldn't be shutdowned.
-        self._is_started = False
-
-        # Attribute indicating whether this executor was shutdown before.
-        # This safeguards cases where this object is automatically shut down (e.g.,
-        # via atexit) and the user also explicitly calls shut down. While this is
-        # permitted, the effect of an executor shutdown should happen only once.
-        self._is_shutdown = False
-
-    def atexit_cleanup(self):
-        # Calls this executor's shutdown method upon Python exiting the process.
-        self.shutdown()
-
     def _get_launch_command(self, block_id):
         # Implements BlockProviderExecutor's abstract method.
         # This executor uses different terminology for worker/launch
@@ -256,9 +237,6 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         """Create submit process and collector thread to create, send, and
         retrieve Parsl tasks within the TaskVine system.
         """
-
-        # Mark this executor object as started
-        self._is_started = True
 
         # Synchronize connection and communication settings between the manager and factory
         self.__synchronize_manager_factory_comm_settings()
@@ -618,14 +596,6 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         """Shutdown the executor. Sets flag to cancel the submit process and
         collector thread, which shuts down the TaskVine system submission.
         """
-        if not self._is_started:
-            # Don't shutdown if the executor never starts.
-            return
-
-        if self._is_shutdown:
-            # Don't shutdown this executor again.
-            return
-
         logger.debug("TaskVine shutdown started")
         self._should_stop.set()
 
@@ -650,7 +620,6 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         self._finished_task_queue.close()
         self._finished_task_queue.join_thread()
 
-        self._is_shutdown = True
         logger.debug("TaskVine shutdown completed")
 
     @wrap_with_logs


### PR DESCRIPTION
# Description

This PR removes the atexit handler of TaskVineExecutor as discussed in https://github.com/Parsl/parsl/issues/3334.

# Changed Behaviour

TaskVineExecutor

# Fixes

Fixes #3334

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix

