### PR TITLE
Bring block table updates together in scale out

### DIFF
--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -188,23 +188,27 @@ class BlockProviderExecutor(ParslExecutor):
         if not self.provider:
             raise ScalingFailed(self, "No execution provider available")
         block_ids = []
+        monitoring_status_changes = {}
         logger.info(f"Scaling out by {n} blocks")
         for _ in range(n):
             block_id = str(self._block_id_counter.get_id())
             logger.info(f"Allocated block ID {block_id}")
             try:
                 job_id = self._launch_block(block_id)
+
+                pending_status = JobStatus(JobState.PENDING)
+
                 self.blocks_to_job_id[block_id] = job_id
                 self.job_ids_to_block[job_id] = block_id
+                self._status[block_id] = pending_status
+
+                monitoring_status_changes[block_id] = pending_status
                 block_ids.append(block_id)
+
             except Exception as ex:
                 self._simulated_status[block_id] = JobStatus(JobState.FAILED, "Failed to start block {}: {}".format(block_id, ex))
 
-        new_status = {}
-        for block_id in block_ids:
-            new_status[block_id] = JobStatus(JobState.PENDING)
-        self.send_monitoring_info(new_status)
-        self._status.update(new_status)
+        self.send_monitoring_info(monitoring_status_changes)
         return block_ids
 
     def scale_in(self, blocks: int) -> List[str]:


### PR DESCRIPTION
There are multiple structures that contain information about blocks and the status of those blocks. This PR is part of ongoing work to make the information contained in those blocks more consistent.

This PR brings updates to executor._status (before PR #3352, living in parsl.jobs.job_status_poller) together with updates to the block/job id mapping structures (which has existed in the executor layer under different names since commit
a1963bf36fa6bac5bb5b28757a2c5d4a1fbe0462 introduced self.engines in 2018).

This PR should not change behaviour: it moves code around in a way that should not affect how the various structures are left populated at the end of the method.

This PR makes the cause of issue #3235 clearer, without attempting to fix it: in the successful code path touched by this PR, executor._status is updated immediately, but in the exception path, the status update only goes into _simulated_status and does not appear in executor._status until much later (when self.status() merges provider-provided status and simulated status driven by the job status poller).

A subsequent PR will address issue #3235

## Type of change

- Code maintenance/cleanup
