### PR TITLE
Add another monitoring kill test, for filesystem router

### DIFF
--- a/parsl/tests/test_shutdown/test_kill_monitoring.py
+++ b/parsl/tests/test_shutdown/test_kill_monitoring.py
@@ -30,7 +30,7 @@ def test_no_kills():
 
 @pytest.mark.local
 @pytest.mark.parametrize("sig", [signal.SIGINT, signal.SIGTERM, signal.SIGKILL, signal.SIGQUIT])
-@pytest.mark.parametrize("process_attr", ["router_proc", "dbm_proc"])
+@pytest.mark.parametrize("process_attr", ["router_proc", "dbm_proc", "filesystem_proc"])
 def test_kill_monitoring_helper_process(sig, process_attr, try_assert):
     """This tests that we can kill a monitoring process and still have successful shutdown.
     SIGINT emulates some racy behaviour when ctrl-C is pressed: that


### PR DESCRIPTION
This treats the filesystem router the same as the general router and DB process in this test.

# Changed Behaviour

more testing

## Type of change

- Code maintenance/cleanup
