### PR TITLE
Run slurm and flux tests in merge queue

### DIFF
--- a/.github/workflows/parsl+flux.yaml
+++ b/.github/workflows/parsl+flux.yaml
@@ -1,6 +1,7 @@
 name: Test Flux Scheduler
 on:
   pull_request: []
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/parsl+slurm.yaml
+++ b/.github/workflows/parsl+slurm.yaml
@@ -1,6 +1,7 @@
 name: Test Slurm Scheduler
 on:
   pull_request:
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
In order to make more tests mandatory, those tests need to run in the merge queue. PR #3661 did this for the main CI tests. This PR does it for flux and slurm tests so that they can be made mandatory (in github non-versioned config)

# Changed Behaviour

more tests will run at merge time. nothing user-facing.

## Type of change

- Code maintenance/cleanup
