### PR TITLE
Remove issue number recommendation from CONTRIBUTING branch names

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -113,7 +113,7 @@ The `Parsl development team <https://github.com/orgs/Parsl/teams>`_ has the addi
 Parsl development follows a common pull request-based workflow similar to `GitHub flow <http://scottchacon.com/2011/08/31/github-flow.html>`_. That is:
 
 * every development activity (except very minor changes, which can be discussed in the PR) should have a related GitHub issue
-* all development occurs in branches (named with a short descriptive name which includes the associated issue number, for example, `add-globus-transfer-#1`)
+* all development occurs in branches (named with a short descriptive name, for example, `add-globus-transfer-#1`)
 * the master branch is always stable
 * development branches should include tests for added features
 * development branches should be tested after being brought up-to-date with the master (in this way, what is being tested is what is actually going into the code; otherwise unexpected issues from merging may come up)


### PR DESCRIPTION
Branch names are largely irrelevant in the squash PR model: PR text provides much richer context; branch names do not find their way into permanent history; and we have been successfully operating with arbitrary branch name choices without trouble for a long time.

## Type of change

- Update to human readable text: Documentation/error messages/comments
