### PR TITLE
Perform initial block scaling immediately

### DIFF
--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -340,6 +340,8 @@ class Timer:
         self._thread.start()
 
     def _wake_up_timer(self) -> None:
+        self.make_callback()
+
         while not self._kill_event.wait(self.interval):
             self.make_callback()
 


### PR DESCRIPTION
Prior to PR #3282, initial block scaling happened at DFK startup.

PR #3282 moved initial scaling to happen inside the scaling strategy, alongside other scaling. This meant that initial block scaling only happens on the first poll cycle, by default 5 seconds after startup.

This PR makes a scaling strategy run happen at startup and then every subsequent poll cycle - removing that one-poll-cycle second delay.

# Changed Behaviour

parsl blocks will start up faster.

## Type of change

- Bug fix
