### PR TITLE
Move usage tracking to use spawn context multiprocessing

### DIFF
--- a/parsl/multiprocessing.py
+++ b/parsl/multiprocessing.py
@@ -6,6 +6,7 @@ import multiprocessing
 import multiprocessing.queues
 import platform
 from multiprocessing.context import ForkProcess as ForkProcessType
+from multiprocessing.context import SpawnProcess as SpawnProcessType
 from typing import Callable
 
 logger = logging.getLogger(__name__)
@@ -14,6 +15,7 @@ ForkContext = multiprocessing.get_context("fork")
 SpawnContext = multiprocessing.get_context("spawn")
 
 ForkProcess: Callable[..., ForkProcessType] = ForkContext.Process
+SpawnProcess: Callable[..., SpawnProcessType] = SpawnContext.Process
 
 
 class MacSafeQueue(multiprocessing.queues.Queue):

--- a/parsl/usage_tracking/usage.py
+++ b/parsl/usage_tracking/usage.py
@@ -8,7 +8,7 @@ import uuid
 
 from parsl.dataflow.states import States
 from parsl.errors import ConfigurationError
-from parsl.multiprocessing import ForkProcess
+from parsl.multiprocessing import SpawnProcess
 from parsl.usage_tracking.api import get_parsl_usage
 from parsl.usage_tracking.levels import DISABLED as USAGE_TRACKING_DISABLED
 from parsl.usage_tracking.levels import LEVEL_3 as USAGE_TRACKING_LEVEL_3
@@ -35,7 +35,7 @@ def async_process(fn: Callable[P, None]) -> Callable[P, None]:
     """ Decorator function to launch a function as a separate process """
 
     def run(*args, **kwargs):
-        proc = ForkProcess(target=fn, args=args, kwargs=kwargs, name="Usage-Tracking")
+        proc = SpawnProcess(target=fn, args=args, kwargs=kwargs, name="Usage-Tracking")
         proc.start()
         return proc
 


### PR DESCRIPTION
Prior to this PR, the usage tracking process was launched using the fork multiprocessing context, which interacts badly with threads.

This is part of a larger project to move Parsl away from the fork context. See https://github.com/Parsl/parsl/issues/3723 for more information.

# Changed Behaviour

This will require users invoking Parsl directly from workflow scripts to put `if __name__ == "__main__":` guards around their workflows, as described in the above issue.

## Type of change

- Bug fix
