### PR TITLE
Remove (possibly) unused ipyparallel dependency

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 flake8==6.1.0
-ipyparallel
 pandas
 paramiko
 pytest>=7.4.0,<8


### PR DESCRIPTION
# Description

Possibly parsl does not need to install ipyparallel as a test dependency any more. This PR is to test that possibility across our test suite.

This is in context of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1082524 which reports ipyparallel packaging issues in the Debian packaging of Parsl.

# Changed Behaviour

if you were expecting ipyparallel to be installed for your application, you'll have to be more explicit about that.

# Fixes

possibly https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1082524 

## Type of change

- Code maintenance/cleanup
