### PR TITLE
Make database manager exit by Event, rather than STOP message

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import multiprocessing.queues as mpq
+import multiprocessing.synchronize as mpe
 import os
 import queue
 import threading
@@ -278,11 +279,13 @@ class Database:
 
 class DatabaseManager:
     def __init__(self,
+                 *,
                  db_url: str = 'sqlite:///runinfo/monitoring.db',
                  run_dir: str = '.',
                  logging_level: int = logging.INFO,
                  batching_interval: float = 1,
                  batching_threshold: float = 99999,
+                 exit_event: mpe.Event
                  ):
 
         self.workflow_end = False
@@ -306,6 +309,8 @@ class DatabaseManager:
         self.pending_node_queue: queue.Queue[MonitoringMessage] = queue.Queue()
         self.pending_block_queue: queue.Queue[MonitoringMessage] = queue.Queue()
         self.pending_resource_queue: queue.Queue[MonitoringMessage] = queue.Queue()
+
+        self.external_exit_event = exit_event
 
     def start(self,
               resource_queue: mpq.Queue) -> None:
@@ -555,15 +560,16 @@ class DatabaseManager:
         while not kill_event.is_set() or logs_queue.qsize() != 0:
             logger.debug("Checking STOP conditions: kill event: %s, queue has entries: %s",
                          kill_event.is_set(), logs_queue.qsize() != 0)
+
+            if self.external_exit_event.is_set():
+                self.close()
+
             try:
                 x = logs_queue.get(timeout=0.1)
             except queue.Empty:
                 continue
             else:
-                if x == 'STOP':
-                    self.close()
-                else:
-                    self._dispatch_to_internal(x)
+                self._dispatch_to_internal(x)
 
     def _dispatch_to_internal(self, x: Tuple) -> None:
         assert isinstance(x, tuple)
@@ -682,7 +688,8 @@ def dbm_starter(exception_q: mpq.Queue,
                 resource_msgs: mpq.Queue,
                 db_url: str,
                 run_dir: str,
-                logging_level: int) -> None:
+                logging_level: int,
+                exit_event: mpe.Event) -> None:
     """Start the database manager process
 
     The DFK should start this function. The args, kwargs match that of the monitoring config
@@ -693,7 +700,8 @@ def dbm_starter(exception_q: mpq.Queue,
     try:
         dbm = DatabaseManager(db_url=db_url,
                               run_dir=run_dir,
-                              logging_level=logging_level)
+                              logging_level=logging_level,
+                              exit_event=exit_event)
         logger.info("Starting dbm in dbm starter")
         dbm.start(resource_msgs)
     except KeyboardInterrupt:


### PR DESCRIPTION
This is for consistency with other monitoring process exit.

The database manager already has an internal exit event for shutdown of threads. This PR does not change handling there: the event is set inside the close() method which is also called in other situations, so it isn't obviously the "same" kind of exit event.

For minimality of change, the exit event is checked in the same polling thread as previously was polling for the STOP message.

There's an expectation that the DBM will stay alive until after the monitoring radio routers have shut down - this is part of loosely defined race-y shutdown behaviour around executor level task completion vs delivery of monitoring messages over radios: without this, occasionally the DBM will shut down very fast, before all task completion messages have been put into the database, and tests will fail.

To preserve that ordering, this new DBM shutdown uses a separate shutdown event, which is set at the point that the STOP message was previously sent.

# Changed Behaviour

peturbation in shutdown timings which might now show new race conditions

## Type of change

- Code maintenance/cleanup
