### PR TITLE
Correct KubernetesProvider.submit docstring, to not return None

### DIFF
--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -171,7 +171,6 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
              - job_name (String): Name for job, must be unique
 
         Returns:
-             - None: At capacity, cannot provision more
              - job_id: (string) Identifier for the job
         """
 


### PR DESCRIPTION
See issue #2949 for context

## Type of change

- Update to human readable text: Documentation/error messages/comments
