### PR TITLE
Promote unable to terminate warning to logger.WARNING

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -832,7 +832,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         try:
             self.interchange_proc.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
-            logger.info("Unable to terminate Interchange process; sending SIGKILL")
+            logger.warning("Unable to terminate Interchange process; sending SIGKILL")
             self.interchange_proc.kill()
 
         logger.info("Closing ZMQ pipes")


### PR DESCRIPTION
Even if the subsequent SIGKILL works, this is an exceptional circumstance that should be logged.

# Changed Behaviour

more logging

## Type of change

- Update to human readable text: Documentation/error messages/comments
