### PR TITLE
Remove exception_q from monitoring

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -684,8 +684,7 @@ class DatabaseManager:
 
 @wrap_with_logs(target="database_manager")
 @typeguard.typechecked
-def dbm_starter(exception_q: mpq.Queue,
-                resource_msgs: mpq.Queue,
+def dbm_starter(resource_msgs: mpq.Queue,
                 db_url: str,
                 run_dir: str,
                 logging_level: int,
@@ -708,9 +707,8 @@ def dbm_starter(exception_q: mpq.Queue,
         logger.exception("KeyboardInterrupt signal caught")
         dbm.close()
         raise
-    except Exception as e:
+    except Exception:
         logger.exception("dbm.start exception")
-        exception_q.put(("DBM", str(e)))
         dbm.close()
 
     logger.info("End of dbm_starter")

--- a/parsl/monitoring/radios/udp_router.py
+++ b/parsl/monitoring/radios/udp_router.py
@@ -118,7 +118,6 @@ class MonitoringRouter:
 @typeguard.typechecked
 def udp_router_starter(*,
                        comm_q: mpq.Queue,
-                       exception_q: mpq.Queue,
                        resource_msgs: mpq.Queue,
                        exit_event: Event,
 
@@ -144,6 +143,5 @@ def udp_router_starter(*,
         router.logger.info("Starting MonitoringRouter in router_starter")
         try:
             router.start()
-        except Exception as e:
+        except Exception:
             router.logger.exception("UDP router start exception")
-            exception_q.put(('Hub', str(e)))

--- a/parsl/monitoring/radios/zmq_router.py
+++ b/parsl/monitoring/radios/zmq_router.py
@@ -107,7 +107,6 @@ class MonitoringRouter:
 @typeguard.typechecked
 def zmq_router_starter(*,
                        comm_q: mpq.Queue,
-                       exception_q: mpq.Queue,
                        resource_msgs: mpq.Queue,
                        exit_event: Event,
 
@@ -129,10 +128,4 @@ def zmq_router_starter(*,
         comm_q.put(f"Monitoring router construction failed: {e}")
     else:
         comm_q.put(router.zmq_receiver_port)
-
-        router.logger.info("Starting MonitoringRouter in router_starter")
-        try:
-            router.start()
-        except Exception as e:
-            router.logger.exception("ZMQ router start exception")
-            exception_q.put(('Hub', str(e)))
+        router.start()


### PR DESCRIPTION
After PR #3811 removed exeception_q's role in exit handling, this code remains only as a rudimentary distributed logging system to convey some specific error messages back to the main process for logging in parsl.log.

No other part of Parsl does this in this way, and instead each process logs to a file with the user expected to look in individual log files.

This PR makes monitoring consistent with that expectation.

# Changed Behaviour

Error messages from monitoring failures will appear in different places, compared to before this PR.

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
