### PR TITLE
Updated glossary: clarified Future, AppFuture, and DataFuture; added …

### DIFF
--- a/docs/userguide/glossary.rst
+++ b/docs/userguide/glossary.rst
@@ -104,7 +104,7 @@ A future is a placeholder for the result of a task that hasn't finished yet. Par
 Both types allow Parsl to manage and track asynchronous computations efficiently.
 
 Comparison: AppFuture vs. DataFuture
-------------------------------------
+++++++++++++++++++++++++++++++++++++
 
 The following table highlights the differences between AppFuture and DataFuture:
 

--- a/docs/userguide/glossary.rst
+++ b/docs/userguide/glossary.rst
@@ -96,7 +96,30 @@ An executor is a manager that determines which app runs on which resource and wh
 Future
 ------
 
-A future is a placeholder for the result of a task that hasn't finished yet. Both AppFuture and DataFuture are types of Futures. You can use the ``.result()`` method to get the actual result when it's ready.
+A future is a placeholder for the result of a task that hasn't finished yet. Parsl provides two specialized types of futures: **AppFuture** and **DataFuture**.
+
+- **AppFuture** represents the result of an app (function execution) that runs in the background. You can retrieve the result using `.result()`.
+- **DataFuture** represents a **file-based dependency** produced by an app. You can retrieve it using `.fetch()`.
+
+Both types allow Parsl to manage and track asynchronous computations efficiently.
+
+Comparison: AppFuture vs. DataFuture
+------------------------------------
+
+The following table highlights the differences between AppFuture and DataFuture:
+
++---------------+----------------------+------------------------+
+| Feature       | AppFuture            | DataFuture             |
++===============+======================+========================+
+| Represents    | Function execution   | File produced by an app|
+| Use Case      | Track function call  | Track data dependency  |
+| Access Method | `.result()`          | `.fetch()`             |
+| Example       | `future = my_func()` | `data_future = write()`|
++---------------+----------------------+------------------------+
+
+This distinction helps users understand when to use **AppFuture** versus **DataFuture** in Parsl workflows.
+
+
 
 .. _jobglossary:
 

--- a/docs/userguide/glossary.rst
+++ b/docs/userguide/glossary.rst
@@ -113,7 +113,7 @@ The following table highlights the differences between AppFuture and DataFuture:
 +===============+======================+========================+
 | Represents    | Function execution   | File produced by an app|
 | Use Case      | Track function call  | Track data dependency  |
-| Access Method | `.result()`          | `.fetch()`             |
+| Access Method | `.result()`          | `.result()`             |
 | Example       | `future = my_func()` | `data_future = write()`|
 +---------------+----------------------+------------------------+
 


### PR DESCRIPTION
# Description

This PR updates the glossary (`glossary.rst`) by clarifying the definitions of **Future, AppFuture, and DataFuture**.  
A **comparison table** has been added to improve clarity and provide a better understanding of their differences.  
These changes aim to enhance the documentation for new users who may find these terms confusing.

# Changed Behaviour

- Improved descriptions for **Future, AppFuture, and DataFuture** to be clearer and more concise.  
- Added a comparison table for easy differentiation.  
- No changes to core functionality, only an improvement in documentation.  

# Fixes

Fixes # (issue number, if applicable)  

## Type of change

- [ ] Bug fix  
- [ ] New feature  
- [x] Update to human readable text: Documentation/error messages/comments  
- [ ] Code maintenance/cleanup  

