### PR TITLE
Upgrade pandas to >=2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,11 @@ extras_require = {
         'networkx>=3.2,<3.3',
         'Flask>=1.0.2',
         'flask_sqlalchemy',
-        'pandas<2.2',
+
+        # pandas uses "loose semantic versioning"
+        # https://pandas.pydata.org/docs/development/policies.html#version-policy
+        'pandas<3,>=2.2',
+
         'plotly',
         'python-daemon'
     ],


### PR DESCRIPTION
# Description
 This is part of supporting Python 3.13 (PR #3646). The previous pandas constraints cannot install on Python 3.13.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
