### PR TITLE
Fix race condition in rundir creation

### DIFF
--- a/parsl/dataflow/rundirs.py
+++ b/parsl/dataflow/rundirs.py
@@ -31,7 +31,11 @@ def make_rundir(path: str) -> str:
             x = sorted([int(os.path.basename(x)) for x in prev_rundirs])[-1]
             current_rundir = os.path.join(path, '{0:03}'.format(x + 1))
 
-        os.makedirs(current_rundir)
+        try:
+            os.makedirs(current_rundir)
+        except FileExistsError:
+            logger.debug("Allocated rundir {0} exists. Making rundir again.".format(current_rundir))
+            return make_rundir(path)
         logger.debug("Parsl run initializing in rundir: {0}".format(current_rundir))
         return os.path.abspath(current_rundir)
 


### PR DESCRIPTION
# Description

Addresses #3728 by attempting `make_rundir` again if it is found that the chosen run directory already exists (`FileExistsError` is thrown). 

Fixes a race condition where multiple workflows can choose the same run directory when operating out of the same `runinfo` root directory. 

# Changed Behaviour

This should keep all existing expected behavior.

# Fixes

Fixes #3728 

## Type of change

- Bug fix
