### PR TITLE
Fix spacing in KubernetesProvider debug log and use deferred formatting

### DIFF
--- a/parsl/providers/kubernetes/kube.py
+++ b/parsl/providers/kubernetes/kube.py
@@ -187,7 +187,7 @@ class KubernetesProvider(ExecutionProvider, RepresentationMixin):
         formatted_cmd = template_string.format(command=cmd_string,
                                                worker_init=self.worker_init)
 
-        logger.debug("Pod name :{}".format(pod_name))
+        logger.debug("Pod name: %s", pod_name)
         self._create_pod(image=self.image,
                          pod_name=pod_name,
                          job_name=job_name,


### PR DESCRIPTION
## Type of change

- Update to human readable text: Documentation/error messages/comments
