### PR TITLE
Remove unused source address on some monitoring messages

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -556,7 +556,7 @@ class DatabaseManager:
             logger.debug("Checking STOP conditions: kill event: %s, queue has entries: %s",
                          kill_event.is_set(), logs_queue.qsize() != 0)
             try:
-                x, addr = logs_queue.get(timeout=0.1)
+                x = logs_queue.get(timeout=0.1)
             except queue.Empty:
                 continue
             else:

--- a/parsl/monitoring/radios.py
+++ b/parsl/monitoring/radios.py
@@ -58,7 +58,7 @@ class FilesystemRadioSender(MonitoringRadioSender):
 
         tmp_filename = f"{self.tmp_path}/{unique_id}"
         new_filename = f"{self.new_path}/{unique_id}"
-        buffer = (message, "NA")
+        buffer = message
 
         # this will write the message out then atomically
         # move it into new/, so that a partially written
@@ -187,7 +187,7 @@ class MultiprocessingQueueRadioSender(MonitoringRadioSender):
         self.queue = queue
 
     def send(self, message: object) -> None:
-        self.queue.put((message, 0))
+        self.queue.put(message)
 
 
 class ZMQRadioSender(MonitoringRadioSender):

--- a/parsl/monitoring/router.py
+++ b/parsl/monitoring/router.py
@@ -14,7 +14,7 @@ import typeguard
 import zmq
 
 from parsl.log_utils import set_file_logger
-from parsl.monitoring.types import AddressedMonitoringMessage, TaggedMonitoringMessage
+from parsl.monitoring.types import TaggedMonitoringMessage
 from parsl.process_loggers import wrap_with_logs
 from parsl.utils import setproctitle
 
@@ -125,7 +125,7 @@ class MonitoringRouter:
                     data, addr = self.udp_sock.recvfrom(2048)
                     resource_msg = pickle.loads(data)
                     self.logger.debug("Got UDP Message from {}: {}".format(addr, resource_msg))
-                    self.resource_msgs.put((resource_msg, addr))
+                    self.resource_msgs.put(resource_msg)
                 except socket.timeout:
                     pass
 
@@ -136,7 +136,7 @@ class MonitoringRouter:
                     data, addr = self.udp_sock.recvfrom(2048)
                     msg = pickle.loads(data)
                     self.logger.debug("Got UDP Message from {}: {}".format(addr, msg))
-                    self.resource_msgs.put((msg, addr))
+                    self.resource_msgs.put(msg)
                     last_msg_received_time = time.time()
                 except socket.timeout:
                     pass
@@ -160,10 +160,7 @@ class MonitoringRouter:
                         assert len(msg) >= 1, "ZMQ Receiver expects tuples of length at least 1, got {}".format(msg)
                         assert len(msg) == 2, "ZMQ Receiver expects message tuples of exactly length 2, got {}".format(msg)
 
-                        msg_0: AddressedMonitoringMessage
-                        msg_0 = (msg, 0)
-
-                        self.resource_msgs.put(msg_0)
+                        self.resource_msgs.put(msg)
                 except zmq.Again:
                     pass
                 except Exception:

--- a/parsl/monitoring/types.py
+++ b/parsl/monitoring/types.py
@@ -1,14 +1,11 @@
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Tuple
 
 from typing_extensions import TypeAlias
 
 from parsl.monitoring.message_type import MessageType
 
-# A basic parsl monitoring message is wrapped by up to two wrappers:
-# The basic monitoring message dictionary can first be tagged, giving
-# a TaggedMonitoringMessage, and then that can be further tagged with
-# an often unused sender address, giving an AddressedMonitoringMessage.
+# A MonitoringMessage dictionary can be tagged, giving a
+# TaggedMonitoringMessage.
 
 MonitoringMessage: TypeAlias = Dict[str, Any]
 TaggedMonitoringMessage: TypeAlias = Tuple[MessageType, MonitoringMessage]
-AddressedMonitoringMessage: TypeAlias = Tuple[TaggedMonitoringMessage, Union[str, int]]


### PR DESCRIPTION
This was an extra protocol complication, the source address was never used beyond immediate logging, and the source address sometimes didn't exist with a few different filler values used instead.

## Type of change

- Code maintenance/cleanup
