### PR TITLE
Update HTEX to report manager version info

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -310,6 +310,8 @@ class Interchange:
                                 'tasks': len(m['tasks']),
                                 'idle_duration': idle_duration,
                                 'active': m['active'],
+                                'parsl_version': m['parsl_version'],
+                                'python_version': m['python_version'],
                                 'draining': m['draining']}
                         reply.append(resp)
 
@@ -435,6 +437,8 @@ class Interchange:
                                                     'worker_count': 0,
                                                     'active': True,
                                                     'draining': False,
+                                                    'parsl_version': msg['parsl_v'],
+                                                    'python_version': msg['python_v'],
                                                     'tasks': []}
                 self.connected_block_history.append(msg['block_id'])
 

--- a/parsl/tests/test_htex/test_managers_command.py
+++ b/parsl/tests/test_htex/test_managers_command.py
@@ -1,0 +1,40 @@
+import pytest
+import logging
+
+import sys
+import parsl
+from parsl.app.app import python_app
+from parsl.tests.configs.htex_local import fresh_config
+
+
+def local_setup():
+    config = fresh_config()
+    config.executors[0].poll_period = 1
+    config.executors[0].max_workers_per_node = 1
+    parsl.load(config)
+
+
+def local_teardown():
+    parsl.dfk().cleanup()
+    parsl.clear()
+
+
+@python_app
+def dummy():
+    pass
+
+
+@pytest.mark.local
+def test_connected_managers():
+
+    # Run dummy function to ensure a manager is online
+    x = dummy()
+    assert x.result() is None
+    executor = parsl.dfk().executors['htex_local']
+    manager_info_list = executor.connected_managers()
+    assert len(manager_info_list) == 1
+    manager_info = manager_info_list[0]
+    assert 'python_version' in manager_info
+    assert 'parsl_version' in manager_info
+    assert manager_info['parsl_version'] == parsl.__version__
+    assert manager_info['python_version'] == f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"


### PR DESCRIPTION
# Description

Currently, we assume that the parsl executor, interchange, and the managers all run the same Parsl and Python version,
and we enforce this with a critical failure that's raised if these versions do not match. Globus Compute extends
this problem where the serialized function body might originate from a different python version that the parsl stack,
and cause deserialization time errors that might cause the worker to die. In these situations, it is valuable to report
the worker's parsl and python versions for debugging. This PR extends the existing `HTEX.connected_managers` method to also report version info for each manager.

# Changed Behaviour

`htex_executor.connected_managers()` will now return a list of dicts, for each manager that will now also include `python_version` and `parsl_version`. Here's an example:

```
{'manager': '3f355f6e8894', 'block_id': '0', 'worker_count': 1, 'tasks': 0, 'idle_duration': 0.0018277168273925781, 'active': True, 'parsl_version': '1.3.0-dev', 'python_version': '3.9.15', 'draining': False}
```

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature
