### PR TITLE
Fix binding when user sets HTEx worker ports manually

### DIFF
--- a/parsl/addresses.py
+++ b/parsl/addresses.py
@@ -161,12 +161,11 @@ def get_any_address() -> str:
 
 def tcp_url(address: str, port: Union[str, int, None] = None) -> str:
     """Construct a tcp url safe for IPv4 and IPv6"""
+    port_suffix = f":{port}" if port else ""
     if address == "*":
-        return "tcp://*"
+        return "tcp://*" + port_suffix
 
     ip_addr = ipaddress.ip_address(address)
-
-    port_suffix = f":{port}" if port else ""
 
     if ip_addr.version == 6 and port_suffix:
         url = f"tcp://[{address}]{port_suffix}"

--- a/parsl/tests/test_htex/test_zmq_binding.py
+++ b/parsl/tests/test_htex/test_zmq_binding.py
@@ -12,12 +12,15 @@ from parsl.executors.high_throughput.interchange import Interchange
 from parsl.executors.high_throughput.manager_selector import RandomManagerSelector
 
 
-def make_interchange(*, interchange_address: Optional[str], cert_dir: Optional[str]) -> Interchange:
+def make_interchange(*,
+                     interchange_address: Optional[str],
+                     cert_dir: Optional[str],
+                     worker_ports: Optional[tuple[int, int]] = None) -> Interchange:
     return Interchange(interchange_address=interchange_address,
                        cert_dir=cert_dir,
                        client_address="127.0.0.1",
                        client_ports=(50055, 50056, 50057),
-                       worker_ports=None,
+                       worker_ports=worker_ports,
                        worker_port_range=(54000, 55000),
                        hub_address=None,
                        hub_zmq_port=None,
@@ -105,3 +108,10 @@ def test_limited_interface_binding(cert_dir: Optional[str]):
     assert len(matched_conns) == 1
     # laddr.ip can return ::ffff:127.0.0.1 when using IPv6
     assert address in matched_conns[0].laddr.ip
+
+
+@pytest.mark.local
+@pytest.mark.parametrize("encrypted", (True, False), indirect=True)
+def test_fixed_ports(cert_dir: Optional[str]):
+    ix = make_interchange(interchange_address=None, cert_dir=cert_dir, worker_ports=(51117, 51118))
+    assert ix.interchange_address == "*"

--- a/parsl/tests/unit/test_address.py
+++ b/parsl/tests/unit/test_address.py
@@ -13,6 +13,7 @@ from parsl.addresses import tcp_url
     ("::ffff:127.0.0.1", None, "tcp://::ffff:127.0.0.1"),
     ("::ffff:127.0.0.1", None, "tcp://::ffff:127.0.0.1"),
     ("*", None, "tcp://*"),
+    ("*", 55001, "tcp://*:55001")
 ])
 def test_tcp_url(address, port, expected):
     """Confirm valid address generation"""


### PR DESCRIPTION
# Description

Fixes the creation of the TCP url when the ports used by HTEx workers are fixed.

The `tcp_url` helper function from addresses.py was only appending the port number when the address was not "*".

# Changed Behaviour

HTEx works with the ports fixed. Not sure when it was broken

I added a unit test which shows that the current code fails when launching an HTEx interchange with user-set ports.

# Fixes

None (yet? should I make one?)

## Type of change

- Bug fix
