### PR TITLE
Extend scaling test startup timeout

### DIFF
--- a/parsl/tests/test_scaling/test_shutdown_scalein.py
+++ b/parsl/tests/test_scaling/test_shutdown_scalein.py
@@ -14,6 +14,9 @@ from parsl.providers import LocalProvider
 # timeout later on.
 BLOCK_COUNT = 3
 
+# the try_assert timeout for the above number of blocks to get started
+PERMITTED_STARTUP_TIME_S = 30
+
 
 class AccumulatingLocalProvider(LocalProvider):
     def __init__(self, *args, **kwargs):
@@ -67,7 +70,7 @@ def test_shutdown_scalein_blocks(tmpd_cwd, try_assert):
 
     with parsl.load(config):
         # this will wait for everything to be scaled out fully
-        try_assert(lambda: len(htex.connected_managers()) == BLOCK_COUNT)
+        try_assert(lambda: len(htex.connected_managers()) == BLOCK_COUNT, timeout_ms=PERMITTED_STARTUP_TIME_S * 1000)
 
     assert len(accumulating_provider.submit_job_ids) == BLOCK_COUNT, f"Exactly {BLOCK_COUNT} blocks should have been launched"
     assert len(accumulating_provider.cancel_job_ids) == BLOCK_COUNT, f"Exactly {BLOCK_COUNT} blocks should have been scaled in"


### PR DESCRIPTION
Recently I've been seeing this test fail because the workers aren't getting started within the default 5 second timeout.

This test isn't a performance test, so this PR makes that timeout substantially more generous.

The most likely candidate for recent increased startup time is PR #3773, but I have not made any attempt to benchmark this.

# Changed Behaviour

this test might run for longer, rather than failing

## Type of change

- Bug fix
