### PR TITLE
Remove unused channel directory handling code

### DIFF
--- a/parsl/channels/base.py
+++ b/parsl/channels/base.py
@@ -80,31 +80,3 @@ class Channel(metaclass=ABCMeta):
             destination_path (string)
         '''
         pass
-
-    @abstractmethod
-    def makedirs(self, path: str, mode: int = 0o511, exist_ok: bool = False) -> None:
-        """Create a directory.
-
-        If intermediate directories do not exist, they will be created.
-
-        Parameters
-        ----------
-        path : str
-            Path of directory to create.
-        mode : int
-            Permissions (posix-style) for the newly-created directory.
-        exist_ok : bool
-            If False, raise an OSError if the target directory already exists.
-        """
-        pass
-
-    @abstractmethod
-    def isdir(self, path: str) -> bool:
-        """Return true if the path refers to an existing directory.
-
-        Parameters
-        ----------
-        path : str
-            Path of directory to check.
-        """
-        pass

--- a/parsl/channels/local/local.py
+++ b/parsl/channels/local/local.py
@@ -91,34 +91,6 @@ class LocalChannel(Channel, RepresentationMixin):
     def pull_file(self, remote_source, local_dir):
         return self.push_file(remote_source, local_dir)
 
-    def isdir(self, path):
-        """Return true if the path refers to an existing directory.
-
-        Parameters
-        ----------
-        path : str
-            Path of directory to check.
-        """
-
-        return os.path.isdir(path)
-
-    def makedirs(self, path, mode=0o700, exist_ok=False):
-        """Create a directory.
-
-        If intermediate directories do not exist, they will be created.
-
-        Parameters
-        ----------
-        path : str
-            Path of directory to create.
-        mode : int
-            Permissions (posix-style) for the newly-created directory.
-        exist_ok : bool
-            If False, raise an OSError if the target directory already exists.
-        """
-
-        return os.makedirs(path, mode, exist_ok)
-
     @property
     def script_dir(self):
         return self._script_dir


### PR DESCRIPTION
This is part of implementing #3515 channel removal code. These methods became unused in PR #3688.

## Type of change

- Code maintenance/cleanup
