### PR TITLE
Switch Kubernetes client to read_namespaced_pod() which requires fewer permissions

### DIFF
--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -243,13 +243,13 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         for jid in to_poll_job_ids:
             phase = None
             try:
-                pod_status = self.kube_client.read_namespaced_pod_status(name=jid, namespace=self.namespace)
+                pod = self.kube_client.read_namespaced_pod(name=jid, namespace=self.namespace)
             except Exception:
                 logger.exception("Failed to poll pod {} status, most likely because pod was terminated".format(jid))
                 if self.resources[jid]['status'] is JobStatus(JobState.RUNNING):
                     phase = 'Unknown'
             else:
-                phase = pod_status.status.phase
+                phase = pod.status.phase
             if phase:
                 status = translate_table.get(phase, JobState.UNKNOWN)
                 logger.debug("Updating pod {} with status {} to parsl status {}".format(jid,


### PR DESCRIPTION
Switch the Kubernetes client call to read_namespaced_pod_status() to read_namespaced_pod(), which is functionally the same but requires fewer permissions

# Description

This change is based on the comment from https://github.com/kubernetes-client/python/issues/993#issuecomment-547566592 . Similar to the user in the reporter of that issue, I was seeing forbidden permission when making the read_namespaced_pod_status() call, and according to the discussion there, this can be fixed by using read_namespaced_pod() instead which is almost exactly the same request/response (except the metadata.selfLink field, which is not used by the parsl code). It seems that the read_namespaced_pod_status() call requires an additional permission on "pods/status", while read_namespaced_pod() does not (I didn't check but I can only assume the latter is using permissions on the pod itself that other parts of the parsl code likely would require as well).

For Google Kubernetes Engine in particular, the predefined "Kubernetes Engine Developer" IAM role grants sufficient permissions for read_namespaced_pod() and everything else needed by parsl but not for read_namespaced_pod_status().

# Changed Behaviour

Change in which Kubernetes permission is needed to run the parsl script with the Kubernetes provider.

# Fixes

Fixes # n/a - minor change

## Type of change

- Code maintenance/cleanup
