### PR TITLE
Move WorkQueue and TaskVine tests to a separate GH Action

### DIFF
--- a/.github/workflows/parsl+cctools.yaml
+++ b/.github/workflows/parsl+cctools.yaml
@@ -1,0 +1,50 @@
+name: WorkQueue and TaskVine tests
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      max-parallel: 5
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.11'
+        
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
+        echo "CONDA BIN: $CONDA/bin"
+        
+    - name: Install parsl and dependencies
+      run: |
+        conda install --channel=conda-forge ndcctools mpich mpi4py openssl
+        make deps
+        pip install .[workqueue]
+        export PATH=/usr/share/miniconda/bin/:$PATH
+
+    - name: Sanity check
+      run: |
+        echo "PATH: $PATH"
+        echo "Python: "; which python3
+        python3 -c "import ndcctools; print(ndcctools.__file__)"
+        python3 -c "from ndcctools import work_queue; print(work_queue.__version__)"
+        python3 -c "import parsl; print(parsl.__version__)"
+        which parsl_coprocess.py
+        which python3
+        find /usr/share/miniconda | grep libssl
+        
+    - name: Run pytest suite for WorkQueue and TaskVine
+      run: |
+        make wqex_local_test
+        make vineex_local_test

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,8 @@ SHELL := $(shell which bash) # Use bash instead of bin/sh as shell
 GIT := $(shell which git || echo ".git_is_missing")
 CWD := $(shell pwd)
 DEPS := .deps
-CCTOOLS_INSTALL := /tmp/cctools
-CCTOOLS_PYTHONPATH := $(CCTOOLS_INSTALL)/lib/python3.12/site-packages
 MPICH=mpich
 OPENMPI=openmpi
-export PATH := $(CCTOOLS_INSTALL)/bin/:$(PATH)
-export CCTOOLS_VERSION=7.15.1
 export HYDRA_LAUNCHER=fork
 export OMPI_MCA_rmaps_base_oversubscribe=yes
 MPI=$(MPICH)
@@ -70,16 +66,13 @@ htex_local_alternate_test: ## run all tests with htex_local config
 	pip3 install ".[monitoring]"
 	pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/htex_local_alternate.py --random-order --durations 10
 
-$(CCTOOLS_INSTALL):	#CCtools contains both taskvine and workqueue so install only once
-	parsl/executors/taskvine/install-taskvine.sh
-
 .PHONY: vineex_local_test
-vineex_local_test: $(CCTOOLS_INSTALL)  ## run all tests with taskvine_ex config
-	PYTHONPATH=$(CCTOOLS_PYTHONPATH)  pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/taskvine_ex.py --random-order --durations 10
+vineex_local_test:
+	pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/taskvine_ex.py --random-order --durations 10
 
 .PHONY: wqex_local_test
-wqex_local_test: $(CCTOOLS_INSTALL)  ## run all tests with workqueue_ex config
-	PYTHONPATH=$(CCTOOLS_PYTHONPATH)  pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/workqueue_ex.py --random-order --durations 10
+wqex_local_test:
+	pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/workqueue_ex.py --random-order --durations 10
 
 .PHONY: radical_local_test
 radical_local_test:
@@ -88,9 +81,9 @@ radical_local_test:
 	pytest parsl/tests/ -k "not cleannet and not issue3328 and not executor_supports_std_stream_tuples" --config parsl/tests/configs/local_radical.py --random-order --durations 10
 
 .PHONY: config_local_test
-config_local_test: $(CCTOOLS_INSTALL)
+config_local_test:
 	pip3 install ".[monitoring,visualization,proxystore,kubernetes]"
-	PYTHONPATH=$(CCTOOLS_PYTHONPATH) pytest parsl/tests/ -k "not cleannet" --config local --random-order --durations 10
+	pytest parsl/tests/ -k "not cleannet" --config local --random-order --durations 10
 
 .PHONY: site_test
 site_test:
@@ -102,7 +95,7 @@ perf_test:
 	parsl-perf --time 5 --config parsl/tests/configs/local_threads.py
 
 .PHONY: test ## run all tests with all config types
-test: clean_coverage isort lint flake8 mypy local_thread_test htex_local_test htex_local_alternate_test wqex_local_test vineex_local_test radical_local_test config_local_test perf_test ## run all tests
+test: clean_coverage isort lint flake8 mypy local_thread_test htex_local_test htex_local_alternate_test radical_local_test config_local_test perf_test ## run all tests
 
 .PHONY: tag
 tag: ## create a tag in git. to run, do a 'make VERSION="version string" tag

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -261,7 +261,6 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         if not _work_queue_enabled:
             raise OptionalModuleMissing(['work_queue'], f"WorkQueueExecutor requires the work_queue module. More info: {IMPORT_EXCEPTION}")
 
-
         self.scaling_cores_per_worker = scaling_cores_per_worker
         self.label = label
         self.task_queue: multiprocessing.Queue = SpawnContext.Queue()

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -40,16 +40,18 @@ from parsl.utils import setproctitle
 
 from .errors import WorkQueueFailure, WorkQueueTaskFailure
 
+IMPORT_EXCEPTION = None
 try:
-    import ndcctools.work_queue as wq
+    from ndcctools import work_queue as wq
     from ndcctools.work_queue import (
         WORK_QUEUE_ALLOCATION_MODE_MAX_THROUGHPUT,
         WORK_QUEUE_DEFAULT_PORT,
         WorkQueue,
     )
-except ImportError:
+except ImportError as e:
     _work_queue_enabled = False
     WORK_QUEUE_DEFAULT_PORT = 0
+    IMPORT_EXCEPTION = e
 else:
     _work_queue_enabled = True
 
@@ -257,7 +259,8 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         BlockProviderExecutor.__init__(self, provider=provider,
                                        block_error_handler=True)
         if not _work_queue_enabled:
-            raise OptionalModuleMissing(['work_queue'], "WorkQueueExecutor requires the work_queue module.")
+            raise OptionalModuleMissing(['work_queue'], f"WorkQueueExecutor requires the work_queue module. More info: {IMPORT_EXCEPTION}")
+
 
         self.scaling_cores_per_worker = scaling_cores_per_worker
         self.label = label

--- a/parsl/tests/test_monitoring/test_basic.py
+++ b/parsl/tests/test_monitoring/test_basic.py
@@ -54,26 +54,8 @@ def htex_filesystem_config():
     return c
 
 
-def workqueue_config():
-    from parsl.tests.configs.workqueue_ex import fresh_config
-    c = fresh_config()
-    c.monitoring = MonitoringHub(
-                        hub_address="localhost",
-                        resource_monitoring_interval=1)
-    return c
-
-
-def taskvine_config():
-    c = Config(executors=[TaskVineExecutor(manager_config=TaskVineManagerConfig(port=9000),
-                                           worker_launch_method='provider')],
-
-               monitoring=MonitoringHub(hub_address="localhost",
-                                        resource_monitoring_interval=1))
-    return c
-
-
 @pytest.mark.local
-@pytest.mark.parametrize("fresh_config", [htex_config, htex_filesystem_config, htex_udp_config, workqueue_config, taskvine_config])
+@pytest.mark.parametrize("fresh_config", [htex_config, htex_filesystem_config, htex_udp_config])
 def test_row_counts(tmpd_cwd, fresh_config):
     # this is imported here rather than at module level because
     # it isn't available in a plain parsl install, so this module


### PR DESCRIPTION
# Description

This PR splits out the testing for WorkQueue and TaskVine into a separate Github action.
The current mechanism that relies on pulling binaries for cctools is broken in Ubuntu 24.04, and based on the discussion here: https://github.com/Parsl/parsl/issues/3544, the recommended solution is to switch to using binaries distributed through conda. 

* Split out TaskVine and WorkQueue test to a separate GH Action
* Update GH Action to use conda instead of virtualenv.

# Changed Behaviour

The default Parsl CI test action will no longer test WorkQueue and TaskVine. A new action is added for these tests.

# Fixes

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Code maintenance/cleanup
