### PR TITLE
Create temp README.md for all-contributors bot installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+[![All Contributors](https://img.shields.io/github/all-contributors/Parsl/parsl?color=ee8449&style=flat-square)](#contributors)


### PR DESCRIPTION
Once I satisfy the first PR merge, I can create a specific "contributors" file to host all this info moving forward.

# Description

The all-contributors bot requires some initial code to be added to a README.md file to complete installation. I plan on creating a separate "contributors" markdown file to host contributor info without adding extra length to our current README.rst file. This README.md will be removed after installation is complete.

# Changed Behaviour

N/A

# Fixes

N/A

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature
