### PR TITLE
Use a single exception class for all resource specification errors

### DIFF
--- a/parsl/executors/errors.py
+++ b/parsl/executors/errors.py
@@ -1,4 +1,6 @@
 """Exceptions raise by Executors."""
+from typing import Set
+
 from parsl.errors import ParslError
 from parsl.executors.base import ParslExecutor
 
@@ -42,6 +44,17 @@ class UnsupportedFeatureError(ExecutorError):
         else:
             return "The {} feature is unsupported in {}.".format(self.feature,
                                                                  self.current_executor)
+
+
+class InvalidResourceSpecificationError(ExecutorError):
+    """Error raised when Invalid input is supplied via resource Specification"""
+
+    def __init__(self, invalid_keys: Set[str], message: str = ''):
+        self.invalid_keys = invalid_keys
+        self.message = message
+
+    def __str__(self):
+        return f"Invalid Resource Specification Supplied: {self.invalid_keys}. {self.message}"
 
 
 class ScalingFailed(ExecutorError):

--- a/parsl/executors/errors.py
+++ b/parsl/executors/errors.py
@@ -46,7 +46,7 @@ class UnsupportedFeatureError(ExecutorError):
                                                                  self.current_executor)
 
 
-class InvalidResourceSpecificationError(ExecutorError):
+class InvalidResourceSpecification(ExecutorError):
     """Error raised when Invalid input is supplied via resource Specification"""
 
     def __init__(self, invalid_keys: Set[str], message: str = ''):

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -16,15 +16,16 @@ from parsl import curvezmq
 from parsl.addresses import get_all_addresses
 from parsl.app.errors import RemoteExceptionWrapper
 from parsl.data_provider.staging import Staging
-from parsl.executors.errors import BadMessage, ScalingFailed
+from parsl.executors.errors import (
+    BadMessage,
+    InvalidResourceSpecificationError,
+    ScalingFailed,
+)
 from parsl.executors.high_throughput import zmq_pipes
 from parsl.executors.high_throughput.errors import CommandClientTimeoutError
 from parsl.executors.high_throughput.manager_selector import (
     ManagerSelector,
     RandomManagerSelector,
-)
-from parsl.executors.high_throughput.mpi_prefix_composer import (
-    InvalidResourceSpecification,
 )
 from parsl.executors.status_handling import BlockProviderExecutor
 from parsl.jobs.states import TERMINAL_STATES, JobState, JobStatus
@@ -341,9 +342,9 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
 
     def validate_resource_spec(self, resource_specification: dict):
         """HTEX does not support *any* resource_specification options and
-        will raise InvalidResourceSpecification is any are passed to it"""
+        will raise InvalidResourceSpecificationError is any are passed to it"""
         if resource_specification:
-            raise InvalidResourceSpecification(
+            raise InvalidResourceSpecificationError(
                 set(resource_specification.keys()),
                 ("HTEX does not support the supplied resource_specifications."
                  "For MPI applications consider using the MPIExecutor. "

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -18,7 +18,7 @@ from parsl.app.errors import RemoteExceptionWrapper
 from parsl.data_provider.staging import Staging
 from parsl.executors.errors import (
     BadMessage,
-    InvalidResourceSpecificationError,
+    InvalidResourceSpecification,
     ScalingFailed,
 )
 from parsl.executors.high_throughput import zmq_pipes
@@ -342,9 +342,9 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
 
     def validate_resource_spec(self, resource_specification: dict):
         """HTEX does not support *any* resource_specification options and
-        will raise InvalidResourceSpecificationError is any are passed to it"""
+        will raise InvalidResourceSpecification is any are passed to it"""
         if resource_specification:
-            raise InvalidResourceSpecificationError(
+            raise InvalidResourceSpecification(
                 set(resource_specification.keys()),
                 ("HTEX does not support the supplied resource_specifications."
                  "For MPI applications consider using the MPIExecutor. "

--- a/parsl/executors/high_throughput/mpi_prefix_composer.py
+++ b/parsl/executors/high_throughput/mpi_prefix_composer.py
@@ -1,5 +1,7 @@
 import logging
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Tuple
+
+from parsl.executors.errors import InvalidResourceSpecificationError
 
 logger = logging.getLogger(__name__)
 
@@ -8,31 +10,10 @@ VALID_LAUNCHERS = ('srun',
                    'mpiexec')
 
 
-class MissingResourceSpecification(Exception):
-    """Exception raised when input is  not supplied a resource specification"""
-
-    def __init__(self, reason: str):
-        self.reason = reason
-
-    def __str__(self):
-        return f"Missing resource specification: {self.reason}"
-
-
-class InvalidResourceSpecification(Exception):
-    """Exception raised when Invalid input is supplied via resource specification"""
-
-    def __init__(self, invalid_keys: Set[str], message: str = ''):
-        self.invalid_keys = invalid_keys
-        self.message = message
-
-    def __str__(self):
-        return f"Invalid resource specification options supplied: {self.invalid_keys} {self.message}"
-
-
 def validate_resource_spec(resource_spec: Dict[str, str]):
     """Basic validation of keys in the resource_spec
 
-    Raises: InvalidResourceSpecification if the resource_spec
+    Raises: InvalidResourceSpecificationError if the resource_spec
         is invalid (e.g, contains invalid keys)
     """
     user_keys = set(resource_spec.keys())
@@ -40,7 +21,8 @@ def validate_resource_spec(resource_spec: Dict[str, str]):
     # empty resource_spec when mpi_mode is set causes parsl to hang
     # ref issue #3427
     if len(user_keys) == 0:
-        raise MissingResourceSpecification('MPI mode requires optional parsl_resource_specification keyword argument to be configured')
+        raise InvalidResourceSpecificationError(user_keys,
+                                                'MPI mode requires optional parsl_resource_specification keyword argument to be configured')
 
     legal_keys = set(("ranks_per_node",
                       "num_nodes",
@@ -49,7 +31,7 @@ def validate_resource_spec(resource_spec: Dict[str, str]):
                       ))
     invalid_keys = user_keys - legal_keys
     if invalid_keys:
-        raise InvalidResourceSpecification(invalid_keys)
+        raise InvalidResourceSpecificationError(invalid_keys=invalid_keys)
     if "num_nodes" in resource_spec:
         if not resource_spec.get("num_ranks") and resource_spec.get("ranks_per_node"):
             resource_spec["num_ranks"] = str(int(resource_spec["num_nodes"]) * int(resource_spec["ranks_per_node"]))

--- a/parsl/executors/high_throughput/mpi_prefix_composer.py
+++ b/parsl/executors/high_throughput/mpi_prefix_composer.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Dict, List, Tuple
 
-from parsl.executors.errors import InvalidResourceSpecificationError
+from parsl.executors.errors import InvalidResourceSpecification
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +13,7 @@ VALID_LAUNCHERS = ('srun',
 def validate_resource_spec(resource_spec: Dict[str, str]):
     """Basic validation of keys in the resource_spec
 
-    Raises: InvalidResourceSpecificationError if the resource_spec
+    Raises: InvalidResourceSpecification if the resource_spec
         is invalid (e.g, contains invalid keys)
     """
     user_keys = set(resource_spec.keys())
@@ -21,8 +21,8 @@ def validate_resource_spec(resource_spec: Dict[str, str]):
     # empty resource_spec when mpi_mode is set causes parsl to hang
     # ref issue #3427
     if len(user_keys) == 0:
-        raise InvalidResourceSpecificationError(user_keys,
-                                                'MPI mode requires optional parsl_resource_specification keyword argument to be configured')
+        raise InvalidResourceSpecification(user_keys,
+                                           'MPI mode requires optional parsl_resource_specification keyword argument to be configured')
 
     legal_keys = set(("ranks_per_node",
                       "num_nodes",
@@ -31,7 +31,7 @@ def validate_resource_spec(resource_spec: Dict[str, str]):
                       ))
     invalid_keys = user_keys - legal_keys
     if invalid_keys:
-        raise InvalidResourceSpecificationError(invalid_keys=invalid_keys)
+        raise InvalidResourceSpecification(invalid_keys)
     if "num_nodes" in resource_spec:
         if not resource_spec.get("num_ranks") and resource_spec.get("ranks_per_node"):
             resource_spec["num_ranks"] = str(int(resource_spec["num_nodes"]) * int(resource_spec["ranks_per_node"]))

--- a/parsl/executors/threads.py
+++ b/parsl/executors/threads.py
@@ -6,7 +6,7 @@ import typeguard
 
 from parsl.data_provider.staging import Staging
 from parsl.executors.base import ParslExecutor
-from parsl.executors.errors import UnsupportedFeatureError
+from parsl.executors.errors import InvalidResourceSpecificationError
 from parsl.utils import RepresentationMixin
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,8 @@ class ThreadPoolExecutor(ParslExecutor, RepresentationMixin):
         if resource_specification:
             logger.error("Ignoring the resource specification. "
                          "Parsl resource specification is not supported in ThreadPool Executor.")
-            raise UnsupportedFeatureError('resource specification', 'ThreadPool Executor', None)
+            raise InvalidResourceSpecificationError(set(resource_specification.keys()),
+                                                    "Parsl resource specification is not supported in ThreadPool Executor.")
 
         return self.executor.submit(func, *args, **kwargs)
 

--- a/parsl/executors/threads.py
+++ b/parsl/executors/threads.py
@@ -6,7 +6,7 @@ import typeguard
 
 from parsl.data_provider.staging import Staging
 from parsl.executors.base import ParslExecutor
-from parsl.executors.errors import InvalidResourceSpecificationError
+from parsl.executors.errors import InvalidResourceSpecification
 from parsl.utils import RepresentationMixin
 
 logger = logging.getLogger(__name__)
@@ -54,8 +54,8 @@ class ThreadPoolExecutor(ParslExecutor, RepresentationMixin):
         if resource_specification:
             logger.error("Ignoring the resource specification. "
                          "Parsl resource specification is not supported in ThreadPool Executor.")
-            raise InvalidResourceSpecificationError(set(resource_specification.keys()),
-                                                    "Parsl resource specification is not supported in ThreadPool Executor.")
+            raise InvalidResourceSpecification(set(resource_specification.keys()),
+                                               "Parsl resource specification is not supported in ThreadPool Executor.")
 
         return self.executor.submit(func, *args, **kwargs)
 

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -28,7 +28,7 @@ import parsl.utils as putils
 from parsl.data_provider.files import File
 from parsl.data_provider.staging import Staging
 from parsl.errors import OptionalModuleMissing
-from parsl.executors.errors import ExecutorError
+from parsl.executors.errors import ExecutorError, InvalidResourceSpecificationError
 from parsl.executors.status_handling import BlockProviderExecutor
 from parsl.executors.workqueue import exec_parsl_function
 from parsl.process_loggers import wrap_with_logs
@@ -419,7 +419,7 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
                 message = "Task resource specification only accepts these types of resources: {}".format(
                         ', '.join(acceptable_fields))
                 logger.error(message)
-                raise ExecutorError(self, message)
+                raise InvalidResourceSpecificationError(keys, message)
 
             # this checks that either all of the required resource types are specified, or
             # that none of them are: the `required_resource_types` are not actually required,
@@ -430,9 +430,10 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
                 logger.error("Running with `autolabel=False`. In this mode, "
                              "task resource specification requires "
                              "three resources to be specified simultaneously: cores, memory, and disk")
-                raise ExecutorError(self, "Task resource specification requires "
-                                          "three resources to be specified simultaneously: cores, memory, and disk. "
-                                          "Try setting autolabel=True if you are unsure of the resource usage")
+                raise InvalidResourceSpecificationError(keys,
+                                                        "Task resource specification requires "
+                                                        "three resources to be specified simultaneously: cores, memory, and disk. "
+                                                        "Try setting autolabel=True if you are unsure of the resource usage")
 
             for k in keys:
                 if k == 'cores':

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -28,7 +28,7 @@ import parsl.utils as putils
 from parsl.data_provider.files import File
 from parsl.data_provider.staging import Staging
 from parsl.errors import OptionalModuleMissing
-from parsl.executors.errors import ExecutorError, InvalidResourceSpecificationError
+from parsl.executors.errors import ExecutorError, InvalidResourceSpecification
 from parsl.executors.status_handling import BlockProviderExecutor
 from parsl.executors.workqueue import exec_parsl_function
 from parsl.process_loggers import wrap_with_logs
@@ -419,7 +419,7 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
                 message = "Task resource specification only accepts these types of resources: {}".format(
                         ', '.join(acceptable_fields))
                 logger.error(message)
-                raise InvalidResourceSpecificationError(keys, message)
+                raise InvalidResourceSpecification(keys, message)
 
             # this checks that either all of the required resource types are specified, or
             # that none of them are: the `required_resource_types` are not actually required,
@@ -430,10 +430,10 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
                 logger.error("Running with `autolabel=False`. In this mode, "
                              "task resource specification requires "
                              "three resources to be specified simultaneously: cores, memory, and disk")
-                raise InvalidResourceSpecificationError(keys,
-                                                        "Task resource specification requires "
-                                                        "three resources to be specified simultaneously: cores, memory, and disk. "
-                                                        "Try setting autolabel=True if you are unsure of the resource usage")
+                raise InvalidResourceSpecification(keys,
+                                                   "Task resource specification requires "
+                                                   "three resources to be specified simultaneously: cores, memory, and disk. "
+                                                   "Try setting autolabel=True if you are unsure of the resource usage")
 
             for k in keys:
                 if k == 'cores':

--- a/parsl/tests/test_error_handling/test_resource_spec.py
+++ b/parsl/tests/test_error_handling/test_resource_spec.py
@@ -1,10 +1,7 @@
 import parsl
 from parsl.app.app import python_app
 from parsl.executors import WorkQueueExecutor
-from parsl.executors.errors import (
-    InvalidResourceSpecificationError,
-    UnsupportedFeatureError,
-)
+from parsl.executors.errors import InvalidResourceSpecification
 from parsl.executors.high_throughput.executor import HighThroughputExecutor
 from parsl.executors.threads import ThreadPoolExecutor
 
@@ -27,13 +24,11 @@ def test_resource(n=2):
     fut = double(n, parsl_resource_specification=spec)
     try:
         fut.result()
-    except InvalidResourceSpecificationError:
+    except InvalidResourceSpecification:
         assert (
             isinstance(executor, HighThroughputExecutor) or
             isinstance(executor, WorkQueueExecutor) or
             isinstance(executor, ThreadPoolExecutor))
-    except UnsupportedFeatureError:
-        assert not isinstance(executor, WorkQueueExecutor)
 
     # Specify resources with wrong types
     # 'cpus' is incorrect, should be 'cores'
@@ -41,10 +36,8 @@ def test_resource(n=2):
     fut = double(n, parsl_resource_specification=spec)
     try:
         fut.result()
-    except InvalidResourceSpecificationError:
+    except InvalidResourceSpecification:
         assert (
             isinstance(executor, HighThroughputExecutor) or
             isinstance(executor, WorkQueueExecutor) or
             isinstance(executor, ThreadPoolExecutor))
-    except UnsupportedFeatureError:
-        assert not isinstance(executor, WorkQueueExecutor)

--- a/parsl/tests/test_error_handling/test_resource_spec.py
+++ b/parsl/tests/test_error_handling/test_resource_spec.py
@@ -2,11 +2,11 @@ import parsl
 from parsl.app.app import python_app
 from parsl.executors import WorkQueueExecutor
 from parsl.executors.errors import (
-    ExecutorError,
     InvalidResourceSpecificationError,
     UnsupportedFeatureError,
 )
 from parsl.executors.high_throughput.executor import HighThroughputExecutor
+from parsl.executors.threads import ThreadPoolExecutor
 
 
 @python_app
@@ -28,11 +28,12 @@ def test_resource(n=2):
     try:
         fut.result()
     except InvalidResourceSpecificationError:
-        assert isinstance(executor, HighThroughputExecutor)
+        assert (
+            isinstance(executor, HighThroughputExecutor) or
+            isinstance(executor, WorkQueueExecutor) or
+            isinstance(executor, ThreadPoolExecutor))
     except UnsupportedFeatureError:
         assert not isinstance(executor, WorkQueueExecutor)
-    except Exception as e:
-        assert isinstance(e, ExecutorError)
 
     # Specify resources with wrong types
     # 'cpus' is incorrect, should be 'cores'
@@ -41,8 +42,9 @@ def test_resource(n=2):
     try:
         fut.result()
     except InvalidResourceSpecificationError:
-        assert isinstance(executor, HighThroughputExecutor)
+        assert (
+            isinstance(executor, HighThroughputExecutor) or
+            isinstance(executor, WorkQueueExecutor) or
+            isinstance(executor, ThreadPoolExecutor))
     except UnsupportedFeatureError:
         assert not isinstance(executor, WorkQueueExecutor)
-    except Exception as e:
-        assert isinstance(e, ExecutorError)

--- a/parsl/tests/test_error_handling/test_resource_spec.py
+++ b/parsl/tests/test_error_handling/test_resource_spec.py
@@ -1,11 +1,12 @@
 import parsl
 from parsl.app.app import python_app
 from parsl.executors import WorkQueueExecutor
-from parsl.executors.errors import ExecutorError, UnsupportedFeatureError
-from parsl.executors.high_throughput.executor import HighThroughputExecutor
-from parsl.executors.high_throughput.mpi_prefix_composer import (
-    InvalidResourceSpecification,
+from parsl.executors.errors import (
+    ExecutorError,
+    InvalidResourceSpecificationError,
+    UnsupportedFeatureError,
 )
+from parsl.executors.high_throughput.executor import HighThroughputExecutor
 
 
 @python_app
@@ -26,7 +27,7 @@ def test_resource(n=2):
     fut = double(n, parsl_resource_specification=spec)
     try:
         fut.result()
-    except InvalidResourceSpecification:
+    except InvalidResourceSpecificationError:
         assert isinstance(executor, HighThroughputExecutor)
     except UnsupportedFeatureError:
         assert not isinstance(executor, WorkQueueExecutor)
@@ -39,7 +40,7 @@ def test_resource(n=2):
     fut = double(n, parsl_resource_specification=spec)
     try:
         fut.result()
-    except InvalidResourceSpecification:
+    except InvalidResourceSpecificationError:
         assert isinstance(executor, HighThroughputExecutor)
     except UnsupportedFeatureError:
         assert not isinstance(executor, WorkQueueExecutor)

--- a/parsl/tests/test_htex/test_resource_spec_validation.py
+++ b/parsl/tests/test_htex/test_resource_spec_validation.py
@@ -4,9 +4,7 @@ from unittest import mock
 import pytest
 
 from parsl.executors import HighThroughputExecutor
-from parsl.executors.high_throughput.mpi_prefix_composer import (
-    InvalidResourceSpecification,
-)
+from parsl.executors.errors import InvalidResourceSpecificationError
 
 
 def double(x):
@@ -36,5 +34,5 @@ def test_resource_spec_validation():
 def test_resource_spec_validation_bad_keys():
     htex = HighThroughputExecutor()
 
-    with pytest.raises(InvalidResourceSpecification):
+    with pytest.raises(InvalidResourceSpecificationError):
         htex.validate_resource_spec({"num_nodes": 2})

--- a/parsl/tests/test_htex/test_resource_spec_validation.py
+++ b/parsl/tests/test_htex/test_resource_spec_validation.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 from parsl.executors import HighThroughputExecutor
-from parsl.executors.errors import InvalidResourceSpecificationError
+from parsl.executors.errors import InvalidResourceSpecification
 
 
 def double(x):
@@ -34,5 +34,5 @@ def test_resource_spec_validation():
 def test_resource_spec_validation_bad_keys():
     htex = HighThroughputExecutor()
 
-    with pytest.raises(InvalidResourceSpecificationError):
+    with pytest.raises(InvalidResourceSpecification):
         htex.validate_resource_spec({"num_nodes": 2})

--- a/parsl/tests/test_mpi_apps/test_mpi_mode_enabled.py
+++ b/parsl/tests/test_mpi_apps/test_mpi_mode_enabled.py
@@ -8,9 +8,7 @@ import pytest
 import parsl
 from parsl import Config, bash_app, python_app
 from parsl.executors import MPIExecutor
-from parsl.executors.high_throughput.mpi_prefix_composer import (
-    MissingResourceSpecification,
-)
+from parsl.executors.errors import InvalidResourceSpecificationError
 from parsl.launchers import SimpleLauncher
 from parsl.providers import LocalProvider
 
@@ -185,6 +183,6 @@ def test_simulated_load(rounds: int = 100):
 @pytest.mark.local
 def test_missing_resource_spec():
 
-    with pytest.raises(MissingResourceSpecification):
+    with pytest.raises(InvalidResourceSpecificationError):
         future = mock_app(sleep_dur=0.4)
         future.result(timeout=10)

--- a/parsl/tests/test_mpi_apps/test_mpi_mode_enabled.py
+++ b/parsl/tests/test_mpi_apps/test_mpi_mode_enabled.py
@@ -8,7 +8,7 @@ import pytest
 import parsl
 from parsl import Config, bash_app, python_app
 from parsl.executors import MPIExecutor
-from parsl.executors.errors import InvalidResourceSpecificationError
+from parsl.executors.errors import InvalidResourceSpecification
 from parsl.launchers import SimpleLauncher
 from parsl.providers import LocalProvider
 
@@ -183,6 +183,6 @@ def test_simulated_load(rounds: int = 100):
 @pytest.mark.local
 def test_missing_resource_spec():
 
-    with pytest.raises(InvalidResourceSpecificationError):
+    with pytest.raises(InvalidResourceSpecification):
         future = mock_app(sleep_dur=0.4)
         future.result(timeout=10)

--- a/parsl/tests/test_mpi_apps/test_resource_spec.py
+++ b/parsl/tests/test_mpi_apps/test_resource_spec.py
@@ -10,12 +10,9 @@ from unittest import mock
 import pytest
 
 from parsl.app.app import python_app
+from parsl.executors.errors import InvalidResourceSpecificationError
 from parsl.executors.high_throughput.executor import HighThroughputExecutor
 from parsl.executors.high_throughput.mpi_executor import MPIExecutor
-from parsl.executors.high_throughput.mpi_prefix_composer import (
-    InvalidResourceSpecification,
-    MissingResourceSpecification,
-)
 from parsl.executors.high_throughput.mpi_resource_management import (
     get_nodes_in_batchjob,
     get_pbs_hosts_list,
@@ -104,8 +101,8 @@ def test_top_level():
 
         ({"num_nodes": 2, "ranks_per_node": 1}, None),
         ({"launcher_options": "--debug_foo"}, None),
-        ({"num_nodes": 2, "BAD_OPT": 1}, InvalidResourceSpecification),
-        ({}, MissingResourceSpecification),
+        ({"num_nodes": 2, "BAD_OPT": 1}, InvalidResourceSpecificationError),
+        ({}, InvalidResourceSpecificationError),
     )
 )
 def test_mpi_resource_spec(resource_spec: Dict, exception):
@@ -137,5 +134,5 @@ def test_mpi_resource_spec_passed_to_htex(resource_spec: dict):
     htex = HighThroughputExecutor()
     htex.outgoing_q = mock.Mock(spec=queue.Queue)
 
-    with pytest.raises(InvalidResourceSpecification):
+    with pytest.raises(InvalidResourceSpecificationError):
         htex.validate_resource_spec(resource_spec)

--- a/parsl/tests/test_mpi_apps/test_resource_spec.py
+++ b/parsl/tests/test_mpi_apps/test_resource_spec.py
@@ -10,7 +10,7 @@ from unittest import mock
 import pytest
 
 from parsl.app.app import python_app
-from parsl.executors.errors import InvalidResourceSpecificationError
+from parsl.executors.errors import InvalidResourceSpecification
 from parsl.executors.high_throughput.executor import HighThroughputExecutor
 from parsl.executors.high_throughput.mpi_executor import MPIExecutor
 from parsl.executors.high_throughput.mpi_resource_management import (
@@ -101,8 +101,8 @@ def test_top_level():
 
         ({"num_nodes": 2, "ranks_per_node": 1}, None),
         ({"launcher_options": "--debug_foo"}, None),
-        ({"num_nodes": 2, "BAD_OPT": 1}, InvalidResourceSpecificationError),
-        ({}, InvalidResourceSpecificationError),
+        ({"num_nodes": 2, "BAD_OPT": 1}, InvalidResourceSpecification),
+        ({}, InvalidResourceSpecification),
     )
 )
 def test_mpi_resource_spec(resource_spec: Dict, exception):
@@ -134,5 +134,5 @@ def test_mpi_resource_spec_passed_to_htex(resource_spec: dict):
     htex = HighThroughputExecutor()
     htex.outgoing_q = mock.Mock(spec=queue.Queue)
 
-    with pytest.raises(InvalidResourceSpecificationError):
+    with pytest.raises(InvalidResourceSpecification):
         htex.validate_resource_spec(resource_spec)


### PR DESCRIPTION
# Description

There are three places where the executors raise the errors regarding resource specification.

 1.  when passing the resource_specification parameter to the htex, it raises the mpi_prefix_composer InvalidResourceSpecification from validate_resource_spec method. https://github.com/Parsl/parsl/blob/master/parsl/executors/high_throughput/executor.py#L342

  2.  ThreadPoolExecutor also raises the UnsupportedFeatureError when passing resource specification to it, https://github.com/Parsl/parsl/blob/master/parsl/executors/threads.py#L54

  3.  WorkQueueExecutor raises two errors similar to this but as a Base ExecutorError, one when there is invalid resource_specification ; https://github.com/Parsl/parsl/blob/master/parsl/executors/workqueue/executor.py#L418 and another one when the autolabel is false and resource_specification is not right, https://github.com/Parsl/parsl/blob/master/parsl/executors/workqueue/executor.py#L429

This PR rationalize these errors by creating a  `InvalidResourceSpecificationError`  in executors.error and using it across the executors. Moreover `InvalidResourceSpecification` and `MissingResourceSpecification` is removed from mpi_prefix_composer and places where the above two used were replaced with `InvalidResourceSpecificationError`.

# Changed Behaviour

From this PR, All executors will raise `InvalidResourceSpecificationError` for errors regarding resource_spec.

# Fixes

Fixes #3589 

## Type of change

- Bug fix
- Code maintenance/cleanup
