### PR TITLE
Restore removed cctools monitoring tests

### DIFF
--- a/.github/workflows/parsl+cctools.yaml
+++ b/.github/workflows/parsl+cctools.yaml
@@ -30,7 +30,7 @@ jobs:
       run: |
         conda install --channel=conda-forge ndcctools mpich mpi4py openssl
         make deps
-        pip install .[workqueue, monitoring]
+        pip install .[workqueue,monitoring]
         export PATH=/usr/share/miniconda/bin/:$PATH
 
     - name: Sanity check

--- a/.github/workflows/parsl+cctools.yaml
+++ b/.github/workflows/parsl+cctools.yaml
@@ -30,7 +30,7 @@ jobs:
       run: |
         conda install --channel=conda-forge ndcctools mpich mpi4py openssl
         make deps
-        pip install .[workqueue]
+        pip install .[workqueue, monitoring]
         export PATH=/usr/share/miniconda/bin/:$PATH
 
     - name: Sanity check

--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,12 @@ htex_local_alternate_test: ## run all tests with htex_local config
 .PHONY: vineex_local_test
 vineex_local_test:
 	pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/taskvine_ex.py --random-order --durations 10
+	pytest parsl/tests/ -k "not cleannet and taskvine" --config local --random-order --durations 10
 
 .PHONY: wqex_local_test
 wqex_local_test:
 	pytest parsl/tests/ -k "not cleannet" --config parsl/tests/configs/workqueue_ex.py --random-order --durations 10
+	pytest parsl/tests/ -k "not cleannet and workqueue" --config local --random-order --durations 10
 
 .PHONY: radical_local_test
 radical_local_test:
@@ -84,7 +86,7 @@ radical_local_test:
 .PHONY: config_local_test
 config_local_test:
 	pip3 install ".[monitoring,visualization,proxystore,kubernetes]"
-	pytest parsl/tests/ -k "not cleannet" --config local --random-order --durations 10
+	pytest parsl/tests/ -k "not cleannet and not workqueue and not taskvine" --config local --random-order --durations 10
 
 .PHONY: site_test
 site_test:

--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -167,6 +167,14 @@ def pytest_configure(config):
         'markers',
         'issue_3620: Marks tests that do not work correctly on GlobusComputeExecutor (ref: issue 3620)'
     )
+    config.addinivalue_line(
+        'markers',
+        'workqueue: Marks local tests that require a working Work Queue installation'
+    )
+    config.addinivalue_line(
+        'markers',
+        'taskvine: Marks local tests that require a working Task Vine installation'
+    )
 
 
 @pytest.fixture(autouse=True, scope='session')


### PR DESCRIPTION
PR #3844 removed those tests as part of CI rearragement.

## Type of change

- Code maintenance/cleanup
