### PR TITLE
Reduce requirements in parsl_resource_specification test

### DIFF
--- a/parsl/tests/test_error_handling/test_resource_spec.py
+++ b/parsl/tests/test_error_handling/test_resource_spec.py
@@ -23,7 +23,7 @@ def test_resource(n=2):
             break
 
     # Specify incorrect number of resources
-    spec = {'cores': 2, 'memory': 1000}
+    spec = {'cores': 1, 'memory': 1}
     fut = double(n, parsl_resource_specification=spec)
     try:
         fut.result()
@@ -35,7 +35,7 @@ def test_resource(n=2):
 
     # Specify resources with wrong types
     # 'cpus' is incorrect, should be 'cores'
-    spec = {'cpus': 2, 'memory': 1000, 'disk': 1000}
+    spec = {'cpus': 1, 'memory': 1, 'disk': 1}
     fut = double(n, parsl_resource_specification=spec)
     try:
         fut.result()


### PR DESCRIPTION
These resources are not actually required for the test, which is only validating behaviour when the resources are specified or not.

On resource constrained systems, prior to this PR, I often encountered a test hang as Task Vine's behaviour on insufficent resource is to wait for the resource to become available.

# Changed Behaviour

tests should be less hangy in resource constrained situations

## Type of change

- Code maintenance/cleanup
