### PR TITLE
Pin radical.utils version, to work with pinned radical.pilot

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras_require = {
     'workqueue': ['work_queue'],
     'flux': ['pyyaml', 'cffi', 'jsonschema'],
     'proxystore': ['proxystore'],
-    'radical-pilot': ['radical.pilot==1.52.1'],
+    'radical-pilot': ['radical.pilot==1.52.1', 'radical.utils==1.52'],
     # Disabling psi-j since github direct links are not allowed by pypi
     # 'psij': ['psi-j-parsl@git+https://github.com/ExaWorks/psi-j-parsl']
 }


### PR DESCRIPTION
On 10th May 2024, a new version of radical.utils was released, which does not work with the pinned radical.pilot==1.52.1 used by Parsl.

I also tried upgrading radical.pilot to 1.60, released alongside the new radical.utils, but that does not work for other reasons documented in the below issue.

See Parsl issue #3429

cc @AymenFJA @andre-merzky

# Changed Behaviour

radical.utils will no longer follow the latest (or at least, the latest under whatever radical.pilot constrains things to) - that's a good thing from this PR's perspective.

# Fixes

Fixes #3429

## Type of change

- Bug fix
