### PR TITLE
Extend dependency error change in #2989 to remaining two dependency types

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -870,7 +870,8 @@ class DataFlowKernel:
 
         return depends
 
-    def _unwrap_futures(self, args, kwargs):
+    def _unwrap_futures(self, args: Sequence[Any], kwargs: Dict[str, Any]) \
+            -> Tuple[Sequence[Any], Dict[str, Any], Sequence[Tuple[Exception, str]]]:
         """This function should be called when all dependencies have completed.
 
         It will rewrite the arguments for that task, replacing each Future
@@ -916,10 +917,10 @@ class DataFlowKernel:
                 try:
                     kwargs[key] = dep.result()
                 except Exception as e:
-                    if hasattr(dep, 'task_record'):
-                        tid = dep.task_record['id']
+                    if hasattr(dep, 'task_record') and dep.task_record['dfk'] == self:
+                        tid = "task " + repr(dep.task_record['id'])
                     else:
-                        tid = None
+                        tid = repr(dep)
                     dep_failures.extend([(e, tid)])
 
         # Check for futures in inputs=[<fut>...]
@@ -930,10 +931,10 @@ class DataFlowKernel:
                     try:
                         new_inputs.extend([dep.result()])
                     except Exception as e:
-                        if hasattr(dep, 'task_record'):
-                            tid = dep.task_record['id']
+                        if hasattr(dep, 'task_record') and dep.task_record['dfk'] == self:
+                            tid = "task " + dep.task_record['id']
                         else:
-                            tid = None
+                            tid = repr(dep)
                         dep_failures.extend([(e, tid)])
 
                 else:


### PR DESCRIPTION
# Description

PR #2989 made dependency errors look nicer, but only did it for positional 
parameters. This PR extends that to kwarg and inputs=... dependencies.
    
PR #2989 describes these changes in more depth.
    
This PR adds a type annotation onto DFK._unwrap_futures that drives this
change - preventing _unwrap_futures from returning None task ids for failed
dependencies and instead requiring the task IDs to be strings.

## Type of change

- Update to human readable text: Documentation/error messages/comments
