### PR TITLE
Remove monitoring UDP hub_port from example/test configs

### DIFF
--- a/docs/userguide/monitoring.rst
+++ b/docs/userguide/monitoring.rst
@@ -42,7 +42,6 @@ configuration. Here the `parsl.monitoring.MonitoringHub` is specified to use por
       ],
       monitoring=MonitoringHub(
           hub_address=address_by_hostname(),
-          hub_port=55055,
           monitoring_debug=False,
           resource_monitoring_interval=10,
       ),

--- a/parsl/configs/ASPIRE1.py
+++ b/parsl/configs/ASPIRE1.py
@@ -34,7 +34,6 @@ config = Config(
         ],
         monitoring=MonitoringHub(
             hub_address=address_by_interface('ib0'),
-            hub_port=55055,
             resource_monitoring_interval=10,
         ),
         strategy='simple',

--- a/parsl/tests/configs/htex_local_alternate.py
+++ b/parsl/tests/configs/htex_local_alternate.py
@@ -62,7 +62,6 @@ def fresh_config():
         retries=2,
         monitoring=MonitoringHub(
                         hub_address="localhost",
-                        hub_port=55055,
                         monitoring_debug=False,
                         resource_monitoring_interval=1,
         ),

--- a/parsl/tests/configs/local_threads_monitoring.py
+++ b/parsl/tests/configs/local_threads_monitoring.py
@@ -5,7 +5,6 @@ from parsl.monitoring import MonitoringHub
 config = Config(executors=[ThreadPoolExecutor(label='threads', max_threads=4)],
                 monitoring=MonitoringHub(
                     hub_address="localhost",
-                    hub_port=55055,
                     resource_monitoring_interval=3,
                 )
                 )

--- a/parsl/tests/manual_tests/test_udp_simple.py
+++ b/parsl/tests/manual_tests/test_udp_simple.py
@@ -15,7 +15,6 @@ def local_setup():
         ],
         monitoring=MonitoringHub(
             hub_address="127.0.0.1",
-            hub_port=55055,
             logging_level=logging.INFO,
             resource_monitoring_interval=10))
 

--- a/parsl/tests/test_monitoring/test_htex_init_blocks_vs_monitoring.py
+++ b/parsl/tests/test_monitoring/test_htex_init_blocks_vs_monitoring.py
@@ -37,7 +37,6 @@ def fresh_config(run_dir, strategy, db_url):
         strategy_period=0.1,
         monitoring=MonitoringHub(
                         hub_address="localhost",
-                        hub_port=55055,
                         logging_endpoint=db_url
         )
     )

--- a/parsl/tests/test_monitoring/test_stdouterr.py
+++ b/parsl/tests/test_monitoring/test_stdouterr.py
@@ -37,7 +37,6 @@ def fresh_config(run_dir):
         strategy_period=0.1,
         monitoring=MonitoringHub(
                         hub_address="localhost",
-                        hub_port=55055,
         )
     )
 


### PR DESCRIPTION
This port will be chosen dynamically, and that is fine in test situations.

This is probably also better in environments where users run multiple Parsl instances at once: they cannot all use the removed port 55055 and will interfere with each other.

Ongoing work to refactor monitoring radios will remove this hub_port parameter, making it either unnecessary (when non-UDP monitoring radios are used) or specified as part of the radio selection.

This PR removes hub_port from tests and examples as preparation for that change.

# Changed Behaviour

The monitoring UDP port will be chosen dynamically in tests and examples.

## Type of change

- Code maintenance/cleanup
