### PR TITLE
Replace SingleNodeLauncher with SimpleLauncher for MPI Mode

### DIFF
--- a/docs/userguide/mpi_apps.rst
+++ b/docs/userguide/mpi_apps.rst
@@ -15,7 +15,7 @@ The broad strokes of a complete solution involves the following components:
 2. Specify an MPI Launcher from one of the supported launchers ("aprun", "srun", "mpiexec") for the
    :class:`~parsl.executors.high_throughput.executor.HighThroughputExecutor` with: ``mpi_launcher="srun"``
 3. Specify the provider that matches your cluster, (eg. user ``SlurmProvider`` for Slurm clusters)
-4. Set the non-mpi launcher to :class:`~parsl.launchers.SingleNodeLauncher`
+4. Set the non-mpi launcher to :class:`~parsl.launchers.SimpleLauncher`
 5. Specify resources required by the application via ``resource_specification`` as shown below:
 
 
@@ -54,7 +54,7 @@ Configuring the Provider
 
 Parsl must be configured to deploy workers on exactly one node per block. This part is
 simple. Instead of defining a launcher which will place an executor on each node in the
-block, simply use the :class:`~parsl.launchers.SingleNodeLauncher`.
+block, simply use the :class:`~parsl.launchers.SimpleLauncher`.
 The MPI Launcher that the application will use is to be specified via ``HighThroughputExecutor(mpi_launcher="LAUNCHER")``
 
 It is also necessary to specify the desired number of blocks for the executor.

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -326,8 +326,8 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         assert mpi_launcher in VALID_LAUNCHERS, \
             f"mpi_launcher must be set to one of {VALID_LAUNCHERS}"
         if self.enable_mpi_mode:
-            assert isinstance(self.provider.launcher, parsl.launchers.SingleNodeLauncher), \
-                "mpi_mode requires the provider to be configured to use a SingleNodeLauncher"
+            assert isinstance(self.provider.launcher, parsl.launchers.SimpleLauncher), \
+                "mpi_mode requires the provider to be configured to use a SimpleLauncher"
 
         self.mpi_launcher = mpi_launcher
 

--- a/parsl/tests/test_mpi_apps/test_bad_mpi_config.py
+++ b/parsl/tests/test_mpi_apps/test_bad_mpi_config.py
@@ -2,15 +2,15 @@ import pytest
 
 from parsl import Config
 from parsl.executors import HighThroughputExecutor
-from parsl.launchers import SrunLauncher, SingleNodeLauncher, SimpleLauncher, AprunLauncher
+from parsl.launchers import SrunLauncher, AprunLauncher, SimpleLauncher
 from parsl.providers import SlurmProvider
 
 
 @pytest.mark.local
 def test_bad_launcher_with_mpi_mode():
-    """AssertionError if a launcher other than SingleNodeLauncher is supplied"""
+    """AssertionError if a launcher other than SimpleLauncher is supplied"""
 
-    for launcher in [SrunLauncher(), SimpleLauncher(), AprunLauncher()]:
+    for launcher in [SrunLauncher(), AprunLauncher()]:
         with pytest.raises(AssertionError):
             Config(executors=[
                 HighThroughputExecutor(
@@ -22,20 +22,12 @@ def test_bad_launcher_with_mpi_mode():
 
 @pytest.mark.local
 def test_correct_launcher_with_mpi_mode():
-    """Confirm that SingleNodeLauncer works with mpi_mode"""
+    """Confirm that SimpleLauncher works with mpi_mode"""
 
     config = Config(executors=[
         HighThroughputExecutor(
             enable_mpi_mode=True,
-            provider=SlurmProvider(launcher=SingleNodeLauncher()),
+            provider=SlurmProvider(launcher=SimpleLauncher()),
         )
     ])
-    assert isinstance(config.executors[0].provider.launcher, SingleNodeLauncher)
-
-    config = Config(executors=[
-        HighThroughputExecutor(
-            enable_mpi_mode=True,
-            provider=SlurmProvider(),
-        )
-    ])
-    assert isinstance(config.executors[0].provider.launcher, SingleNodeLauncher)
+    assert isinstance(config.executors[0].provider.launcher, SimpleLauncher)

--- a/parsl/tests/test_mpi_apps/test_mpi_mode_disabled.py
+++ b/parsl/tests/test_mpi_apps/test_mpi_mode_disabled.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Dict
 import pytest
 import parsl


### PR DESCRIPTION
# Description

Corrects a problem in the MPI mode implementation of HTEx.
SingleNodeLauncher creates too many workers when running in MPI mode because it
launches multiple copies of the executor onto the head node.

We want SimpleLauncher, which (instead) launches a single copy of the executor.

# Changed Behaviour

Anything that uses the MPI mode will now create the desired number of workers.

# Fixes

No issue, but see discussion in Slack.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix
- Update to human readable text: Documentation/error messages/comments
