### PR TITLE
Formalize required argument

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -828,7 +828,7 @@ def get_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-a",
         "--addresses",
-        default='',
+        required=True,
         help="Comma separated list of addresses at which the interchange could be reached",
     )
     parser.add_argument(

--- a/parsl/tests/unit/executors/high_throughput/test_process_worker_pool.py
+++ b/parsl/tests/unit/executors/high_throughput/test_process_worker_pool.py
@@ -17,6 +17,7 @@ _known_required = (  # type: ignore[unreachable, unused-ignore]
     "--cpu-affinity",
     "--result_port",
     "--task_port",
+    "--addresses",
 )
 
 
@@ -62,6 +63,7 @@ def test_arg_parser_validates_cpu_affinity(valid, val):
     reqd_args.extend(("--cert_dir", "/some/path"))
     reqd_args.extend(("--result_port", "123"))
     reqd_args.extend(("--task_port", "123"))
+    reqd_args.extend(("--addresses", "asdf"))
     reqd_args.extend(("--cpu-affinity", val))
 
     p = process_worker_pool.get_arg_parser()


### PR DESCRIPTION
`--addresses` is de facto expected to be specified, and breaks if not specified.  Formalize that expectation.

# Changed Behaviour

No changed behaviour.

## Type of change

- Code maintenance/cleanup