### PR TITLE
Move Radical tests to a separate GH Action

### DIFF
--- a/.github/workflows/parsl+radical.yaml
+++ b/.github/workflows/parsl+radical.yaml
@@ -43,4 +43,5 @@ jobs:
         
     - name: Run pytest suite for Radical
       run: |
+        export RADICAL_CI=1
         make radical_local_test

--- a/.github/workflows/parsl+radical.yaml
+++ b/.github/workflows/parsl+radical.yaml
@@ -38,8 +38,7 @@ jobs:
         echo "PATH: $PATH"
         echo "Python: "; which python3
         mpiexec --version
-        mpiexec -n 4 python3 -c "from mpi4py import MPI; print(f'Rank {MPI.COMM_WORLD.Get_rank()} of {MPI.COMM_WORLD.Get_size()}')"
-        which python3
+        mpiexec -n 4 python3 -c "from mpi4py import MPI; assert MPI.COMM_WORLD.Get_size() == 4, 'Expected 4 ranks'; print(f'Rank {MPI.COMM_WORLD.Get_rank()} of {MPI.COMM_WORLD.Get_size()}')"
         
     - name: Run pytest suite for Radical
       run: |

--- a/.github/workflows/parsl+radical.yaml
+++ b/.github/workflows/parsl+radical.yaml
@@ -1,4 +1,4 @@
-name: WorkQueue and TaskVine tests
+name: Radical tests
 on:
   pull_request:
     types:
@@ -32,6 +32,14 @@ jobs:
         make deps
         pip3 install ".[radical-pilot]"
         export PATH=/usr/share/miniconda/bin/:$PATH
+    
+    - name: Sanity check
+      run: |
+        echo "PATH: $PATH"
+        echo "Python: "; which python3
+        mpiexec --version
+        mpiexec -n 4 python3 -c "from mpi4py import MPI; print(f'Rank {MPI.COMM_WORLD.Get_rank()} of {MPI.COMM_WORLD.Get_size()}')"
+        which python3
         
     - name: Run pytest suite for Radical
       run: |

--- a/.github/workflows/parsl+radical.yaml
+++ b/.github/workflows/parsl+radical.yaml
@@ -1,0 +1,38 @@
+name: WorkQueue and TaskVine tests
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      max-parallel: 5
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.11'
+        
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
+        echo "CONDA BIN: $CONDA/bin"
+        
+    - name: Install parsl and dependencies
+      run: |
+        conda install --channel=conda-forge mpich mpi4py openssl
+        make deps
+        pip3 install ".[radical-pilot]"
+        export PATH=/usr/share/miniconda/bin/:$PATH
+        
+    - name: Run pytest suite for Radical
+      run: |
+        make radical_local_test

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ radical_local_test:
 	pip3 install ".[radical-pilot]"
 	mkdir -p ~/.radical/pilot/configs && echo '{"localhost": {"virtenv_mode": "local"}}' > ~/.radical/pilot/configs/resource_local.json
 	pytest parsl/tests/ -k "not cleannet and not issue3328 and not executor_supports_std_stream_tuples" --config parsl/tests/configs/local_radical.py --random-order --durations 10
+	pytest parsl/tests/ -m "radical" --config local --random-order --durations 10
 
 .PHONY: config_local_test
 config_local_test:

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ perf_test:
 	parsl-perf --time 5 --config parsl/tests/configs/local_threads.py
 
 .PHONY: test ## run all tests with all config types
-test: clean_coverage isort lint flake8 mypy local_thread_test htex_local_test htex_local_alternate_test radical_local_test config_local_test perf_test ## run all tests
+test: clean_coverage isort lint flake8 mypy local_thread_test htex_local_test htex_local_alternate_test config_local_test perf_test ## run all tests
 
 .PHONY: tag
 tag: ## create a tag in git. to run, do a 'make VERSION="version string" tag

--- a/parsl/tests/test_radical/test_mpi_funcs.py
+++ b/parsl/tests/test_radical/test_mpi_funcs.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 import parsl
@@ -18,6 +20,10 @@ apps = []
 
 @pytest.mark.local
 @pytest.mark.radical
+@pytest.mark.skipif(
+    os.environ.get("RADICAL_CI") != "1",
+    reason="Only runs in Radical CI workflow"
+)
 def test_radical_mpi(n=7):
     # rank size should be > 1 for the
     # radical runtime system to run this function in MPI env

--- a/parsl/tests/test_radical/test_mpi_funcs.py
+++ b/parsl/tests/test_radical/test_mpi_funcs.py
@@ -16,6 +16,7 @@ def some_mpi_func(msg, sleep, comm=None, parsl_resource_specification={}):
 apps = []
 
 
+@pytest.mark.skip(reason="Skipping due to issue #3849")
 @pytest.mark.local
 @pytest.mark.radical
 def test_radical_mpi(n=7):

--- a/parsl/tests/test_radical/test_mpi_funcs.py
+++ b/parsl/tests/test_radical/test_mpi_funcs.py
@@ -16,7 +16,6 @@ def some_mpi_func(msg, sleep, comm=None, parsl_resource_specification={}):
 apps = []
 
 
-@pytest.mark.skip(reason="Skipping due to issue #3849")
 @pytest.mark.local
 @pytest.mark.radical
 def test_radical_mpi(n=7):


### PR DESCRIPTION
# Description

This PR aims to separate the Radical executor test suite from the main parsl workflow. The current CI workflow encounters issues when installing MPI via system packages and pip when moving from Ubuntu 20.04 to 24.04. This new workflow fixes this by doing the following:

- Move radical tests to a separate GH action
- Use conda to install MPI and other external dependencies 

# Changed Behaviour

The main Parsl GH Action no longer tests radical executor tests. A new action has been added for radical specific tests.

# Fixes

Fixes #3844 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix

