### PR TITLE
Update quickstart example config

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -180,6 +180,11 @@ An example which launches 4 workers on 1 node of the Polaris supercomputer looks
 
 .. code-block:: python
 
+    from parsl import Config
+    from parsl.executors import HighThroughputExecutor
+    from parsl.providers import PBSProProvider
+    from parsl.launchers import MpiExecLauncher
+
     config = Config(
         retries=1,  # Restart task if they fail once
         executors=[

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -176,7 +176,7 @@ This script runs on a system that must stay on-line until all of your tasks comp
 much computing power, such as the login node for a supercomputer.
 
 The :class:`~parsl.config.Config` object holds definitions of Executors and the Providers and Launchers they rely on.
-An example which launches 512 workers on 128 nodes of the Polaris supercomputer looks like
+An example which launches 4 workers on 1 node of the Polaris supercomputer looks like
 
 .. code-block:: python
 
@@ -191,13 +191,13 @@ An example which launches 512 workers on 128 nodes of the Polaris supercomputer 
                     account="example",
                     worker_init="module load conda; conda activate parsl",
                     walltime="1:00:00",
-                    queue="prod",
+                    queue="debug",
                     scheduler_options="#PBS -l filesystems=home:eagle",  # Change if data on other filesystem
                     launcher=MpiExecLauncher(
                         bind_cmd="--cpu-bind", overrides="--depth=64 --ppn 1"
                     ),  # Ensures 1 manger per node and allows it to divide work to all 64 cores
                     select_options="ngpus=4",
-                    nodes_per_block=128,
+                    nodes_per_block=1,
                     cpus_per_node=64,
                 ),
             ),

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -181,7 +181,7 @@ An example which launches 512 workers on 128 nodes of the Polaris supercomputer 
 .. code-block:: python
 
     config = Config(
-        retires=1,  # Restart task if they fail once
+        retries=1,  # Restart task if they fail once
         executors=[
             HighThroughputExecutor(
                 available_accelerators=4,  # Maps one worker per GPU


### PR DESCRIPTION
# Description

Minor modifications to the Quickstart documentation. Fixes a typo in `retries`, adds the relevant import statements to the Polaris config, and changes the config to use the debug queue rather than prod.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Update to human readable text: Documentation/error messages/comments