### PR TITLE
Tidy mess from initial TaskRecord implementation

### DIFF
--- a/parsl/dataflow/taskrecord.py
+++ b/parsl/dataflow/taskrecord.py
@@ -43,12 +43,11 @@ class TaskRecord(TypedDict, total=False):
     executed on.
     """
 
-    retries_left: int
     fail_count: int
     fail_cost: float
     fail_history: List[str]
 
-    checkpoint: bool  # this change is also in #1516
+    checkpoint: bool
     """Should this task be checkpointed?
     """
 
@@ -68,7 +67,6 @@ class TaskRecord(TypedDict, total=False):
 
     # these three could be more strongly typed perhaps but I'm not thinking about that now
     func: Callable
-    fn_hash: str
     args: Sequence[Any]
     # in some places we uses a Tuple[Any, ...] and in some places a List[Any].
     # This is an attempt to correctly type both of those.


### PR DESCRIPTION
TaskRecord was merged in PR #2392 from a separate
development branch, and contained some cruft which this PR removes:

* a comment on checkpoint, that was a note on that development branch, not relevant to the main codebase

* retries_left was removed in #1773 and has never been used in TaskRecord

* fn_has was removed in #1945 and has never been used in TaskRecord

## Type of change

- Code maintenance/cleanup
