### PR TITLE
Remove reassignment of interchange global logger

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -605,8 +605,6 @@ def start_file_logger(filename: str, level: int = logging.DEBUG, format_string: 
 
         )
 
-    global logger
-    logger = logging.getLogger(LOGGER_NAME)
     logger.setLevel(level)
     handler = logging.FileHandler(filename)
     handler.setLevel(level)


### PR DESCRIPTION
Since PR #2828, this has been assigned at the top level as part of module import, and the reassignment has always been reassigning to the same Logger value - effectively a no-op

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
