### PR TITLE
Make FilesystemRadio serialize monitoring messages the same as UDP and HTEX radios

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import multiprocessing.synchronize as ms
 import os
+import pickle
 import queue
 import time
 from multiprocessing import Event, Process
@@ -18,7 +19,6 @@ from parsl.monitoring.router import router_starter
 from parsl.monitoring.types import TaggedMonitoringMessage
 from parsl.multiprocessing import ForkProcess, SizedQueue
 from parsl.process_loggers import wrap_with_logs
-from parsl.serialize import deserialize
 from parsl.utils import RepresentationMixin, setproctitle
 
 _db_manager_excepts: Optional[Exception]
@@ -282,7 +282,7 @@ def filesystem_receiver(logdir: str, q: "queue.Queue[TaggedMonitoringMessage]", 
                 logger.info("Processing filesystem radio file %s", filename)
                 full_path_filename = f"{new_dir}/{filename}"
                 with open(full_path_filename, "rb") as f:
-                    message = deserialize(f.read())
+                    message = pickle.load(f)
                 logger.debug("Message received is: %s", message)
                 assert isinstance(message, tuple)
                 q.put(cast(TaggedMonitoringMessage, message))

--- a/parsl/monitoring/radios.py
+++ b/parsl/monitoring/radios.py
@@ -8,8 +8,6 @@ from multiprocessing.queues import Queue
 
 import zmq
 
-from parsl.serialize import serialize
-
 logger = logging.getLogger(__name__)
 
 
@@ -59,7 +57,7 @@ class FilesystemRadioSender(MonitoringRadioSender):
         # move it into new/, so that a partially written
         # file will never be observed in new/
         with open(tmp_filename, "wb") as f:
-            f.write(serialize(buffer))
+            pickle.dump(buffer, f)
         os.rename(tmp_filename, new_filename)
 
 


### PR DESCRIPTION
UDP and HTEX radios both use pickle, not parsl.serialize, and there is no reason for this inconsistency.

## Type of change

- Code maintenance/cleanup
