### PR TITLE
Don't forward worker heartbeats to the submit side

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -460,9 +460,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
                     except pickle.UnpicklingError:
                         raise BadMessage("Message received could not be unpickled")
 
-                    if msg['type'] == 'heartbeat':
-                        continue
-                    elif msg['type'] == 'result':
+                    if msg['type'] == 'result':
                         try:
                             tid = msg['task_id']
                         except Exception:

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -549,7 +549,6 @@ class Interchange:
                         monitoring_radio.send(r['payload'])
                     elif r['type'] == 'heartbeat':
                         logger.debug("Manager %r sent heartbeat via results connection", manager_id)
-                        b_messages.append((p_message, r))
                     else:
                         logger.error("Interchange discarding result_queue message of unknown type: %s", r["type"])
 


### PR DESCRIPTION
Prior to this PR, heartbeats sent from worker pools to the interchange on the results channel would be forwarded on to the submit side along the interchange to submit side results channel.

These heartbeat messages would then be discarded on the submit side.

I think these forwarded messages don't do anything, so this PR removes the forwarding.

The network path between interchange and submit side is on localhost and unlikely to need any TCP level keepalives. There is no handling for missing heartbeats, and indeed no expectation of heartbeats arriving: an interchange might exist for many hours with no connected workers, and so no forwarded heartbeats.

This PR should reduce message load on the submit side results channel by one message per work pool per heartbeat period.

See issue #3464 for further context.

# Changed Behaviour

This should be removing spurious messages, which shouldn't affect workflow functionality except for maybe a slight performance improvement.

## Type of change

- Code maintenance/cleanup
