### PR TITLE
Fix too-low heartbeat threshold in test

### DIFF
--- a/parsl/tests/test_serialization/test_3495_deserialize_managerlost.py
+++ b/parsl/tests/test_serialization/test_3495_deserialize_managerlost.py
@@ -32,7 +32,7 @@ def test_manager_lost_system_failure(tmpd_cwd):
         cores_per_worker=1,
         worker_logdir_root=str(tmpd_cwd),
         heartbeat_period=1,
-        heartbeat_threshold=1,
+        heartbeat_threshold=3,
     )
     c = Config(executors=[hte], strategy='simple', strategy_period=0.1)
 


### PR DESCRIPTION
The threshold was the same as the heartbeat period, leading to races in CI where the manager would be expired before the heartbeat was received.

## Type of change

- Bug fix
