### PR TITLE
Add a marker for tests which test errors caused by unix filesystem permisions

### DIFF
--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -153,6 +153,10 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         'markers',
+        'unix_filesystem_permissions_required: Marks tests that require unix-level filesystem permission enforcement'
+    )
+    config.addinivalue_line(
+        'markers',
         'issue3328: Marks tests broken by issue #3328'
     )
     config.addinivalue_line(

--- a/parsl/tests/test_bash_apps/test_stdout.py
+++ b/parsl/tests/test_bash_apps/test_stdout.py
@@ -16,7 +16,6 @@ def echo_to_streams(msg, stderr=None, stdout=None):
 whitelist = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'configs', '*threads*')
 
 speclist = (
-    '/bad/dir/t.out',
     ['t3.out', 'w'],
     ('t4.out', None),
     (42, 'w'),
@@ -26,7 +25,6 @@ speclist = (
 )
 
 testids = [
-    'nonexistent_dir',
     'list_not_tuple',
     'null_mode',
     'not_a_string',
@@ -55,6 +53,26 @@ def test_bad_stdout_specs(spec):
 
 
 @pytest.mark.issue3328
+@pytest.mark.unix_filesystem_permissions_required
+def test_bad_stdout_file():
+    """Testing bad stderr file"""
+
+    o = "/bad/dir/t2.out"
+
+    fn = echo_to_streams("Hello world", stdout=o, stderr='t.err')
+
+    try:
+        fn.result()
+    except perror.BadStdStreamFile:
+        pass
+    else:
+        assert False, "Did not raise expected exception BadStdStreamFile"
+
+    return
+
+
+@pytest.mark.issue3328
+@pytest.mark.unix_filesystem_permissions_required
 def test_bad_stderr_file():
     """Testing bad stderr file"""
 


### PR DESCRIPTION
I've encountered a bunch of situations in the last few months where people were running the test suite in environments where filesystem permissions were not enforced - various container/virtual machine situations running as root.

In such a situation, some tests are not expected to pass, as those tests test that a (not-happening) OS-level filesystem permission error is correctly passed back to the Parsl user.

## Type of change

- Bug fix
