### PR TITLE
Fixed Kubernetes worker container launch command to remove trailing semicolon.

### DIFF
--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -286,7 +286,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         # Create the environment variables and command to initiate IPP
         environment_vars = client.V1EnvVar(name="TEST", value="SOME DATA")
 
-        launch_args = ["-c", "{0};".format(cmd_string)]
+        launch_args = ["-c", "{0}".format(cmd_string)]
 
         volume_mounts = []
         # Create mount paths for the volumes


### PR DESCRIPTION
# Description

The launch command is formatted with a newline at the end so when the trailing semicolon is added here, it causes the semicolon to be run as a separate bash command by the worker. A single semicolon is a syntax error in bash and produces an error in container logs when the container tries to run it. Removing it is safe since it's at the end of the command and nothing is concatenated after it.

# Changed Behaviour

Remove an error in the Kubernetes worker container logs.

# Fixes

Fixes # n/a - minor issue

## Type of change

- Bug fix