### PR TITLE
Add Modular Manager Selector Interface

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -265,7 +265,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
                  worker_logdir_root: Optional[str] = None,
                  enable_mpi_mode: bool = False,
                  mpi_launcher: str = "mpiexec",
-                 manager_selector: Optional[ManagerSelectorBase] = ManagerSelectorRandom(),
+                 manager_selector: ManagerSelectorBase = ManagerSelectorRandom(),
                  block_error_handler: Union[bool, Callable[[BlockProviderExecutor, Dict[str, JobStatus]], None]] = True,
                  encrypted: bool = False):
 

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -20,6 +20,10 @@ from parsl.data_provider.staging import Staging
 from parsl.executors.errors import BadMessage, ScalingFailed
 from parsl.executors.high_throughput import zmq_pipes
 from parsl.executors.high_throughput.errors import CommandClientTimeoutError
+from parsl.executors.high_throughput.manager_selector import (
+    ManagerSelectorBase,
+    ManagerSelectorRandom,
+)
 from parsl.executors.high_throughput.mpi_prefix_composer import (
     VALID_LAUNCHERS,
     validate_resource_spec,
@@ -261,6 +265,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
                  worker_logdir_root: Optional[str] = None,
                  enable_mpi_mode: bool = False,
                  mpi_launcher: str = "mpiexec",
+                 manager_selector: Optional[ManagerSelectorBase] = ManagerSelectorRandom(),
                  block_error_handler: Union[bool, Callable[[BlockProviderExecutor, Dict[str, JobStatus]], None]] = True,
                  encrypted: bool = False):
 
@@ -276,6 +281,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         self.prefetch_capacity = prefetch_capacity
         self.address = address
         self.address_probe_timeout = address_probe_timeout
+        self.manager_selector = manager_selector
         if self.address:
             self.all_addresses = address
         else:
@@ -544,6 +550,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
                               "poll_period": self.poll_period,
                               "logging_level": logging.DEBUG if self.worker_debug else logging.INFO,
                               "cert_dir": self.cert_dir,
+                              "manager_selector": self.manager_selector,
                               }
 
         config_pickle = pickle.dumps(interchange_config)

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -21,8 +21,8 @@ from parsl.executors.errors import BadMessage, ScalingFailed
 from parsl.executors.high_throughput import zmq_pipes
 from parsl.executors.high_throughput.errors import CommandClientTimeoutError
 from parsl.executors.high_throughput.manager_selector import (
-    ManagerSelectorBase,
-    ManagerSelectorRandom,
+    ManagerSelector,
+    RandomManagerSelector,
 )
 from parsl.executors.high_throughput.mpi_prefix_composer import (
     VALID_LAUNCHERS,
@@ -265,7 +265,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
                  worker_logdir_root: Optional[str] = None,
                  enable_mpi_mode: bool = False,
                  mpi_launcher: str = "mpiexec",
-                 manager_selector: ManagerSelectorBase = ManagerSelectorRandom(),
+                 manager_selector: ManagerSelector = RandomManagerSelector(),
                  block_error_handler: Union[bool, Callable[[BlockProviderExecutor, Dict[str, JobStatus]], None]] = True,
                  encrypted: bool = False):
 

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -18,7 +18,7 @@ from parsl import curvezmq
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.executors.high_throughput.errors import ManagerLost, VersionMismatch
 from parsl.executors.high_throughput.manager_record import ManagerRecord
-from parsl.executors.high_throughput.manager_selector import ManagerSelectorBase
+from parsl.executors.high_throughput.manager_selector import ManagerSelector
 from parsl.monitoring.message_type import MessageType
 from parsl.process_loggers import wrap_with_logs
 from parsl.serialize import serialize as serialize_object
@@ -53,7 +53,7 @@ class Interchange:
                  logging_level: int,
                  poll_period: int,
                  cert_dir: Optional[str],
-                 manager_selector: ManagerSelectorBase,
+                 manager_selector: ManagerSelector,
                  ) -> None:
         """
         Parameters

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -6,7 +6,6 @@ import os
 import pickle
 import platform
 import queue
-import random
 import signal
 import sys
 import threading
@@ -19,6 +18,7 @@ from parsl import curvezmq
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.executors.high_throughput.errors import ManagerLost, VersionMismatch
 from parsl.executors.high_throughput.manager_record import ManagerRecord
+from parsl.executors.high_throughput.manager_selector import ManagerSelectorBase
 from parsl.monitoring.message_type import MessageType
 from parsl.process_loggers import wrap_with_logs
 from parsl.serialize import serialize as serialize_object
@@ -53,6 +53,7 @@ class Interchange:
                  logging_level: int,
                  poll_period: int,
                  cert_dir: Optional[str],
+                 manager_selector: Optional[ManagerSelectorBase] = None,
                  ) -> None:
         """
         Parameters
@@ -159,6 +160,9 @@ class Interchange:
         self.connected_block_history: List[str] = []
 
         self.heartbeat_threshold = heartbeat_threshold
+
+        assert manager_selector is not None, "Undefined manager_selector"
+        self.manager_selector = manager_selector
 
         self.current_platform = {'parsl_v': PARSL_VERSION,
                                  'python_v': "{}.{}.{}".format(sys.version_info.major,
@@ -485,8 +489,8 @@ class Interchange:
             interesting=len(interesting_managers)))
 
         if interesting_managers and not self.pending_task_queue.empty():
-            shuffled_managers = list(interesting_managers)
-            random.shuffle(shuffled_managers)
+            unsorted_managers = list(interesting_managers)
+            shuffled_managers = self.manager_selector.sort_managers(self._ready_managers, unsorted_managers)
 
             while shuffled_managers and not self.pending_task_queue.empty():  # cf. the if statement above...
                 manager_id = shuffled_managers.pop()

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -53,7 +53,7 @@ class Interchange:
                  logging_level: int,
                  poll_period: int,
                  cert_dir: Optional[str],
-                 manager_selector: Optional[ManagerSelectorBase] = None,
+                 manager_selector: ManagerSelectorBase,
                  ) -> None:
         """
         Parameters
@@ -161,7 +161,6 @@ class Interchange:
 
         self.heartbeat_threshold = heartbeat_threshold
 
-        assert manager_selector is not None, "Undefined manager_selector"
         self.manager_selector = manager_selector
 
         self.current_platform = {'parsl_v': PARSL_VERSION,
@@ -489,8 +488,7 @@ class Interchange:
             interesting=len(interesting_managers)))
 
         if interesting_managers and not self.pending_task_queue.empty():
-            unsorted_managers = list(interesting_managers)
-            shuffled_managers = self.manager_selector.sort_managers(self._ready_managers, unsorted_managers)
+            shuffled_managers = self.manager_selector.sort_managers(self._ready_managers, interesting_managers)
 
             while shuffled_managers and not self.pending_task_queue.empty():  # cf. the if statement above...
                 manager_id = shuffled_managers.pop()

--- a/parsl/executors/high_throughput/manager_selector.py
+++ b/parsl/executors/high_throughput/manager_selector.py
@@ -1,22 +1,25 @@
-import copy
 import random
-from typing import Dict, List
+from abc import ABCMeta, abstractmethod
+from typing import Dict, List, Set
 
 from parsl.executors.high_throughput.manager_record import ManagerRecord
 
 
-class ManagerSelectorBase:
+class ManagerSelectorBase(metaclass=ABCMeta):
 
-    def sort_managers(self, ready_managers: Dict[bytes, ManagerRecord], manager_list: List[bytes]) -> List[bytes]:
-        raise NotImplementedError
+    @abstractmethod
+    def sort_managers(self, ready_managers: Dict[bytes, ManagerRecord], manager_list: Set[bytes]) -> List[bytes]:
+        """ Sort a given list of managers.
+
+        Any operations pertaining to the sorting and rearrangement of the
+        interesting_managers Set should be performed here.
+        """
+        pass
 
 
 class ManagerSelectorRandom(ManagerSelectorBase):
 
-    def __init__(self):
-        pass
-
-    def sort_managers(self, ready_managers: Dict[bytes, ManagerRecord], manager_list: List[bytes]) -> List[bytes]:
-        c_manager_list = copy.copy(manager_list)
+    def sort_managers(self, ready_managers: Dict[bytes, ManagerRecord], manager_list: Set[bytes]) -> List[bytes]:
+        c_manager_list = list(manager_list)
         random.shuffle(c_manager_list)
         return c_manager_list

--- a/parsl/executors/high_throughput/manager_selector.py
+++ b/parsl/executors/high_throughput/manager_selector.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Set
 from parsl.executors.high_throughput.manager_record import ManagerRecord
 
 
-class ManagerSelectorBase(metaclass=ABCMeta):
+class ManagerSelector(metaclass=ABCMeta):
 
     @abstractmethod
     def sort_managers(self, ready_managers: Dict[bytes, ManagerRecord], manager_list: Set[bytes]) -> List[bytes]:
@@ -17,7 +17,7 @@ class ManagerSelectorBase(metaclass=ABCMeta):
         pass
 
 
-class ManagerSelectorRandom(ManagerSelectorBase):
+class RandomManagerSelector(ManagerSelector):
 
     def sort_managers(self, ready_managers: Dict[bytes, ManagerRecord], manager_list: Set[bytes]) -> List[bytes]:
         c_manager_list = list(manager_list)

--- a/parsl/executors/high_throughput/manager_selector.py
+++ b/parsl/executors/high_throughput/manager_selector.py
@@ -1,0 +1,22 @@
+import copy
+import random
+from typing import Dict, List
+
+from parsl.executors.high_throughput.manager_record import ManagerRecord
+
+
+class ManagerSelectorBase:
+
+    def sort_managers(self, ready_managers: Dict[bytes, ManagerRecord], manager_list: List[bytes]) -> List[bytes]:
+        raise NotImplementedError
+
+
+class ManagerSelectorRandom(ManagerSelectorBase):
+
+    def __init__(self):
+        pass
+
+    def sort_managers(self, ready_managers: Dict[bytes, ManagerRecord], manager_list: List[bytes]) -> List[bytes]:
+        c_manager_list = copy.copy(manager_list)
+        random.shuffle(c_manager_list)
+        return c_manager_list

--- a/parsl/tests/test_htex/test_zmq_binding.py
+++ b/parsl/tests/test_htex/test_zmq_binding.py
@@ -9,6 +9,7 @@ import zmq
 
 from parsl import curvezmq
 from parsl.executors.high_throughput.interchange import Interchange
+from parsl.executors.high_throughput.manager_selector import ManagerSelectorRandom
 
 
 def make_interchange(*, interchange_address: Optional[str], cert_dir: Optional[str]) -> Interchange:
@@ -23,6 +24,7 @@ def make_interchange(*, interchange_address: Optional[str], cert_dir: Optional[s
                        heartbeat_threshold=60,
                        logdir=".",
                        logging_level=logging.INFO,
+                       manager_selector=ManagerSelectorRandom(),
                        poll_period=10)
 
 

--- a/parsl/tests/test_htex/test_zmq_binding.py
+++ b/parsl/tests/test_htex/test_zmq_binding.py
@@ -9,7 +9,7 @@ import zmq
 
 from parsl import curvezmq
 from parsl.executors.high_throughput.interchange import Interchange
-from parsl.executors.high_throughput.manager_selector import ManagerSelectorRandom
+from parsl.executors.high_throughput.manager_selector import RandomManagerSelector
 
 
 def make_interchange(*, interchange_address: Optional[str], cert_dir: Optional[str]) -> Interchange:
@@ -24,7 +24,7 @@ def make_interchange(*, interchange_address: Optional[str], cert_dir: Optional[s
                        heartbeat_threshold=60,
                        logdir=".",
                        logging_level=logging.INFO,
-                       manager_selector=ManagerSelectorRandom(),
+                       manager_selector=RandomManagerSelector(),
                        poll_period=10)
 
 

--- a/parsl/tests/test_mpi_apps/test_mpiex.py
+++ b/parsl/tests/test_mpi_apps/test_mpiex.py
@@ -44,7 +44,7 @@ def test_init():
 
     new_kwargs = {'max_workers_per_block'}
     excluded_mpix_kwargs = {'available_accelerators', 'enable_mpi_mode', 'cores_per_worker', 'max_workers_per_node',
-                       'mem_per_worker', 'cpu_affinity', 'max_workers'}
+                            'mem_per_worker', 'cpu_affinity', 'max_workers'}
     excluded_htex_kwargs = {'manager_selector'}
 
     # Get the kwargs from both HTEx and MPIEx

--- a/parsl/tests/test_mpi_apps/test_mpiex.py
+++ b/parsl/tests/test_mpi_apps/test_mpiex.py
@@ -43,16 +43,17 @@ def test_init():
     """Ensure all relevant kwargs are copied over from HTEx"""
 
     new_kwargs = {'max_workers_per_block'}
-    excluded_kwargs = {'available_accelerators', 'enable_mpi_mode', 'cores_per_worker', 'max_workers_per_node',
+    excluded_mpix_kwargs = {'available_accelerators', 'enable_mpi_mode', 'cores_per_worker', 'max_workers_per_node',
                        'mem_per_worker', 'cpu_affinity', 'max_workers'}
+    excluded_htex_kwargs = {'manager_selector'}
 
     # Get the kwargs from both HTEx and MPIEx
     htex_kwargs = set(signature(HighThroughputExecutor.__init__).parameters)
     mpix_kwargs = set(signature(MPIExecutor.__init__).parameters)
 
     assert mpix_kwargs.difference(htex_kwargs) == new_kwargs
-    assert len(mpix_kwargs.intersection(excluded_kwargs)) == 0
-    assert mpix_kwargs.union(excluded_kwargs).difference(new_kwargs) == htex_kwargs
+    assert len(mpix_kwargs.intersection(excluded_mpix_kwargs)) == 0
+    assert mpix_kwargs.union(excluded_mpix_kwargs).difference(new_kwargs) == htex_kwargs.difference(excluded_htex_kwargs)
 
 
 @pytest.mark.local

--- a/parsl/tests/test_mpi_apps/test_mpiex.py
+++ b/parsl/tests/test_mpi_apps/test_mpiex.py
@@ -43,17 +43,16 @@ def test_init():
     """Ensure all relevant kwargs are copied over from HTEx"""
 
     new_kwargs = {'max_workers_per_block'}
-    excluded_mpix_kwargs = {'available_accelerators', 'enable_mpi_mode', 'cores_per_worker', 'max_workers_per_node',
-                            'mem_per_worker', 'cpu_affinity', 'max_workers'}
-    excluded_htex_kwargs = {'manager_selector'}
+    excluded_kwargs = {'available_accelerators', 'enable_mpi_mode', 'cores_per_worker', 'max_workers_per_node',
+                       'mem_per_worker', 'cpu_affinity', 'max_workers', 'manager_selector'}
 
     # Get the kwargs from both HTEx and MPIEx
     htex_kwargs = set(signature(HighThroughputExecutor.__init__).parameters)
     mpix_kwargs = set(signature(MPIExecutor.__init__).parameters)
 
     assert mpix_kwargs.difference(htex_kwargs) == new_kwargs
-    assert len(mpix_kwargs.intersection(excluded_mpix_kwargs)) == 0
-    assert mpix_kwargs.union(excluded_mpix_kwargs).difference(new_kwargs) == htex_kwargs.difference(excluded_htex_kwargs)
+    assert len(mpix_kwargs.intersection(excluded_kwargs)) == 0
+    assert mpix_kwargs.union(excluded_kwargs).difference(new_kwargs) == htex_kwargs
 
 
 @pytest.mark.local


### PR DESCRIPTION
# Description

Please include a summary of the change and (optionally) which issue is fixed. Please also include
relevant motivation and context.
Added a Manager Selector interface which allows users to choose an algorithm to sort the interesting managers. This will allow for flexible testing and implementation of manager selection strategies to optimize efficiency of the interchange. 

# Changed Behaviour

When using defining a config for the HTEX, users can now optionally specify a ManagerSelector to change the strategy. Default algorithm is the original random shuffle.

# Fixes

Further development of project outlined by [issue 3323](https://github.com/Parsl/parsl/issues/3323)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature

