### PR TITLE
Launch interchange as a fresh process

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -807,7 +807,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         logger.info("Attempting HighThroughputExecutor shutdown")
 
         self.interchange_proc.terminate()
-        if self.interchange_proc.poll() is None:
+        if self.interchange_proc.wait(timeout=timeout) is None:
             logger.info("Unable to terminate Interchange process; sending SIGKILL")
             self.interchange_proc.kill()
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -532,7 +532,8 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         get the worker task and result ports that the interchange has bound to.
         """
         self.interchange_proc = ForkProcess(target=interchange.starter,
-                                            kwargs={"client_ports": (self.outgoing_q.port,
+                                            kwargs={"client_address": "127.0.0.1",
+                                                    "client_ports": (self.outgoing_q.port,
                                                                      self.incoming_q.port,
                                                                      self.command_client.port),
                                                     "interchange_address": self.address,

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -807,7 +807,9 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         logger.info("Attempting HighThroughputExecutor shutdown")
 
         self.interchange_proc.terminate()
-        if self.interchange_proc.wait(timeout=timeout) is None:
+        try:
+            self.interchange_proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
             logger.info("Unable to terminate Interchange process; sending SIGKILL")
             self.interchange_proc.kill()
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -554,7 +554,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         """Method to start the management thread as a daemon.
 
         Checks if a thread already exists, then starts it.
-        Could be used later as a restart if the management thread dies
+        Could be used later as a restart if the management thread dies.
         """
         if self._queue_management_thread is None:
             logger.debug("Starting queue management thread")

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -525,7 +525,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         Starts the interchange process locally and uses the command queue to
         get the worker task and result ports that the interchange has bound to.
         """
-        cli: List[str] = ["interchange.py",
+        cmd: List[str] = ["interchange.py",
                           "--client-address", "127.0.0.1",
                           "--client-ports", f"{self.outgoing_q.port},{self.incoming_q.port},{self.command_client.port}",
                           "--interchange-address", str(self.address),
@@ -541,8 +541,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
                           "--logging-level", str(logging.DEBUG) if self.worker_debug else str(logging.INFO),
                           "--cert-dir", str(self.cert_dir)
                           ]
-        logger.info(f"BENC: cli = {cli}")
-        self.interchange_proc = subprocess.Popen(cli)
+        self.interchange_proc = subprocess.Popen(cmd)
 
         try:
             (self.worker_task_port, self.worker_result_port) = self.command_client.run("WORKER_PORTS", timeout_s=120)

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -673,17 +673,6 @@ def start_file_logger(filename: str, level: int = logging.DEBUG, format_string: 
     logger.addHandler(handler)
 
 
-# @wrap_with_logs(target="interchange")
-# def starter(*args: Any, **kwargs: Any) -> None:
-#    """Start the interchange process
-
-#    The executor is expected to call this function. The args, kwargs match that of the Interchange.__init__
-#    """
-#    setproctitle("parsl: HTEX interchange")
-#    # logger = multiprocessing.get_logger()
-#    ic = Interchange(*args, **kwargs)
-#    ic.start()
-
 if __name__ == "__main__":
     setproctitle("parsl: HTEX interchange")
 

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -743,9 +743,6 @@ if __name__ == "__main__":
     # TODO: all these ad-hoc parsers are pretty horrible - using a command line
     # is a bit of a horrible way to do this...
 
-    # TODO: initialize logging here and log any exceptions raised during
-    # these two lines into the log file:
-
     ic = Interchange(client_address=args.client_address,
                      interchange_address=parseNone(args.interchange_address),
                      client_ports=parseInt3(args.client_ports),

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import argparse
+import base64
 import datetime
 import json
 import logging
@@ -676,84 +676,7 @@ def start_file_logger(filename: str, level: int = logging.DEBUG, format_string: 
 if __name__ == "__main__":
     setproctitle("parsl: HTEX interchange")
 
-    parser = argparse.ArgumentParser()
+    config = pickle.loads(base64.b64decode(sys.argv[1]))
 
-    parser.add_argument("--client-address", required=True,
-                        help="Address to connect back to submitting client")
-    parser.add_argument("--interchange-address", required=True,
-                        help="Address this interchange should listen on")
-    parser.add_argument("--client-ports", required=True,
-                        help="Three ports on submitting client that the interchange should connect back to")
-    parser.add_argument("--worker-ports", required=True,
-                        help="Two ports on this interchange that workers can connect to")
-    parser.add_argument("--worker-port-range", required=True,
-                        help="Low and high port numbers that interchange will select worker ports from")
-    parser.add_argument("--hub-address", required=True,
-                        help="Address to connect to send monitoring info")
-    parser.add_argument("--hub-zmq-port", required=True,
-                        help="Address to connect to send monitoring info")
-    parser.add_argument("--heartbeat-threshold", required=True,
-                        help="Number of seconds without heartbeat after which a worker is considered lost")
-    parser.add_argument("--logdir", required=True,
-                        help="Directory in which to create interchange.log")
-    parser.add_argument("--logging-level", required=True,
-                        help="Level to log at")
-    parser.add_argument("--poll-period", required=True,
-                        help="Main thread polling period, in milliseconds")
-    parser.add_argument("--cert-dir", required=True,
-                        help="Directory in which to find CurveZMQ certificates")
-
-    args = parser.parse_args()
-
-    def parseOptStr(s: str) -> Optional[str]:
-        if s == "None":
-            return None
-        else:
-            return s
-
-    def parseInt2(s: str) -> Tuple[int, int]:
-        t = [int(v) for v in s.split(',')]
-        if len(t) != 2:
-            raise RuntimeError("Bad parse for 2-tuple of ints")
-        return (t[0], t[1])
-
-    def parseOptInt2(s: str) -> Optional[Tuple[int, int]]:
-        if s == "None":
-            return None
-        else:
-            t = [int(v) for v in s.split(',')]
-            if len(t) != 2:
-                raise RuntimeError("Bad parse for 2-tuple of ints")
-            return (t[0], t[1])
-
-    def parseInt3(s: str) -> Tuple[int, int, int]:
-        t = [int(v) for v in s.split(',')]
-        if len(t) != 3:
-            raise RuntimeError("Bad parse for 3-tuple of ints")
-        return (t[0], t[1], t[2])
-
-    def parseOptInt(s: str) -> Optional[int]:
-        if s == "None":
-            return None
-        else:
-            return int(s)
-
-    # TODO: can these parses move into argparse so that argparse handles errors?
-
-    # TODO: all these ad-hoc parsers are pretty horrible - using a command line
-    # is a bit of a horrible way to do this...
-
-    ic = Interchange(client_address=args.client_address,
-                     interchange_address=parseOptStr(args.interchange_address),
-                     client_ports=parseInt3(args.client_ports),
-                     worker_ports=parseOptInt2(args.worker_ports),
-                     worker_port_range=parseInt2(args.worker_port_range),
-                     hub_address=parseOptStr(args.hub_address),
-                     hub_zmq_port=parseOptInt(args.hub_zmq_port),
-                     heartbeat_threshold=int(args.heartbeat_threshold),
-                     logdir=args.logdir,
-                     logging_level=int(args.logging_level),    # TODO: is this ever None?
-                     poll_period=int(args.poll_period),
-                     cert_dir=parseOptStr(args.cert_dir),
-                     )
+    ic = Interchange(**config)
     ic.start()

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -705,7 +705,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    def parseNone(s: str) -> Optional[str]:
+    def parseOptStr(s: str) -> Optional[str]:
         if s == "None":
             return None
         else:
@@ -717,7 +717,7 @@ if __name__ == "__main__":
             raise RuntimeError("Bad parse for 2-tuple of ints")
         return (t[0], t[1])
 
-    def parseInt2Optional(s: str) -> Optional[Tuple[int, int]]:
+    def parseOptInt2(s: str) -> Optional[Tuple[int, int]]:
         if s == "None":
             return None
         else:
@@ -732,7 +732,7 @@ if __name__ == "__main__":
             raise RuntimeError("Bad parse for 2-tuple of ints")
         return (t[0], t[1], t[2])
 
-    def parseNoneInt(s: str) -> Optional[int]:
+    def parseOptInt(s: str) -> Optional[int]:
         if s == "None":
             return None
         else:
@@ -744,16 +744,16 @@ if __name__ == "__main__":
     # is a bit of a horrible way to do this...
 
     ic = Interchange(client_address=args.client_address,
-                     interchange_address=parseNone(args.interchange_address),
+                     interchange_address=parseOptStr(args.interchange_address),
                      client_ports=parseInt3(args.client_ports),
-                     worker_ports=parseInt2Optional(args.worker_ports),
+                     worker_ports=parseOptInt2(args.worker_ports),
                      worker_port_range=parseInt2(args.worker_port_range),
-                     hub_address=parseNone(args.hub_address),
-                     hub_zmq_port=parseNoneInt(args.hub_zmq_port),
+                     hub_address=parseOptStr(args.hub_address),
+                     hub_zmq_port=parseOptInt(args.hub_zmq_port),
                      heartbeat_threshold=int(args.heartbeat_threshold),
                      logdir=args.logdir,
                      logging_level=int(args.logging_level),    # TODO: is this ever None?
                      poll_period=int(args.poll_period),
-                     cert_dir=parseNone(args.cert_dir),
+                     cert_dir=parseOptStr(args.cert_dir),
                      )
     ic.start()

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import base64
 import datetime
 import json
 import logging
@@ -676,7 +675,7 @@ def start_file_logger(filename: str, level: int = logging.DEBUG, format_string: 
 if __name__ == "__main__":
     setproctitle("parsl: HTEX interchange")
 
-    config = pickle.loads(base64.b64decode(sys.argv[1]))
+    config = pickle.load(sys.stdin.buffer)
 
     ic = Interchange(**config)
     ic.start()

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -729,7 +729,7 @@ if __name__ == "__main__":
     def parseInt3(s: str) -> Tuple[int, int, int]:
         t = [int(v) for v in s.split(',')]
         if len(t) != 3:
-            raise RuntimeError("Bad parse for 2-tuple of ints")
+            raise RuntimeError("Bad parse for 3-tuple of ints")
         return (t[0], t[1], t[2])
 
     def parseOptInt(s: str) -> Optional[int]:

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -67,18 +67,19 @@ class Interchange:
     3. Detect workers that have failed using heartbeats
     """
     def __init__(self,
-                 client_address: str = "127.0.0.1",
-                 interchange_address: Optional[str] = None,
-                 client_ports: Tuple[int, int, int] = (50055, 50056, 50057),
-                 worker_ports: Optional[Tuple[int, int]] = None,
-                 worker_port_range: Tuple[int, int] = (54000, 55000),
-                 hub_address: Optional[str] = None,
-                 hub_zmq_port: Optional[int] = None,
-                 heartbeat_threshold: int = 60,
-                 logdir: str = ".",
-                 logging_level: int = logging.INFO,
-                 poll_period: int = 10,
-                 cert_dir: Optional[str] = None,
+                 *,
+                 client_address: str,
+                 interchange_address: Optional[str],
+                 client_ports: Tuple[int, int, int],
+                 worker_ports: Optional[Tuple[int, int]],
+                 worker_port_range: Tuple[int, int],
+                 hub_address: Optional[str],
+                 hub_zmq_port: Optional[int],
+                 heartbeat_threshold: int,
+                 logdir: str,
+                 logging_level: int,
+                 poll_period: int,
+                 cert_dir: Optional[str],
                  ) -> None:
         """
         Parameters
@@ -94,34 +95,34 @@ class Interchange:
              The ports at which the client can be reached
 
         worker_ports : tuple(int, int)
-             The specific two ports at which workers will connect to the Interchange. Default: None
+             The specific two ports at which workers will connect to the Interchange.
 
         worker_port_range : tuple(int, int)
              The interchange picks ports at random from the range which will be used by workers.
-             This is overridden when the worker_ports option is set. Default: (54000, 55000)
+             This is overridden when the worker_ports option is set.
 
         hub_address : str
              The IP address at which the interchange can send info about managers to when monitoring is enabled.
-             Default: None (meaning monitoring disabled)
+             When None, monitoring is disabled.
 
         hub_zmq_port : str
              The port at which the interchange can send info about managers to when monitoring is enabled.
-             Default: None (meaning monitoring disabled)
+             When None, monitoring is disabled.
 
         heartbeat_threshold : int
              Number of seconds since the last heartbeat after which worker is considered lost.
 
         logdir : str
-             Parsl log directory paths. Logs and temp files go here. Default: '.'
+             Parsl log directory paths. Logs and temp files go here.
 
         logging_level : int
-             Logging level as defined in the logging module. Default: logging.INFO
+             Logging level as defined in the logging module.
 
         poll_period : int
-             The main thread polling period, in milliseconds. Default: 10ms
+             The main thread polling period, in milliseconds.
 
         cert_dir : str | None
-            Path to the certificate directory. Default: None
+            Path to the certificate directory.
         """
         self.cert_dir = cert_dir
         self.logdir = logdir

--- a/parsl/tests/test_htex/test_htex.py
+++ b/parsl/tests/test_htex/test_htex.py
@@ -80,6 +80,12 @@ def test_htex_shutdown(
 ):
     mock_ix_proc = mock.Mock(spec=Popen)
 
+    # TODO: I think this is implementing the wrong behaviour for wait:
+    # wait is supposed to raise an exception on timeout, but this code
+    # below does not do so, and so I think it is not correctly
+    # detecting a broken impl in htex shutdown in the presence of
+    # wait timeouts...
+
     if started:
         htex.interchange_proc = mock_ix_proc
         mock_ix_proc.wait.return_value = None

--- a/parsl/tests/test_htex/test_htex.py
+++ b/parsl/tests/test_htex/test_htex.py
@@ -1,7 +1,7 @@
 import pathlib
 import warnings
-from unittest import mock
 from subprocess import Popen
+from unittest import mock
 
 import pytest
 

--- a/parsl/tests/test_htex/test_zmq_binding.py
+++ b/parsl/tests/test_htex/test_zmq_binding.py
@@ -2,12 +2,28 @@ import pathlib
 from typing import Optional
 from unittest import mock
 
+import logging
 import psutil
 import pytest
 import zmq
 
 from parsl import curvezmq
 from parsl.executors.high_throughput.interchange import Interchange
+
+
+def make_interchange(*, interchange_address: Optional[str], cert_dir: Optional[str]) -> Interchange:
+    return Interchange(interchange_address=interchange_address,
+                       cert_dir=cert_dir,
+                       client_address="127.0.0.1",
+                       client_ports=(50055, 50056, 50057),
+                       worker_ports=None,
+                       worker_port_range=(54000, 55000),
+                       hub_address=None,
+                       hub_zmq_port=None,
+                       heartbeat_threshold=60,
+                       logdir=".",
+                       logging_level=logging.INFO,
+                       poll_period=10)
 
 
 @pytest.fixture
@@ -31,7 +47,7 @@ def test_interchange_curvezmq_sockets(
     mock_socket: mock.MagicMock, cert_dir: Optional[str], encrypted: bool
 ):
     address = "127.0.0.1"
-    ix = Interchange(interchange_address=address, cert_dir=cert_dir)
+    ix = make_interchange(interchange_address=address, cert_dir=cert_dir)
     assert isinstance(ix.zmq_context, curvezmq.ServerContext)
     assert ix.zmq_context.encrypted is encrypted
     assert mock_socket.call_count == 5
@@ -40,7 +56,7 @@ def test_interchange_curvezmq_sockets(
 @pytest.mark.local
 @pytest.mark.parametrize("encrypted", (True, False), indirect=True)
 def test_interchange_binding_no_address(cert_dir: Optional[str]):
-    ix = Interchange(cert_dir=cert_dir)
+    ix = make_interchange(interchange_address=None, cert_dir=cert_dir)
     assert ix.interchange_address == "*"
 
 
@@ -49,7 +65,7 @@ def test_interchange_binding_no_address(cert_dir: Optional[str]):
 def test_interchange_binding_with_address(cert_dir: Optional[str]):
     # Using loopback address
     address = "127.0.0.1"
-    ix = Interchange(interchange_address=address, cert_dir=cert_dir)
+    ix = make_interchange(interchange_address=address, cert_dir=cert_dir)
     assert ix.interchange_address == address
 
 
@@ -60,7 +76,7 @@ def test_interchange_binding_with_non_ipv4_address(cert_dir: Optional[str]):
     # Confirm that a ipv4 address is required
     address = "localhost"
     with pytest.raises(zmq.error.ZMQError):
-        Interchange(interchange_address=address, cert_dir=cert_dir)
+        make_interchange(interchange_address=address, cert_dir=cert_dir)
 
 
 @pytest.mark.local
@@ -69,7 +85,7 @@ def test_interchange_binding_bad_address(cert_dir: Optional[str]):
     """Confirm that we raise a ZMQError when a bad address is supplied"""
     address = "550.0.0.0"
     with pytest.raises(zmq.error.ZMQError):
-        Interchange(interchange_address=address, cert_dir=cert_dir)
+        make_interchange(interchange_address=address, cert_dir=cert_dir)
 
 
 @pytest.mark.local
@@ -77,7 +93,7 @@ def test_interchange_binding_bad_address(cert_dir: Optional[str]):
 def test_limited_interface_binding(cert_dir: Optional[str]):
     """When address is specified the worker_port would be bound to it rather than to 0.0.0.0"""
     address = "127.0.0.1"
-    ix = Interchange(interchange_address=address, cert_dir=cert_dir)
+    ix = make_interchange(interchange_address=address, cert_dir=cert_dir)
     ix.worker_result_port
     proc = psutil.Process()
     conns = proc.connections(kind="tcp")

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
     python_requires=">=3.8.0",
     install_requires=install_requires,
     scripts = ['parsl/executors/high_throughput/process_worker_pool.py',
+               'parsl/executors/high_throughput/interchange.py',
                'parsl/executors/workqueue/exec_parsl_function.py',
                'parsl/executors/workqueue/parsl_coprocess.py',
     ],


### PR DESCRIPTION
This PR removes a use of multiprocessing fork-without-exec.

At heart, this is how the interchange has wanted to be launched for some time (because of earlier remote interchange work).

Launching multiprocessing fork caused a bunch of problems related to inheriteing state from from the parent submitting process that go away with this (jumbled logging topics, race conditions around at least logging-while-forking, inherited signal handlers).

The configuration dictionary, previously passed in memory over a fork, is now sent in pickled form over `stdin`. Using pickle here rather than (eg.) JSON keeps the path open for sending richer configuration objects, beyond what can be encoded in JSON. This isn't something needed right now, but at least configurable monitoring radios (the immediate driving force behind this PR) are modelled around passing arbitrary configuration objects around to configure things - and so it seems likely that if interchange monitoring configuration is exposed to the user, richer objects would be passed here. See PR #3315 for monitoring radio prototype.