### PR TITLE
Split MonitoringRouter into ZMQ and UDP processes

### DIFF
--- a/parsl/monitoring/radios/udp_router.py
+++ b/parsl/monitoring/radios/udp_router.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import logging
+import multiprocessing.queues as mpq
+import os
+import pickle
+import socket
+import threading
+import time
+from multiprocessing.synchronize import Event
+from typing import Optional
+
+import typeguard
+
+from parsl.log_utils import set_file_logger
+from parsl.monitoring.radios.multiprocessing import MultiprocessingQueueRadioSender
+from parsl.process_loggers import wrap_with_logs
+from parsl.utils import setproctitle
+
+logger = logging.getLogger(__name__)
+
+
+class MonitoringRouter:
+
+    def __init__(self,
+                 *,
+                 hub_address: str,
+                 udp_port: Optional[int] = None,
+
+                 monitoring_hub_address: str = "127.0.0.1",
+                 run_dir: str = ".",
+                 logging_level: int = logging.INFO,
+                 atexit_timeout: int = 3,   # in seconds
+                 resource_msgs: mpq.Queue,
+                 exit_event: Event,
+                 ):
+        """ Initializes a monitoring configuration class.
+
+        Parameters
+        ----------
+        hub_address : str
+             The ip address at which the workers will be able to reach the Hub.
+        udp_port : int
+             The specific port at which workers will be able to reach the Hub via UDP. Default: None
+        run_dir : str
+             Parsl log directory paths. Logs and temp files go here. Default: '.'
+        logging_level : int
+             Logging level as defined in the logging module. Default: logging.INFO
+        atexit_timeout : float, optional
+            The amount of time in seconds to terminate the hub without receiving any messages, after the last dfk workflow message is received.
+        resource_msgs : multiprocessing.Queue
+            A multiprocessing queue to receive messages to be routed onwards to the database process
+        exit_event : Event
+            An event that the main Parsl process will set to signal that the monitoring router should shut down.
+        """
+        os.makedirs(run_dir, exist_ok=True)
+        self.logger = set_file_logger(f"{run_dir}/monitoring_udp_router.log",
+                                      name="monitoring_router",
+                                      level=logging_level)
+        self.logger.debug("Monitoring router starting")
+
+        self.hub_address = hub_address
+        self.atexit_timeout = atexit_timeout
+
+        self.loop_freq = 10.0  # milliseconds
+
+        # Initialize the UDP socket
+        self.udp_sock = socket.socket(socket.AF_INET,
+                                      socket.SOCK_DGRAM,
+                                      socket.IPPROTO_UDP)
+
+        # We are trying to bind to all interfaces with 0.0.0.0
+        if not udp_port:
+            self.udp_sock.bind(('0.0.0.0', 0))
+            self.udp_port = self.udp_sock.getsockname()[1]
+        else:
+            self.udp_port = udp_port
+            try:
+                self.udp_sock.bind(('0.0.0.0', self.udp_port))
+            except Exception as e:
+                raise RuntimeError(f"Could not bind to udp_port {udp_port} because: {e}")
+        self.udp_sock.settimeout(self.loop_freq / 1000)
+        self.logger.info("Initialized the UDP socket on 0.0.0.0:{}".format(self.udp_port))
+
+        self.target_radio = MultiprocessingQueueRadioSender(resource_msgs)
+        self.exit_event = exit_event
+
+    @wrap_with_logs(target="monitoring_router")
+    def start(self) -> None:
+        self.logger.info("Starting UDP listener thread")
+        udp_radio_receiver_thread = threading.Thread(target=self.start_udp_listener, daemon=True)
+        udp_radio_receiver_thread.start()
+
+        self.logger.info("Joining on UDP listener thread")
+        udp_radio_receiver_thread.join()
+        self.logger.info("Joined on both ZMQ and UDP listener threads")
+
+    @wrap_with_logs(target="monitoring_router")
+    def start_udp_listener(self) -> None:
+        try:
+            while not self.exit_event.is_set():
+                try:
+                    data, addr = self.udp_sock.recvfrom(2048)
+                    resource_msg = pickle.loads(data)
+                    self.logger.debug("Got UDP Message from {}: {}".format(addr, resource_msg))
+                    self.target_radio.send(resource_msg)
+                except socket.timeout:
+                    pass
+
+            self.logger.info("UDP listener draining")
+            last_msg_received_time = time.time()
+            while time.time() - last_msg_received_time < self.atexit_timeout:
+                try:
+                    data, addr = self.udp_sock.recvfrom(2048)
+                    msg = pickle.loads(data)
+                    self.logger.debug("Got UDP Message from {}: {}".format(addr, msg))
+                    self.target_radio.send(msg)
+                    last_msg_received_time = time.time()
+                except socket.timeout:
+                    pass
+
+            self.logger.info("UDP listener finishing normally")
+        finally:
+            self.logger.info("UDP listener finished")
+
+
+@wrap_with_logs
+@typeguard.typechecked
+def udp_router_starter(*,
+                       comm_q: mpq.Queue,
+                       exception_q: mpq.Queue,
+                       resource_msgs: mpq.Queue,
+                       exit_event: Event,
+
+                       hub_address: str,
+                       udp_port: Optional[int],
+
+                       run_dir: str,
+                       logging_level: int) -> None:
+    setproctitle("parsl: monitoring UDP router")
+    try:
+        router = MonitoringRouter(hub_address=hub_address,
+                                  udp_port=udp_port,
+                                  run_dir=run_dir,
+                                  logging_level=logging_level,
+                                  resource_msgs=resource_msgs,
+                                  exit_event=exit_event)
+    except Exception as e:
+        logger.error("MonitoringRouter construction failed.", exc_info=True)
+        comm_q.put(f"Monitoring router construction failed: {e}")
+    else:
+        comm_q.put(router.udp_port)
+
+        router.logger.info("Starting MonitoringRouter in router_starter")
+        try:
+            router.start()
+        except Exception as e:
+            router.logger.exception("UDP router start exception")
+            exception_q.put(('Hub', str(e)))

--- a/parsl/monitoring/radios/zmq_router.py
+++ b/parsl/monitoring/radios/zmq_router.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 import logging
 import multiprocessing.queues as mpq
 import os
-import pickle
-import socket
 import threading
 import time
 from multiprocessing.synchronize import Event
-from typing import Optional, Tuple
+from typing import Tuple
 
 import typeguard
 import zmq
@@ -27,7 +25,6 @@ class MonitoringRouter:
     def __init__(self,
                  *,
                  hub_address: str,
-                 udp_port: Optional[int] = None,
                  zmq_port_range: Tuple[int, int] = (55050, 56000),
 
                  run_dir: str = ".",
@@ -42,8 +39,6 @@ class MonitoringRouter:
         ----------
         hub_address : str
              The ip address at which the workers will be able to reach the Hub.
-        udp_port : int
-             The specific port at which workers will be able to reach the Hub via UDP. Default: None
         zmq_port_range : tuple(int, int)
              The MonitoringHub picks ports at random from the range which will be used by Hub.
              Default: (55050, 56000)
@@ -59,7 +54,7 @@ class MonitoringRouter:
             An event that the main Parsl process will set to signal that the monitoring router should shut down.
         """
         os.makedirs(run_dir, exist_ok=True)
-        self.logger = set_file_logger(f"{run_dir}/monitoring_router.log",
+        self.logger = set_file_logger(f"{run_dir}/monitoring_zmq_router.log",
                                       name="monitoring_router",
                                       level=logging_level)
         self.logger.debug("Monitoring router starting")
@@ -68,24 +63,6 @@ class MonitoringRouter:
         self.atexit_timeout = atexit_timeout
 
         self.loop_freq = 10.0  # milliseconds
-
-        # Initialize the UDP socket
-        self.udp_sock = socket.socket(socket.AF_INET,
-                                      socket.SOCK_DGRAM,
-                                      socket.IPPROTO_UDP)
-
-        # We are trying to bind to all interfaces with 0.0.0.0
-        if not udp_port:
-            self.udp_sock.bind(('0.0.0.0', 0))
-            self.udp_port = self.udp_sock.getsockname()[1]
-        else:
-            self.udp_port = udp_port
-            try:
-                self.udp_sock.bind(('0.0.0.0', self.udp_port))
-            except Exception as e:
-                raise RuntimeError(f"Could not bind to udp_port {udp_port} because: {e}")
-        self.udp_sock.settimeout(self.loop_freq / 1000)
-        self.logger.info("Initialized the UDP socket on 0.0.0.0:{}".format(self.udp_port))
 
         self._context = zmq.Context()
         self.zmq_receiver_channel = self._context.socket(zmq.DEALER)
@@ -102,47 +79,13 @@ class MonitoringRouter:
 
     @wrap_with_logs(target="monitoring_router")
     def start(self) -> None:
-        self.logger.info("Starting UDP listener thread")
-        udp_radio_receiver_thread = threading.Thread(target=self.start_udp_listener, daemon=True)
-        udp_radio_receiver_thread.start()
-
         self.logger.info("Starting ZMQ listener thread")
         zmq_radio_receiver_thread = threading.Thread(target=self.start_zmq_listener, daemon=True)
         zmq_radio_receiver_thread.start()
 
         self.logger.info("Joining on ZMQ listener thread")
         zmq_radio_receiver_thread.join()
-        self.logger.info("Joining on UDP listener thread")
-        udp_radio_receiver_thread.join()
-        self.logger.info("Joined on both ZMQ and UDP listener threads")
-
-    @wrap_with_logs(target="monitoring_router")
-    def start_udp_listener(self) -> None:
-        try:
-            while not self.exit_event.is_set():
-                try:
-                    data, addr = self.udp_sock.recvfrom(2048)
-                    resource_msg = pickle.loads(data)
-                    self.logger.debug("Got UDP Message from {}: {}".format(addr, resource_msg))
-                    self.target_radio.send(resource_msg)
-                except socket.timeout:
-                    pass
-
-            self.logger.info("UDP listener draining")
-            last_msg_received_time = time.time()
-            while time.time() - last_msg_received_time < self.atexit_timeout:
-                try:
-                    data, addr = self.udp_sock.recvfrom(2048)
-                    msg = pickle.loads(data)
-                    self.logger.debug("Got UDP Message from {}: {}".format(addr, msg))
-                    self.target_radio.send(msg)
-                    last_msg_received_time = time.time()
-                except socket.timeout:
-                    pass
-
-            self.logger.info("UDP listener finishing normally")
-        finally:
-            self.logger.info("UDP listener finished")
+        self.logger.info("Joined on ZMQ listener threads")
 
     @wrap_with_logs(target="monitoring_router")
     def start_zmq_listener(self) -> None:
@@ -176,22 +119,20 @@ class MonitoringRouter:
 
 @wrap_with_logs
 @typeguard.typechecked
-def router_starter(*,
-                   comm_q: mpq.Queue,
-                   exception_q: mpq.Queue,
-                   resource_msgs: mpq.Queue,
-                   exit_event: Event,
+def zmq_router_starter(*,
+                       comm_q: mpq.Queue,
+                       exception_q: mpq.Queue,
+                       resource_msgs: mpq.Queue,
+                       exit_event: Event,
 
-                   hub_address: str,
-                   udp_port: Optional[int],
-                   zmq_port_range: Tuple[int, int],
+                       hub_address: str,
+                       zmq_port_range: Tuple[int, int],
 
-                   run_dir: str,
-                   logging_level: int) -> None:
-    setproctitle("parsl: monitoring router")
+                       run_dir: str,
+                       logging_level: int) -> None:
+    setproctitle("parsl: monitoring zmq router")
     try:
         router = MonitoringRouter(hub_address=hub_address,
-                                  udp_port=udp_port,
                                   zmq_port_range=zmq_port_range,
                                   run_dir=run_dir,
                                   logging_level=logging_level,
@@ -201,11 +142,11 @@ def router_starter(*,
         logger.error("MonitoringRouter construction failed.", exc_info=True)
         comm_q.put(f"Monitoring router construction failed: {e}")
     else:
-        comm_q.put((router.udp_port, router.zmq_receiver_port))
+        comm_q.put(router.zmq_receiver_port)
 
         router.logger.info("Starting MonitoringRouter in router_starter")
         try:
             router.start()
         except Exception as e:
-            router.logger.exception("router.start exception")
+            router.logger.exception("ZMQ router start exception")
             exception_q.put(('Hub', str(e)))

--- a/parsl/tests/test_shutdown/test_kill_monitoring.py
+++ b/parsl/tests/test_shutdown/test_kill_monitoring.py
@@ -30,7 +30,7 @@ def test_no_kills():
 
 @pytest.mark.local
 @pytest.mark.parametrize("sig", [signal.SIGINT, signal.SIGTERM, signal.SIGKILL, signal.SIGQUIT])
-@pytest.mark.parametrize("process_attr", ["router_proc", "dbm_proc", "filesystem_proc"])
+@pytest.mark.parametrize("process_attr", ["zmq_router_proc", "udp_router_proc", "dbm_proc", "filesystem_proc"])
 def test_kill_monitoring_helper_process(sig, process_attr, try_assert):
     """This tests that we can kill a monitoring process and still have successful shutdown.
     SIGINT emulates some racy behaviour when ctrl-C is pressed: that


### PR DESCRIPTION
This is to facilitate further work where the ZMQ and UDP router processes can have different lifetimes (along with the already separated filesystem router process and any future plugins).

The ZMQ router process is only needed when HTEX is being used, to route messages from the interchange.

The UDP router process is only needed when resource monitoring is enabled, and an executor is configured with the udp radio mode.

This PR does not change when these two processes run, but is only intended to help future PRs make this change.

# Changed Behaviour

one more process at runtime when monitoring is enabled

## Type of change

- Code maintenance/cleanup
