### PR TITLE
Remove environment variable configuration for usage tracking

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -236,8 +236,7 @@ for reporting purposes.
 
 As an NSF-funded project, our ability to track usage metrics is important for continued funding. 
 
-You can opt-in by setting ``PARSL_TRACKING=true`` in your environment or by 
-setting ``usage_tracking=True`` in the configuration object (`parsl.config.Config`). 
+You can opt-in by setting ``usage_tracking=True`` in the configuration object (`parsl.config.Config`). 
 
 To read more about what information is collected and how it is used see :ref:`label-usage-tracking`.
 

--- a/docs/userguide/usage_tracking.rst
+++ b/docs/userguide/usage_tracking.rst
@@ -32,7 +32,7 @@ will choose to send us this information. The reason is that we need this data - 
 By opting-in, and allowing these statistics to be reported back, you are explicitly supporting the
 further development of Parsl.
 
-If you wish to opt in to usage reporting, set ``PARSL_TRACKING=true`` in your environment or set ``usage_tracking=True`` in the configuration object (`parsl.config.Config`).
+If you wish to opt in to usage reporting, set ``usage_tracking=True`` in the configuration object (`parsl.config.Config`).
 
 
 .. _what-is-sent:

--- a/parsl/usage_tracking/usage.py
+++ b/parsl/usage_tracking/usage.py
@@ -59,7 +59,6 @@ def udp_messenger(domain_name: str, UDP_PORT: int, sock_timeout: int, message: b
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)  # UDP
         sock.settimeout(sock_timeout)
         sock.sendto(message, (UDP_IP, UDP_PORT))
-        print(message)
         sock.close()
 
     except socket.timeout:

--- a/parsl/usage_tracking/usage.py
+++ b/parsl/usage_tracking/usage.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import platform
 import socket
 import sys
@@ -60,6 +59,7 @@ def udp_messenger(domain_name: str, UDP_PORT: int, sock_timeout: int, message: b
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)  # UDP
         sock.settimeout(sock_timeout)
         sock.sendto(message, (UDP_IP, UDP_PORT))
+        print(message)
         sock.close()
 
     except socket.timeout:
@@ -117,19 +117,14 @@ class UsageTracker:
     def check_tracking_enabled(self):
         """Check if tracking is enabled.
 
-        Tracking will be enabled unless either of these is true:
+        Tracking will be enabled unless the following is true:
 
             1. dfk.config.usage_tracking is set to False
-            2. Environment variable PARSL_TRACKING is set to false (case insensitive)
 
         """
         track = True
 
         if not self.config.usage_tracking:
-            track = False
-
-        envvar = str(os.environ.get("PARSL_TRACKING", True)).lower()
-        if envvar == "false":
             track = False
 
         return track

--- a/parsl/usage_tracking/usage.py
+++ b/parsl/usage_tracking/usage.py
@@ -121,12 +121,7 @@ class UsageTracker:
             1. dfk.config.usage_tracking is set to False
 
         """
-        track = True
-
-        if not self.config.usage_tracking:
-            track = False
-
-        return track
+        return self.config.usage_tracking
 
     def construct_start_message(self) -> bytes:
         """Collect preliminary run info at the start of the DFK.


### PR DESCRIPTION
# Description

This PR removes the use of `$PARSL_TRACKING` env variable to setup usage tracking configuration. Parsl will now only take usage tracking configuration from the `config`


# Changed Behavior
Anyone using only the env variable `PARSL_TRACKING` to enable usage tracking will need to set `usage_tracking = True` within the `config` to enable usage tracking.

# Fixes

Fixes #3456 

## Type of change

- Code maintenance/cleanup
- Update documentation