### PR TITLE
isort only parsl/ for consistency with flake8, mypy, lint-inits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint: ## run linter script
 
 .PHONY: isort
 isort: ## run isort on all files
-	isort --check .
+	isort --check parsl/
 
 .PHONY: flake8
 flake8:  ## run flake


### PR DESCRIPTION
# Changed Behaviour

This shoudn't change user-facing behaviour, but will enforce sorting on fewer files than before this PR when testing.

## Type of change

- Code maintenance/cleanup
