### PR TITLE
Remove empty default values for inputs/outputs arguments

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -45,7 +45,7 @@ How can I make an App dependent on multiple inputs?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can pass any number of futures in to a single App either as positional arguments
-or as a list of futures via the special keyword ``inputs=()``.
+or as a list of futures via the special keyword ``inputs``.
 The App will wait for all inputs to be satisfied before execution.
 
 

--- a/docs/historical/changelog.rst
+++ b/docs/historical/changelog.rst
@@ -301,7 +301,7 @@ New Functionality
    .. code-block:: python
 
       @bash_app
-      def cat(inputs=(), outputs=()):
+      def cat(inputs, outputs):
            return 'cat {} > {}'.format(inputs[0], outputs[0])
 
       concat = cat(inputs=['hello-0.txt'],
@@ -314,7 +314,7 @@ New Functionality
       from parsl import File
 
       @bash_app
-      def cat(inputs=(), outputs=()):
+      def cat(inputs, outputs):
            return 'cat {} > {}'.format(inputs[0].filepath, outputs[0].filepath)
 
       concat = cat(inputs=[File('hello-0.txt')],
@@ -328,7 +328,7 @@ New Functionality
       from parsl import File
 
       @bash_app
-      def cat(inputs=(), outputs=()):
+      def cat(inputs, outputs):
            return 'cat {} > {}'.format(inputs[0].filepath, outputs[0].filepath)
 
 
@@ -409,16 +409,16 @@ New Functionality
 
         # The following example worked until v0.8.0
         @bash_app
-        def cat(inputs=(), outputs=()):
+        def cat(inputs, outputs):
             return 'cat {inputs[0]} > {outputs[0]}' # <-- Relies on Parsl auto formatting the string
 
         # Following are two mechanisms that will work going forward from v0.9.0
         @bash_app
-        def cat(inputs=(), outputs=()):
+        def cat(inputs, outputs):
             return 'cat {} > {}'.format(inputs[0], outputs[0]) # <-- Use str.format method
 
         @bash_app
-        def cat(inputs=(), outputs=()):
+        def cat(inputs, outputs):
             return f'cat {inputs[0]} > {outputs[0]}' # <-- OR use f-strings introduced in Python3.6
 
 
@@ -522,12 +522,12 @@ New Functionality
 
      # Old style: " ".join(inputs) is legal since inputs will behave like a list of strings
      @bash_app
-     def concat(inputs=(), outputs=(), stdout="stdout.txt", stderr='stderr.txt'):
+     def concat(inputs, outputs, stdout="stdout.txt", stderr='stderr.txt'):
          return "cat {0} > {1}".format(" ".join(inputs), outputs[0])
 
      # New style:
      @bash_app
-     def concat(inputs=(), outputs=(), stdout="stdout.txt", stderr='stderr.txt'):
+     def concat(inputs, outputs, stdout="stdout.txt", stderr='stderr.txt'):
          return "cat {0} > {1}".format(" ".join(list(map(str,inputs))), outputs[0])
 
 * Cleaner user app file log management.

--- a/docs/userguide/apps/python.rst
+++ b/docs/userguide/apps/python.rst
@@ -196,7 +196,7 @@ Some keyword arguments to the Python function are treated differently by Parsl
         return x * 2
 
     @python_app()
-    def reduce_app(inputs = ()):
+    def reduce_app(inputs):
         return sum(inputs)
 
     map_futures = [map_app(x) for x in range(3)]
@@ -212,7 +212,7 @@ Some keyword arguments to the Python function are treated differently by Parsl
 .. code-block:: python
 
     @python_app()
-    def write_app(message, outputs=()):
+    def write_app(message, outputs):
         """Write a single message to every file in outputs"""
         for path in outputs:
             with open(path, 'w') as fp:

--- a/docs/userguide/configuration/data.rst
+++ b/docs/userguide/configuration/data.rst
@@ -67,7 +67,7 @@ irrespective of where that app executes.
 .. code-block:: python
 
     @python_app
-    def print_file(inputs=()):
+    def print_file(inputs):
         with open(inputs[0].filepath, 'r') as inp:
             content = inp.read()
             return(content)
@@ -189,7 +189,7 @@ The following example illustrates how the remote file is implicitly downloaded f
 .. code-block:: python
 
     @python_app
-    def convert(inputs=(), outputs=()):
+    def convert(inputs, outputs):
         with open(inputs[0].filepath, 'r') as inp:
             content = inp.read()
             with open(outputs[0].filepath, 'w') as out:

--- a/docs/userguide/configuration/execution.rst
+++ b/docs/userguide/configuration/execution.rst
@@ -216,12 +216,12 @@ The following code snippet shows how apps can specify suitable executors in the 
 
      # A mock molecular dynamics simulation app
      @bash_app(executors=["Theta.Phi"])
-     def MD_Sim(arg, outputs=()):
+     def MD_Sim(arg, outputs):
          return "MD_simulate {} -o {}".format(arg, outputs[0])
 
      # Visualize results from the mock MD simulation app
      @bash_app(executors=["Cooley.GPU"])
-     def visualize(inputs=(), outputs=()):
+     def visualize(inputs, outputs):
          bash_array = " ".join(inputs)
          return "viz {} -o {}".format(bash_array, outputs[0])
 

--- a/docs/userguide/workflows/futures.rst
+++ b/docs/userguide/workflows/futures.rst
@@ -151,7 +151,7 @@ be created (``hello.outputs[0].result()``).
       # This app echoes the input string to the first file specified in the
       # outputs list
       @bash_app
-      def echo(message, outputs=()):
+      def echo(message, outputs):
           return 'echo {} &> {}'.format(message, outputs[0])
 
       # Call echo specifying the output file

--- a/docs/userguide/workflows/workflow.rst
+++ b/docs/userguide/workflows/workflow.rst
@@ -63,7 +63,7 @@ Sequential workflows can be created by passing an AppFuture from one task to ano
 
       # Write a message to a file
       @bash_app
-      def save(message, outputs=()):
+      def save(message, outputs):
             return 'echo {} &> {}'.format(message, outputs[0])
 
       message = generate(10)
@@ -159,15 +159,15 @@ In other cases, it can be convenient to pass data in files, as in the following 
       parsl.load()
 			
       @bash_app
-      def generate(outputs=()):
+      def generate(outputs):
           return 'echo $(( RANDOM % (10 - 5 + 1 ) + 5 )) &> {}'.format(outputs[0])
 
       @bash_app
-      def concat(inputs=(), outputs=(), stdout='stdout.txt', stderr='stderr.txt'):
+      def concat(inputs, outputs, stdout='stdout.txt', stderr='stderr.txt'):
           return 'cat {0} >> {1}'.format(' '.join(inputs), outputs[0])
 
       @python_app
-      def total(inputs=()):
+      def total(inputs):
           total = 0
           with open(inputs[0].filepath, 'r') as f:
               for l in f:
@@ -209,7 +209,7 @@ the sum of those results.
 
     # Reduce function that returns the sum of a list
     @python_app
-    def app_sum(inputs=()):
+    def app_sum(inputs):
         return sum(inputs)
 
     # Create a list of integers

--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -96,7 +96,7 @@ def remote_side_bash_executor(func, *args, **kwargs):
     # TODO : Add support for globs here
 
     missing = []
-    for outputfile in kwargs.get('outputs', []):
+    for outputfile in kwargs.get('outputs') or []:
         fpath = outputfile.filepath
 
         if not os.path.exists(fpath):

--- a/parsl/data_provider/ftp.py
+++ b/parsl/data_provider/ftp.py
@@ -66,7 +66,7 @@ def in_task_transfer_wrapper(func, file, working_dir):
     return wrapper
 
 
-def _ftp_stage_in(working_dir, parent_fut=None, outputs=[], _parsl_staging_inhibit=True):
+def _ftp_stage_in(working_dir, outputs, parent_fut=None, _parsl_staging_inhibit=True):
     file = outputs[0]
     if working_dir:
         os.makedirs(working_dir, exist_ok=True)

--- a/parsl/data_provider/globus.py
+++ b/parsl/data_provider/globus.py
@@ -267,7 +267,7 @@ class GlobusStaging(Staging, RepresentationMixin):
 # this cannot be a class method, but must be a function, because I want
 # to be able to use partial() on it - and partial() does not work on
 # class methods
-def _globus_stage_in(provider, executor, parent_fut=None, outputs, _parsl_staging_inhibit=True):
+def _globus_stage_in(provider, executor, outputs, parent_fut=None, _parsl_staging_inhibit=True):
     globus_ep = provider._get_globus_endpoint(executor)
     file = outputs[0]
     dst_path = os.path.join(

--- a/parsl/data_provider/globus.py
+++ b/parsl/data_provider/globus.py
@@ -267,7 +267,7 @@ class GlobusStaging(Staging, RepresentationMixin):
 # this cannot be a class method, but must be a function, because I want
 # to be able to use partial() on it - and partial() does not work on
 # class methods
-def _globus_stage_in(provider, executor, parent_fut=None, outputs=[], _parsl_staging_inhibit=True):
+def _globus_stage_in(provider, executor, parent_fut=None, outputs, _parsl_staging_inhibit=True):
     globus_ep = provider._get_globus_endpoint(executor)
     file = outputs[0]
     dst_path = os.path.join(
@@ -280,7 +280,7 @@ def _globus_stage_in(provider, executor, parent_fut=None, outputs=[], _parsl_sta
             file.path, dst_path)
 
 
-def _globus_stage_out(provider, executor, app_fu, inputs=[], _parsl_staging_inhibit=True):
+def _globus_stage_out(provider, executor, app_fu, inputs, _parsl_staging_inhibit=True):
     """
     Although app_fu isn't directly used in the stage out code,
     it is needed as an input dependency to ensure this code

--- a/parsl/data_provider/http.py
+++ b/parsl/data_provider/http.py
@@ -73,7 +73,7 @@ def in_task_transfer_wrapper(func, file, working_dir):
     return wrapper
 
 
-def _http_stage_in(working_dir, parent_fut=None, outputs=[], _parsl_staging_inhibit=True):
+def _http_stage_in(working_dir, outputs, parent_fut=None, _parsl_staging_inhibit=True):
     file = outputs[0]
     if working_dir:
         os.makedirs(working_dir, exist_ok=True)

--- a/parsl/data_provider/zip.py
+++ b/parsl/data_provider/zip.py
@@ -96,7 +96,7 @@ class ZipFileStaging(Staging):
         return app_fut._outputs[0]
 
 
-def _zip_stage_out(zip_file, inside_path, working_dir, parent_fut=None, inputs=[], _parsl_staging_inhibit=True):
+def _zip_stage_out(zip_file, inside_path, working_dir, inputs, parent_fut=None, _parsl_staging_inhibit=True):
     file = inputs[0]
 
     os.makedirs(os.path.dirname(zip_file), exist_ok=True)

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -788,7 +788,7 @@ class DataFlowKernel:
             logger.debug("Not performing input staging")
             return args, kwargs, func
 
-        inputs = kwargs.get('inputs', [])
+        inputs = kwargs.get('inputs') or []
         for idx, f in enumerate(inputs):
             (inputs[idx], func) = self.data_manager.optionally_stage_in(f, func, executor)
 
@@ -807,7 +807,7 @@ class DataFlowKernel:
 
     def _add_output_deps(self, executor: str, args: Sequence[Any], kwargs: Dict[str, Any], app_fut: AppFuture, func: Callable) -> Callable:
         logger.debug("Adding output dependencies")
-        outputs = kwargs.get('outputs', [])
+        outputs = kwargs.get('outputs') or []
         app_fut._outputs = []
 
         # Pass over all possible outputs: the outputs kwarg, stdout and stderr
@@ -890,7 +890,7 @@ class DataFlowKernel:
             check_dep(dep)
 
         # Check for futures in inputs=[<fut>...]
-        for dep in kwargs.get('inputs', []):
+        for dep in kwargs.get('inputs') or []:
             check_dep(dep)
 
         return depends

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -944,7 +944,7 @@ class DataFlowKernel:
                 append_failure(e, dep)
 
         # Check for futures in inputs=[<fut>...]
-        if 'inputs' in kwargs:
+        if kwargs.get('inputs'):
             new_inputs = []
             for dep in kwargs['inputs']:
                 try:

--- a/parsl/dataflow/memoization.py
+++ b/parsl/dataflow/memoization.py
@@ -191,7 +191,7 @@ class Memoizer:
             logger.debug("Ignoring kwarg %s", k)
             del filtered_kw[k]
 
-        if 'outputs' in task['kwargs']:
+        if task['kwargs'].get('outputs'):
             outputs = task['kwargs']['outputs']
             del filtered_kw['outputs']
             t.append(id_for_memo(outputs, output_ref=True))

--- a/parsl/executors/radical/executor.py
+++ b/parsl/executors/radical/executor.py
@@ -422,9 +422,9 @@ class RadicalPilotExecutor(ParslExecutor, RepresentationMixin):
                 task.use_mpi = False
                 task.function = self._pack_and_apply_message(func, args, kwargs)
 
-        task.input_staging = self._stage_files(kwargs.get("inputs", []),
+        task.input_staging = self._stage_files(kwargs.get("inputs") or [],
                                                mode='in')
-        task.output_staging = self._stage_files(kwargs.get("outputs", []),
+        task.output_staging = self._stage_files(kwargs.get("outputs") or [],
                                                 mode='out')
 
         task.input_staging.extend(self._stage_files(list(args), mode='in'))

--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -360,8 +360,8 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
 
         # Determine whether to stage input files that will exist at the workers
         # Input and output files are always cached
-        input_files += [self._register_file(f) for f in kwargs.get("inputs", []) if isinstance(f, File)]
-        output_files += [self._register_file(f) for f in kwargs.get("outputs", []) if isinstance(f, File)]
+        input_files += [self._register_file(f) for f in kwargs.get("inputs") or [] if isinstance(f, File)]
+        output_files += [self._register_file(f) for f in kwargs.get("outputs") or [] if isinstance(f, File)]
 
         # Also consider any *arg that looks like a file as an input:
         input_files += [self._register_file(f) for f in args if isinstance(f, File)]

--- a/parsl/executors/taskvine/install-taskvine.sh
+++ b/parsl/executors/taskvine/install-taskvine.sh
@@ -12,7 +12,7 @@ TARBALL="cctools-$CCTOOLS_VERSION-x86_64-ubuntu20.04.tar.gz"
 
 # If stderr is *not* a TTY, then disable progress bar and show HTTP response headers
 [[ ! -t 1 ]] && NO_VERBOSE="--no-verbose" SHOW_HEADERS="-S"
-wget "$NO_VERBOSE" "$SHOW_HEADERS" -O /tmp/cctools.tar.gz "https://github.com/cooperative-computing-lab/cctools/releases/download/release/$CCTOOLS_VERSION/$TARBALL"
+wget $NO_VERBOSE $SHOW_HEADERS -O /tmp/cctools.tar.gz "https://github.com/cooperative-computing-lab/cctools/releases/download/release/$CCTOOLS_VERSION/$TARBALL"
 
 mkdir -p /tmp/cctools
 tar -C /tmp/cctools -zxf /tmp/cctools.tar.gz --strip-components=1

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -461,8 +461,8 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         output_files = []
 
         # Determine the input and output files that will exist at the workers:
-        input_files += [self._register_file(f) for f in kwargs.get("inputs", []) if isinstance(f, File)]
-        output_files += [self._register_file(f) for f in kwargs.get("outputs", []) if isinstance(f, File)]
+        input_files += [self._register_file(f) for f in kwargs.get("inputs") or [] if isinstance(f, File)]
+        output_files += [self._register_file(f) for f in kwargs.get("outputs") or [] if isinstance(f, File)]
 
         # Also consider any *arg that looks like a file as an input:
         input_files += [self._register_file(f) for f in args if isinstance(f, File)]

--- a/parsl/tests/integration/test_parsl_load_default_config.py
+++ b/parsl/tests/integration/test_parsl_load_default_config.py
@@ -3,7 +3,7 @@ from parsl import python_app
 
 
 @python_app
-def cpu_stress(inputs=[], outputs=[]):
+def cpu_stress(inputs=None, outputs=None):
     s = 0
     for i in range(10**8):
         s += i

--- a/parsl/tests/test_aalst_patterns.py
+++ b/parsl/tests/test_aalst_patterns.py
@@ -76,7 +76,7 @@ def slow_increment(x, dur=1):
 
 
 @python_app
-def join(inputs=[]):
+def join(inputs):
     return sum(inputs)
 
 

--- a/parsl/tests/test_bash_apps/test_apptimeout.py
+++ b/parsl/tests/test_bash_apps/test_apptimeout.py
@@ -7,7 +7,7 @@ from parsl.tests.configs.local_threads import config
 
 
 @bash_app
-def echo_to_file(inputs=(), outputs=(), walltime=0.01):
+def echo_to_file(inputs=None, outputs=None, walltime=0.01):
     return """echo "sleeping"; sleep 0.05"""
 
 

--- a/parsl/tests/test_bash_apps/test_basic.py
+++ b/parsl/tests/test_bash_apps/test_basic.py
@@ -11,7 +11,7 @@ from parsl.app.app import bash_app
 
 
 @bash_app
-def echo_to_file(inputs=(), outputs=(), stderr=None, stdout=None):
+def echo_to_file(inputs, outputs, stderr=None, stdout=None):
     res = ""
     for o in outputs:
         for i in inputs:

--- a/parsl/tests/test_bash_apps/test_memoize.py
+++ b/parsl/tests/test_bash_apps/test_memoize.py
@@ -5,7 +5,7 @@ from parsl.app.app import bash_app
 
 
 @bash_app(cache=True)
-def fail_on_presence(outputs=()):
+def fail_on_presence(outputs):
     return 'if [ -f {0} ] ; then exit 1 ; else touch {0}; fi'.format(outputs[0])
 
 
@@ -23,7 +23,7 @@ def test_bash_memoization(tmpd_cwd, n=2):
 
 
 @bash_app(cache=True)
-def fail_on_presence_kw(outputs=(), foo=None):
+def fail_on_presence_kw(outputs, foo=None):
     return 'if [ -f {0} ] ; then exit 1 ; else touch {0}; fi'.format(outputs[0])
 
 

--- a/parsl/tests/test_bash_apps/test_multiline.py
+++ b/parsl/tests/test_bash_apps/test_multiline.py
@@ -5,7 +5,7 @@ from parsl.app.app import bash_app
 
 
 @bash_app
-def multiline(inputs=(), outputs=(), stderr=None, stdout=None):
+def multiline(inputs, outputs, stderr=None, stdout=None):
     return """echo {inputs[0]} &> {outputs[0]}
     echo {inputs[1]} &> {outputs[1]}
     echo {inputs[2]} &> {outputs[2]}

--- a/parsl/tests/test_bash_apps/test_pipeline.py
+++ b/parsl/tests/test_bash_apps/test_pipeline.py
@@ -6,7 +6,7 @@ from parsl.data_provider.files import File
 
 
 @bash_app
-def increment(inputs=(), outputs=(), stdout=None, stderr=None):
+def increment(inputs, outputs, stdout=None, stderr=None):
     cmd_line = """
     if ! [ -f {inputs[0]} ] ; then exit 43 ; fi
     x=$(cat {inputs[0]})
@@ -16,7 +16,7 @@ def increment(inputs=(), outputs=(), stdout=None, stderr=None):
 
 
 @bash_app
-def slow_increment(dur, inputs=(), outputs=(), stdout=None, stderr=None):
+def slow_increment(dur, inputs, outputs, stdout=None, stderr=None):
     cmd_line = """
     x=$(cat {inputs[0]})
     echo $(($x+1)) > {outputs[0]}

--- a/parsl/tests/test_docs/test_from_slides.py
+++ b/parsl/tests/test_docs/test_from_slides.py
@@ -7,12 +7,12 @@ from parsl.data_provider.files import File
 
 
 @bash_app
-def echo(message, outputs=[]):
+def echo(message, outputs):
     return 'echo {m} &> {o}'.format(m=message, o=outputs[0])
 
 
 @python_app
-def cat(inputs=[]):
+def cat(inputs):
     with open(inputs[0].filepath) as f:
         return f.readlines()
 

--- a/parsl/tests/test_docs/test_kwargs.py
+++ b/parsl/tests/test_docs/test_kwargs.py
@@ -12,7 +12,7 @@ def test_inputs():
         return x * 2
 
     @python_app()
-    def reduce_app(inputs=()):
+    def reduce_app(inputs):
         return sum(inputs)
 
     map_futures = [map_app(x) for x in range(3)]
@@ -24,7 +24,7 @@ def test_inputs():
 @pytest.mark.shared_fs
 def test_outputs(tmpd_cwd):
     @python_app()
-    def write_app(message, outputs=()):
+    def write_app(message, outputs):
         """Write a single message to every file in outputs"""
         for path in outputs:
             with open(path, 'w') as fp:

--- a/parsl/tests/test_docs/test_tutorial_1.py
+++ b/parsl/tests/test_docs/test_tutorial_1.py
@@ -10,7 +10,7 @@ local_config = config
 
 
 @bash_app
-def sim_mol_dyn(i, dur, outputs=[], stdout=None, stderr=None):
+def sim_mol_dyn(i, dur, outputs, stdout=None, stderr=None):
     # The bash app function, requires that the bash script is assigned to the special variable
     # cmd_line. Positional and Keyword args to the fn() are formatted into the cmd_line string
     cmd_line = """echo "{0}" > {outputs[0]}

--- a/parsl/tests/test_docs/test_workflow1.py
+++ b/parsl/tests/test_docs/test_workflow1.py
@@ -18,7 +18,7 @@ def generate(limit):
 
 
 @bash_app
-def save(message, outputs=[]):
+def save(message, outputs):
     return 'echo {m} &> {o}'.format(m=message, o=outputs[0])
 
 

--- a/parsl/tests/test_docs/test_workflow4.py
+++ b/parsl/tests/test_docs/test_workflow4.py
@@ -5,17 +5,17 @@ from parsl.data_provider.files import File
 
 
 @bash_app
-def generate(outputs=()):
+def generate(outputs):
     return "echo 1 &> {o}".format(o=outputs[0])
 
 
 @bash_app
-def concat(inputs=(), outputs=(), stdout=None, stderr=None):
+def concat(inputs, outputs, stdout=None, stderr=None):
     return "cat {0} >> {1}".format(" ".join(map(lambda x: x.filepath, inputs)), outputs[0])
 
 
 @python_app
-def total(inputs=()):
+def total(inputs):
     with open(inputs[0].filepath, "r") as f:
         return sum(int(line) for line in f)
 

--- a/parsl/tests/test_error_handling/test_rand_fail.py
+++ b/parsl/tests/test_error_handling/test_rand_fail.py
@@ -14,7 +14,7 @@ def local_config():
 
 
 @python_app
-def sleep_fail(sleep_dur, sleep_rand_max, fail_prob, inputs=[]):
+def sleep_fail(sleep_dur, sleep_rand_max, fail_prob, inputs=None):
     import random
     import time
 

--- a/parsl/tests/test_error_handling/test_retries.py
+++ b/parsl/tests/test_error_handling/test_retries.py
@@ -13,7 +13,7 @@ def local_config():
 
 
 @python_app
-def sleep_then_fail(inputs=[], sleep_dur=0.1):
+def sleep_then_fail(inputs=None, sleep_dur=0.1):
     import math
     import time
     time.sleep(sleep_dur)

--- a/parsl/tests/test_monitoring/test_incomplete_futures.py
+++ b/parsl/tests/test_monitoring/test_incomplete_futures.py
@@ -9,7 +9,7 @@ import parsl
 
 
 @parsl.python_app
-def this_app(inputs=()):
+def this_app(inputs):
     return inputs[0]
 
 

--- a/parsl/tests/test_python_apps/test_arg_input_types.py
+++ b/parsl/tests/test_python_apps/test_arg_input_types.py
@@ -7,12 +7,12 @@ from parsl import python_app
 
 
 @python_app
-def take_a_value(inputs=[]):
+def take_a_value(inputs):
     return str(inputs[0])
 
 
 @python_app
-def add_two_values(inputs=[]):
+def add_two_values(inputs):
     return inputs[0] + inputs[1]
 
 

--- a/parsl/tests/test_python_apps/test_fail.py
+++ b/parsl/tests/test_python_apps/test_fail.py
@@ -9,7 +9,7 @@ class ManufacturedTestFailure(Exception):
 
 
 @python_app
-def random_fail(fail_prob: float, inputs=()):
+def random_fail(fail_prob: float, inputs=None):
     import random
     if random.random() < fail_prob:
         raise ManufacturedTestFailure("App failure")

--- a/parsl/tests/test_python_apps/test_futures.py
+++ b/parsl/tests/test_python_apps/test_futures.py
@@ -20,7 +20,7 @@ from parsl.data_provider.files import File
 
 
 @python_app
-def delay_incr(x, delay=0.0, outputs=()):
+def delay_incr(x, delay=0.0, outputs=None):
     import time
     if outputs:
         with open(outputs[0].filepath, 'w') as outs:

--- a/parsl/tests/test_python_apps/test_mapred.py
+++ b/parsl/tests/test_python_apps/test_mapred.py
@@ -9,7 +9,7 @@ def times_two(x):
 
 
 @python_app
-def accumulate(inputs=()):
+def accumulate(inputs):
     return sum(inputs)
 
 

--- a/parsl/tests/test_python_apps/test_memoize_bad_id_for_memo.py
+++ b/parsl/tests/test_python_apps/test_memoize_bad_id_for_memo.py
@@ -25,7 +25,7 @@ def failing_memoizer(v, output_ref=False):
 
 
 @python_app(cache=True)
-def noop_app(x, inputs=[], cache=True):
+def noop_app(x, inputs=None, cache=True):
     return None
 
 

--- a/parsl/tests/test_python_apps/test_outputs.py
+++ b/parsl/tests/test_python_apps/test_outputs.py
@@ -7,7 +7,7 @@ from parsl import File, python_app
 
 
 @python_app
-def double(x, outputs=[]):
+def double(x, outputs):
     with open(outputs[0], 'w') as f:
         f.write(x * 5)
     return x * 5

--- a/parsl/tests/test_python_apps/test_overview.py
+++ b/parsl/tests/test_python_apps/test_overview.py
@@ -7,7 +7,7 @@ def app_double(x):
 
 
 @python_app
-def app_sum(inputs=()):
+def app_sum(inputs):
     return sum(inputs)
 
 

--- a/parsl/tests/test_regression/test_69a.py
+++ b/parsl/tests/test_regression/test_69a.py
@@ -10,7 +10,7 @@ local_config = config
 
 
 @bash_app
-def echo_slow_message(msg, sleep=0, fu=None, outputs=[], stderr='std.err', stdout='std.out'):
+def echo_slow_message(msg, sleep=0, fu=None, outputs, stderr='std.err', stdout='std.out'):
     cmd_line = 'sleep {sleep}; echo {0} > {outputs[0]}'
     return cmd_line
 

--- a/parsl/tests/test_regression/test_69a.py
+++ b/parsl/tests/test_regression/test_69a.py
@@ -10,7 +10,7 @@ local_config = config
 
 
 @bash_app
-def echo_slow_message(msg, sleep=0, fu=None, outputs, stderr='std.err', stdout='std.out'):
+def echo_slow_message(msg, outputs, sleep=0, fu=None, stderr='std.err', stdout='std.out'):
     cmd_line = 'sleep {sleep}; echo {0} > {outputs[0]}'
     return cmd_line
 
@@ -28,7 +28,7 @@ def test_immediate_datafuture():
     """
 
     import time
-    fu = echo_slow_message("Hello world", sleep=1, outputs=["hello.1.txt"])
+    fu = echo_slow_message("Hello world", outputs=["hello.1.txt"], sleep=1)
     d_fu = fu.outputs[0]
 
     time.sleep(0.1)
@@ -50,8 +50,8 @@ def test_delayed_datafuture():
     import time
     sleep_fu = sleep()
 
-    fu = echo_slow_message("Hello world", sleep=1, fu=sleep_fu,
-                           outputs=["hello.1.txt"])
+    fu = echo_slow_message("Hello world", outputs=["hello.1.txt"], sleep=1,
+                           fu=sleep_fu)
     d_fu = fu.outputs[0]
     state_1 = d_fu.__str__()
     print("State_1 : ", state_1, "Fu:", fu.parent)

--- a/parsl/tests/test_scaling/test_scale_down.py
+++ b/parsl/tests/test_scaling/test_scale_down.py
@@ -41,7 +41,7 @@ def local_config():
 
 
 @python_app
-def waiting_app(ident: int, inputs=(), outputs=()):
+def waiting_app(ident: int, inputs=None, outputs=None):
     import pathlib
     import time
 

--- a/parsl/tests/test_scaling/test_scale_down_htex_auto_scale.py
+++ b/parsl/tests/test_scaling/test_scale_down_htex_auto_scale.py
@@ -39,7 +39,7 @@ def local_config():
 
 
 @python_app
-def waiting_app(ident: int, outputs=(), inputs=()):
+def waiting_app(ident: int, outputs, inputs):
     import pathlib
     import time
 

--- a/parsl/tests/test_staging/staging_provider.py
+++ b/parsl/tests/test_staging/staging_provider.py
@@ -61,7 +61,7 @@ def make_stage_out_app(executor, dfk):
     return python_app(executors=[executor], data_flow_kernel=dfk)(stage_out_noop)
 
 
-def stage_out_noop(app_fu, inputs=[], _parsl_staging_inhibit=True):
+def stage_out_noop(app_fu, inputs=None, _parsl_staging_inhibit=True):
     import logging
     import time
     logger = logging.getLogger(__name__)
@@ -74,7 +74,7 @@ def make_stage_in_app(executor, dfk):
     return python_app(executors=[executor], data_flow_kernel=dfk)(stage_in_noop)
 
 
-def stage_in_noop(parent_fut=None, outputs=[], _parsl_staging_inhibit=True):
+def stage_in_noop(parent_fut=None, outputs=None, _parsl_staging_inhibit=True):
     import logging
     import time
     logger = logging.getLogger(__name__)

--- a/parsl/tests/test_staging/test_1316.py
+++ b/parsl/tests/test_staging/test_1316.py
@@ -18,7 +18,7 @@ def observe_input_local_path(f):
 
 
 @python_app
-def wait_and_create(outputs=[]):
+def wait_and_create(outputs=None):
     # for test purposes, this doesn't actually need to create the output
     # file as nothing ever touches file content - the test only deals with
     # names and Futures.

--- a/parsl/tests/test_staging/test_docs_1.py
+++ b/parsl/tests/test_staging/test_docs_1.py
@@ -4,7 +4,7 @@ from parsl import File, python_app
 
 
 @python_app
-def convert(inputs=[], outputs=[]):
+def convert(inputs, outputs):
     with open(inputs[0].filepath, 'r') as inp:
         content = inp.read()
         with open(outputs[0].filepath, 'w') as out:

--- a/parsl/tests/test_staging/test_docs_2.py
+++ b/parsl/tests/test_staging/test_docs_2.py
@@ -5,7 +5,7 @@ from parsl.tests.configs.local_threads import fresh_config as local_config
 
 
 @bash_app
-def cat(inputs=[], stdout='stdout.txt'):
+def cat(inputs, stdout='stdout.txt'):
     return 'cat %s' % (inputs[0])
 
 

--- a/parsl/tests/test_staging/test_elaborate_noop_file.py
+++ b/parsl/tests/test_staging/test_elaborate_noop_file.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 @bash_app
-def touch(filename, outputs=()):
+def touch(filename, outputs=None):
     return f"touch {filename}"
 
 
@@ -51,7 +51,7 @@ def test_regression_stage_out_does_not_stage_in(storage_access_parsl, tmpd_cwd):
     storage_access_parsl(allow_stage_in=False)
 
     # Test that the helper app runs with no staging
-    touch(str(tmpd_cwd / "test.1"), outputs=[]).result()
+    touch(str(tmpd_cwd / "test.1"), outputs=None).result()
 
     # Test with stage-out, checking that provider stage-in is never
     # invoked. If stage-in is invoked, then the NoOpTestingFileStaging

--- a/parsl/tests/test_staging/test_file_apps.py
+++ b/parsl/tests/test_staging/test_file_apps.py
@@ -5,7 +5,7 @@ from parsl.data_provider.files import File
 
 
 @bash_app
-def cat(inputs=(), outputs=(), stdout=None, stderr=None):
+def cat(inputs, outputs, stdout=None, stderr=None):
     infiles = " ".join(i.filepath for i in inputs)
     return f"cat {infiles} &> {outputs[0]}"
 
@@ -27,7 +27,7 @@ def test_files(setup_data):
 
 
 @bash_app
-def increment(inputs=(), outputs=(), stdout=None, stderr=None):
+def increment(inputs, outputs, stdout=None, stderr=None):
     return (
         f"x=$(cat {inputs[0]})\n"
         f"echo $(($x+1)) > {outputs[0]}"

--- a/parsl/tests/test_staging/test_file_staging.py
+++ b/parsl/tests/test_staging/test_file_staging.py
@@ -5,7 +5,7 @@ from parsl.data_provider.files import File
 
 
 @bash_app
-def cat(inputs=(), outputs=(), stdout=None, stderr=None):
+def cat(inputs, outputs, stdout=None, stderr=None):
     infiles = " ".join(i.filepath for i in inputs)
     return f"cat {infiles} &> {outputs[0]}"
 

--- a/parsl/tests/test_staging/test_output_chain_filenames.py
+++ b/parsl/tests/test_staging/test_output_chain_filenames.py
@@ -7,12 +7,12 @@ from parsl.app.app import bash_app
 
 
 @bash_app
-def app1(inputs=(), outputs=(), stdout=None, stderr=None, mock=False):
+def app1(outputs, inputs=None, stdout=None, stderr=None, mock=False):
     return f"echo 'test' > {outputs[0]}"
 
 
 @bash_app
-def app2(inputs=(), outputs=(), stdout=None, stderr=None, mock=False):
+def app2(inputs, outputs, stdout=None, stderr=None, mock=False):
     return f"echo '{inputs[0]}' > {outputs[0]}"
 
 

--- a/parsl/tests/test_staging/test_staging_ftp.py
+++ b/parsl/tests/test_staging/test_staging_ftp.py
@@ -5,7 +5,7 @@ from parsl.data_provider.files import File
 
 
 @python_app
-def sort_strings(inputs=[], outputs=[]):
+def sort_strings(inputs, outputs):
     with open(inputs[0].filepath, 'r') as u:
         strs = u.readlines()
         strs.sort()

--- a/parsl/tests/test_staging/test_staging_ftp_in_task.py
+++ b/parsl/tests/test_staging/test_staging_ftp_in_task.py
@@ -6,7 +6,7 @@ from parsl.tests.configs.local_threads_ftp_in_task import fresh_config as local_
 
 
 @python_app
-def sort_strings(inputs=[], outputs=[]):
+def sort_strings(inputs, outputs):
     with open(inputs[0].filepath, 'r') as u:
         strs = u.readlines()
         strs.sort()

--- a/parsl/tests/test_staging/test_staging_globus.py
+++ b/parsl/tests/test_staging/test_staging_globus.py
@@ -9,7 +9,7 @@ local_config = config
 
 
 @python_app
-def sort_strings(inputs=[], outputs=[]):
+def sort_strings(inputs, outputs):
     with open(inputs[0].filepath, 'r') as u:
         strs = u.readlines()
         strs.sort()

--- a/parsl/tests/test_staging/test_staging_https.py
+++ b/parsl/tests/test_staging/test_staging_https.py
@@ -24,25 +24,25 @@ _exp_sorted = sorted(f"{i}\n" for i in range(1, 101))[:20]
 
 
 @python_app
-def sort_strings(inputs=(), outputs=()):
+def sort_strings(inputs, outputs):
     from parsl.tests.test_staging import read_sort_write
     read_sort_write(inputs[0].filepath, outputs[0].filepath)
 
 
 @python_app
-def sort_strings_kw(*, x=None, outputs=()):
+def sort_strings_kw(*, x=None, outputs):
     from parsl.tests.test_staging import read_sort_write
     read_sort_write(x.filepath, outputs[0].filepath)
 
 
 @python_app
-def sort_strings_arg(x, /, outputs=()):
+def sort_strings_arg(x, /, outputs):
     from parsl.tests.test_staging import read_sort_write
     read_sort_write(x.filepath, outputs[0].filepath)
 
 
 @python_app(executors=['other'])
-def sort_strings_additional_executor(inputs=(), outputs=()):
+def sort_strings_additional_executor(inputs, outputs):
     from parsl.tests.test_staging import read_sort_write
     read_sort_write(inputs[0].filepath, outputs[0].filepath)
 

--- a/parsl/tests/test_staging/test_zip_out.py
+++ b/parsl/tests/test_staging/test_zip_out.py
@@ -20,7 +20,7 @@ def test_zip_path_split():
 
 
 @parsl.bash_app
-def output_something(outputs=()):
+def output_something(outputs):
     """This should output something into every specified output file:
     the position in the output sequence will be written into the
     corresponding output file.


### PR DESCRIPTION
# Description

Using a mutable object like `[]` as a default argument value can be dangerous (see the description of [this PR](https://github.com/Parsl/parsl-tutorial/pull/39) for the tutorial, the [Important warning](https://docs.python.org/3/tutorial/controlflow.html#default-argument-values) from the Python docs, [Google's style guide](https://google.github.io/styleguide/pyguide.html#2124-decision), or the sad stories from googling "python mutable default argument"). This PR removes those.

An immutable default-argument value is nominally safe, but erroneous in a case like that where `inputs=()` appears in the formal arguments but `inputs[0]` appears in the function body (i.e., `()` cannot possibly be a valid value). This PR removes those.

There were a handful of cases, like `inputs=()` followed by `for input in inputs: ...`, where an empty iterable would be safe and correct, but where it seemed like it wouldn't make sense to call an app this way. This PR removes those, but I'd be happy to restore those (or anything, really) if I misunderstood the intent.

Given that the common "pythonic" advice is to specify e.g. `inputs=None`, I updated some bits of code to deal with this correctly. I'll flag those via inline comments.

I was able to pass the `make test` tests except for `htex_local_alternate_test`, `wqex_local_test`, `vineex_local_test`,  `radical_local_test, and `config_local_test`. `htex_local_alternate_test` and `config_local_test` run but appear to hang, `wqex_local_test` and `vineex_local_test` appear to require Python modules I don't have installed, and `radical_local_test` fails with a complaint about `mpiexec` -- but the behavior is the same for me on `master`, so I'm not sure it has anything to do with the PR changes. 

# Changed Behaviour

I wouldn't expect existing workflows to behave differently.

# Fixes

NA but I'd be happy to open an Issue if it'd be helpful.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup