### PR TITLE
Made paramiko and globus optional dependencies to fix #2218

### DIFF
--- a/parsl/channels/oauth_ssh/oauth_ssh.py
+++ b/parsl/channels/oauth_ssh/oauth_ssh.py
@@ -1,10 +1,14 @@
 import logging
 import socket
 
-import paramiko
-
 from parsl.channels.ssh.ssh import SSHChannel
 from parsl.errors import OptionalModuleMissing
+
+try:
+    import paramiko
+    _ssh_enabled = True
+except (ImportError, NameError, FileNotFoundError):
+    _ssh_enabled = False
 
 try:
     from oauth_ssh.oauth_ssh_token import find_access_token
@@ -38,6 +42,10 @@ class OAuthSSHChannel(SSHChannel):
 
         Raises:
         '''
+        if not _ssh_enabled:
+            raise OptionalModuleMissing(['ssh'],
+                                        "OauthSSHChannel requires the ssh module and config.")
+
         if not _oauth_ssh_enabled:
             raise OptionalModuleMissing(['oauth_ssh'],
                                         "OauthSSHChannel requires oauth_ssh module and config.")

--- a/parsl/channels/ssh/ssh.py
+++ b/parsl/channels/ssh/ssh.py
@@ -2,8 +2,6 @@ import errno
 import logging
 import os
 
-import paramiko
-
 from parsl.channels.base import Channel
 from parsl.channels.errors import (
     AuthException,
@@ -13,15 +11,24 @@ from parsl.channels.errors import (
     FileCopyException,
     SSHException,
 )
+from parsl.errors import OptionalModuleMissing
 from parsl.utils import RepresentationMixin
+
+try:
+    import paramiko
+    _ssh_enabled = True
+except (ImportError, NameError, FileNotFoundError):
+    _ssh_enabled = False
+
 
 logger = logging.getLogger(__name__)
 
 
-class NoAuthSSHClient(paramiko.SSHClient):
-    def _auth(self, username, *args):
-        self._transport.auth_none(username)
-        return
+if _ssh_enabled:
+    class NoAuthSSHClient(paramiko.SSHClient):
+        def _auth(self, username, *args):
+            self._transport.auth_none(username)
+            return
 
 
 class SSHChannel(Channel, RepresentationMixin):
@@ -53,6 +60,9 @@ class SSHChannel(Channel, RepresentationMixin):
 
         Raises:
         '''
+        if not _ssh_enabled:
+            raise OptionalModuleMissing(['ssh'],
+                                        "SSHChannel requires the ssh module and config.")
 
         self.hostname = hostname
         self.username = username

--- a/parsl/channels/ssh_il/ssh_il.py
+++ b/parsl/channels/ssh_il/ssh_il.py
@@ -1,9 +1,15 @@
 import getpass
 import logging
 
-import paramiko
-
 from parsl.channels.ssh.ssh import SSHChannel
+from parsl.errors import OptionalModuleMissing
+
+try:
+    import paramiko
+    _ssh_enabled = True
+except (ImportError, NameError, FileNotFoundError):
+    _ssh_enabled = False
+
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +36,10 @@ class SSHInteractiveLoginChannel(SSHChannel):
 
         Raises:
         '''
+        if not _ssh_enabled:
+            raise OptionalModuleMissing(['ssh'],
+                                        "SSHInteractiveLoginChannel requires the ssh module and config.")
+
         self.hostname = hostname
         self.username = username
         self.password = password

--- a/parsl/data_provider/globus.py
+++ b/parsl/data_provider/globus.py
@@ -4,13 +4,19 @@ import os
 from functools import partial
 from typing import Optional
 
-import globus_sdk
 import typeguard
 
 import parsl
 from parsl.app.app import python_app
 from parsl.data_provider.staging import Staging
+from parsl.errors import OptionalModuleMissing
 from parsl.utils import RepresentationMixin
+
+try:
+    import globus_sdk
+    _globus_enabled = True
+except (ImportError, NameError, FileNotFoundError):
+    _globus_enalbed = False
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +70,10 @@ class Globus:
 
     @classmethod
     def init(cls):
+        if not _globus_enabled:
+            raise OptionalModuleMissing(['globus'],
+                                        "Globus requires the globus module and config.")
+
         token_path = os.path.join(os.path.expanduser('~'), '.parsl')
         if not os.path.isdir(token_path):
             os.mkdir(token_path)
@@ -219,6 +229,10 @@ class GlobusStaging(Staging, RepresentationMixin):
 
     @typeguard.typechecked
     def __init__(self, endpoint_uuid: str, endpoint_path: Optional[str] = None, local_path: Optional[str] = None):
+        if not _globus_enabled:
+            raise OptionalModuleMissing(['globus'],
+                                        "GlobusStaging requires the globus module and config.")
+
         self.endpoint_uuid = endpoint_uuid
         self.endpoint_path = endpoint_path
         self.local_path = local_path

--- a/parsl/tests/test_python_apps/test_basic.py
+++ b/parsl/tests/test_python_apps/test_basic.py
@@ -14,12 +14,6 @@ def import_square(x):
     return math.pow(x, 2)
 
 
-@python_app
-def custom_exception():
-    from globus_sdk import GlobusError
-    raise GlobusError('foobar')
-
-
 def test_simple(n=2):
     x = double(n)
     assert x.result() == n * 2
@@ -38,11 +32,3 @@ def test_parallel_for(n):
 
     for i in d:
         assert d[i].result() == 2 * i
-
-
-def test_custom_exception():
-    from globus_sdk import GlobusError
-
-    x = custom_exception()
-    with pytest.raises(GlobusError):
-        x.result()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,9 @@ typeguard>=2.10,!=3.*,<5
 
 
 typing-extensions>=4.6,<5
-globus-sdk
 dill
 tblib
 requests
-paramiko
 psutil>=5.5.1
 setproctitle
 filelock>=3.13,<4

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ extras_require = {
     'flux': ['pyyaml', 'cffi', 'jsonschema'],
     'proxystore': ['proxystore'],
     'radical-pilot': ['radical.pilot==1.60', 'radical.utils==1.60'],
+    'ssh': ['paramiko'],
+    'globus': ['globus-sdk'],
     # Disabling psi-j since github direct links are not allowed by pypi
     # 'psij': ['psi-j-parsl@git+https://github.com/ExaWorks/psi-j-parsl']
 }


### PR DESCRIPTION
# Description

Removed paramiko and globus_sdk from requirements.txt and added them as optional modules in setup.py. Added OptionalModuleMissing errors for the affected files if usage is attempted without the correct module being installed. Removed test that required globus_sdk to test external exceptions.

# Changed Behaviour

If users have code that depends on these now optional modules they might have to ensure that the proper extra modules are installed as well.

# Fixes

Fixes #2218

## Type of change

- Bug fix
