### PR TITLE
Remove unneeded threads in ZMQ/UDP routers

### DIFF
--- a/parsl/monitoring/radios/udp_router.py
+++ b/parsl/monitoring/radios/udp_router.py
@@ -5,7 +5,6 @@ import multiprocessing.queues as mpq
 import os
 import pickle
 import socket
-import threading
 import time
 from multiprocessing.synchronize import Event
 from typing import Optional
@@ -87,16 +86,7 @@ class MonitoringRouter:
 
     @wrap_with_logs(target="monitoring_router")
     def start(self) -> None:
-        self.logger.info("Starting UDP listener thread")
-        udp_radio_receiver_thread = threading.Thread(target=self.start_udp_listener, daemon=True)
-        udp_radio_receiver_thread.start()
-
-        self.logger.info("Joining on UDP listener thread")
-        udp_radio_receiver_thread.join()
-        self.logger.info("Joined on both ZMQ and UDP listener threads")
-
-    @wrap_with_logs(target="monitoring_router")
-    def start_udp_listener(self) -> None:
+        self.logger.info("Starting UDP listener")
         try:
             while not self.exit_event.is_set():
                 try:

--- a/parsl/monitoring/radios/zmq_router.py
+++ b/parsl/monitoring/radios/zmq_router.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import multiprocessing.queues as mpq
 import os
-import threading
 import time
 from multiprocessing.synchronize import Event
 from typing import Tuple
@@ -79,16 +78,7 @@ class MonitoringRouter:
 
     @wrap_with_logs(target="monitoring_router")
     def start(self) -> None:
-        self.logger.info("Starting ZMQ listener thread")
-        zmq_radio_receiver_thread = threading.Thread(target=self.start_zmq_listener, daemon=True)
-        zmq_radio_receiver_thread.start()
-
-        self.logger.info("Joining on ZMQ listener thread")
-        zmq_radio_receiver_thread.join()
-        self.logger.info("Joined on ZMQ listener threads")
-
-    @wrap_with_logs(target="monitoring_router")
-    def start_zmq_listener(self) -> None:
+        self.logger.info("Starting ZMQ listener")
         try:
             while not self.exit_event.is_set():
                 try:


### PR DESCRIPTION
Before this PR, the ZMQ/UDP router main threads only launched the receiver threads and then waiting for them to terminate. There is no need for separate threads for this.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
