### PR TITLE
Usage tracking project name

### DIFF
--- a/parsl/config.py
+++ b/parsl/config.py
@@ -83,6 +83,9 @@ class Config(RepresentationMixin, UsageInformation):
         Setting this field to 0 will disable usage tracking. Default (this field is not set): usage tracking is not enabled.
         Parsl only collects minimal, non personally-identifiable,
         information used for reporting to our funding agencies.
+    project_name: str, optional
+        Option to deanonymize usage tracking data.
+        If set, this value will be used as the project name in the usage tracking data and placed on the leaderboard.
     initialize_logging : bool, optional
         Make DFK optionally not initialize any logging. Log messages
         will still be passed into the python logging system under the
@@ -118,6 +121,7 @@ class Config(RepresentationMixin, UsageInformation):
                  max_idletime: float = 120.0,
                  monitoring: Optional[MonitoringHub] = None,
                  usage_tracking: int = 0,
+                 project_name: Optional[str] = None,
                  initialize_logging: bool = True) -> None:
 
         executors = tuple(executors or [])
@@ -154,6 +158,7 @@ class Config(RepresentationMixin, UsageInformation):
         self.max_idletime = max_idletime
         self.validate_usage_tracking(usage_tracking)
         self.usage_tracking = usage_tracking
+        self.project_name = project_name
         self.initialize_logging = initialize_logging
         self.monitoring = monitoring
         self.std_autopath: Optional[Callable] = std_autopath

--- a/parsl/tests/unit/test_usage_tracking.py
+++ b/parsl/tests/unit/test_usage_tracking.py
@@ -43,3 +43,24 @@ def test_invalid_types(level):
     # we can't instantiate TypeCheckError if we're in typeguard 2.x environment
     # because it does not exist... so check name using strings.
     assert ex.type.__name__ in ["TypeCheckError", "TypeError"]
+
+
+@pytest.mark.local
+def test_valid_project_name():
+    """Test valid project_name."""
+    assert (
+        Config(
+            usage_tracking=3,
+            project_name="unit-test",
+        ).project_name == "unit-test"
+    )
+
+
+@pytest.mark.local
+@pytest.mark.parametrize("name", (1, 1.0, True, object()))
+def test_invalid_project_name(name):
+    """Test invalid project_name."""
+    with pytest.raises(Exception) as ex:
+        Config(usage_tracking=3, project_name=name)
+
+    assert ex.type.__name__ in ["TypeCheckError", "TypeError"]

--- a/parsl/usage_tracking/usage.py
+++ b/parsl/usage_tracking/usage.py
@@ -166,7 +166,6 @@ class UsageTracker:
 
         logger.debug(f"Usage tracking start message: {message}")
 
-        print(f"Usage tracking end message (unencoded): {message}")
         return self.encode_message(message)
 
     def construct_end_message(self) -> bytes:
@@ -199,7 +198,6 @@ class UsageTracker:
 
         logger.debug(f"Usage tracking end message (unencoded): {message}")
 
-        print(f"Usage tracking end message (unencoded): {message}")
         return self.encode_message(message)
 
     def encode_message(self, obj):

--- a/parsl/usage_tracking/usage.py
+++ b/parsl/usage_tracking/usage.py
@@ -114,6 +114,7 @@ class UsageTracker:
                                                 sys.version_info.minor,
                                                 sys.version_info.micro)
         self.tracking_level = self.check_tracking_level()
+        self.project_name = self.config.project_name
         self.start_time = None
         logger.debug("Tracking level: {}".format(self.tracking_level))
 
@@ -153,6 +154,9 @@ class UsageTracker:
                    'platform.system': platform.system(),
                    'tracking_level': int(self.tracking_level)}
 
+        if self.project_name:
+            message['project_name'] = self.project_name
+
         if self.tracking_level >= 2:
             message['components'] = get_parsl_usage(self.dfk._config)
 
@@ -162,6 +166,7 @@ class UsageTracker:
 
         logger.debug(f"Usage tracking start message: {message}")
 
+        print(f"Usage tracking end message (unencoded): {message}")
         return self.encode_message(message)
 
     def construct_end_message(self) -> bytes:
@@ -188,8 +193,13 @@ class UsageTracker:
                    'end': end_time,
                    'execution_time': end_time - self.start_time,
                    'components': [dfk_component] + get_parsl_usage(self.dfk._config)}
+
+        if self.project_name:
+            message['project_name'] = self.project_name
+
         logger.debug(f"Usage tracking end message (unencoded): {message}")
 
+        print(f"Usage tracking end message (unencoded): {message}")
         return self.encode_message(message)
 
     def encode_message(self, obj):


### PR DESCRIPTION
# Description
Add option to deanonymize usage tracking data by tagging it with a name using `parsl.Config.project_name`.

# Changed Behaviour

Usage Tracking messages will include `project_name` if set. 

Ex: 
```json
{
   "correlator":"e578ad3e-dddb-465e-93df-2db42a097883",
   "end":1727729064,
   "execution_time":3,
   "components":[
      {
         "c":"parsl.dataflow.dflow.DataFlowKernel",
         "app_count":3,
         "app_fails":0
      },
      {
         "c":"parsl.config.Config",
         "executors_len":1,
         "dependency_resolver":false
      },
      "parsl.executors.threads.ThreadPoolExecutor"
   ],
   "project_name":"my-test-project"
}
```


## Type of change

- New feature
