### PR TITLE
Fix filesystem radio type annotation: the wrong kind of Queue

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -258,7 +258,7 @@ class MonitoringHub(RepresentationMixin):
 
 
 @wrap_with_logs
-def filesystem_receiver(logdir: str, q: "queue.Queue[TaggedMonitoringMessage]", run_dir: str) -> None:
+def filesystem_receiver(logdir: str, q: Queue[TaggedMonitoringMessage], run_dir: str) -> None:
     logger = set_file_logger("{}/monitoring_filesystem_radio.log".format(logdir),
                              name="monitoring_filesystem_radio",
                              level=logging.INFO)


### PR DESCRIPTION
Prior to this PR, filesystem_receiver was annotated as taking queue.Queue. This was incorrect (but not detected or enforced by any tooling - because type annotations are not carried across the invoking Process constructor)

The receiver actually takes a multiprocessing.Queue, which is used without a namespace, like the rest of this source file.

## Type of change

- Code maintenance/cleanup
