### PR TITLE
Remove unused copy-paste code

### DIFF
--- a/parsl/monitoring/radios/base.py
+++ b/parsl/monitoring/radios/base.py
@@ -1,8 +1,5 @@
 import logging
 from abc import ABCMeta, abstractmethod
-from typing import Optional
-
-_db_manager_excepts: Optional[Exception]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This was introduced in PR #3707 and never used. It is a piece of the monitoring database manager optional-import handling code.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
