### PR TITLE
Removal of 'task_block' parameter from serveral launcher's docstring

### DIFF
--- a/parsl/launchers/launchers.py
+++ b/parsl/launchers/launchers.py
@@ -61,7 +61,6 @@ class SingleNodeLauncher(Launcher):
         """
         Args:
         - command (string): The command string to be launched
-        - task_block (string) : bash evaluated string.
         - fail_on_any: If True, return a nonzero exit code if any worker failed, otherwise zero;
                        if False, return a nonzero exit code if all workers failed, otherwise zero.
 
@@ -131,7 +130,6 @@ class GnuParallelLauncher(Launcher):
         """
         Args:
         - command (string): The command string to be launched
-        - task_block (string) : bash evaluated string.
 
         """
         task_blocks = tasks_per_node * nodes_per_block
@@ -208,7 +206,6 @@ class MpiExecLauncher(Launcher):
         """
         Args:
         - command (string): The command string to be launched
-        - task_block (string) : bash evaluated string.
 
         """
         task_blocks = tasks_per_node * nodes_per_block
@@ -263,7 +260,6 @@ class MpiRunLauncher(Launcher):
         """
         Args:
         - command (string): The command string to be launched
-        - task_block (string) : bash evaluated string.
 
         """
         task_blocks = tasks_per_node * nodes_per_block
@@ -311,7 +307,6 @@ class SrunLauncher(Launcher):
         """
         Args:
         - command (string): The command string to be launched
-        - task_block (string) : bash evaluated string.
 
         """
         task_blocks = tasks_per_node * nodes_per_block
@@ -363,7 +358,6 @@ class SrunMPILauncher(Launcher):
         """
         Args:
         - command (string): The command string to be launched
-        - task_block (string) : bash evaluated string.
 
         """
         task_blocks = tasks_per_node * nodes_per_block


### PR DESCRIPTION
# Description

In current version, Some of the launchers have parameter called 'task_block' mentioned in the docstring of the `__call__` method but it is redundant and have no reflection on the code. This fix removes the mentioned parameter from the docstrings.

# Changed Behaviour

This doesnt change any behaviour and everything is expected to behave the same

# Fixes

Fixes #3612 

## Type of change

- Code maintenance/cleanup
