### PR TITLE
Use concurrency in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,17 +22,19 @@ Parsl lets you chain functions together and will launch each function as inputs 
         return x + 1
 
     @python_app
-    def g(x):
-        return x * 2
+    def g(x, y):
+        return x + y
 
     # Start Parsl on a single computer
     with parsl.load():
-        # These functions now return Futures, and can be chained
+        # These functions now return Futures
         future = f(1)
         assert future.result() == 2
 
-        future = g(f(1))
-        assert future.result() == 4
+        # Functions run in parallel, can be chained 
+        f_a, f_b = f(2), f(3)
+        future = g(f_a, f_b)
+        assert future.result() == 7
 
 
 Start with the `configuration quickstart <https://parsl.readthedocs.io/en/stable/quickstart.html#getting-started>`_ to learn how to tell Parsl how to use your computing resource,

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Parsl lets you chain functions together and will launch each function as inputs 
         future = f(1)
         assert future.result() == 2
 
-        # Functions run in parallel, can be chained 
+        # Functions run concurrently, can be chained
         f_a, f_b = f(2), f(3)
         future = g(f_a, f_b)
         assert future.result() == 7

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,8 +30,10 @@ Parsl lets you chain functions together and will launch each function as inputs 
     future = f(1)
     assert future.result() == 2
 
-    future = g(f(1))
-    assert future.result() == 4
+    # Functions run in parallel, can be chained
+    f_a, f_b = f(2), f(3)
+    future = g(f_a, f_b)
+    assert future.result() == 7
 
 
 Start with the `configuration quickstart <quickstart.html#getting-started>`_ to learn how to tell Parsl how to use your computing resource,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Parsl lets you chain functions together and will launch each function as inputs 
     future = f(1)
     assert future.result() == 2
 
-    # Functions run in parallel, can be chained
+    # Functions run concurrently, can be chained
     f_a, f_b = f(2), f(3)
     future = g(f_a, f_b)
     assert future.result() == 7

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -43,9 +43,6 @@ class BlockProviderExecutor(ParslExecutor):
     invoking scale_out, but it will not initialize the blocks requested by
     any init_blocks parameter. Subclasses must implement that behaviour
     themselves.
-
-    BENC: TODO: block error handling: maybe I want this more user pluggable?
-    I'm not sure of use cases for switchability at the moment beyond "yes or no"
     """
     def __init__(self, *,
                  provider: Optional[ExecutionProvider],


### PR DESCRIPTION
# Description

It bothers me that there is no parallelism in the README.

# Changed Behaviour

N/A

# Fixes

N/A

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Update to human readable text: Documentation/error messages/comments
