### PR TITLE
Remove Status Badge from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 Parsl - Parallel Scripting Library
 ==================================
-|licence| |build-status| |docs| |NSF-1550588| |NSF-1550476| |NSF-1550562| |NSF-1550528| |CZI-EOSS|
+|licence| |docs| |NSF-1550588| |NSF-1550476| |NSF-1550562| |NSF-1550528| |CZI-EOSS|
 
 Parsl extends parallelism in Python beyond a single computer.
 
@@ -43,9 +43,6 @@ then explore the `parallel computing patterns <https://parsl.readthedocs.io/en/s
 .. |licence| image:: https://img.shields.io/badge/License-Apache%202.0-blue.svg
    :target: https://github.com/Parsl/parsl/blob/master/LICENSE
    :alt: Apache Licence V2.0
-.. |build-status| image:: https://github.com/Parsl/parsl/actions/workflows/ci.yaml/badge.svg
-   :target: https://github.com/Parsl/parsl/actions/workflows/ci.yaml
-   :alt: Build status
 .. |docs| image:: https://readthedocs.org/projects/parsl/badge/?version=stable
    :target: http://parsl.readthedocs.io/en/stable/?badge=stable
    :alt: Documentation Status


### PR DESCRIPTION
# Description

Currently Parsl has a status badge showing the status of the recent workflow runs. As Parsl has a strict PR check run before merging, if an arbritrary PR fails , the badge ends up with Parsl "failing" which is not true. As of now, there are no events that can target the status of PRs raised against master branch. This PR removes the status badge from the `README.rst`.

# Changed Behaviour

This change doesnt reflect on the functional behaviour of parsl and all programs are expected to work the same.

# Fixes

Fixes #3610 

## Type of change

- Bug fix

