### PR TITLE
Make router_starter parameters mandatory kwargs

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -154,9 +154,14 @@ class MonitoringHub(RepresentationMixin):
         self.router_exit_event = Event()
 
         self.router_proc = ForkProcess(target=router_starter,
-                                       args=(comm_q, self.exception_q, self.priority_msgs, self.node_msgs,
-                                             self.block_msgs, self.resource_msgs, self.router_exit_event),
-                                       kwargs={"hub_address": self.hub_address,
+                                       kwargs={"comm_q": comm_q,
+                                               "exception_q": self.exception_q,
+                                               "priority_msgs": self.priority_msgs,
+                                               "node_msgs": self.node_msgs,
+                                               "block_msgs": self.block_msgs,
+                                               "resource_msgs": self.resource_msgs,
+                                               "exit_event": self.router_exit_event,
+                                               "hub_address": self.hub_address,
                                                "udp_port": self.hub_port,
                                                "zmq_port_range": self.hub_port_range,
                                                "logdir": self.logdir,

--- a/parsl/monitoring/router.py
+++ b/parsl/monitoring/router.py
@@ -204,7 +204,8 @@ class MonitoringRouter:
 
 @wrap_with_logs
 @typeguard.typechecked
-def router_starter(comm_q: mpq.Queue,
+def router_starter(*,
+                   comm_q: mpq.Queue,
                    exception_q: mpq.Queue,
                    priority_msgs: mpq.Queue,
                    node_msgs: mpq.Queue,


### PR DESCRIPTION
See PR #2973 for justification of mandatory keyword args.

# Changed Behaviour

none for users

## Type of change

- Code maintenance/cleanup
