### PR TITLE
Remove redundant `if` statement in dependency resolver deep traversal

### DIFF
--- a/parsl/dataflow/dependency_resolvers.py
+++ b/parsl/dataflow/dependency_resolvers.py
@@ -74,7 +74,7 @@ def _(fut: Future):
 @deep_traverse_to_gather.register(list)
 @deep_traverse_to_gather.register(set)
 def _(iterable):
-    return [e for v in iterable for e in deep_traverse_to_gather(v) if isinstance(e, Future)]
+    return [e for v in iterable for e in deep_traverse_to_gather(v)]
 
 
 @deep_traverse_to_unwrap.register(tuple)


### PR DESCRIPTION
deep_traverse_to_gather (and any traverse_to_gather) always returns only Futures in its return list, so this if statement will always fire (or at least, if it doesn't, it is a bug, not something to be ignored by this `if`)

## Type of change

- Code maintenance/cleanup
