### PR TITLE
Raising UnsupportedFeatureError instead of InvalidResourceSpecification on passing resource_specification to HTEX

### DIFF
--- a/parsl/executors/errors.py
+++ b/parsl/executors/errors.py
@@ -28,17 +28,18 @@ class BadStateException(ExecutorError):
 class UnsupportedFeatureError(ExecutorError):
     """Error raised when attemping to use unsupported feature in an Executor"""
 
-    def __init__(self, feature, current_executor, target_executor):
+    def __init__(self, feature, current_executor, suggestion):
         self.feature = feature
         self.current_executor = current_executor
-        self.target_executor = target_executor
+        self.suggestion = suggestion
 
     def __str__(self):
-        if self.target_executor:
+        if self.suggestion:
             return "The {} feature is unsupported in {}. \
-                    Please checkout {} for this feature".format(self.feature,
-                                                                self.current_executor,
-                                                                self.target_executor)
+                    Suggestion: \
+                    {}".format(self.feature,
+                               self.current_executor,
+                               self.target_executor)
         else:
             return "The {} feature is unsupported in {}.".format(self.feature,
                                                                  self.current_executor)

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -16,15 +16,12 @@ from parsl import curvezmq
 from parsl.addresses import get_all_addresses
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.data_provider.staging import Staging
-from parsl.executors.errors import BadMessage, ScalingFailed
+from parsl.executors.errors import BadMessage, ScalingFailed, UnsupportedFeatureError
 from parsl.executors.high_throughput import zmq_pipes
 from parsl.executors.high_throughput.errors import CommandClientTimeoutError
 from parsl.executors.high_throughput.manager_selector import (
     ManagerSelector,
     RandomManagerSelector,
-)
-from parsl.executors.high_throughput.mpi_prefix_composer import (
-    InvalidResourceSpecification,
 )
 from parsl.executors.status_handling import BlockProviderExecutor
 from parsl.jobs.states import TERMINAL_STATES, JobState, JobStatus
@@ -341,14 +338,13 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
 
     def validate_resource_spec(self, resource_specification: dict):
         """HTEX does not support *any* resource_specification options and
-        will raise InvalidResourceSpecification is any are passed to it"""
+        will raise UnsupportedFeatureError if any are passed to it"""
         if resource_specification:
-            raise InvalidResourceSpecification(
-                set(resource_specification.keys()),
-                ("HTEX does not support the supplied resource_specifications."
-                 "For MPI applications consider using the MPIExecutor. "
-                 "For specifications for core count/memory/walltime, consider using WorkQueueExecutor. ")
-            )
+            raise UnsupportedFeatureError(
+                "resource specification",
+                "HTEX",
+                "For MPI applications consider using the MPIExecutor. "
+                "For specifications for core count/memory/walltime, consider using WorkQueueExecutor.")
         return
 
     def initialize_scaling(self):

--- a/parsl/tests/test_error_handling/test_resource_spec.py
+++ b/parsl/tests/test_error_handling/test_resource_spec.py
@@ -3,9 +3,7 @@ from parsl.app.app import python_app
 from parsl.executors import WorkQueueExecutor
 from parsl.executors.errors import ExecutorError, UnsupportedFeatureError
 from parsl.executors.high_throughput.executor import HighThroughputExecutor
-from parsl.executors.high_throughput.mpi_prefix_composer import (
-    InvalidResourceSpecification,
-)
+from parsl.executors.threads import ThreadPoolExecutor
 
 
 @python_app
@@ -26,9 +24,8 @@ def test_resource(n=2):
     fut = double(n, parsl_resource_specification=spec)
     try:
         fut.result()
-    except InvalidResourceSpecification:
-        assert isinstance(executor, HighThroughputExecutor)
     except UnsupportedFeatureError:
+        assert isinstance(executor, HighThroughputExecutor) or isinstance(executor, ThreadPoolExecutor)
         assert not isinstance(executor, WorkQueueExecutor)
     except Exception as e:
         assert isinstance(e, ExecutorError)
@@ -39,9 +36,8 @@ def test_resource(n=2):
     fut = double(n, parsl_resource_specification=spec)
     try:
         fut.result()
-    except InvalidResourceSpecification:
-        assert isinstance(executor, HighThroughputExecutor)
     except UnsupportedFeatureError:
+        assert isinstance(executor, HighThroughputExecutor) or isinstance(executor, ThreadPoolExecutor)
         assert not isinstance(executor, WorkQueueExecutor)
     except Exception as e:
         assert isinstance(e, ExecutorError)

--- a/parsl/tests/test_htex/test_resource_spec_validation.py
+++ b/parsl/tests/test_htex/test_resource_spec_validation.py
@@ -4,9 +4,7 @@ from unittest import mock
 import pytest
 
 from parsl.executors import HighThroughputExecutor
-from parsl.executors.high_throughput.mpi_prefix_composer import (
-    InvalidResourceSpecification,
-)
+from parsl.executors.errors import UnsupportedFeatureError
 
 
 def double(x):
@@ -36,5 +34,5 @@ def test_resource_spec_validation():
 def test_resource_spec_validation_bad_keys():
     htex = HighThroughputExecutor()
 
-    with pytest.raises(InvalidResourceSpecification):
+    with pytest.raises(UnsupportedFeatureError):
         htex.validate_resource_spec({"num_nodes": 2})

--- a/parsl/tests/test_mpi_apps/test_resource_spec.py
+++ b/parsl/tests/test_mpi_apps/test_resource_spec.py
@@ -10,6 +10,7 @@ from unittest import mock
 import pytest
 
 from parsl.app.app import python_app
+from parsl.executors.errors import UnsupportedFeatureError
 from parsl.executors.high_throughput.executor import HighThroughputExecutor
 from parsl.executors.high_throughput.mpi_executor import MPIExecutor
 from parsl.executors.high_throughput.mpi_prefix_composer import (
@@ -137,5 +138,5 @@ def test_mpi_resource_spec_passed_to_htex(resource_spec: dict):
     htex = HighThroughputExecutor()
     htex.outgoing_q = mock.Mock(spec=queue.Queue)
 
-    with pytest.raises(InvalidResourceSpecification):
+    with pytest.raises(UnsupportedFeatureError):
         htex.validate_resource_spec(resource_spec)


### PR DESCRIPTION
# Description

Currently in Parsl, HTEX doesnt support resource_specification and upon passing , it will raise InvalidResourceSpecification from mpi_prefix_compose. Similar behaviour can be seen in ThreadPoolExecutor but instead of raising InvalidResourceSpecification , it raises UnsupportedFeatureError from `parsl.executors.error`.  So, Ideally HTEX should do the same,

# Changed Behaviour

From this PR, HTEX will raise the same when resource_specification is passed to it. Moreover UnsupportedFeatureError is changed slightly to support suggestions for the users when for the feature.

# Fixes

Fixes #3589

## Type of change

- Code maintenance/cleanup
