### PR TITLE
Add resource specification fields to HTEX

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -351,7 +351,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         as long as it is consistent across the workload
         priority: lower value is higher priority"""
         if resource_specification:
-            acceptable_fields = set(['running_time_min', 'priority'])
+            acceptable_fields = set(['priority'])
             keys = set(resource_specification.keys())
             if not keys.issubset(acceptable_fields):
                 message = "Task resource specification only accepts these types of resources: {}".format(

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -357,7 +357,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
                 message = "Task resource specification only accepts these types of resources: {}".format(
                     ', '.join(acceptable_fields))
                 logger.error(message)
-                raise InvalidResourceSpecification(self, message)
+                raise InvalidResourceSpecification(set(resource_specification.keys()), message)
         return
 
     def initialize_scaling(self):

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -347,8 +347,6 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
 
     def validate_resource_spec(self, resource_specification: dict):
         """HTEX supports the following *Optional* resource specifications:
-        running_time_min: estimate of task runtime, any unit of time is acceptable
-        as long as it is consistent across the workload
         priority: lower value is higher priority"""
         if resource_specification:
             acceptable_fields = set(['priority'])

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -346,8 +346,10 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         return self.logdir
 
     def validate_resource_spec(self, resource_specification: dict):
-        """HTEX does not support *any* resource_specification options and
-        will raise InvalidResourceSpecification is any are passed to it"""
+        """HTEX supports the following *Optional* resource specifications:
+        running_time_min: estimate of task runtime, any unit of time is acceptable
+        as long as it is consistent across the workload
+        priority: lower value is higher priority"""
         if resource_specification:
             acceptable_fields = set(['running_time_min', 'priority'])
             keys = set(resource_specification.keys())

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -349,13 +349,14 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         """HTEX supports the following *Optional* resource specifications:
         priority: lower value is higher priority"""
         if resource_specification:
-            acceptable_fields = set(['priority'])
+            acceptable_fields = {'priority'}
             keys = set(resource_specification.keys())
-            if not keys.issubset(acceptable_fields):
+            invalid_keys = keys - acceptable_fields
+            if invalid_keys:
                 message = "Task resource specification only accepts these types of resources: {}".format(
                     ', '.join(acceptable_fields))
                 logger.error(message)
-                raise InvalidResourceSpecification(set(resource_specification.keys()), message)
+                raise InvalidResourceSpecification(set(invalid_keys), message)
         return
 
     def initialize_scaling(self):

--- a/parsl/tests/test_htex/test_resource_spec_validation.py
+++ b/parsl/tests/test_htex/test_resource_spec_validation.py
@@ -38,13 +38,6 @@ def test_resource_spec_validation_one_key():
 
 
 @pytest.mark.local
-def test_resource_spec_validation_two_key():
-    htex = HighThroughputExecutor()
-    ret_val = htex.validate_resource_spec({"priority": 2, "running_time_min": 4})
-    assert ret_val is None
-
-
-@pytest.mark.local
 def test_resource_spec_validation_bad_keys():
     htex = HighThroughputExecutor()
 

--- a/parsl/tests/test_htex/test_resource_spec_validation.py
+++ b/parsl/tests/test_htex/test_resource_spec_validation.py
@@ -29,17 +29,20 @@ def test_resource_spec_validation():
     ret_val = htex.validate_resource_spec({})
     assert ret_val is None
 
+
 @pytest.mark.local
 def test_resource_spec_validation_one_key():
     htex = HighThroughputExecutor()
     ret_val = htex.validate_resource_spec({"priority": 2})
     assert ret_val is None
 
+
 @pytest.mark.local
 def test_resource_spec_validation_two_key():
     htex = HighThroughputExecutor()
     ret_val = htex.validate_resource_spec({"priority": 2, "running_time_min": 4})
     assert ret_val is None
+
 
 @pytest.mark.local
 def test_resource_spec_validation_bad_keys():

--- a/parsl/tests/test_htex/test_resource_spec_validation.py
+++ b/parsl/tests/test_htex/test_resource_spec_validation.py
@@ -29,6 +29,17 @@ def test_resource_spec_validation():
     ret_val = htex.validate_resource_spec({})
     assert ret_val is None
 
+@pytest.mark.local
+def test_resource_spec_validation_one_key():
+    htex = HighThroughputExecutor()
+    ret_val = htex.validate_resource_spec({"priority": 2})
+    assert ret_val is None
+
+@pytest.mark.local
+def test_resource_spec_validation_two_key():
+    htex = HighThroughputExecutor()
+    ret_val = htex.validate_resource_spec({"priority": 2, "running_time_min": 4})
+    assert ret_val is None
 
 @pytest.mark.local
 def test_resource_spec_validation_bad_keys():


### PR DESCRIPTION
# Description

Adds the parameter  'priority' as a valid entry in the resource spec dict. Necessary for changing the pending_task_queue to a different structure than queue.Queue. Also passes resource spec to the interchange.

# Changed Behaviour

Users can now specify values for 'priority' within the resource spec of parsl apps. Currently doesn't do anything with that information. 

# Fixes

N/a

## Type of change

- New feature
