### PR TITLE
Clarify dev instructions in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ For Developers
 
 3. Install::
 
-    $ cd parsl
+    $ cd parsl # only if you didn't enter the top-level directory in step 2 above
     $ python3 setup.py install
 
 4. Use Parsl!


### PR DESCRIPTION
# Description

If one tries to follow step 3 after step 2, which I think is something somewhat reasonable to expect, they end up inside directory `parsl/parsl`, where there's no `setup.py` script.  Instead, the script is in the top-level directory, so if you already entered `parsl`, you don't need to go into `parsl/parsl`.  This adds a comment to clarify this possible point of confusion.

# Changed Behaviour

Make following installation instructions for developers less confusing.

# Fixes

N/A

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Update to human readable text: Documentation/error messages/comments
