### PR TITLE
PBSProProvider to log and skip block status updates when qstat fails

### DIFF
--- a/parsl/providers/pbspro/pbspro.py
+++ b/parsl/providers/pbspro/pbspro.py
@@ -98,6 +98,14 @@ class PBSProProvider(TorqueProvider):
 
         retcode, stdout, stderr = self.execute_wait("qstat -f -F json {0}".format(job_id_list))
 
+        # If qstat failed do not update job state
+        if retcode != 0:
+            logger.warning("qstat failed with retcode:%s STDOUT:%s STDERR:%s",
+                           retcode,
+                           stdout.strip(),
+                           stderr.strip())
+            return
+
         job_statuses = json.loads(stdout)
 
         if 'Jobs' in job_statuses:


### PR DESCRIPTION
# Description

This PR addresses concerns raised by @cms21 in https://github.com/Parsl/parsl/issues/3793 where the `PBSProProvider` does not handle failure to probe job status from PBS using `qstat`. This PR makes 2 changes:

1. The provider will now log the return code, stdout, and stderr when `qstat` fails with a non-zero exitcode
2. Instead of the current behavior, where blocks will be treated as missing and set with `JobState.COMPLETED`, this change skips the block status updates. The assumption here is that `qstat` failing does not imply the batch jobs have failed, and we are better off polling the batch system later.

# Changed Behaviour

* Additional debug info will be logged if and when calls to `qstat` fails.
* Defensive updates to job status when the batch system glitches

# Fixes

Fixes #3793 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix
- Code maintenance/cleanup
