### PR TITLE
Remove description of exception handling from exception text

### DIFF
--- a/parsl/executors/high_throughput/errors.py
+++ b/parsl/executors/high_throughput/errors.py
@@ -27,7 +27,7 @@ class VersionMismatch(Exception):
     def __str__(self) -> str:
         return (
             f"Manager version info {self.manager_version} does not match interchange"
-            f" version info {self.interchange_version}, causing a critical failure"
+            f" version info {self.interchange_version}"
         )
 
 


### PR DESCRIPTION
An exception should describe the exception, not other associated behaviour.

## Type of change

- Update to human readable text: Documentation/error messages/comments
