### PR TITLE
Add breadcrumbs for users trying to match configs to their machines

### DIFF
--- a/docs/userguide/configuring.rst
+++ b/docs/userguide/configuring.rst
@@ -542,6 +542,9 @@ Perlmutter (NERSC)
 ------------------
 
 NERSC provides documentation on `how to use Parsl on Perlmutter <https://docs.nersc.gov/jobs/workflow/parsl/>`_.
+Perlmutter is a Slurm based HPC system and parsl uses `parsl.providers.SlurmProvider` with `parsl.launchers.SrunLauncher`
+to launch tasks onto this machine.
+
 
 Frontera (TACC)
 ---------------
@@ -599,6 +602,8 @@ Polaris (ALCF)
     :width: 75%
 
 ALCF provides documentation on `how to use Parsl on Polaris <https://docs.alcf.anl.gov/polaris/workflows/parsl/>`_.
+Polaris uses `parsl.providers.PBSProProvider` and `parsl.launchers.MpiExecLauncher` to launch tasks onto the HPC system.
+
 
 
 Stampede2 (TACC)


### PR DESCRIPTION
# Description

Both Polaris and Perlmutter have configuration documentation hosted by their respective facilities. This is great, but it makes it harder for users trying to match an undocumented machine to existing configs. This PR adds some hints to both Polaris and Perlmutter listing the provider and launcher combo used in the hopes that it might lead the user to configs from those machines.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Update to human readable text: Documentation/error messages/comments
