### PR TITLE
Make ZMQ, UDP and filesystem monitoring routers send via radios

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -270,6 +270,8 @@ def filesystem_receiver(logdir: str, q: Queue[TaggedMonitoringMessage], run_dir:
     new_dir = f"{base_path}/new/"
     logger.debug("Creating new and tmp paths under %s", base_path)
 
+    target_radio = MultiprocessingQueueRadioSender(q)
+
     os.makedirs(tmp_dir, exist_ok=True)
     os.makedirs(new_dir, exist_ok=True)
 
@@ -285,7 +287,7 @@ def filesystem_receiver(logdir: str, q: Queue[TaggedMonitoringMessage], run_dir:
                     message = pickle.load(f)
                 logger.debug("Message received is: %s", message)
                 assert isinstance(message, tuple)
-                q.put(cast(TaggedMonitoringMessage, message))
+                target_radio.send(cast(TaggedMonitoringMessage, message))
                 os.remove(full_path_filename)
             except Exception:
                 logger.exception("Exception processing %s - probably will be retried next iteration", filename)


### PR DESCRIPTION
This PR is intended to consolidate monitoring message sending in the monitoring radio code.

This is a step towards removing Python multiprocessing from the monitoring code base (see issue #2343) by making it clearer how to change to a different message send implementation (by swapping out the radio implementation and configuration)

Compare to how the interchange forwards HTEXRadio messages onwards via some other radio (which right now is always the ZMQRadioSender) -- rather than having its own ZMQ code.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
