### PR TITLE
Move monitoring hub/router to use spawn context multiprocessing

### DIFF
--- a/parsl/multiprocessing.py
+++ b/parsl/multiprocessing.py
@@ -17,6 +17,9 @@ SpawnContext = multiprocessing.get_context("spawn")
 ForkProcess: Callable[..., ForkProcessType] = ForkContext.Process
 SpawnProcess: Callable[..., SpawnProcessType] = SpawnContext.Process
 
+SpawnEvent = SpawnContext.Event
+SpawnQueue = SpawnContext.Queue
+
 
 class MacSafeQueue(multiprocessing.queues.Queue):
     """ Multiprocessing queues do not have qsize attributes on MacOS.
@@ -28,7 +31,7 @@ class MacSafeQueue(multiprocessing.queues.Queue):
 
     def __init__(self, *args, **kwargs):
         if 'ctx' not in kwargs:
-            kwargs['ctx'] = multiprocessing.get_context()
+            kwargs['ctx'] = multiprocessing.get_context('spawn')
         super().__init__(*args, **kwargs)
         self._counter = multiprocessing.Value('i', 0)
 
@@ -61,6 +64,6 @@ SizedQueue: Callable[..., multiprocessing.Queue]
 
 if platform.system() != 'Darwin':
     import multiprocessing
-    SizedQueue = multiprocessing.Queue
+    SizedQueue = SpawnQueue
 else:
     SizedQueue = MacSafeQueue


### PR DESCRIPTION
This follows on from PR #3816 and is discussed in issue #3723

This PR makes one test timeout slightly longer: the spawn method is slower to start up new processes (mostly due to re-importing rather than copying from the parent process). On my laptop, that test starts failing with a timeout of 0.7s and github runners are definitely resource constrained and slower than my laptop, so I increased the previous 1s timeout to 2s.

# Changed Behaviour

Users will now require `if __name__ == "__main__"` protective sigil when using monitoring - see issue #3723 for more info.

## Type of change

- Bug fix
