### PR TITLE
Fix delay/hang when resolving deep dictionary dependencies

### DIFF
--- a/parsl/dataflow/dependency_resolvers.py
+++ b/parsl/dataflow/dependency_resolvers.py
@@ -44,6 +44,7 @@ def _(fut: Future):
 @shallow_traverse_to_unwrap.register
 @singledispatch
 def _(fut: Future):
+    assert fut.done()
     return fut.result()
 
 
@@ -67,6 +68,7 @@ def _(fut: Future):
 @deep_traverse_to_unwrap.register
 @singledispatch
 def _(fut: Future):
+    assert fut.done()
     return fut.result()
 
 

--- a/parsl/dataflow/dependency_resolvers.py
+++ b/parsl/dataflow/dependency_resolvers.py
@@ -93,10 +93,8 @@ def _(iterable):
 def _(dictionary):
     futures = []
     for key, value in dictionary.items():
-        if isinstance(key, Future):
-            futures.append(key)
-        if isinstance(value, Future):
-            futures.append(value)
+        futures.extend(deep_traverse_to_gather(key))
+        futures.extend(deep_traverse_to_gather(value))
     return futures
 
 

--- a/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
+++ b/parsl/tests/test_python_apps/test_pluggable_future_resolution.py
@@ -138,3 +138,24 @@ def test_dictionary():
 
     # this .result() will fail if the asserts fail
     dictionary_checker({k1: [30, v1], k2: 20}).result()
+
+
+@pytest.mark.local
+def test_dictionary_later():
+    k1 = Future()
+    k2 = Future()
+    v1 = Future()
+
+    f1 = dictionary_checker({k1: [30, v1], k2: 20})
+
+    assert not f1.done()
+    k1.set_result("a")
+    k2.set_result("b")
+    v1.set_result(10)
+
+    # having set the results, f1 should fairly rapidly complete (but not
+    # instantly) so we can't assert on done() here... but we can
+    # check that f1 does "eventually" complete... meaning that
+    # none of the assertions inside test_dictionary have failed
+
+    assert f1.result() is None


### PR DESCRIPTION
# Description

Prior to this PR, the `dict` part of `DEEP_DEPENDENCY_RESOLVER` did not extract all futures that it should in the gather stage, meaning that sometimes the unwrap stage would happen too early. Prior to this PR, only keys and values of a `dict` that were directly `Future` objects would be waited for by the DFK, rather than deep-recursing into those key/value objects. This would result in `Future.result()` happening too early (and blocking, potentially forever).

This PR switches out that behaviour to call deep_traverse_to_gather recursively, instead of using an `if`.

This PR adds a test case which demonstrates this change. That test case will hang without the above change, but pass with this change.

This PR adds asserts to the code that unwraps `Future` objects, to assert that the future object is in a suitable state for immediate unwrapping (i.e. that it is `done()`). This changes the above bug from a hang into a dependency failure that is reported to the user, and because it happens in any unwrapping of `Future` objects, is probably useful in the future to anyone modifying on the deep dependency resolver.

## Type of change

- Bug fix
