### PR TITLE
Better closing of SSH channel

### DIFF
--- a/parsl/tests/test_providers/test_local_provider.py
+++ b/parsl/tests/test_providers/test_local_provider.py
@@ -92,13 +92,17 @@ def test_ssh_channel():
                 # already exist, so create it here.
                 pathlib.Path('{}/known.hosts'.format(config_dir)).touch(mode=0o600)
                 script_dir = tempfile.mkdtemp()
-                p = LocalProvider(channel=SSHChannel('127.0.0.1', port=server_port,
-                                                     script_dir=remote_script_dir,
-                                                     host_keys_filename='{}/known.hosts'.format(config_dir),
-                                                     key_filename=priv_key),
-                                  launcher=SingleNodeLauncher(debug=False))
-                p.script_dir = script_dir
-                _run_tests(p)
+                channel = SSHChannel('127.0.0.1', port=server_port,
+                                     script_dir=remote_script_dir,
+                                     host_keys_filename='{}/known.hosts'.format(config_dir),
+                                     key_filename=priv_key)
+                try:
+                    p = LocalProvider(channel=channel,
+                                      launcher=SingleNodeLauncher(debug=False))
+                    p.script_dir = script_dir
+                    _run_tests(p)
+                finally:
+                    channel.close()
         finally:
             _stop_sshd(sshd_thread)
 


### PR DESCRIPTION
This is paired with DFK behaviour introduced in PR #3503 which closes channels in the DFK.

This PR makes SSHChannel.close (soft) wait until its worker thread is shut down. This is initially driven by the desire for threads to be shut down before test cases end, but more generally is part of a goal of shutting everything down *before* the relevant close/cleanup operation completes.

"soft" in this sense means that after 30 seconds, a warning will be emitted, rather than hanging longer than that.

This PR modifies a test which does not use the DFK to also perform that shutdown - with parsl/tests/test_providers/test_local_provider.py, this reduces the number of threads remaining at the end of execution from 3 to 2.

## Type of change

- Code maintenance/cleanup
