### PR TITLE
Move WorkQueue._port_mailbox to be a local variable

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -333,7 +333,7 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
 
         logger.debug("Starting WorkQueueExecutor")
 
-        self._port_mailbox = multiprocessing.Queue()
+        port_mailbox = multiprocessing.Queue()
 
         # Create a Process to perform WorkQueue submissions
         submit_process_kwargs = {"task_queue": self.task_queue,
@@ -351,7 +351,7 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
                                  "wq_log_dir": self.wq_log_dir,
                                  "project_password_file": self.project_password_file,
                                  "project_name": self.project_name,
-                                 "port_mailbox": self._port_mailbox,
+                                 "port_mailbox": port_mailbox,
                                  "coprocess": self.coprocess
                                  }
         self.submit_process = multiprocessing.Process(target=_work_queue_submit_wait,
@@ -366,7 +366,7 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         self.submit_process.start()
         self.collector_thread.start()
 
-        self._chosen_port = self._port_mailbox.get(timeout=60)
+        self._chosen_port = port_mailbox.get(timeout=60)
 
         logger.debug(f"Chosen listening port is {self._chosen_port}")
 


### PR DESCRIPTION
This is a small step in restricting global/broadly scoped state around multithread/multiprocess use - something which is an ongoing problem in Parsl in general.

This change should not change any behaviour as the changed variable was already only used in local scope.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
