### PR TITLE
Remove the opportunity to configure script_dir for LocalChannel

### DIFF
--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -15,14 +15,14 @@ class LocalChannel(Channel, RepresentationMixin):
     and done so infrequently that they do not need a persistent channel
     '''
 
-    def __init__(self, script_dir=None):
+    def __init__(self):
         ''' Initialize the local channel. script_dir is required by set to a default.
 
         KwArgs:
             - script_dir (string): Directory to place scripts
         '''
         self.hostname = "localhost"
-        self.script_dir = script_dir
+        self.script_dir = None
 
     def execute_wait(self, cmd, walltime=None):
         ''' Synchronously execute a commandline string on the shell.

--- a/parsl/tests/test_providers/test_pbspro_template.py
+++ b/parsl/tests/test_providers/test_pbspro_template.py
@@ -12,9 +12,10 @@ def test_submit_script_basic(tmp_path):
     """Test slurm resources table"""
 
     provider = PBSProProvider(
-        queue="debug", channel=LocalChannel(script_dir=tmp_path)
+        queue="debug", channel=LocalChannel()
     )
     provider.script_dir = tmp_path
+    provider.channel.script_dir = tmp_path
     job_id = str(random.randint(55000, 59000))
     provider.execute_wait = mock.Mock(spec=PBSProProvider.execute_wait)
     provider.execute_wait.return_value = (0, job_id, "")

--- a/parsl/tests/test_providers/test_slurm_template.py
+++ b/parsl/tests/test_providers/test_slurm_template.py
@@ -13,9 +13,10 @@ def test_submit_script_basic(tmp_path):
     """Test slurm resources table"""
 
     provider = SlurmProvider(
-        partition="debug", channel=LocalChannel(script_dir=tmp_path)
+        partition="debug", channel=LocalChannel()
     )
     provider.script_dir = tmp_path
+    provider.channel.script_dir = tmp_path
     job_id = str(random.randint(55000, 59000))
     provider.execute_wait = mock.MagicMock(spec=SlurmProvider.execute_wait)
     provider.execute_wait.return_value = (0, f"Submitted batch job {job_id}", "")


### PR DESCRIPTION
Prior to this PR, if the argument defaulted to None, then the DFK would set a script dir based on the workflow rundir.

Post this PR, this default behaviour is the only behaviour and the user cannot specify an overriding value.

Future PRs will remove channel level script directories entirely. This is part of issues #3515 removing channels,

# Changed Behaviour

This PR removes a little-used user configuration option.

## Type of change

- Code maintenance/cleanup
