### PR TITLE
Mark scale_out method as internal to BlockProviderExecutor

### DIFF
--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -180,7 +180,7 @@ class BlockProviderExecutor(ParslExecutor):
         # Filters first iterable by bool values in second
         return list(compress(to_kill, killed))
 
-    def scale_out(self, blocks: int = 1) -> List[str]:
+    def _scale_out(self, blocks: int = 1) -> List[str]:
         """Scales out the number of blocks by "blocks"
         """
         if not self.provider:
@@ -304,7 +304,7 @@ class BlockProviderExecutor(ParslExecutor):
         return block_ids
 
     def scale_out_facade(self, n: int) -> List[str]:
-        block_ids = self.scale_out(n)
+        block_ids = self._scale_out(n)
         if block_ids is not None:
             new_status = {}
             for block_id in block_ids:


### PR DESCRIPTION
See PEP-8 https://peps.python.org/pep-0008/#descriptive-naming-styles

# Changed Behaviour

This should not change any behaviour.

## Type of change

- Code maintenance/cleanup
