### PR TITLE
Upgrade SQLAlchemy to version 2

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -78,7 +78,7 @@ class Database:
 
     def _get_mapper(self, table_obj: Table) -> Mapper:
         all_mappers: Set[Mapper] = set()
-        for mapper_registry in mapperlib._all_registries():  # type: ignore[attr-defined]
+        for mapper_registry in mapperlib._all_registries():
             all_mappers.update(mapper_registry.mappers)
         mapper_gen = (
             mapper for mapper in all_mappers

--- a/parsl/tests/configs/htex_local.py
+++ b/parsl/tests/configs/htex_local.py
@@ -9,7 +9,7 @@ def fresh_config():
         executors=[
             HighThroughputExecutor(
                 label="htex_local",
-                loopback_address="127.0.0.1",
+                loopback_address="::1",
                 worker_debug=True,
                 cores_per_worker=1,
                 encrypted=True,

--- a/parsl/tests/configs/htex_local.py
+++ b/parsl/tests/configs/htex_local.py
@@ -9,7 +9,7 @@ def fresh_config():
         executors=[
             HighThroughputExecutor(
                 label="htex_local",
-                loopback_address="::1",
+                loopback_address="127.0.0.1",
                 worker_debug=True,
                 cores_per_worker=1,
                 encrypted=True,

--- a/parsl/tests/test_monitoring/test_app_names.py
+++ b/parsl/tests/test_monitoring/test_app_names.py
@@ -67,7 +67,7 @@ def test_app_name(get_app, expected_name, expected_result, tmpd_cwd):
     with engine.begin() as connection:
 
         def count_rows(table: str):
-            result = connection.execute(f"SELECT COUNT(*) FROM {table}")
+            result = connection.execute(sqlalchemy.text(f"SELECT COUNT(*) FROM {table}"))
             (c, ) = result.first()
             return c
 
@@ -81,6 +81,6 @@ def test_app_name(get_app, expected_name, expected_result, tmpd_cwd):
         assert count_rows("try") == 1
 
         # ... and has the expected name.
-        result = connection.execute("SELECT task_func_name FROM task")
+        result = connection.execute(sqlalchemy.text("SELECT task_func_name FROM task"))
         (c, ) = result.first()
         assert c == expected_name

--- a/parsl/tests/test_monitoring/test_stdouterr.py
+++ b/parsl/tests/test_monitoring/test_stdouterr.py
@@ -106,7 +106,7 @@ def test_stdstream_to_monitoring(stdx, expected_stdx, stream, tmpd_cwd, caplog):
     with engine.begin() as connection:
 
         def count_rows(table: str):
-            result = connection.execute(f"SELECT COUNT(*) FROM {table}")
+            result = connection.execute(sqlalchemy.text(f"SELECT COUNT(*) FROM {table}"))
             (c, ) = result.first()
             return c
 
@@ -120,7 +120,7 @@ def test_stdstream_to_monitoring(stdx, expected_stdx, stream, tmpd_cwd, caplog):
         assert count_rows("try") == 1
 
         # ... and has the expected name.
-        result = connection.execute(f"SELECT task_{stream} FROM task")
+        result = connection.execute(sqlalchemy.text(f"SELECT task_{stream} FROM task"))
         (c, ) = result.first()
 
         if isinstance(expected_stdx, str):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,9 @@ with open('requirements.txt') as f:
 
 extras_require = {
     'monitoring' : [
-        'sqlalchemy>=1.4,<2'
+        # sqlalchemy does not use semantic versioning.
+        # see https://github.com/sqlalchemy/sqlalchemy/discussions/11391#discussioncomment-9472033
+        'sqlalchemy>=2,<2.1'
     ],
     'visualization' : [
         # this pydot bound is copied from networkx's pyproject.toml,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,8 +14,7 @@ mpi4py
 # sqlalchemy is needed for typechecking, so it's here
 # as well as at runtime for optional monitoring execution
 # (where it's specified in setup.py)
-sqlalchemy>=1.4,<2
-sqlalchemy2-stubs
+sqlalchemy>=2,<2.1
 
 Sphinx==4.5.0
 twine


### PR DESCRIPTION
This is part of supporting Python 3.13 (PR #3646), as a prereq to upgrading pandas.

# Changed Behaviour

Development environments (which have the requirements in `test-requirements.txt` installed) will break and need `pip uninstall sqlalchemy2-stubs` - sqlalchemy packaging does not express a negative/removal requirement against that transitional package.

non-parsl user code which happens to use the parsl-installed sqlalchemy might break - for example, see API changes in the test suite in this PR

## Type of change

- Code maintenance/cleanup
