### PR TITLE
Remove bad cut/paste from PR #2439

### DIFF
--- a/parsl/monitoring/radios.py
+++ b/parsl/monitoring/radios.py
@@ -5,14 +5,10 @@ import socket
 import uuid
 from abc import ABCMeta, abstractmethod
 from multiprocessing.queues import Queue
-from typing import Optional
 
 import zmq
 
 from parsl.serialize import serialize
-
-_db_manager_excepts: Optional[Exception]
-
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
PR #2439 split out radios from monitoring.py, but miscopied these lines from there. They also exist in real form in monitoring.py

## Type of change

- Code maintenance/cleanup
