### PR TITLE
Remove $ when writing job name

### DIFF
--- a/parsl/providers/local/local.py
+++ b/parsl/providers/local/local.py
@@ -206,7 +206,7 @@ class LocalProvider(ExecutionProvider, RepresentationMixin):
         script_path = "{0}/{1}.sh".format(self.script_dir, job_name)
         script_path = os.path.abspath(script_path)
 
-        wrap_command = self.worker_init + f'\nexport JOBNAME=${job_name}\n' + self.launcher(command, tasks_per_node, self.nodes_per_block)
+        wrap_command = self.worker_init + f'\nexport JOBNAME={job_name}\n' + self.launcher(command, tasks_per_node, self.nodes_per_block)
 
         self._write_submit_script(wrap_command, script_path)
 


### PR DESCRIPTION

# Description

Fixes #3437, a problem which was created by me in the first place.

# Changed Behaviour

Does not remove the `parsl.` prefix from the hostfile written when using localprovider.

# Fixes

Fixes #3437 

## Type of change

- Bug fix
