### PR TITLE
Add more usage tracking to htex_local_alternate test

### DIFF
--- a/parsl/tests/configs/htex_local_alternate.py
+++ b/parsl/tests/configs/htex_local_alternate.py
@@ -66,7 +66,8 @@ def fresh_config():
                         monitoring_debug=False,
                         resource_monitoring_interval=1,
         ),
-        usage_tracking=True
+        usage_tracking=3,
+        project_name="parsl htex_local_alternate test configuration"
     )
 
 


### PR DESCRIPTION
This uses the project name feature introduced in PR #3624 in one of the standard Parsl tests that already had usage turned on.

# Changed Behaviour

More usage tracking on `pytest parsl/tests/ --config parsl/tests/configs/htex_local_alternate.py` which runs in CI and often on my laptop.

## Type of change

- New feature
