### PR TITLE
Unregister atexit hook at cleanup

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1177,12 +1177,9 @@ class DataFlowKernel:
         self.job_status_poller.add_executors(block_executors)
 
     def atexit_cleanup(self) -> None:
-        if not self.cleanup_called:
-            logger.warning("Python is exiting with a DFK still running. "
-                           "You should call parsl.dfk().cleanup() before "
-                           "exiting to release any resources")
-        else:
-            logger.info("python process is exiting, but DFK has already been cleaned up")
+        logger.warning("Python is exiting with a DFK still running. "
+                       "You should call parsl.dfk().cleanup() before "
+                       "exiting to release any resources")
 
     def wait_for_current_tasks(self) -> None:
         """Waits for all tasks in the task list to be completed, by waiting for their
@@ -1269,6 +1266,10 @@ class DataFlowKernel:
             logger.info("Terminating monitoring")
             self.monitoring.close()
             logger.info("Terminated monitoring")
+
+        logger.info("Unregistering atexit hook")
+        atexit.unregister(self.atexit_cleanup)
+        logger.info("Unregistered atexit hook")
 
         logger.info("DFK cleanup complete")
 


### PR DESCRIPTION
This hook is only to deal with reminder the user about cleanup and is otherwise unnecessary.

The exit warning about cleanup state is now switched based on the presence of the atexit handler or not, rather than the cleanup called variable.

Effects of this PR:

* removed log noise

* one less garbage collector reference to the DFK - although that won't directly lead to the DFK being collected earlier, it might in combination with other future work.

# Changed Behaviour

peturbed exit behaviour, hopefully for the better

## Type of change

- Code maintenance/cleanup
