### PR TITLE
Remove unused inputs and outputs fields for AppBase

### DIFF
--- a/parsl/app/app.py
+++ b/parsl/app/app.py
@@ -66,8 +66,6 @@ class AppBase(metaclass=ABCMeta):
             self.kwargs['walltime'] = params['walltime'].default
         if 'parsl_resource_specification' in params:
             self.kwargs['parsl_resource_specification'] = params['parsl_resource_specification'].default
-        self.outputs = params['outputs'].default if 'outputs' in params else []
-        self.inputs = params['inputs'].default if 'inputs' in params else []
 
     @abstractmethod
     def __call__(self, *args: Any, **kwargs: Any) -> AppFuture:


### PR DESCRIPTION
# Description

Testing to see if `AppBase` needs `outputs` and `inputs` fields or the lines changed are necessary.

# Changed Behaviour

Removed the last 2 lines of `AppBase.__init__` which set `AppBase.inputs` and `AppBase.outputs` to default values if they exist.

## Type of change

- Code maintenance/cleanup
