### PR TITLE
Move join_terminate_close_proc to parsl.utils

### DIFF
--- a/parsl/multiprocessing.py
+++ b/parsl/multiprocessing.py
@@ -67,3 +67,38 @@ if platform.system() != 'Darwin':
     SizedQueue = SpawnQueue
 else:
     SizedQueue = MacSafeQueue
+
+
+def join_terminate_close_proc(process: SpawnProcessType, *, timeout: int = 30) -> None:
+    """Increasingly aggressively terminate a process.
+
+    This function assumes that the process is likely to exit before
+    the join timeout, driven by some other means, such as the
+    MonitoringHub router_exit_event. If the process does not exit, then
+    first terminate() and then kill() will be used to end the process.
+
+    In the case of a very mis-behaving process, this function might take
+    up to 3*timeout to exhaust all termination methods and return.
+    """
+    logger.debug("Joining process")
+    process.join(timeout)
+
+    # run a sequence of increasingly aggressive steps to shut down the process.
+    if process.is_alive():
+        logger.error("Process did not join. Terminating.")
+        process.terminate()
+        process.join(timeout)
+        if process.is_alive():
+            logger.error("Process did not join after terminate. Killing.")
+            process.kill()
+            process.join(timeout)
+            # This kill should not be caught by any signal handlers so it is
+            # unlikely that this join will timeout. If it does, there isn't
+            # anything further to do except log an error in the next if-block.
+
+    if process.is_alive():
+        logger.error("Process failed to end")
+        # don't call close if the process hasn't ended:
+        # process.close() doesn't work on a running process.
+    else:
+        process.close()

--- a/parsl/tests/test_monitoring/test_exit_helper.py
+++ b/parsl/tests/test_monitoring/test_exit_helper.py
@@ -4,8 +4,7 @@ import signal
 import psutil
 import pytest
 
-from parsl.monitoring.monitoring import join_terminate_close_proc
-from parsl.multiprocessing import SpawnEvent, SpawnProcess
+from parsl.multiprocessing import SpawnEvent, SpawnProcess, join_terminate_close_proc
 
 
 def noop():


### PR DESCRIPTION
This is used within parsl.monitoring.monitoring, but upcoming code rearrangements to monitoring code want to use it in different places.

There is nothing monitoring specific about this - it should work with any SpawnProcess at least (and probably any multiprocessing Process) so this PR moves it to parsl.multiprocessing.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
