### PR TITLE
Adding warning about provider options in MPI context

### DIFF
--- a/docs/userguide/mpi_apps.rst
+++ b/docs/userguide/mpi_apps.rst
@@ -60,6 +60,13 @@ An example for ALCF's Polaris supercomputer that will run 3 MPI tasks of 2 nodes
     )
 
 
+.. warning::
+   Please note that ``Provider`` options that specify per-task or per-node resources, for example,
+   ``SlurmProvider(cores_per_node=N, ...)`` should not be used with :class:`~parsl.executors.high_throughput.MPIExecutor`.
+   Parsl primarily uses a pilot job model and assumptions from that context do not translate to the MPI context. For
+   more info refer to :
+   `github issue #3006 <https://github.com/Parsl/parsl/issues/3006>`_
+
 Writing an MPI App
 ------------------
 


### PR DESCRIPTION
# Description

Parsl providers assume a pilot job model, where a single manager runs per node. This model conflicts with the model that `MPIExecutor` uses where the scheduler starts a single manager on the entire job which then launches MPI apps. This PR adds a warning to documentation cautioning use of `cores_per_node` in the SlurmProvider and similar options.  

This PR comes Christopher Harrop from NOAA reported on the help channel. 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Update to human readable text: Documentation/error messages/comments
