### PR TITLE
Fix pytest caplog heisenbug introduced in PR #3559

### DIFF
--- a/parsl/tests/test_htex/test_htex.py
+++ b/parsl/tests/test_htex/test_htex.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 from subprocess import Popen, TimeoutExpired
 from typing import Optional, Sequence
@@ -107,7 +108,8 @@ def test_htex_shutdown(
 
         mock_ix_proc.terminate.side_effect = kill_interchange
 
-    htex.shutdown()
+    with caplog.at_level(logging.INFO):
+        htex.shutdown()
 
     if started:
         assert mock_ix_proc.terminate.called


### PR DESCRIPTION
Prior to this PR, this usage of caplog is dependent on the level of the root logger, which is not set by this test and so ends up being dependent on which tests have run before: sometimes the INFO logs output by htex.shutdown are not captured by caplog.

This PR explicitly tells caplog to get at least INFO level logs, to capture the expected messages.

# Changed Behaviour

eliminates a bug in test code

## Type of change

- Bug fix
