### PR TITLE
Remove over-verbose debug message

### DIFF
--- a/parsl/executors/high_throughput/zmq_pipes.py
+++ b/parsl/executors/high_throughput/zmq_pipes.py
@@ -213,7 +213,6 @@ class ResultsIncoming:
         """Get a message from the queue, returning None if timeout expires
         without a message. timeout is measured in milliseconds.
         """
-        logger.debug("Waiting for ResultsIncoming message")
         socks = dict(self.poller.poll(timeout=timeout_ms))
         if self.results_receiver in socks and socks[self.results_receiver] == zmq.POLLIN:
             m = self.results_receiver.recv_multipart()


### PR DESCRIPTION
This was introduced in PR #2965 to help debug ZMQ hangs.

PR #3709 changed this loop to run every poll period (by default, every 10ms) rather than every result message.

That turns this log line into a huge source of log noise/volume.

This PR removes that log line - ZMQ debugging must proceed without it.

# Changed Behaviour

parsl.log size from:
pytest parsl/tests/ --config parsl/tests/configs/htex_local.py

before this PR: 7 megabytes
after this PR: 2 megabytes

## Type of change

- Bug fix
