### PR TITLE
Usage Tracking: Only log messages when tracking is enabled

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -47,6 +47,7 @@ from parsl.monitoring import MonitoringHub
 from parsl.monitoring.message_type import MessageType
 from parsl.monitoring.remote import monitor_wrapper
 from parsl.process_loggers import wrap_with_logs
+from parsl.usage_tracking.levels import DISABLED as USAGE_TRACKING_DISABLED
 from parsl.usage_tracking.usage import UsageTracker
 from parsl.utils import Timer, get_all_checkpoints, get_std_fname_mode, get_version
 
@@ -1200,10 +1201,11 @@ class DataFlowKernel:
                 self._checkpoint_timer.close()
 
         # Send final stats
-        logger.info("Sending end message for usage tracking")
-        self.usage_tracker.send_end_message()
-        self.usage_tracker.close()
-        logger.info("Closed usage tracking")
+        if self.usage_tracker.tracking_level != USAGE_TRACKING_DISABLED:
+            logger.info("Sending end message for usage tracking")
+            self.usage_tracker.send_end_message()
+            self.usage_tracker.close()
+            logger.info("Closed usage tracking")
 
         logger.info("Closing job status poller")
         self.job_status_poller.close()

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -47,7 +47,6 @@ from parsl.monitoring import MonitoringHub
 from parsl.monitoring.message_type import MessageType
 from parsl.monitoring.remote import monitor_wrapper
 from parsl.process_loggers import wrap_with_logs
-from parsl.usage_tracking.levels import DISABLED as USAGE_TRACKING_DISABLED
 from parsl.usage_tracking.usage import UsageTracker
 from parsl.utils import Timer, get_all_checkpoints, get_std_fname_mode, get_version
 
@@ -1201,11 +1200,8 @@ class DataFlowKernel:
                 self._checkpoint_timer.close()
 
         # Send final stats
-        if self.usage_tracker.tracking_level != USAGE_TRACKING_DISABLED:
-            logger.info("Sending end message for usage tracking")
-            self.usage_tracker.send_end_message()
-            self.usage_tracker.close()
-            logger.info("Closed usage tracking")
+        self.usage_tracker.send_end_message()
+        self.usage_tracker.close()
 
         logger.info("Closing job status poller")
         self.job_status_poller.close()

--- a/parsl/usage_tracking/usage.py
+++ b/parsl/usage_tracking/usage.py
@@ -213,12 +213,14 @@ class UsageTracker:
 
     def send_start_message(self) -> None:
         if self.tracking_level:
+            logger.info("Sending start message for usage tracking")
             self.start_time = time.time()
             message = self.construct_start_message()
             self.send_UDP_message(message)
 
     def send_end_message(self) -> None:
         if self.tracking_level == 3:
+            logger.info("Sending end message for usage tracking")
             message = self.construct_end_message()
             self.send_UDP_message(message)
 
@@ -229,11 +231,14 @@ class UsageTracker:
         definitely either: going to behave broadly the same as to SIGKILL,
         or won't respond to SIGTERM.
         """
-        for proc in self.procs:
-            logger.debug("Joining usage tracking process %s", proc)
-            proc.join(timeout=timeout)
-            if proc.is_alive():
-                logger.warning("Usage tracking process did not end itself; sending SIGKILL")
-                proc.kill()
+        if self.tracking_level:
+            logger.info("Closing usage tracking")
 
-            proc.close()
+            for proc in self.procs:
+                logger.debug("Joining usage tracking process %s", proc)
+                proc.join(timeout=timeout)
+                if proc.is_alive():
+                    logger.warning("Usage tracking process did not end itself; sending SIGKILL")
+                    proc.kill()
+
+                proc.close()


### PR DESCRIPTION
Fix the bug where the DFK logs that it is entering usage tracking code in a way that suggests it is logging usage tracking data, even when turned off.

# Changed Behaviour

The DFK will only log messages about usage tracking data being sent when usage tracking is enabled.

# Fixes

Fixes #3740 

## Type of change

- Bug fix

