### PR TITLE
Remove unneeded interchange SIGTERM handler

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -6,7 +6,6 @@ import os
 import pickle
 import platform
 import queue
-import signal
 import sys
 import threading
 import time
@@ -318,16 +317,6 @@ class Interchange:
     def start(self) -> None:
         """ Start the interchange
         """
-
-        # If a user workflow has set its own signal handler for sigterm, that
-        # handler will be inherited by the interchange process because it is
-        # launched as a multiprocessing fork process.
-        # That can interfere with the interchange shutdown mechanism, which is
-        # to receive a SIGTERM and exit immediately.
-        # See Parsl issue #2343 (Threads and multiprocessing cannot be
-        # intermingled without deadlocks) which talks about other fork-related
-        # parent-process-inheritance problems.
-        signal.signal(signal.SIGTERM, signal.SIG_DFL)
 
         logger.info("Starting main interchange method")
 


### PR DESCRIPTION
This was introduced in PR #2629 to guard against the submit process installing a SIGTERM handler and then that handler being unexpectedly inherited by the interchange via multiprocesssing fork

PR #3463 changed the interchange to run as a fresh Python process, which will not inherit SIGTERM handlers, so since then this line has been vestigial.

Fixes issue #3588

# Changed Behaviour

none - the interchange should already be starting with the default signal handler for SIGTERM

## Type of change

- Code maintenance/cleanup
