### PR TITLE
Add debug logging around local channel process launch

### DIFF
--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -68,13 +68,13 @@ class LocalChannel(Channel, RepresentationMixin):
             logger.debug("Created process with pid %s. Performing communicate", proc.pid)
             (stdout, stderr) = proc.communicate(timeout=walltime)
             retcode = proc.returncode
-            logger.debug("Process returned %s", proc.returncode)
+            logger.debug("Process %s returned %s", proc.pid, proc.returncode)
 
         except Exception:
-            logger.exception(f"Execution of command '{cmd}' failed")
+            logger.exception(f"Execution of command failed:\n{cmd}")
             raise
         else:
-            logger.debug("Execution of command completed normally")
+            logger.debug("Execution of command in process %s completed normally", proc.pid)
 
         return (retcode, stdout.decode("utf-8"), stderr.decode("utf-8"))
 

--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -55,6 +55,7 @@ class LocalChannel(Channel, RepresentationMixin):
         current_env.update(envs)
 
         try:
+            logger.debug("Creating process with command '%s'", cmd)
             proc = subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE,
@@ -64,12 +65,16 @@ class LocalChannel(Channel, RepresentationMixin):
                 shell=True,
                 preexec_fn=os.setpgrp
             )
+            logger.debug("Created process with pid %s. Performing communicate", proc.pid)
             (stdout, stderr) = proc.communicate(timeout=walltime)
             retcode = proc.returncode
+            logger.debug("Process returned %s", proc.returncode)
 
-        except Exception as e:
-            logger.warning("Execution of command '{}' failed due to \n{}".format(cmd, e))
+        except Exception:
+            logger.exception(f"Execution of command '{cmd}' failed")
             raise
+        else:
+            logger.debug("Execution of command completed normally")
 
         return (retcode, stdout.decode("utf-8"), stderr.decode("utf-8"))
 


### PR DESCRIPTION
This is driven by a case where it is unclear when the Parsl scaling code is launching processes to monitor batch queue status.

# Changed Behaviour

This will add 4 debug lines per block started, block cancelled, and per poll (limited by provider.status_polling_interval() and config.strategy_period)

## Type of change

- New feature
