### PR TITLE
Log commands that the interchange does not recognise, as an error

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -329,6 +329,7 @@ class Interchange:
                     reply = None
 
                 else:
+                    logger.error(f"Received unknown command: {command_req}")
                     reply = None
 
                 logger.debug("Reply: {}".format(reply))


### PR DESCRIPTION
The interchange command protocol is tied to the submit side closely, and it is generally a programmer or deployment error rather than intentional cross-version compatibility that would result in this unknown command code path firing.

# Changed Behaviour

more logging in error situations

## Type of change

- Code maintenance/cleanup
