### PR TITLE
Join on stopped thread at end of LocalProvider+ssh test

### DIFF
--- a/parsl/tests/test_providers/test_local_provider.py
+++ b/parsl/tests/test_providers/test_local_provider.py
@@ -105,6 +105,7 @@ def test_ssh_channel():
 
 def _stop_sshd(sshd_thread):
     sshd_thread.stop()
+    sshd_thread.join()
 
 
 class SSHDThread(threading.Thread):


### PR DESCRIPTION
This stops that thread being left still running over the end of the test - which is needed in work in PR #3397 to ensure that no threads are left running at the end of a test.

If that shutdown hangs, this test will now hang rather than leave the thread behind.

Along with PR #3504, this eliminates any threads left behind after parsl/tests/test_providers/test_local_provider.py

## Type of change

- Code maintenance/cleanup
