### PR TITLE
Codify assumptions about provider.channel and provider.channels as asserts

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1186,6 +1186,12 @@ class DataFlowKernel:
             if self.monitoring:
                 executor.monitoring_radio = self.monitoring.radio
             if hasattr(executor, 'provider'):
+
+                assert hasattr(executor.provider, 'channel') or hasattr(executor.provider, 'channels'), \
+                    "The provider model assumes a provider has channel(s)"
+                assert not (hasattr(executor.provider, 'channel') and hasattr(executor.provider, 'channels')), \
+                    "The provider model assumes a provider does not have both .channel and .channels"
+
                 if hasattr(executor.provider, 'script_dir'):
                     executor.provider.script_dir = os.path.join(self.run_dir, 'submit_scripts')
                     os.makedirs(executor.provider.script_dir, exist_ok=True)


### PR DESCRIPTION
The code will misbehave if a provider lacks channel(s) or if it has both.

Historically: a provider must have some way to run its commands, and that is what having a channel means. But the AdHocProvider wants to be given many channels, and the type system cannot express: "has .channel XOR has .channels"

## Type of change

- Code maintenance/cleanup
