### PR TITLE
Update block monitoring log message

### DIFF
--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -243,7 +243,7 @@ class BlockProviderExecutor(ParslExecutor):
         # Send monitoring info for HTEX when monitoring enabled
         if self.monitoring_radio:
             msg = self.create_monitoring_info(status)
-            logger.debug("Sending message {} to hub from job status poller".format(msg))
+            logger.debug("Sending block monitoring message: %s", repr(msg))
             self.monitoring_radio.send((MessageType.BLOCK_INFO, msg))
 
     def create_monitoring_info(self, status: Dict[str, JobStatus]) -> Sequence[object]:

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -243,7 +243,7 @@ class BlockProviderExecutor(ParslExecutor):
         # Send monitoring info for HTEX when monitoring enabled
         if self.monitoring_radio:
             msg = self.create_monitoring_info(status)
-            logger.debug("Sending block monitoring message: %s", repr(msg))
+            logger.debug("Sending block monitoring message: %r", msg)
             self.monitoring_radio.send((MessageType.BLOCK_INFO, msg))
 
     def create_monitoring_info(self, status: Dict[str, JobStatus]) -> Sequence[object]:


### PR DESCRIPTION
* This monitoring message is not coming from the job status poller - this moved in PR #3349.

* This monitoring message is not being sent to the hub, but rather to the monitoring router on the far end of the monitoring radio.

* Debug messages should be formatted with deferred logger formatting.

## Type of change

- Update to human readable text: Documentation/error messages/comments
