### PR TITLE
Close stdin used to send config to Interchange

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -551,6 +551,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         logger.debug("Popened interchange process. Writing config object")
         stdin.write(config_pickle)
         stdin.flush()
+        stdin.close()
         logger.debug("Sent config object. Requesting worker ports")
         try:
             (self.worker_task_port, self.worker_result_port) = self.command_client.run("WORKER_PORTS", timeout_s=120)


### PR DESCRIPTION
This was introduced in PR #3463 and at the time I incorrectly assumed that interchange exit would close both ends of the pipe. That is untrue.

For example: pytest parsl/tests/test_htex/ --config local ends with 341 fds open before this PR,
and 327 file descriptors open after this PR.

# Changed Behaviour

nothing should be user visible, but less file descriptor usage

## Type of change

- Bug fix
