### PR TITLE
Drop support for end-of-life Python 3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
   main-test-suite:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on: ubuntu-20.04
     timeout-minutes: 60
 

--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,7 @@ For Developers
 Requirements
 ============
 
-Parsl is supported in Python 3.8+. Requirements can be found `here <requirements.txt>`_. Requirements for running tests can be found `here <test-requirements.txt>`_.
+Parsl is supported in Python 3.9+. Requirements can be found `here <requirements.txt>`_. Requirements for running tests can be found `here <test-requirements.txt>`_.
 
 Code of Conduct
 ===============

--- a/codemeta.json
+++ b/codemeta.json
@@ -191,8 +191,8 @@
         "name": "The Python Package Index",
         "url": "https://pypi.org"
     },
-    "runtimePlatform": "Python 3.8",
+    "runtimePlatform": "Python 3.9",
     "url": "https://github.com/Parsl/parsl",
     "developmentStatus": "active",
-    "programmingLanguage": "Python :: 3.8"
+    "programmingLanguage": "Python :: 3.9"
 }

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -10,7 +10,7 @@ Installation
 
 Parsl is available on `PyPI <https://pypi.org/project/parsl/>`_ and `conda-forge <https://anaconda.org/conda-forge/parsl>`_. 
 
-Parsl requires Python3.8+ and has been tested on Linux and macOS.
+Parsl requires Python3.9+ and has been tested on Linux and macOS.
 
 
 Installation using Pip
@@ -31,7 +31,7 @@ Installation using Conda
 
 1. Create and activate a new conda environment::
 
-     $ conda create --name parsl_py38 python=3.8
+     $ conda create --name parsl_py38 python=3.9
      $ source activate parsl_py38
 
 2. Install Parsl::

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     package_data={'parsl': ['py.typed']},
     packages=find_packages(),
-    python_requires=">=3.8.0",
+    python_requires=">=3.9.0",
     install_requires=install_requires,
     scripts = ['parsl/executors/high_throughput/process_worker_pool.py',
                'parsl/executors/high_throughput/interchange.py',
@@ -71,7 +71,6 @@ setup(
         # Licence, must match with licence above
         'License :: OSI Approved :: Apache Software License',
         # Python versions supported
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
Python 3.8 entered the end-of-life phase on 2024-10-07. See https://peps.python.org/pep-0569/

This PR removes CI testing for Python 3.8 and relabels several occurences of 3.8 to 3.9 in the documentation.

# Changed Behaviour

Although this PR will not directly break users using Python 3.8, the removal of testing and the requirement that things work in Python 3.8 means things will likely break soon.

## Type of change

- Code maintenance/cleanup
