### PR TITLE
Refactor result loop, remove timeout

### DIFF
--- a/parsl/executors/high_throughput/mpi_resource_management.py
+++ b/parsl/executors/high_throughput/mpi_resource_management.py
@@ -203,6 +203,8 @@ class MPITaskScheduler(TaskScheduler):
     def get_result(self, block: bool = True, timeout: Optional[float] = None):
         """Return result and relinquish provisioned nodes"""
         result_pkl = self.pending_result_q.get(block, timeout)
+        if result_pkl is None:
+            return None
         result_dict = pickle.loads(result_pkl)
         # TODO (wardlt): If the task did not request nodes, it won't be in `self._map_tasks_to_nodes`.
         #  Causes Parsl to hang. See Issue #3427


### PR DESCRIPTION
There is no need to iterate the loop to send a heartbeat.  Instead, use a dedicated thread (heartbeater), and no longer send messages to ZMQ in bulk.  ZMQ already handles messages messages performantly and `_multipart()` is for an _atomic_ send of multiple messages or message parts.

This reduces the complexity of the loop, and also reduces the idle CPU load.  On my local hardware, it reduces the idle load by about 40% (not scientific; just looking at htop).

In future work, can replace `result_outgoing.send_multipart()` with just `result_outgoing.send()`

# Changed Behaviour

No changed user-facing behavior.  Potentially visible is less idle CPU use.

## Type of change

- Code maintenance/cleanup