### PR TITLE
TaskVine Executor: add vine tune to manager config

### DIFF
--- a/parsl/executors/taskvine/manager.py
+++ b/parsl/executors/taskvine/manager.py
@@ -44,10 +44,16 @@ def _set_manager_attributes(m, config):
     # Enable peer transfer feature between workers if specified
     if config.enable_peer_transfers:
         m.enable_peer_transfers()
+    else:
+        m.disable_peer_transfers()
 
     # Set catalog report to parsl if project name exists
     if m.name:
         m.set_property("framework", "parsl")
+
+    if config.tune_parameters is not None:
+        for k,v in config.tune_parameters.items():
+            m.tune(k, v)
 
 
 def _prepare_environment_serverless(manager_config, env_cache_dir, poncho_create_script):

--- a/parsl/executors/taskvine/manager.py
+++ b/parsl/executors/taskvine/manager.py
@@ -52,7 +52,7 @@ def _set_manager_attributes(m, config):
         m.set_property("framework", "parsl")
 
     if config.tune_parameters is not None:
-        for k,v in config.tune_parameters.items():
+        for k, v in config.tune_parameters.items():
             m.tune(k, v)
 
 

--- a/parsl/executors/taskvine/manager_config.py
+++ b/parsl/executors/taskvine/manager_config.py
@@ -156,6 +156,10 @@ class TaskVineManagerConfig:
         Directory to store TaskVine logging facilities.
         Default is None, in which all TaskVine logs will be contained
         in the Parsl logging directory.
+
+    tune_parameters: Optional[dict]
+        Extended vine_tune parameters, expressed in a dictionary
+        by { 'tune-parameter' : value }.
     """
 
     # Connection and communication settings
@@ -181,6 +185,7 @@ class TaskVineManagerConfig:
     autocategory: bool = True
     enable_peer_transfers: bool = True
     wait_for_workers: Optional[int] = None
+    tune_parameters: Optional[dict] = None
 
     # Logging settings
     vine_log_dir: Optional[str] = None


### PR DESCRIPTION
# Description
Make vine_tune config parameters accessible through the manager config while using the TaskVine executor

## Type of change

- New feature

