### PR TITLE
Remove unused timeout parameter from ZMQ router

### DIFF
--- a/parsl/monitoring/radios/zmq_router.py
+++ b/parsl/monitoring/radios/zmq_router.py
@@ -29,7 +29,6 @@ class MonitoringRouter:
 
                  run_dir: str = ".",
                  logging_level: int = logging.INFO,
-                 atexit_timeout: int = 3,   # in seconds
                  resource_msgs: mpq.Queue,
                  exit_event: Event,
                  ):
@@ -46,8 +45,6 @@ class MonitoringRouter:
              Parsl log directory paths. Logs and temp files go here. Default: '.'
         logging_level : int
              Logging level as defined in the logging module. Default: logging.INFO
-        atexit_timeout : float, optional
-            The amount of time in seconds to terminate the hub without receiving any messages, after the last dfk workflow message is received.
         resource_msgs : multiprocessing.Queue
             A multiprocessing queue to receive messages to be routed onwards to the database process
         exit_event : Event
@@ -60,7 +57,6 @@ class MonitoringRouter:
         self.logger.debug("Monitoring router starting")
 
         self.hub_address = hub_address
-        self.atexit_timeout = atexit_timeout
 
         self.loop_freq = 10.0  # milliseconds
 


### PR DESCRIPTION
This was used as part of the exit behaviour for UDP part of the monitoring router, from before PR #3796 router split.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
