### PR TITLE
Remove a deliberately non-deterministic test

### DIFF
--- a/parsl/tests/test_python_apps/test_fail.py
+++ b/parsl/tests/test_python_apps/test_fail.py
@@ -41,28 +41,3 @@ def test_fail_sequence(fail_probs):
 
     with pytest.raises(DependencyError):
         t_final.result()
-
-
-def test_deps(width=3):
-    """Random failures in branches of Map -> Map -> reduce"""
-    # App1   App2  ... AppN
-    futs = [random_fail(fail_prob=0.4) for _ in range(width)]
-
-    # App1   App2  ... AppN
-    # |       |        |
-    # V       V        V
-    # App1   App2  ... AppN
-
-    futs = [random_fail(fail_prob=0.8, inputs=[f]) for f in futs]
-
-    # App1   App2  ... AppN
-    #   |       |        |
-    #   V       V        V
-    # App1   App2  ... AppN
-    #    \      |       /
-    #     \     |      /
-    # App_Final
-    try:
-        random_fail(fail_prob=0, inputs=futs).result()
-    except DependencyError:
-        pass


### PR DESCRIPTION
This test would pass if execution either succeeded or failed with a `DependencyError`. It did not assert any relationship between those two possibilities and whether earlier tasks actually succeeded or failed.

`test_fail_sequence` in the same file tests more strongly whether a failure is correctly propagated.

## Type of change

- Code maintenance/cleanup
