### PR TITLE
Correctly calculate new manager real capacity

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -481,7 +481,7 @@ class Interchange:
                         m['idle_since'] = None
                         logger.debug("Sent tasks: %s to manager %r", tids, manager_id)
                         # recompute real_capacity after sending tasks
-                        real_capacity = m['max_capacity'] - tasks_inflight
+                        real_capacity -= task_count
                         if real_capacity > 0:
                             logger.debug("Manager %r has free capacity %s", manager_id, real_capacity)
                             # ... so keep it in the interesting_managers list


### PR DESCRIPTION
# Description

The inner else condition was never utilized before, as the value of `real_capacity` never changed.  Calculate the value correctly by including the tasks that moved.

# Changed Behaviour

No user workflows should be changed; managers will be removed from the interesting_managers variable one iteration sooner.

## Type of change

- Code maintenance/cleanup