### PR TITLE
Enable main Github Actions test for merge queues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - synchronize
+  merge_group:
 
 jobs:
   main-test-suite:


### PR DESCRIPTION
This won't directly make anything run more often, but is needed for experimenting with GitHub merge queues, where a new type of commit is automatically made that also needs to pass testing.

See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

# Changed Behaviour

enables CI testing of merge queue candidate commits if Github merge queues are turned on (which they are not as of this PR)

## Type of change

- New feature
