### PR TITLE
Change some exceptions to put human readable text in __str__ not __repr__

### DIFF
--- a/parsl/app/errors.py
+++ b/parsl/app/errors.py
@@ -70,8 +70,8 @@ class MissingOutputs(ParslError):
         self.reason = reason
         self.outputs = outputs
 
-    def __repr__(self) -> str:
-        return "Missing Outputs: {0}, Reason:{1}".format(self.outputs, self.reason)
+    def __str__(self) -> str:
+        return "Missing Outputs: {0}, Reason: {1}".format(self.outputs, self.reason)
 
 
 class BadStdStreamFile(ParslError):
@@ -85,11 +85,8 @@ class BadStdStreamFile(ParslError):
         super().__init__(reason)
         self._reason = reason
 
-    def __repr__(self) -> str:
-        return "Bad Stream File: {}".format(self._reason)
-
     def __str__(self) -> str:
-        return self.__repr__()
+        return "Bad Stream File: {}".format(self._reason)
 
 
 class RemoteExceptionWrapper:

--- a/parsl/dataflow/errors.py
+++ b/parsl/dataflow/errors.py
@@ -25,11 +25,8 @@ class BadCheckpoint(DataFlowException):
     def __init__(self, reason: str) -> None:
         self.reason = reason
 
-    def __repr__(self) -> str:
-        return self.reason
-
     def __str__(self) -> str:
-        return self.__repr__()
+        return self.reason
 
 
 class DependencyError(DataFlowException):

--- a/parsl/executors/high_throughput/errors.py
+++ b/parsl/executors/high_throughput/errors.py
@@ -38,11 +38,8 @@ class WorkerLost(Exception):
         self.worker_id = worker_id
         self.hostname = hostname
 
-    def __repr__(self):
-        return "Task failure due to loss of worker {} on host {}".format(self.worker_id, self.hostname)
-
     def __str__(self):
-        return self.__repr__()
+        return "Task failure due to loss of worker {} on host {}".format(self.worker_id, self.hostname)
 
 
 class CommandClientTimeoutError(Exception):


### PR DESCRIPTION
# Description

See #2025 for more context.

# Changed Behaviour

Rendering of exceptions made with `__repr__` will change to a more machine readable format. Generally Python itself reports exceptions using `__str__`, but DFK task failure history (which goes into the monitoring database) is rendered with `__repr__`. This is probably better behaviour for that history field, which is quasi-machine-readable.

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
