### PR TITLE
demo of retry handlers returning a substitute value rather than choosing to retry or fail

### DIFF
--- a/parsl/config.py
+++ b/parsl/config.py
@@ -5,6 +5,7 @@ import typeguard
 from typing_extensions import Literal
 
 from parsl.dataflow.dependency_resolvers import DependencyResolver
+from parsl.dataflow.retries import RetryBehaviour
 from parsl.dataflow.taskrecord import TaskRecord
 from parsl.errors import ConfigurationError
 from parsl.executors.base import ParslExecutor
@@ -110,7 +111,7 @@ class Config(RepresentationMixin, UsageInformation):
                  garbage_collect: bool = True,
                  internal_tasks_max_threads: int = 10,
                  retries: int = 0,
-                 retry_handler: Optional[Callable[[Exception, TaskRecord], float]] = None,
+                 retry_handler: Optional[Callable[[Exception, TaskRecord], Union[float, RetryBehaviour]]] = None,
                  run_dir: str = 'runinfo',
                  std_autopath: Optional[Callable] = None,
                  strategy: Optional[str] = 'simple',

--- a/parsl/dataflow/retries.py
+++ b/parsl/dataflow/retries.py
@@ -1,0 +1,11 @@
+from abc import ABCMeta
+from dataclasses import dataclass
+
+
+class RetryBehaviour(metaclass=ABCMeta):
+    pass
+
+
+@dataclass
+class CompleteWithAlternateValue(RetryBehaviour):
+    value: object

--- a/parsl/tests/test_error_handling/test_retry_handler.py
+++ b/parsl/tests/test_error_handling/test_retry_handler.py
@@ -4,6 +4,7 @@ import pytest
 
 import parsl
 from parsl import bash_app
+from parsl.dataflow.retries import CompleteWithAlternateValue
 from parsl.tests.configs.local_threads import fresh_config
 
 

--- a/parsl/tests/test_error_handling/test_retry_handler_result.py
+++ b/parsl/tests/test_error_handling/test_retry_handler_result.py
@@ -1,0 +1,57 @@
+import os
+
+import pytest
+
+import parsl
+from parsl import python_app
+from parsl.dataflow.retries import CompleteWithAlternateValue
+from parsl.tests.configs.local_threads import fresh_config
+
+
+class SpecialException(Exception):
+    pass
+
+
+def error_to_result_handler(exc, task_record):
+    """Given a particular exception, turn it into a specific result"""
+    if isinstance(exc, SpecialException):
+        # substitute the exception with an alternate success
+        return CompleteWithAlternateValue(8)
+    else:
+        return 1  # regular retry cost
+
+
+def local_config():
+    c = fresh_config()
+    c.retries = 2
+    c.retry_handler = error_to_result_handler
+    return c
+
+
+@python_app
+def returns_val():
+    return 7
+
+
+@python_app
+def raises_runtime():
+    raise RuntimeError("from raises_runtime")
+
+
+@python_app
+def raises_special():
+    raise SpecialException(Exception)
+
+
+@pytest.mark.local
+def test_retry():
+
+    # two pre-reqs to validate that results and normal exceptions are handled
+    # correctly with the test retry handler
+    assert returns_val().result() == 7
+    with pytest.raises(RuntimeError):
+        raises_runtime().result()
+
+    # the actual test: check that a special exception has been replaced by a
+    # a real value
+    assert raises_special().result() == 8


### PR DESCRIPTION
This is a prototype I've made for @svandenhaute but maybe also of interest to Micha Pfeiffer

This prototype allows a retry handler to decide that on a particular task failure, the task should complete with a value of its own choosing.

In the scenario I talked of with @svandenhaute this would allow a tasks exception to be replaced by a substitute value that later other tasks would be able to observe - rather than task flow stopping - and so in a sense allows reification of the exception in a regular value.

In Micha's case, this may be a route to "permanently failing" a task into the checkpoint database, so that it does not re-run when restarting from checkpoints. (or might not - because this code means that other parts of a workflow will no longer observe a failure)

The supplied test case shows catching a particular exception and making that task not fail but instead complete with the value 8.

I'm unclear how this works in practice but the prototype was quick to make and I appreciate feedback.

# Changed Behaviour

none

## Type of change

- New feature
