### PR TITLE
Make monitoring shutdown always event-terminate-kill-close

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -285,6 +285,7 @@ def join_terminate_close_proc(process: ForkProcessType, *, timeout: int = 30) ->
     In the case of a very mis-behaving process, this function might take
     up to 3*timeout to exhaust all termination methods and return.
     """
+    logger.debug("Joining process")
     process.join(timeout)
 
     # run a sequence of increasingly aggressive steps to shut down the process.

--- a/parsl/tests/test_monitoring/test_exit_helper.py
+++ b/parsl/tests/test_monitoring/test_exit_helper.py
@@ -13,8 +13,7 @@ def noop():
 
 
 @pytest.mark.local
-def test_pre_exit():
-    """Test calling against a process that has already exited."""
+def test_end_process_already_exited():
     p = ForkProcess(target=noop)
     p.start()
     p.join()
@@ -27,7 +26,7 @@ def hang():
 
 
 @pytest.mark.local
-def test_hang():
+def test_end_hung_process():
     """Test calling against a process that will not exit itself."""
     p = ForkProcess(target=hang)
     p.start()
@@ -45,7 +44,7 @@ def hang_no_sigint(e):
 
 
 @pytest.mark.local
-def test_hang_no_sigint():
+def test_end_hung_process_no_sigint():
     """Test calling against a process that will not exit itself."""
     e = multiprocessing.Event()
     p = ForkProcess(target=hang_no_sigint, args=(e,))

--- a/parsl/tests/test_monitoring/test_exit_helper.py
+++ b/parsl/tests/test_monitoring/test_exit_helper.py
@@ -1,0 +1,56 @@
+import multiprocessing
+import signal
+
+import psutil
+import pytest
+
+from parsl.monitoring.monitoring import join_terminate_close_proc
+from parsl.multiprocessing import ForkProcess
+
+
+def noop():
+    pass
+
+
+@pytest.mark.local
+def test_pre_exit():
+    """Test calling against a process that has already exited."""
+    p = ForkProcess(target=noop)
+    p.start()
+    p.join()
+    join_terminate_close_proc(p)
+
+
+def hang():
+    while True:
+        pass
+
+
+@pytest.mark.local
+def test_hang():
+    """Test calling against a process that will not exit itself."""
+    p = ForkProcess(target=hang)
+    p.start()
+    pid = p.pid
+    join_terminate_close_proc(p, timeout=1)
+    assert not psutil.pid_exists(pid), "process should not exist any more"
+
+
+def hang_no_sigint(e):
+    def s(*args, **kwargs):
+        e.set()
+    signal.signal(signal.SIGTERM, s)
+    while True:
+        pass
+
+
+@pytest.mark.local
+def test_hang_no_sigint():
+    """Test calling against a process that will not exit itself."""
+    e = multiprocessing.Event()
+    p = ForkProcess(target=hang_no_sigint, args=(e,))
+    p.start()
+    pid = p.pid
+    join_terminate_close_proc(p, timeout=1)
+    assert not psutil.pid_exists(pid), "process should not exist any more"
+    assert e.is_set(), "hung process should have set event on signal"


### PR DESCRIPTION
Prior to this PR, the monitoring proceses were shut down in two ways:

* In the happy path, processes would be notified that it was shutdown time via a multiprocessing.Event(). They would be joined on, with no timeout, assuming that they would eventually shut down based on the Event. In the unhappy case that one does not shut down, DFK shutdown would hang here.

* In the unhappy path, processes each have an opportunity to notify that an exception has happened via the exception_q. This is used for two purposes: to transcribe the exception into the main Parsl log, and to change how shutdown happens: if any exception has been delivered this way by any of the monitoring processes, then shutdown will happen by calling .terminate() on each process, without event notification.

This PR changes that so the exception_q is ignored for termination purposes (so it becomes purely a remote-logging system).

In both situations, processes will be ended using a sequence:

* notify by event

* join with timeout

* .terminate()

* join with timeout

* .kill()

The timeout for join is set quite high: monitoring processes sometimes take a while to shut down, and the timeout path is an error path not the fast happy path.

# Changed Behaviour

Monitoring processes which take longer than the timeout but would still otherwise successfully shut down will now be .terminate()ed, meaning whatever they were usefully doing will not happen.

Shutdown in the failing case might take longer: if a process reports an exception and then hangs, it will now take the timeout period to be terminated, rather than immediately.

If a process hangs without reporting an exception, it will now eventually be terminated rather than shutdown hanging.

## Type of change

- Code maintenance/cleanup
