### PR TITLE
Remove docstring saying used "walltime" parameter is unused

### DIFF
--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -37,7 +37,7 @@ class LocalChannel(Channel, RepresentationMixin):
 
         Args:
             - cmd (string) : Commandline string to execute
-            - walltime (int) : walltime in seconds, this is not really used now.
+            - walltime (int) : walltime in seconds
 
         Kwargs:
             - envs (dict) : Dictionary of env variables. This will be used


### PR DESCRIPTION
walltime is used in LocalProvider

This is part of tidyups during implemention of #3515

## Type of change

- Update to human readable text: Documentation/error messages/comments
