### PR TITLE
Unhide pytest output by removing dotfile directory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
         export PARSL_TEST_PRESERVE_NUM_RUNS=7
 
         make test
-        ln -s .pytest/parsltest-current test_runinfo
+        ln -s pytest-parsl/parsltest-current test_runinfo
 
     - name: Documentation checks
       run: |
@@ -80,11 +80,11 @@ jobs:
         # database manager log file or monitoring router log file. It would be better if
         # the tests themselves failed immediately when there was a monitoring error, but
         # in the absence of that, this is a dirty way to check.
-        bash -c '! grep ERROR .pytest/parsltest-current/runinfo*/*/database_manager.log'
-        bash -c '! grep ERROR .pytest/parsltest-current/runinfo*/*/monitoring_router.log'
+        bash -c '! grep ERROR pytest-parsl/parsltest-current/runinfo*/*/database_manager.log'
+        bash -c '! grep ERROR pytest-parsl/parsltest-current/runinfo*/*/monitoring_router.log'
 
         # temporary; until test-matrixification
-        rm -f .pytest/parsltest-current test_runinfo
+        rm -f pytest-parsl/parsltest-current test_runinfo
 
     - name: Checking parsl-visualize
       run: |
@@ -105,6 +105,6 @@ jobs:
         name: runinfo-${{ matrix.python-version }}-${{ steps.job-info.outputs.as-ascii }}-${{ github.sha }}
         path: |
           runinfo/
-          .pytest/
+          pytest-parsl/
           ci_job_info.txt
         compression-level: 9

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ coverage.xml
 *.cover
 .hypothesis/
 /.pytest/
+/pytest-parsl/
 
 # Translations
 *.mo

--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -58,7 +58,7 @@ def tmpd_cwd_session(pytestconfig):
 
     config = re.sub(r"[^A-z0-9_-]+", "_", pytestconfig.getoption('config')[0])
     cwd = pathlib.Path(os.getcwd())
-    pytest_dir = cwd / ".pytest"
+    pytest_dir = cwd / "pytest-parsl"
     pytest_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
 
     test_dir_prefix = "parsltest-"


### PR DESCRIPTION
Prior to this PR, output from pytest was generally hidden by placing it in the .pytest directory.

After this PR, that .pytest directory is now pytest-parsl.

Most immediately, a breaking change in the GitHub actions artifact upload has started respecting that dotfile hiddenness, and so with that version of the artifact uploader, test runs prior to this PR are missing a bunch of output. https://github.com/actions/upload-artifact/issues/602

The uploader now has an option to enable hidden files...

but ...

.. before this most immediate motivation, I've run into a couple of developer experience cases that look like:

  Q: I cannot find the output of pytest
  A: We have deliberately made it hard for you to find

which is enough to make me rename the directory rather than turn on the artifact uploader hidden files option.

## Type of change

- Bug fix
