### PR TITLE
Upgrade networkx to support Numpy 2 to support Python 3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,13 @@ extras_require = {
         'sqlalchemy>=1.4,<2'
     ],
     'visualization' : [
-        'pydot',
-        'networkx>=2.5,<2.6',
+        # this pydot bound is copied from networkx's pyproject.toml,
+        # version 3.2 (aa2de1adecea09f7b86ff6093b212ca86f22b3ef),
+        # because networkx[extra] installs quite a lot of extra stuff
+        # that needs more OS dependencies in addition to pydot.
+        'pydot>=1.4.2',
+
+        'networkx>=3.2,<3.3',
         'Flask>=1.0.2',
         'flask_sqlalchemy',
         'pandas<2.2',


### PR DESCRIPTION
This is a piece of PR #3646 to support Python 3.13

networkx 3.2 is the first version to support numpy 2. Later versions do not support Python 3.9.

# Changed Behaviour

This is a package upgrade that behaves the same in my testing

## Type of change

- Code maintenance/cleanup
