### PR TITLE
Move ZMQ monitoring radio initialization into HTEX

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1129,7 +1129,7 @@ class DataFlowKernel:
             executor.run_dir = self.run_dir
             if self.monitoring:
                 executor.hub_address = self.monitoring.hub_address
-                executor.hub_zmq_port = self.monitoring.hub_zmq_port
+                executor.monitoring_messages = self.monitoring.resource_msgs
                 executor.submit_monitoring_radio = self.monitoring.radio
             if hasattr(executor, 'provider'):
                 if hasattr(executor.provider, 'script_dir'):

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -29,6 +29,7 @@ from parsl.executors.high_throughput.manager_selector import (
 )
 from parsl.executors.status_handling import BlockProviderExecutor
 from parsl.jobs.states import TERMINAL_STATES, JobState, JobStatus
+from parsl.monitoring.radios.zmq_router import ZMQRadioReceiver, start_zmq_receiver
 from parsl.process_loggers import wrap_with_logs
 from parsl.providers import LocalProvider
 from parsl.providers.base import ExecutionProvider
@@ -334,6 +335,10 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         self._result_queue_thread_exit = threading.Event()
         self._result_queue_thread: Optional[threading.Thread] = None
 
+        self.zmq_monitoring: Optional[ZMQRadioReceiver]
+        self.zmq_monitoring = None
+        self.hub_zmq_port = None
+
     radio_mode = "htex"
     enable_mpi_mode: bool = False
     mpi_launcher: str = "mpiexec"
@@ -426,6 +431,15 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         self.command_client = zmq_pipes.CommandClient(
             self.loopback_address, self.interchange_port_range, self.cert_dir
         )
+
+        if self.monitoring_messages is not None:
+            self.zmq_monitoring = start_zmq_receiver(monitoring_messages=self.monitoring_messages,
+                                                     loopback_address=self.loopback_address,
+                                                     port_range=self.interchange_port_range,
+                                                     logdir=self.logdir,
+                                                     worker_debug=self.worker_debug,
+                                                     )
+            self.hub_zmq_port = self.zmq_monitoring.port
 
         self._result_queue_thread = None
         self._start_result_queue_thread()
@@ -860,6 +874,9 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         logger.info("Waiting for result queue thread exit")
         if self._result_queue_thread:
             self._result_queue_thread.join()
+
+        if self.zmq_monitoring:
+            self.zmq_monitoring.close()
 
         logger.info("Finished HighThroughputExecutor shutdown attempt")
 

--- a/parsl/monitoring/errors.py
+++ b/parsl/monitoring/errors.py
@@ -4,3 +4,8 @@ from parsl.errors import ParslError
 class MonitoringHubStartError(ParslError):
     def __str__(self) -> str:
         return "Hub failed to start"
+
+
+class MonitoringRouterStartError(ParslError):
+    def __str__(self) -> str:
+        return "Monitoring router failed to start"

--- a/parsl/tests/test_monitoring/test_fuzz_zmq.py
+++ b/parsl/tests/test_monitoring/test_fuzz_zmq.py
@@ -45,7 +45,7 @@ def test_row_counts():
 
     # dig out the interchange port...
     hub_address = parsl.dfk().monitoring.hub_address
-    hub_zmq_port = parsl.dfk().monitoring.hub_zmq_port
+    hub_zmq_port = parsl.dfk().executors["htex_Local"].hub_zmq_port
 
     # this will send a string to a new socket connection
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:

--- a/parsl/tests/test_monitoring/test_radio_zmq.py
+++ b/parsl/tests/test_monitoring/test_radio_zmq.py
@@ -1,0 +1,27 @@
+import pytest
+
+from parsl.monitoring.radios.zmq import ZMQRadioSender
+from parsl.monitoring.radios.zmq_router import start_zmq_receiver
+from parsl.multiprocessing import SpawnQueue
+
+
+@pytest.mark.local
+def test_send_recv_message(tmpd_cwd, try_assert):
+    q = SpawnQueue()
+    loopback = "127.0.0.1"
+    r = start_zmq_receiver(monitoring_messages=q,
+                           loopback_address=loopback,
+                           port_range=(49152, 65535),
+                           logdir=str(tmpd_cwd),
+                           worker_debug=False)
+
+    s = ZMQRadioSender(loopback, r.port)
+
+    test_msg = ("test", {})
+    s.send(test_msg)
+
+    assert q.get() == test_msg
+
+    assert r.process.is_alive()
+    r.exit_event.set()
+    try_assert(lambda: not r.process.is_alive())

--- a/parsl/tests/test_monitoring/test_stdouterr.py
+++ b/parsl/tests/test_monitoring/test_stdouterr.py
@@ -102,6 +102,9 @@ def test_stdstream_to_monitoring(stdx, expected_stdx, stream, tmpd_cwd, caplog):
         kwargs = {stream: stdx}
         stdapp(**kwargs).result()
 
+    for record in caplog.records:
+        assert record.levelno < logging.ERROR
+
     engine = sqlalchemy.create_engine(c.monitoring.logging_endpoint)
     with engine.begin() as connection:
 

--- a/parsl/tests/test_shutdown/test_kill_monitoring.py
+++ b/parsl/tests/test_shutdown/test_kill_monitoring.py
@@ -30,7 +30,7 @@ def test_no_kills():
 
 @pytest.mark.local
 @pytest.mark.parametrize("sig", [signal.SIGINT, signal.SIGTERM, signal.SIGKILL, signal.SIGQUIT])
-@pytest.mark.parametrize("process_attr", ["zmq_router_proc", "udp_router_proc", "dbm_proc", "filesystem_proc"])
+@pytest.mark.parametrize("process_attr", ["udp_router_proc", "dbm_proc", "filesystem_proc"])
 def test_kill_monitoring_helper_process(sig, process_attr, try_assert):
     """This tests that we can kill a monitoring process and still have successful shutdown.
     SIGINT emulates some racy behaviour when ctrl-C is pressed: that


### PR DESCRIPTION
This is part of an ongoing project to move monitoring message forwarding into relevant executors, with executors only initializing whichever routers are needed.

In this step of the project:

The ZMQ radio/router is only used by the high throughput executor to receive messages from the interchange. This PR makes the initialization of that look more like other interchange<->submit side ZMQ initialiation, rather than look like monitoring system initialization.

This does not stop other future components which want to use monitoring-over-ZMQ: those components would initialize ZMQ routing themselves.

API-wise:

Parsl executors lose the hub_zmq_port attribute which was configured by the DFK after initialising monitoring.

As a replacement, Parsl executors gain a monitoring_messages attribute, which is the multiprocessing.Queue where executors should send monitoring messages when they have received them from their own components. This queue already existed between monitoring components, but is now exposed as an interface for other Parsl components.

Configuration-wise:

Several ZMQ-related monitoring configuration options now come from HTEX configuration, rather than from MonitoringHub configuration. There are no new configuration options.

* Choice of ZMQ port now comes from the same range as other HTEX ZMQ ports, rather than from the port range in MonitoringHub. This means the minimum number of available ports there is now 4, instead of 3.

* ZMQ router log files now go into the High Throughput Executor's log directory, usually a subdirectory of the main log directory.

* ZMQ log verbosity is configured by High Throughput Executor's worker_debug configuration parameter, rather than by MonitoringHub.monitoring_debug.

* The ZMQ router will now listen on the interchange loopback address, configured by HighThroughputExecutor.loopback_address, rather than on all addresses.

## Type of change

- New feature
- Code maintenance/cleanup
