### PR TITLE
Fix excessive whitespace in Task Vine log message

### DIFF
--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -623,8 +623,8 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
                 with self._tasks_lock:
                     future = self.tasks.pop(task_report.executor_id)
 
-                logger.debug(f'Updating Future for Parsl Task: {task_report.executor_id}. \
-                               Task {task_report.executor_id} has result_received set to {task_report.result_received}')
+                logger.debug(f'Updating Future for Parsl Task: {task_report.executor_id}. '
+                             f'Task {task_report.executor_id} has result_received set to {task_report.result_received}')
                 if task_report.result_received:
                     try:
                         with open(task_report.result_file, 'rb') as f_in:


### PR DESCRIPTION
Before:
```
1743168380.056636 2025-03-28 13:26:20 MainProcess-55205 TaskVine-Collector-Thread-140654853220032 parsl.executors.taskvine.executor:626 _collect_taskvine_results DEBUG: Updating Future for Parsl Task: 0.                                Task 0 has result_received set to True
```

After:

```
1743168797.042448 2025-03-28 13:33:17 MainProcess-56555 TaskVine-Collector-Thread-140356603016896 parsl.executors.taskvine.executor:626 _collect_taskvine_results DEBUG: Updating Future for Parsl Task: 0. Task 0 has result_received set to True
```

# Changed Behaviour

log formatting

## Type of change

- Update to human readable text: Documentation/error messages/comments
