### PR TITLE
Extract MPI code from `execute_task()`

### DIFF
--- a/parsl/executors/high_throughput/mpi_resource_management.py
+++ b/parsl/executors/high_throughput/mpi_resource_management.py
@@ -177,6 +177,7 @@ class MPITaskScheduler(TaskScheduler):
                 self._map_tasks_to_nodes[task_package["task_id"]] = allocated_nodes
                 buffer = pack_res_spec_apply_message(_f, _args, _kwargs, resource_spec)
                 task_package["buffer"] = buffer
+                task_package["resource_spec"] = resource_spec
 
         self.pending_task_q.put(task_package)
 


### PR DESCRIPTION
# Description

The `execute_task()` function is used by multiple executors, but the MPI code is specific to HTEX.

## Type of change

- Code maintenance/cleanup
