### PR TITLE
Split monitoring router into two radio-specific receiver threads

### DIFF
--- a/parsl/monitoring/router.py
+++ b/parsl/monitoring/router.py
@@ -119,10 +119,6 @@ class MonitoringRouter:
         zmq_radio_receiver_thread = threading.Thread(target=self.start_zmq_listener, daemon=True)
         zmq_radio_receiver_thread.start()
 
-        # exit when both of those have exiting
-        # TODO: this is to preserve the existing behaviour of start(), but it
-        # isn't necessarily the *right* thing to do...
-
         self.logger.info("Joining on ZMQ listener thread")
         zmq_radio_receiver_thread.join()
         self.logger.info("Joining on UDP listener thread")

--- a/parsl/monitoring/router.py
+++ b/parsl/monitoring/router.py
@@ -112,11 +112,11 @@ class MonitoringRouter:
     @wrap_with_logs(target="monitoring_router")
     def start(self) -> None:
         self.logger.info("Starting UDP listener thread")
-        udp_radio_receiver_thread = threading.Thread(target=self.start_udp_listener)
+        udp_radio_receiver_thread = threading.Thread(target=self.start_udp_listener, daemon=True)
         udp_radio_receiver_thread.start()
 
         self.logger.info("Starting ZMQ listener thread")
-        zmq_radio_receiver_thread = threading.Thread(target=self.start_zmq_listener)
+        zmq_radio_receiver_thread = threading.Thread(target=self.start_zmq_listener, daemon=True)
         zmq_radio_receiver_thread.start()
 
         # exit when both of those have exiting


### PR DESCRIPTION
This is part of two ongoing strands of development:

* Preparation for arbitrary monitoring radio receivers, where UDP is not special compared to other methods. This code separates out the UDP specific code making it easier to move around later (see development in PR #3315)

* Avoiding poll-one-thing, poll-another-thing tight polling loops in favour of multiple blocking loops. The two router receiver sections used to run in a single tight non-blocking loop, each component waiting loop_freq (= 10 ms) for something to happen. After this PR, the separated loops are more amenable to longer blocking times - they only need to discover when exit event is set which probably can be more on the order of 1 second.

# Changed Behaviour

no functional changes - time of delivery of monitoring messages will be very slightly different, which in the race-condition prone parsl environment might be relevant

## Type of change

- Code maintenance/cleanup
