### PR TITLE
Remove DFK-set executor.submit_monitoring_radio

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1129,7 +1129,6 @@ class DataFlowKernel:
             executor.run_dir = self.run_dir
             if self.monitoring:
                 executor.monitoring_messages = self.monitoring.resource_msgs
-                executor.submit_monitoring_radio = self.monitoring.radio
             if hasattr(executor, 'provider'):
                 if hasattr(executor.provider, 'script_dir'):
                     executor.provider.script_dir = os.path.join(self.run_dir, 'submit_scripts')

--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -8,7 +8,6 @@ from typing import Any, Callable, Dict, Optional
 
 from typing_extensions import Literal, Self
 
-from parsl.monitoring.radios.base import MonitoringRadioSender
 from parsl.monitoring.types import TaggedMonitoringMessage
 
 
@@ -47,15 +46,12 @@ class ParslExecutor(metaclass=ABCMeta):
               persuaded otherwise. So if you're implementing an executor and want to
               @typeguard the constructor, you'll have to use List[Any] here.
 
-    The DataFlowKernel will set these two attributes before calling .start(),
+    The DataFlowKernel will set this attribute before calling .start(),
     if monitoring is enabled:
 
         monitoring_messages: Optional[Queue[TaggedMonitoringMessage]] - an executor
             can send messages to the monitoring hub by putting them into
             this queue.
-
-        submit_monitoring_radio: Optional[MonitoringRadioSender] - an executor can
-            send messages to the monitoring hub by sending them using this sender.
     """
 
     label: str = "undefined"
@@ -65,12 +61,10 @@ class ParslExecutor(metaclass=ABCMeta):
         self,
         *,
         monitoring_messages: Optional[Queue[TaggedMonitoringMessage]] = None,
-        submit_monitoring_radio: Optional[MonitoringRadioSender] = None,
         run_dir: str = ".",
         run_id: Optional[str] = None,
     ):
         self.monitoring_messages = monitoring_messages
-        self.submit_monitoring_radio = submit_monitoring_radio
         self.run_dir = os.path.abspath(run_dir)
         self.run_id = run_id
 
@@ -137,13 +131,3 @@ class ParslExecutor(metaclass=ABCMeta):
     @run_id.setter
     def run_id(self, value: Optional[str]) -> None:
         self._run_id = value
-
-    @property
-    def submit_monitoring_radio(self) -> Optional[MonitoringRadioSender]:
-        """Local radio for sending monitoring messages
-        """
-        return self._submit_monitoring_radio
-
-    @submit_monitoring_radio.setter
-    def submit_monitoring_radio(self, value: Optional[MonitoringRadioSender]) -> None:
-        self._submit_monitoring_radio = value

--- a/parsl/executors/flux/executor.py
+++ b/parsl/executors/flux/executor.py
@@ -231,6 +231,7 @@ class FluxExecutor(ParslExecutor, RepresentationMixin):
 
     def start(self):
         """Called when DFK starts the executor when the config is loaded."""
+        super().start()
         os.makedirs(self.working_dir, exist_ok=True)
         self._submission_thread.start()
 

--- a/parsl/executors/globus_compute.py
+++ b/parsl/executors/globus_compute.py
@@ -67,7 +67,7 @@ class GlobusComputeExecutor(ParslExecutor, RepresentationMixin):
 
     def start(self) -> None:
         """ Start the Globus Compute Executor """
-        pass
+        super().start()
 
     def submit(self, func: Callable, resource_specification: Dict[str, Any], *args: Any, **kwargs: Any) -> Future:
         """ Submit func to globus-compute

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -412,6 +412,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
     def start(self):
         """Create the Interchange process and connect to it.
         """
+        super().start()
         if self.encrypted and self.cert_dir is None:
             logger.debug("Creating CurveZMQ certificates")
             self.cert_dir = curvezmq.create_certificates(self.logdir)

--- a/parsl/executors/radical/executor.py
+++ b/parsl/executors/radical/executor.py
@@ -215,6 +215,7 @@ class RadicalPilotExecutor(ParslExecutor, RepresentationMixin):
         """Create the Pilot component and pass it.
         """
         logger.info("starting RadicalPilotExecutor")
+        super().start()
         logger.info('Parsl: {0}'.format(parsl.__version__))
         logger.info('RADICAL pilot: {0}'.format(rp.version))
         self.session = rp.Session(cfg={'base': self.run_dir},

--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -239,6 +239,7 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         retrieve Parsl tasks within the TaskVine system.
         """
 
+        super().start()
         # Synchronize connection and communication settings between the manager and factory
         self.__synchronize_manager_factory_comm_settings()
 

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -314,6 +314,7 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         """Create submit process and collector thread to create, send, and
         retrieve Parsl tasks within the Work Queue system.
         """
+        super().start()
         self.tasks_lock = threading.Lock()
 
         # Create directories for data and results


### PR DESCRIPTION
This attribute is now set by BlockProviderExecutor.start(), using executor.monitoring_messages.

This makes it so there is only be one path for monitoring messages from executor to the MonitoringHub.

# Changed Behaviour

Non-block-provider executors will now get no submit_monitoring_radio attributed injected, but I don't think any executors need that as it is only used for block reporting.


## Type of change

- Code maintenance/cleanup
