### PR TITLE
Update CoC link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ Parsl is supported in Python 3.8+. Requirements can be found `here <requirements
 Code of Conduct
 ===============
 
-Parsl seeks to foster an open and welcoming environment - Please see the `Parsl Code of Conduct <https://github.com/Parsl/parsl/blob/master/CODE_OF_CONDUCT.md>`_ for more details.
+Parsl seeks to foster an open and welcoming environment - Please see the `Parsl Code of Conduct <https://github.com/Parsl/parsl?tab=coc-ov-file#parsl-code-of-conduct>`_ for more details.
 
 Contributing
 ============


### PR DESCRIPTION
# Description

Updating the CoC link in the README's [Code of Conduct](https://github.com/Parsl/parsl/blob/master/README.rst#code-of-conduct) section reflects recent updates. I've linked it to the CoC tab in parsl/parsl so users aren't unnecessarily routed to the .github repo.

# Changed Behaviour

N/A

# Fixes

N/A

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Update to human readable text: Documentation/error messages/comments
