### PR TITLE
Reduce thread exit log level

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -416,7 +416,7 @@ class Manager:
                 logger.exception("Failed to send result to interchange")
 
         result_outgoing.close()
-        logger.info("Exiting")
+        logger.debug("Exiting")
 
     @wrap_with_logs
     def heartbeater(self):
@@ -453,7 +453,7 @@ class Manager:
                     self.procs[worker_id] = p
                     logger.info("Worker {} has been restarted".format(worker_id))
 
-        logger.critical("Exiting")
+        logger.debug("Exiting")
 
     @wrap_with_logs
     def handle_monitoring_messages(self):
@@ -483,7 +483,7 @@ class Manager:
                 self.pending_result_queue.put(msg)
                 logger.debug("Put monitoring message on pending_result_queue")
 
-        logger.critical("Exiting")
+        logger.debug("Exiting")
 
     def start(self):
         """ Start the worker processes.


### PR DESCRIPTION
Threads exiting normally is not unexpected -- the program is shutting down. Match the log level of the counterpart log message when starting the thread.

# Changed Behaviour

Mild changing of thread state log line levels.  For 99% of users, this could be considered a noop.

## Type of change

- Code maintenance/cleanup