### PR TITLE
Add Add priority queue to HTEX interchange v4

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -8,7 +8,7 @@ import warnings
 from collections import defaultdict
 from concurrent.futures import Future
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
+from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import typeguard
 
@@ -363,7 +363,9 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
 
     def validate_resource_spec(self, resource_specification: dict):
         if resource_specification:
-            acceptable_fields: Set[str] = set()  # add new resource spec field names here to make htex accept them
+            """HTEX supports the following *Optional* resource specifications:
+            priority: lower value is higher priority"""
+            acceptable_fields = {'priority'}  # add new resource spec field names here to make htex accept them
             keys = set(resource_specification.keys())
             invalid_keys = keys - acceptable_fields
             if invalid_keys:

--- a/parsl/tests/test_htex/test_priority_queue.py
+++ b/parsl/tests/test_htex/test_priority_queue.py
@@ -1,0 +1,74 @@
+import pytest
+
+import parsl
+from parsl.app.app import python_app
+from parsl.config import Config
+from parsl.executors import HighThroughputExecutor
+from parsl.executors.high_throughput.manager_selector import RandomManagerSelector
+from parsl.providers import LocalProvider
+from parsl.usage_tracking.levels import LEVEL_1
+
+
+@python_app
+def fake_task(parsl_resource_specification=None):
+    import time
+    return time.time()
+
+
+@pytest.mark.local
+def test_priority_queue():
+    provider = LocalProvider(
+        init_blocks=0,
+        max_blocks=0,
+        min_blocks=0,
+    )
+
+    htex = HighThroughputExecutor(
+        label="htex_local",
+        max_workers_per_node=1,
+        manager_selector=RandomManagerSelector(),
+        provider=provider,
+    )
+
+    config = Config(
+        executors=[htex],
+        strategy="htex_auto_scale",
+        usage_tracking=LEVEL_1,
+    )
+
+    with parsl.load(config):
+        futures = {}
+
+        # Submit tasks with mixed priorities
+        # Priorities: [10, 10, 5, 5, 1, 1] to test fallback behavior
+        for i, priority in enumerate([10, 10, 5, 5, 1, 1]):
+            spec = {'priority': priority}
+            futures[(priority, i)] = fake_task(parsl_resource_specification=spec)
+
+        provider.max_blocks = 1
+
+        # Wait for completion
+        results = {
+            key: future.result() for key, future in futures.items()
+        }
+
+        # Sort by finish time
+        sorted_by_completion = sorted(results.items(), key=lambda item: item[1])
+        execution_order = [key for key, _ in sorted_by_completion]
+
+        # print("\nExecution Order (priority, submission index):")
+        # for key in execution_order:
+        #     print(f"  {key}")
+
+        # check priority queue functionality
+        priorities_only = [p for (p, i) in execution_order]
+        assert priorities_only == sorted(priorities_only), "Priority execution order failed"
+
+        # check FIFO fallback
+        from collections import defaultdict
+        seen = defaultdict(list)
+        for (priority, idx) in execution_order:
+            seen[priority].append(idx)
+
+        for priority, indices in seen.items():
+            assert indices == sorted(indices), f"FIFO fallback violated for priority {priority}"

--- a/parsl/tests/test_htex/test_resource_spec_validation.py
+++ b/parsl/tests/test_htex/test_resource_spec_validation.py
@@ -36,3 +36,10 @@ def test_resource_spec_validation_bad_keys():
 
     with pytest.raises(InvalidResourceSpecification):
         htex.validate_resource_spec({"num_nodes": 2})
+
+
+@pytest.mark.local
+def test_resource_spec_validation_one_key():
+    htex = HighThroughputExecutor()
+    ret_val = htex.validate_resource_spec({"priority": 2})
+    assert ret_val is None

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,6 +16,7 @@ globus-compute-sdk>=2.34.0
 # as well as at runtime for optional monitoring execution
 # (where it's specified in setup.py)
 sqlalchemy>=2,<2.1
+sortedcontainers-stubs
 
 Sphinx==4.5.0
 twine


### PR DESCRIPTION
# Description

Replaces pending_task_queue's queue.Queue() as a SortedList which functions as a priority queue in the interchange. Used to prioritize certain user-labeled tasks when distributing tasks to managers

# Changed Behaviour

Users can now use the parsl_resource_specification keyword in python apps to specify a 'priority'. Lower value is higher priority, tasks with higher priority will be distributed to workers first. If no priority is given, tasks default to the lowest priority and the FIFO queue behavior of the original queue.Queue() is retained.

# Fixes

Part of #3323, reverts changes in #3750 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature
