### PR TITLE
Remove unused dfk.memo_lookup_table attribute

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1460,8 +1460,6 @@ class DataFlowKernel:
         Returns:
              - dict containing, hashed -> future mappings
         """
-        self.memo_lookup_table = None
-
         if checkpointDirs:
             return self._load_checkpoints(checkpointDirs)
         else:


### PR DESCRIPTION
This attribute is initialised sometimes, but not always, and is never read from. There's a similarly named attribute in Memoizer, so I think this was mistakenly introduced in commit
307b419dbcc847aeaf021f04c45b5149aa81d190.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
