### PR TITLE
Remove FileExists channel exception that is unused

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -174,7 +174,6 @@ Exceptions
     parsl.channels.errors.BadHostKeyException
     parsl.channels.errors.BadScriptPath
     parsl.channels.errors.BadPermsScriptPath
-    parsl.channels.errors.FileExists
     parsl.channels.errors.AuthException
     parsl.channels.errors.SSHException
     parsl.channels.errors.FileCopyException

--- a/parsl/channels/errors.py
+++ b/parsl/channels/errors.py
@@ -1,7 +1,5 @@
 ''' Exceptions raise by Apps.
 '''
-from typing import Optional
-
 from parsl.errors import ParslError
 
 
@@ -58,21 +56,6 @@ class BadPermsScriptPath(ChannelError):
 
     def __init__(self, e: Exception, hostname: str) -> None:
         super().__init__("User does not have permissions to access the script_dir", e, hostname)
-
-
-class FileExists(ChannelError):
-    ''' Push or pull of file over channel fails since a file of the name already
-    exists on the destination.
-
-    Contains:
-    reason(string)
-    e (paramiko exception object)
-    hostname (string)
-    '''
-
-    def __init__(self, e: Exception, hostname: str, filename: Optional[str] = None) -> None:
-        super().__init__("File name collision in channel transport phase: {}".format(filename),
-                         e, hostname)
 
 
 class AuthException(ChannelError):

--- a/parsl/channels/ssh/ssh.py
+++ b/parsl/channels/ssh/ssh.py
@@ -214,7 +214,6 @@ class DeprecatedSSHChannel(Channel, RepresentationMixin):
             - str: Local path to file
 
         Raises:
-            - FileExists : Name collision at local directory.
             - FileCopyException : FileCopy failed.
         '''
 


### PR DESCRIPTION
This is part of staged removal of channels - see issue #3515 and PR #3650.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
