### PR TITLE
Remove a TODO for pluggable block error handling

### DIFF
--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -43,9 +43,6 @@ class BlockProviderExecutor(ParslExecutor):
     invoking scale_out, but it will not initialize the blocks requested by
     any init_blocks parameter. Subclasses must implement that behaviour
     themselves.
-
-    BENC: TODO: block error handling: maybe I want this more user pluggable?
-    I'm not sure of use cases for switchability at the moment beyond "yes or no"
     """
     def __init__(self, *,
                  provider: Optional[ExecutionProvider],


### PR DESCRIPTION
This TODO was implemented in PR #2858

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
