### PR TITLE
Fix occasional error on exit with usage tracking enabled (#3859)

### DIFF
--- a/parsl/usage_tracking/usage.py
+++ b/parsl/usage_tracking/usage.py
@@ -240,5 +240,6 @@ class UsageTracker:
                 if proc.is_alive():
                     logger.warning("Usage tracking process did not end itself; sending SIGKILL")
                     proc.kill()
+                    proc.join(timeout=timeout)
 
                 proc.close()


### PR DESCRIPTION
# Description

Occasionally usage tracking can fail to exit cleanly at the end of a parsl run and raise an error.

# Changed Behaviour

Call join() after kill() in usage.py.

# Fixes

Fixes # (#3859)

## Type of change

- Bug fix