### PR TITLE
enable usage tracking in example configs

### DIFF
--- a/parsl/configs/ASPIRE1.py
+++ b/parsl/configs/ASPIRE1.py
@@ -4,6 +4,7 @@ from parsl.executors import HighThroughputExecutor
 from parsl.launchers import MpiRunLauncher
 from parsl.monitoring.monitoring import MonitoringHub
 from parsl.providers import PBSProProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 config = Config(
         executors=[
@@ -39,5 +40,6 @@ config = Config(
         strategy='simple',
         retries=3,
         app_cache=True,
-        checkpoint_mode='task_exit'
+        checkpoint_mode='task_exit',
+        usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/Azure.py
+++ b/parsl/configs/Azure.py
@@ -8,6 +8,7 @@ from parsl.data_provider.http import HTTPInTaskStaging
 from parsl.data_provider.rsync import RSyncStaging
 from parsl.executors import HighThroughputExecutor
 from parsl.providers import AzureProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 vm_reference = {
     # All fields below are required
@@ -33,5 +34,6 @@ config = Config(
                             FTPInTaskStaging(),
                             RSyncStaging(getpass.getuser() + "@" + address_by_query())],
         )
-    ]
+    ],
+    usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/ad_hoc.py
+++ b/parsl/configs/ad_hoc.py
@@ -4,6 +4,7 @@ from parsl.channels import SSHChannel
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.providers import AdHocProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 user_opts: Dict[str, Dict[str, Any]]
 user_opts = {'adhoc':
@@ -33,4 +34,5 @@ config = Config(
     ],
     #  AdHoc Clusters should not be setup with scaling strategy.
     strategy='none',
+    usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/bridges.py
+++ b/parsl/configs/bridges.py
@@ -3,6 +3,7 @@ from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 """ This config assumes that it is used to launch parsl tasks from the login nodes
 of Bridges at PSC. Each job submitted to the scheduler will request 2 nodes for 10 minutes.
@@ -34,5 +35,6 @@ config = Config(
                 cmd_timeout=120,
             ),
         )
-    ]
+    ],
+    usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/cc_in2p3.py
+++ b/parsl/configs/cc_in2p3.py
@@ -2,6 +2,7 @@ from parsl.channels import LocalChannel
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.providers import GridEngineProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 config = Config(
     executors=[
@@ -19,4 +20,5 @@ config = Config(
             ),
         )
     ],
+    usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/ec2.py
+++ b/parsl/configs/ec2.py
@@ -1,6 +1,7 @@
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.providers import AWSProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 config = Config(
     executors=[
@@ -25,4 +26,5 @@ config = Config(
             ),
         )
     ],
+    usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/expanse.py
+++ b/parsl/configs/expanse.py
@@ -2,6 +2,7 @@ from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 config = Config(
     executors=[
@@ -24,5 +25,6 @@ config = Config(
                 nodes_per_block=2,
             ),
         )
-    ]
+    ],
+    usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/frontera.py
+++ b/parsl/configs/frontera.py
@@ -3,6 +3,7 @@ from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 """ This config assumes that it is used to launch parsl tasks from the login nodes
 of Frontera at TACC. Each job submitted to the scheduler will request 2 nodes for 10 minutes.
@@ -32,4 +33,5 @@ config = Config(
             ),
         )
     ],
+    usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/htex_local.py
+++ b/parsl/configs/htex_local.py
@@ -2,6 +2,7 @@ from parsl.channels import LocalChannel
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.providers import LocalProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 config = Config(
     executors=[
@@ -15,4 +16,5 @@ config = Config(
             ),
         )
     ],
+    usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/illinoiscluster.py
+++ b/parsl/configs/illinoiscluster.py
@@ -2,6 +2,7 @@ from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 """ This config assumes that it is used to launch parsl tasks from the login nodes
 of the Campus Cluster at UIUC. Each job submitted to the scheduler will request 2 nodes for 10 minutes.
@@ -25,4 +26,5 @@ config = Config(
                ),
           )
      ],
+     usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/kubernetes.py
+++ b/parsl/configs/kubernetes.py
@@ -2,6 +2,7 @@ from parsl.addresses import address_by_route
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.providers import KubernetesProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 config = Config(
     executors=[
@@ -36,5 +37,6 @@ config = Config(
                 max_blocks=10,
             ),
         ),
-    ]
+    ],
+    usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/local_threads.py
+++ b/parsl/configs/local_threads.py
@@ -1,4 +1,8 @@
 from parsl.config import Config
 from parsl.executors.threads import ThreadPoolExecutor
+from parsl.usage_tracking.levels import LEVEL_1
 
-config = Config(executors=[ThreadPoolExecutor()])
+config = Config(
+    executors=[ThreadPoolExecutor()],
+    usage_tracking=LEVEL_1,
+)

--- a/parsl/configs/midway.py
+++ b/parsl/configs/midway.py
@@ -3,6 +3,7 @@ from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 config = Config(
     executors=[
@@ -28,4 +29,5 @@ config = Config(
             ),
         )
     ],
+    usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/osg.py
+++ b/parsl/configs/osg.py
@@ -1,6 +1,7 @@
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.providers import CondorProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 config = Config(
     executors=[
@@ -26,5 +27,6 @@ python3 -m venv parsl_env; source parsl_env/bin/activate; python3 -m pip install
             worker_logdir_root='$OSG_WN_TMP',
             worker_ports=(31000, 31001)
         )
-    ]
+    ],
+    usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/polaris.py
+++ b/parsl/configs/polaris.py
@@ -3,6 +3,7 @@ from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.launchers import MpiExecLauncher
 from parsl.providers import PBSProProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 # There are three user parameters to change for the PBSProProvider:
 #  YOUR_ACCOUNT: Account to charge usage
@@ -34,5 +35,6 @@ config = Config(
                 cpus_per_node=64,
             ),
         ),
-    ]
+    ],
+    usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/stampede2.py
+++ b/parsl/configs/stampede2.py
@@ -4,6 +4,7 @@ from parsl.data_provider.globus import GlobusStaging
 from parsl.executors import HighThroughputExecutor
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 config = Config(
     executors=[
@@ -34,4 +35,5 @@ config = Config(
         )
 
     ],
+    usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/summit.py
+++ b/parsl/configs/summit.py
@@ -3,6 +3,7 @@ from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.launchers import JsrunLauncher
 from parsl.providers import LSFProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 config = Config(
     executors=[
@@ -26,4 +27,5 @@ config = Config(
         )
 
     ],
+    usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/toss3_llnl.py
+++ b/parsl/configs/toss3_llnl.py
@@ -2,6 +2,7 @@ from parsl.config import Config
 from parsl.executors import FluxExecutor
 from parsl.launchers import SrunLauncher
 from parsl.providers import SlurmProvider
+from parsl.usage_tracking.levels import LEVEL_1
 
 config = Config(
     executors=[
@@ -24,5 +25,6 @@ config = Config(
                 cmd_timeout=120,
             ),
         )
-    ]
+    ],
+    usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/vineex_local.py
+++ b/parsl/configs/vineex_local.py
@@ -2,6 +2,7 @@ import uuid
 
 from parsl.config import Config
 from parsl.executors.taskvine import TaskVineExecutor, TaskVineManagerConfig
+from parsl.usage_tracking.levels import LEVEL_1
 
 config = Config(
     executors=[
@@ -15,5 +16,6 @@ config = Config(
             # To disable status reporting, comment out the project_name.
             manager_config=TaskVineManagerConfig(project_name="parsl-vine-" + str(uuid.uuid4())),
         )
-    ]
+    ],
+    usage_tracking=LEVEL_1,
 )

--- a/parsl/configs/wqex_local.py
+++ b/parsl/configs/wqex_local.py
@@ -2,6 +2,7 @@ import uuid
 
 from parsl.config import Config
 from parsl.executors import WorkQueueExecutor
+from parsl.usage_tracking.levels import LEVEL_1
 
 config = Config(
     executors=[
@@ -21,5 +22,6 @@ config = Config(
             # A shared filesystem is not needed when using Work Queue.
             shared_fs=False
         )
-    ]
+    ],
+    usage_tracking=LEVEL_1,
 )


### PR DESCRIPTION
# Description

Enable usage tracking with level 1 in the configs

# Changed Behaviour

Example configs will have `usage_tracking` set to the lowest level and share the following user data: `python-version`, `parsl-version` and `platform`

## Type of change

- New feature

