### PR TITLE
Ignore mypy errors and skip tests that don't work on MacOS

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -677,7 +677,8 @@ def worker(
     # If desired, set process affinity
     if cpu_affinity != "none":
         # Count the number of cores per worker
-        avail_cores = sorted(os.sched_getaffinity(0))  # Get the available threads
+        # OSX does not implement os.sched_getaffinity
+        avail_cores = sorted(os.sched_getaffinity(0))  # type: ignore[attr-defined]
         cores_per_worker = len(avail_cores) // pool_size
         assert cores_per_worker > 0, "Affinity does not work if there are more workers than cores"
 
@@ -717,7 +718,8 @@ def worker(
         os.environ["KMP_AFFINITY"] = f"explicit,proclist=[{proc_list}]"  # For Intel OpenMP
 
         # Set the affinity for this worker
-        os.sched_setaffinity(0, my_cores)
+        # OSX does not implement os.sched_setaffinity
+        os.sched_setaffinity(0, my_cores)  # type: ignore[attr-defined]
         logger.info("Set worker CPU affinity to {}".format(my_cores))
 
     # If desired, pin to accelerator

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -678,7 +678,7 @@ def worker(
     if cpu_affinity != "none":
         # Count the number of cores per worker
         # OSX does not implement os.sched_getaffinity
-        avail_cores = sorted(os.sched_getaffinity(0))  # type: ignore[attr-defined]
+        avail_cores = sorted(os.sched_getaffinity(0))  # type: ignore[attr-defined, unused-ignore]
         cores_per_worker = len(avail_cores) // pool_size
         assert cores_per_worker > 0, "Affinity does not work if there are more workers than cores"
 
@@ -718,8 +718,15 @@ def worker(
         os.environ["KMP_AFFINITY"] = f"explicit,proclist=[{proc_list}]"  # For Intel OpenMP
 
         # Set the affinity for this worker
-        # OSX does not implement os.sched_setaffinity
-        os.sched_setaffinity(0, my_cores)  # type: ignore[attr-defined]
+        # OSX does not implement os.sched_setaffinity so type checking
+        # is ignored here in two ways:
+        # On a platform without sched_setaffinity, that attribute will not
+        # be defined, so ignore[attr-defined] will tell mypy to ignore this
+        # incorrect-for-OS X attribute access.
+        # On a platform with sched_setaffinity, that type: ignore message
+        # will be redundant, and ignore[unused-ignore] tells mypy to ignore
+        # that this ignore is unneeded.
+        os.sched_setaffinity(0, my_cores)  # type: ignore[attr-defined, unused-ignore]
         logger.info("Set worker CPU affinity to {}".format(my_cores))
 
     # If desired, pin to accelerator

--- a/parsl/tests/test_htex/test_cpu_affinity_explicit.py
+++ b/parsl/tests/test_htex/test_cpu_affinity_explicit.py
@@ -18,6 +18,7 @@ def my_affinity():
 
 @pytest.mark.local
 @pytest.mark.multiple_cores_required
+@pytest.mark.skipif('sched_getaffinity' not in dir(os), reason='System does not support sched_setaffinity')
 def test_cpu_affinity_explicit():
     available_cores = os.sched_getaffinity(0)
 


### PR DESCRIPTION
# Description

This PR makes two changes:
1. `os.sched_(get/set)affinity` is not supported on MacOS. This PR ignores mypy errors from code blocks that touch on affinity that are not used in MacOS.
2. Skip tests that touch on affinity that are not expected to work on MacOS.


## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix
- Code maintenance/cleanup
