### PR TITLE
Add type annotation and error log to _filter_scale_in_ids

### DIFF
--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -167,10 +167,14 @@ class BlockProviderExecutor(ParslExecutor):
     def provider(self):
         return self._provider
 
-    def _filter_scale_in_ids(self, to_kill, killed):
+    def _filter_scale_in_ids(self, to_kill: Sequence[Any], killed: Sequence[bool]) -> Sequence[Any]:
         """ Filter out job id's that were not killed
         """
         assert len(to_kill) == len(killed)
+
+        if False in killed:
+            logger.warning(f"Some jobs were not killed successfully: to_kill list is {to_kill}, killed list is {killed}")
+
         # Filters first iterable by bool values in second
         return list(compress(to_kill, killed))
 

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -173,7 +173,11 @@ class BlockProviderExecutor(ParslExecutor):
         assert len(to_kill) == len(killed)
 
         if False in killed:
-            logger.warning(f"Some jobs were not killed successfully: to_kill list is {to_kill}, killed list is {killed}")
+            killed_job_ids = [jid for jid, k in zip(to_kill, killed) if k]
+            not_killed_job_ids = [jid for jid, k in zip(to_kill, killed) if not k]
+            logger.warning("Some jobs were not killed successfully: "
+                           f"killed jobs: {killed_job_ids}, "
+                           f"not-killed jobs: {not_killed_job_ids}")
 
         # Filters first iterable by bool values in second
         return list(compress(to_kill, killed))


### PR DESCRIPTION
Especially this log message is intended to help user understanding when Parsl is not scaling in as they expected - before this PR, any blocks marked as not-scaled-in were not reported to the user (perhaps on the assumption that it might work next time round?)

# Changed Behaviour

Slightly more logging in the case of providers not killing blocks.

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
