### PR TITLE
Fix definition of `g` in very first example in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,8 +23,8 @@ Parsl lets you chain functions together and will launch each function as inputs 
         return x + 1
 
     @python_app
-    def g(x):
-        return x * 2
+    def g(x, y):
+        return x + y
 
     # These functions now return Futures, and can be chained
     future = f(1)


### PR DESCRIPTION
I'm trying to get my head around Parsl, but the first example in the documentation already lost me.  I believe the example was broken by #3428.  CC: @WardLT

# Description

`g` was defined as a single-argument function, but called with two.

# Changed Behaviour

First example in the documentation now actually works.  With this change, the example is now consistent with the README (also changed in #3428): https://github.com/Parsl/parsl/blob/2fc20d8da76198db13145bd4341d8ad9db1c6a37/README.rst#L24-L26

# Fixes

N/A

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Update to human readable text: Documentation/error messages/comments