### PR TITLE
Make deliberately scaled-in unstarted blocks not be failures

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -791,7 +791,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         for job_id in job_status:
             job_info = job_status[job_id]
             if job_info.terminal and job_id not in connected_blocks and job_info.state != JobState.SCALED_IN:
-                logger.debug(f"BENC: job {job_id} was status {job_info}, overriding to MISSING")
+                logger.debug("Rewriting job %s from status %s to MISSING", job_id, job_info)
                 job_status[job_id].state = JobState.MISSING
                 if job_status[job_id].message is None:
                     job_status[job_id].message = (

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -790,7 +790,8 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         connected_blocks = self.connected_blocks()
         for job_id in job_status:
             job_info = job_status[job_id]
-            if job_info.terminal and job_id not in connected_blocks:
+            if job_info.terminal and job_id not in connected_blocks and job_info.state != JobState.SCALED_IN:
+                logger.debug(f"BENC: job {job_id} was status {job_info}, overriding to MISSING")
                 job_status[job_id].state = JobState.MISSING
                 if job_status[job_id].message is None:
                     job_status[job_id].message = (

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -321,8 +321,6 @@ class BlockProviderExecutor(ParslExecutor):
             status = self._make_status_dict(block_ids, self._provider.status(job_ids))
         else:
             status = {}
-
-        logger.debug(f"status from provider is {status}, simulated status to override is {self._simulated_status}")
         status.update(self._simulated_status)
 
         return status

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -337,7 +337,6 @@ class BlockProviderExecutor(ParslExecutor):
 
     def scale_in_facade(self, n: int, max_idletime: Optional[float] = None) -> List[str]:
 
-        logger.debug("BENC: scale_in_facade")
         if max_idletime is None:
             block_ids = self.scale_in(n)
         else:
@@ -350,7 +349,7 @@ class BlockProviderExecutor(ParslExecutor):
         if block_ids is not None:
             new_status = {}
             for block_id in block_ids:
-                logger.debug(f"BENC: recorded scaled in simulated status for block {block_id}")
+                logger.debug("Marking block %s as SCALED_IN", block_id)
                 s = JobStatus(JobState.SCALED_IN)
                 new_status[block_id] = s
                 self._status[block_id] = s

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -321,6 +321,8 @@ class BlockProviderExecutor(ParslExecutor):
             status = self._make_status_dict(block_ids, self._provider.status(job_ids))
         else:
             status = {}
+
+        logger.debug(f"status from provider is {status}, simulated status to override is {self._simulated_status}")
         status.update(self._simulated_status)
 
         return status
@@ -335,6 +337,7 @@ class BlockProviderExecutor(ParslExecutor):
 
     def scale_in_facade(self, n: int, max_idletime: Optional[float] = None) -> List[str]:
 
+        logger.debug("BENC: scale_in_facade")
         if max_idletime is None:
             block_ids = self.scale_in(n)
         else:
@@ -347,7 +350,10 @@ class BlockProviderExecutor(ParslExecutor):
         if block_ids is not None:
             new_status = {}
             for block_id in block_ids:
-                new_status[block_id] = JobStatus(JobState.CANCELLED)
-                del self._status[block_id]
+                logger.debug(f"BENC: recorded scaled in simulated status for block {block_id}")
+                s = JobStatus(JobState.SCALED_IN)
+                new_status[block_id] = s
+                self._status[block_id] = s
+                self._simulated_status[block_id] = s
             self.send_monitoring_info(new_status)
         return block_ids

--- a/parsl/jobs/states.py
+++ b/parsl/jobs/states.py
@@ -46,12 +46,17 @@ class JobState(IntEnum):
     bad worker environment or network connectivity issues.
     """
 
+    SCALED_IN = 9
+    """This job has been deliberately scaled in. Scaling code should not be concerned
+    that the job never ran (for example for error handling purposes).
+    """
+
     def __str__(self) -> str:
         return f"{self.__class__.__name__}.{self.name}"
 
 
 TERMINAL_STATES = [JobState.CANCELLED, JobState.COMPLETED, JobState.FAILED,
-                   JobState.TIMEOUT, JobState.MISSING]
+                   JobState.TIMEOUT, JobState.MISSING, JobState.SCALED_IN]
 
 
 class JobStatus:

--- a/parsl/tests/test_htex/test_multiple_disconnected_blocks.py
+++ b/parsl/tests/test_htex/test_multiple_disconnected_blocks.py
@@ -11,6 +11,7 @@ from parsl.providers import LocalProvider
 
 logger = logging.getLogger(__name__)
 
+
 def local_config():
     """Config to simulate failing blocks without connecting"""
     return Config(
@@ -40,8 +41,10 @@ def double(x):
     return x * 2
 
 
+# shouldn't be expecting a bad state exception if we've scaled in block 0
+# rather than it failing - maybe need to tweak min/max/init blocks?
 @pytest.mark.local
-@pytest.mark.skip("shouldn't be expecting a bad state exception if we've scaled in block 0 rather than it failing - maybe need to tweak min/max/init blocks?")
+@pytest.mark.skip("see comment")
 def test_multiple_disconnected_blocks():
     """Test reporting of blocks that fail to connect from HTEX
     When init_blocks == N, error handling expects N failures before

--- a/parsl/tests/test_htex/test_multiple_disconnected_blocks.py
+++ b/parsl/tests/test_htex/test_multiple_disconnected_blocks.py
@@ -9,6 +9,7 @@ from parsl.executors.errors import BadStateException
 from parsl.jobs.states import JobState, JobStatus
 from parsl.providers import LocalProvider
 
+logger = logging.getLogger(__name__)
 
 def local_config():
     """Config to simulate failing blocks without connecting"""
@@ -40,21 +41,29 @@ def double(x):
 
 
 @pytest.mark.local
+@pytest.mark.skip("shouldn't be expecting a bad state exception if we've scaled in block 0 rather than it failing - maybe need to tweak min/max/init blocks?")
 def test_multiple_disconnected_blocks():
     """Test reporting of blocks that fail to connect from HTEX
     When init_blocks == N, error handling expects N failures before
     the run is cancelled
     """
+
+    logger.error("BENC: 1")
     dfk = parsl.dfk()
     executor = dfk.executors["HTEX"]
 
     connected_blocks = executor.connected_blocks()
     assert not connected_blocks, "Expected 0 blocks"
 
+    logger.error("BENC: 2")
     future = double(5)
+    logger.error("BENC: 2.1")
     with pytest.raises(BadStateException):
+        logger.error("BENC: 2.2")
         future.result()
+        logger.error("BENC: 2.3")
 
+    logger.error("BENC: 3")
     assert isinstance(future.exception(), BadStateException)
     exception_body = str(future.exception())
     assert "EXIT CODE: 0" in exception_body
@@ -65,5 +74,7 @@ def test_multiple_disconnected_blocks():
         assert isinstance(status, JobStatus)
         assert status.state == JobState.MISSING
 
+    logger.error("BENC: 4")
     connected_blocks = executor.connected_blocks()
     assert not connected_blocks, "Expected 0 blocks"
+    logger.error("BENC: 5")

--- a/parsl/tests/test_htex/test_multiple_disconnected_blocks.py
+++ b/parsl/tests/test_htex/test_multiple_disconnected_blocks.py
@@ -9,8 +9,6 @@ from parsl.executors.errors import BadStateException
 from parsl.jobs.states import JobState, JobStatus
 from parsl.providers import LocalProvider
 
-logger = logging.getLogger(__name__)
-
 
 def local_config():
     """Config to simulate failing blocks without connecting"""
@@ -45,7 +43,6 @@ def test_multiple_disconnected_blocks():
     When init_blocks == N, error handling expects N failures before
     the run is cancelled
     """
-
     dfk = parsl.dfk()
     executor = dfk.executors["HTEX"]
 

--- a/parsl/tests/test_monitoring/test_htex_init_blocks_vs_monitoring.py
+++ b/parsl/tests/test_monitoring/test_htex_init_blocks_vs_monitoring.py
@@ -78,6 +78,6 @@ def test_row_counts(tmpd_cwd, strategy):
         (c, ) = result.first()
         assert c == 1, "There should be a single pending status"
 
-        result = connection.execute(text("SELECT COUNT(*) FROM block WHERE block_id = 0 AND status = 'CANCELLED' AND run_id = :run_id"), binds)
+        result = connection.execute(text("SELECT COUNT(*) FROM block WHERE block_id = 0 AND status = 'SCALED_IN' AND run_id = :run_id"), binds)
         (c, ) = result.first()
         assert c == 1, "There should be a single cancelled status"

--- a/parsl/tests/test_scaling/test_regression_3568_scaledown_vs_MISSING.py
+++ b/parsl/tests/test_scaling/test_regression_3568_scaledown_vs_MISSING.py
@@ -11,24 +11,22 @@ from parsl.providers import LocalProvider
 
 
 def local_config():
+    # see the comments inside test_regression for reasoning about why each
+    # of these parameters is set why it is.
     return Config(
         max_idletime=1,
+
         strategy='htex_auto_scale',
         strategy_period=1,
+
         executors=[
             HighThroughputExecutor(
                 label="htex_local",
-                address="127.0.0.1",
-                cores_per_worker=1,
                 encrypted=True,
                 provider=LocalProvider(
-                    channel=LocalChannel(),
                     init_blocks=1,
                     min_blocks=0,
                     max_blocks=1,
-                    # TODO: swap out the launcher during the test. make it use a much longer sleep (or infinite sleep)
-                    # to give blocks that run but never complete themselves. then swap that for a launcher which
-                    # launches the worker pool immediately.
                     launcher=WrappedLauncher(prepend="sleep inf ; "),
                 ),
             )
@@ -43,14 +41,23 @@ def task():
 
 @pytest.mark.local
 def test_regression(try_assert):
-    # config means that we should start with one block and very rapidly scale
-    # it down to 0 blocks. Because of 'sleep inf' in the WrappedLaucher, the
-    # block will not ever register. This lack of registration is part of the
-    # bug being tested for regression.
+    # The above config means that we should start scaling out one initial
+    # block, but then scale it back in after a second or so if the executor
+    # is kept idle (which this test does using try_assert).
 
-    # After that scaling has happened, we should see that we have one block
-    # and it should be in a terminal state. We should also see htex reporting
-    # no blocks connected.
+    # Because of 'sleep inf' in the WrappedLaucher, the block will not ever
+    # register.
+
+    # The bug being tested is about mistreatment of blocks which are scaled in
+    # before they have a chance to register, and the above forces that to
+    # happen.
+
+    # After that scaling in has happened, we should see that we have one block
+    # and it should be in a terminal state. The below try_assert waits for
+    # that to become true.
+
+    # At that time, we should also see htex reporting no blocks registered - as
+    # mentioned above, that is a necessary part of the bug being tested here.
 
     # Give 10 strategy periods for the above to happen: each step of scale up,
     # and scale down due to idleness isn't guaranteed to happen in exactly one
@@ -68,9 +75,9 @@ def test_regression(try_assert):
     # run the task successfully.
 
     # Prior to issue #3568, the bug was that the scale in of the first
-    # block earlier in the test case would have been treated as a failure,
-    # and then the block error handler would have treated that failure as a
-    # permanent htex failure, and so the task execution below would raise
+    # block earlier in the test case would have incorrectly been treated as a
+    # failure, and then the block error handler would have treated that failure
+    # as a permanent htex failure, and so the task execution below would raise
     # a BadStateException rather than attempt to run the task.
 
     assert htex.provider.launcher.prepend != "", "Pre-req: prepend attribute should exist and be non-empty"

--- a/parsl/tests/test_scaling/test_regression_3568_scaledown_vs_MISSING.py
+++ b/parsl/tests/test_scaling/test_regression_3568_scaledown_vs_MISSING.py
@@ -1,0 +1,42 @@
+import parsl
+from parsl.channels import LocalChannel
+from parsl.config import Config
+from parsl.executors import HighThroughputExecutor
+from parsl.launchers import WrappedLauncher
+from parsl.providers import LocalProvider
+
+import pytest
+
+def local_config():
+    return Config(
+        max_idletime = 6,
+        strategy = 'htex_auto_scale',
+        executors=[
+            HighThroughputExecutor(
+                label="htex_local",
+                worker_debug=True,
+                cores_per_worker=1,
+                encrypted=True,
+                provider=LocalProvider(
+                    channel=LocalChannel(),
+                    init_blocks=20,
+                    min_blocks=0,
+                    max_blocks=20,
+                    launcher=WrappedLauncher(prepend="sleep 60 ; "),
+                ),
+            )
+        ],
+    )
+
+
+@parsl.python_app
+def task():
+  return 7
+
+@pytest.mark.local
+def test_regression():
+  print("waiting")
+  import time
+  time.sleep(120)
+  print("task2")
+  assert task().result() == 7

--- a/parsl/tests/test_scaling/test_regression_3568_scaledown_vs_MISSING.py
+++ b/parsl/tests/test_scaling/test_regression_3568_scaledown_vs_MISSING.py
@@ -47,7 +47,7 @@ def test_regression(try_assert):
     # it down to 0 blocks. Because of 'sleep inf' in the WrappedLaucher, the
     # block will not ever register. This lack of registration is part of the
     # bug being tested for regression.
-  
+
     # After that scaling has happened, we should see that we have one block
     # and it should be in a terminal state. We should also see htex reporting
     # no blocks connected.
@@ -63,16 +63,15 @@ def test_regression(try_assert):
 
     assert htex.connected_blocks() == [], "No block should have connected to interchange"
 
-    # So after a few seconds we should see
-    # 0 blocks connected, 1 block marked as terminal
-    # (post-fix that should be marked as SCALED_IN
-    # but pre-fix it won't be... so for checking it
-    # fails before the fix, we can't check SCALED_IN)
-    # but we can check the historical blocks connected
-    # which should show no blocks connected.
+    # Now we can reconfigure the launcher to let subsequent blocks launch ok,
+    # and run a trivial task. That trivial task will scale up a new block and
+    # run the task successfully.
 
-    # once we see that we can swap in the new launcher
-    # and try running an app.
+    # Prior to issue #3568, the bug was that the scale in of the first
+    # block earlier in the test case would have been treated as a failure,
+    # and then the block error handler would have treated that failure as a
+    # permanent htex failure, and so the task execution below would raise
+    # a BadStateException rather than attempt to run the task.
 
     assert htex.provider.launcher.prepend != "", "Pre-req: prepend attribute should exist and be non-empty"
     htex.provider.launcher.prepend = ""

--- a/parsl/tests/test_scaling/test_regression_3568_scaledown_vs_MISSING.py
+++ b/parsl/tests/test_scaling/test_regression_3568_scaledown_vs_MISSING.py
@@ -1,3 +1,7 @@
+import time
+
+import pytest
+
 import parsl
 from parsl.channels import LocalChannel
 from parsl.config import Config
@@ -5,12 +9,11 @@ from parsl.executors import HighThroughputExecutor
 from parsl.launchers import WrappedLauncher
 from parsl.providers import LocalProvider
 
-import pytest
 
 def local_config():
     return Config(
-        max_idletime = 6,
-        strategy = 'htex_auto_scale',
+        max_idletime=6,
+        strategy='htex_auto_scale',
         executors=[
             HighThroughputExecutor(
                 label="htex_local",
@@ -31,12 +34,10 @@ def local_config():
 
 @parsl.python_app
 def task():
-  return 7
+    return 7
+
 
 @pytest.mark.local
 def test_regression():
-  print("waiting")
-  import time
-  time.sleep(120)
-  print("task2")
-  assert task().result() == 7
+    time.sleep(120)
+    assert task().result() == 7

--- a/parsl/tests/test_scaling/test_regression_3568_scaledown_vs_MISSING.py
+++ b/parsl/tests/test_scaling/test_regression_3568_scaledown_vs_MISSING.py
@@ -12,20 +12,24 @@ from parsl.providers import LocalProvider
 
 def local_config():
     return Config(
-        max_idletime=6,
+        max_idletime=1,
         strategy='htex_auto_scale',
+        strategy_period=1,
         executors=[
             HighThroughputExecutor(
                 label="htex_local",
-                worker_debug=True,
+                address="127.0.0.1",
                 cores_per_worker=1,
                 encrypted=True,
                 provider=LocalProvider(
                     channel=LocalChannel(),
-                    init_blocks=20,
+                    init_blocks=1,
                     min_blocks=0,
-                    max_blocks=20,
-                    launcher=WrappedLauncher(prepend="sleep 60 ; "),
+                    max_blocks=1,
+                    # TODO: swap out the launcher during the test. make it use a much longer sleep (or infinite sleep)
+                    # to give blocks that run but never complete themselves. then swap that for a launcher which
+                    # launches the worker pool immediately.
+                    launcher=WrappedLauncher(prepend="sleep inf ; "),
                 ),
             )
         ],
@@ -38,6 +42,38 @@ def task():
 
 
 @pytest.mark.local
-def test_regression():
-    time.sleep(120)
+def test_regression(try_assert):
+    # config means that we should start with one block and very rapidly scale
+    # it down to 0 blocks. Because of 'sleep inf' in the WrappedLaucher, the
+    # block will not ever register. This lack of registration is part of the
+    # bug being tested for regression.
+  
+    # After that scaling has happened, we should see that we have one block
+    # and it should be in a terminal state. We should also see htex reporting
+    # no blocks connected.
+
+    # Give 10 strategy periods for the above to happen: each step of scale up,
+    # and scale down due to idleness isn't guaranteed to happen in exactly one
+    # scaling step.
+
+    htex = parsl.dfk().executors['htex_local']
+
+    try_assert(lambda: len(htex.status_facade) == 1 and htex.status_facade['0'].terminal,
+               timeout_ms=10000)
+
+    assert htex.connected_blocks() == [], "No block should have connected to interchange"
+
+    # So after a few seconds we should see
+    # 0 blocks connected, 1 block marked as terminal
+    # (post-fix that should be marked as SCALED_IN
+    # but pre-fix it won't be... so for checking it
+    # fails before the fix, we can't check SCALED_IN)
+    # but we can check the historical blocks connected
+    # which should show no blocks connected.
+
+    # once we see that we can swap in the new launcher
+    # and try running an app.
+
+    assert htex.provider.launcher.prepend != "", "Pre-req: prepend attribute should exist and be non-empty"
+    htex.provider.launcher.prepend = ""
     assert task().result() == 7


### PR DESCRIPTION
This PR adds a new terminal job state, SCALED_IN. None of the existing providers will return it, but the scaling layer will use it to mark a job as deliberately scaled in, so that error handling code will not regard it as failed.

Fixes #3568 