### PR TITLE
Add result-side monitoring update

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -548,6 +548,8 @@ class Interchange:
                     if len(m['tasks']) == 0 and m['idle_since'] is None:
                         m['idle_since'] = time.time()
 
+                    self._send_monitoring_info(monitoring_radio, m)
+
                 logger.debug("Current tasks on manager %r: %s", manager_id, m["tasks"])
 
             logger.debug("leaving results_incoming section")

--- a/parsl/tests/test_monitoring/test_basic.py
+++ b/parsl/tests/test_monitoring/test_basic.py
@@ -120,7 +120,7 @@ def test_row_counts(tmpd_cwd, fresh_config):
             # Two entries: one showing manager active, one inactive
             result = connection.execute(text("SELECT COUNT(*) FROM node"))
             (c, ) = result.first()
-            assert c == 3
+            assert c == 4
 
         # There should be one block polling status
         # local provider has a status_polling_interval of 5s


### PR DESCRIPTION
# Description

This is a followup to #3833; had meant to add it in there after #3834, but miscommunicated so adding now.

# Changed Behaviour

Adds a result-side monitoring messages for managers that send results.  No workflows should be impacted, but there is now an additional NODEINFO record in the sqlite database.  This PR will bring the total up to 4 (as shown in the changed test).

## Type of change

- New feature