### PR TITLE
Remove interchange logging for sections where nothing happens

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -220,11 +220,11 @@ class Interchange:
     def process_command(self, monitoring_radio: Optional[MonitoringRadioSender]) -> None:
         """ Command server to run async command to the interchange
         """
-        logger.debug("entering command_server section")
 
         reply: Any  # the type of reply depends on the command_req received (aka this needs dependent types...)
 
         if self.command_channel in self.socks and self.socks[self.command_channel] == zmq.POLLIN:
+            logger.debug("entering command_server section")
 
             command_req = self.command_channel.recv_pyobj()
             logger.debug("Received command request: {}".format(command_req))
@@ -493,8 +493,6 @@ class Interchange:
                     interesting_managers.remove(manager_id)
                     # logger.debug("Nothing to send to manager {}".format(manager_id))
             logger.debug("leaving _ready_managers section, with %s managers still interesting", len(interesting_managers))
-        else:
-            logger.debug("either no interesting managers or no tasks, so skipping manager pass")
 
     def process_results_incoming(self, interesting_managers: Set[bytes], monitoring_radio: Optional[MonitoringRadioSender]) -> None:
         # Receive any results and forward to client


### PR DESCRIPTION
The interchange tight loops through several sections. Two of those sections log that they are doing nothing. Other sections only log when they do something.

This PR makes those two sections no longer log when they do nothing.

As an example, an interchange idle for 20 seconds in a test case on my laptop logs:

before this PR: 5699 lines
after this PR: 1925 lines

The bulk of the remaining 1925 lines is another per-iteration message that is interchange status summary information, rather than per-section activity logging. Rather than implement something specific for this message to log it less frequently, this is left for a future PR which will make the interchange loop only when something happens, rather than in a tight poll.

# Description

Please include a summary of the change and (optionally) which issue is fixed. Please also include
relevant motivation and context.

# Changed Behaviour

Which existing user workflows or functionality will behave differently after this PR?

# Fixes

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix
- New feature
- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
