### PR TITLE
Revert part of PR #3638 which is part of a now-abandoned task priority PR series

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -357,17 +357,15 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         return self.logdir
 
     def validate_resource_spec(self, resource_specification: dict):
-        """HTEX supports the following *Optional* resource specifications:
-        priority: lower value is higher priority"""
+        """HTEX does not support *any* resource_specification options and
+        will raise InvalidResourceSpecification is any are passed to it"""
         if resource_specification:
-            acceptable_fields = {'priority'}
-            keys = set(resource_specification.keys())
-            invalid_keys = keys - acceptable_fields
-            if invalid_keys:
-                message = "Task resource specification only accepts these types of resources: {}".format(
-                    ', '.join(acceptable_fields))
-                logger.error(message)
-                raise InvalidResourceSpecification(set(invalid_keys), message)
+            raise InvalidResourceSpecification(
+                set(resource_specification.keys()),
+                ("HTEX does not support the supplied resource_specifications. "
+                 "For MPI applications consider using the MPIExecutor. "
+                 "For specifications for core count/memory/walltime, consider using WorkQueueExecutor.")
+            )
         return
 
     def initialize_scaling(self):
@@ -679,7 +677,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         except TypeError:
             raise SerializationError(func.__name__)
 
-        msg = {"task_id": task_id, "resource_spec": resource_specification, "buffer": fn_buf}
+        msg = {"task_id": task_id, "buffer": fn_buf}
 
         # Post task to the outgoing queue
         self.outgoing_q.put(msg)

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -357,15 +357,17 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         return self.logdir
 
     def validate_resource_spec(self, resource_specification: dict):
-        """HTEX does not support *any* resource_specification options and
-        will raise InvalidResourceSpecification is any are passed to it"""
+        """HTEX supports the following *Optional* resource specifications:
+        priority: lower value is higher priority"""
         if resource_specification:
-            raise InvalidResourceSpecification(
-                set(resource_specification.keys()),
-                ("HTEX does not support the supplied resource_specifications. "
-                 "For MPI applications consider using the MPIExecutor. "
-                 "For specifications for core count/memory/walltime, consider using WorkQueueExecutor.")
-            )
+            acceptable_fields = {'priority'}
+            keys = set(resource_specification.keys())
+            invalid_keys = keys - acceptable_fields
+            if invalid_keys:
+                message = "Task resource specification only accepts these types of resources: {}".format(
+                    ', '.join(acceptable_fields))
+                logger.error(message)
+                raise InvalidResourceSpecification(set(invalid_keys), message)
         return
 
     def initialize_scaling(self):
@@ -677,7 +679,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         except TypeError:
             raise SerializationError(func.__name__)
 
-        msg = {"task_id": task_id, "buffer": fn_buf}
+        msg = {"task_id": task_id, "resource_spec": resource_specification, "buffer": fn_buf}
 
         # Post task to the outgoing queue
         self.outgoing_q.put(msg)

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -8,7 +8,7 @@ import warnings
 from collections import defaultdict
 from concurrent.futures import Future
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import typeguard
 
@@ -357,10 +357,8 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         return self.logdir
 
     def validate_resource_spec(self, resource_specification: dict):
-        """HTEX supports the following *Optional* resource specifications:
-        priority: lower value is higher priority"""
         if resource_specification:
-            acceptable_fields = {'priority'}
+            acceptable_fields: Set[str] = set()  # add new resource spec field names here to make htex accept them
             keys = set(resource_specification.keys())
             invalid_keys = keys - acceptable_fields
             if invalid_keys:

--- a/parsl/tests/test_htex/test_resource_spec_validation.py
+++ b/parsl/tests/test_htex/test_resource_spec_validation.py
@@ -31,13 +31,6 @@ def test_resource_spec_validation():
 
 
 @pytest.mark.local
-def test_resource_spec_validation_one_key():
-    htex = HighThroughputExecutor()
-    ret_val = htex.validate_resource_spec({"priority": 2})
-    assert ret_val is None
-
-
-@pytest.mark.local
 def test_resource_spec_validation_bad_keys():
     htex = HighThroughputExecutor()
 

--- a/parsl/tests/test_htex/test_resource_spec_validation.py
+++ b/parsl/tests/test_htex/test_resource_spec_validation.py
@@ -31,6 +31,13 @@ def test_resource_spec_validation():
 
 
 @pytest.mark.local
+def test_resource_spec_validation_one_key():
+    htex = HighThroughputExecutor()
+    ret_val = htex.validate_resource_spec({"priority": 2})
+    assert ret_val is None
+
+
+@pytest.mark.local
 def test_resource_spec_validation_bad_keys():
     htex = HighThroughputExecutor()
 


### PR DESCRIPTION
PR #3638 introduced parameters and documentation for a task priority field which was never implemented in mainline Parsl. This PR leaves most of the infrastructure in place, as other code now depends on it, but removes `priority` as a valid resource specification field.

# Changed Behaviour

users trying to use the no-effect priority parameter will now get runtime errors rather than silent ignore.

## Type of change

- Code maintenance/cleanup
