### PR TITLE
TaskVine executor: add parsl serialize module to default library context

### DIFF
--- a/parsl/executors/taskvine/manager.py
+++ b/parsl/executors/taskvine/manager.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import uuid
 
+import parsl.serialize
 from parsl.executors.taskvine import exec_parsl_function
 from parsl.executors.taskvine.utils import VineTaskToParsl, run_parsl_function
 from parsl.process_loggers import wrap_with_logs
@@ -249,7 +250,8 @@ def _taskvine_submit_wait(ready_task_queue=None,
                                                                      run_parsl_function,
                                                                      poncho_env=poncho_env_path,
                                                                      init_command=manager_config.init_command,
-                                                                     add_env=add_env)
+                                                                     add_env=add_env,
+                                                                     hoisting_modules=[parsl.serialize, run_parsl_function])
 
                     # Configure the library if provided
                     if manager_config.library_config:


### PR DESCRIPTION
# Description

This improves task throughput for taskvine serverless by caching the serialize module and base function definition in the library

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature

