### PR TITLE
TaskVineExecutor: write function data to temp directory

### DIFF
--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -18,6 +18,7 @@ import tempfile
 import threading
 import uuid
 from concurrent.futures import Future
+from datetime import datetime
 from typing import List, Literal, Optional, Union
 
 # Import other libraries
@@ -215,7 +216,8 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
 
         # Create directories for data and results
         log_dir = os.path.join(run_dir, self.label)
-        self._function_data_dir = os.path.join(run_dir, self.label, "function_data")
+        tmp_dir = os.path.join('/tmp/', f'{self.label}-{os.getlogin()}')
+        self._function_data_dir = os.path.join(tmp_dir, datetime.now().strftime('%Y%m%d%H%M%S%f'), "function_data")
         os.makedirs(log_dir)
         os.makedirs(self._function_data_dir)
 

--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -3,6 +3,7 @@ Cooperative Computing Lab (CCL) at Notre Dame to provide a fault-tolerant,
 high-throughput system for delegating Parsl tasks to thousands of remote machines
 """
 
+import getpass
 import hashlib
 import inspect
 import itertools
@@ -216,7 +217,7 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
 
         # Create directories for data and results
         log_dir = os.path.join(run_dir, self.label)
-        tmp_dir = os.path.join('/tmp/', f'{self.label}-{os.getlogin()}')
+        tmp_dir = os.path.join('/tmp/', f'{self.label}-{getpass.getuser()}')
         self._function_data_dir = os.path.join(tmp_dir, datetime.now().strftime('%Y%m%d%H%M%S%f'), "function_data")
         os.makedirs(log_dir)
         os.makedirs(self._function_data_dir)

--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -218,7 +218,6 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         # Create directories for data and results
         log_dir = os.path.join(run_dir, self.label)
         os.makedirs(log_dir)
-        
         tmp_prefix = f'{self.label}-{getpass.getuser()}-{datetime.now().strftime("%Y%m%d%H%M%S%f")}-'
         self._function_data_dir = tempfile.TemporaryDirectory(prefix=tmp_prefix)
 


### PR DESCRIPTION
# Description

This moves the working directory for TaskVine executor function data to a directory in /tmp

These files were previously written adjacent to the logging in the working directory. They may be written in excess when running a large number of tasks.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature

