### PR TITLE
Fix misformatted 'Credits and Contributions' section heading

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -147,7 +147,7 @@ Project documentation
 All project documentation is written in reStructuredText. `Sphinx <http://sphinx-doc.org/>`_ is used to generate the HTML documentation from the rst documentation and structured docstrings in Parsl code.  Project documentation is built automatically and added to the `Parsl documentation <https://parsl.readthedocs.io>`_.
 
 Credit and Contributions
-----------------------
+------------------------
 
 Parsl wants to make sure that all contributors get credit for their contributions.  When you make your first contribution, it should include updating the codemeta.json file to include yourself as a contributor to the project.
 


### PR DESCRIPTION
Prior to this PR, there were not enough `-` symbols so GitHub's RST renderer did not recognise this as a heading.

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
