### PR TITLE
Remove documentation that KubernetesProvider job_name must be unique

### DIFF
--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -168,7 +168,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
              - tasks_per_node (int) : command invocations to be launched per node
 
         Kwargs:
-             - job_name (String): Name for job, must be unique
+             - job_name (String): Name for job
 
         Returns:
              - None: At capacity, cannot provision more


### PR DESCRIPTION
The job_name is uniquified with a timestamp inside the submit method, and the default job_name is "parsl", which is not unique wrt other invocations using the default.

## Type of change

- Update to human readable text: Documentation/error messages/comments
