### PR TITLE
Update ManagerLost references in docs

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -366,7 +366,7 @@ How can my tasks survive ``WorkerLost`` and ``ManagerLost`` at the end of a batc
 When a batch job ends, pilot workers will be terminated by the batch system,
 and any tasks running there will fail. With `HighThroughputExecutor`,
 this failure will be reported as a `parsl.executors.high_throughput.errors.WorkerLost` or
-`parsl.executors.high_throughput.interchange.ManagerLost` in the task future.
+`parsl.executors.high_throughput.errors.ManagerLost` in the task future.
 
 To mitigate against this:
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -173,7 +173,7 @@ Exceptions
     parsl.providers.errors.SchedulerMissingArgs
     parsl.providers.errors.ScriptPathError
     parsl.executors.high_throughput.errors.WorkerLost
-    parsl.executors.high_throughput.interchange.ManagerLost
+    parsl.executors.high_throughput.errors.ManagerLost
     parsl.serialize.errors.DeserializationError
     parsl.serialize.errors.SerializationError
 


### PR DESCRIPTION
# Description

Updates references in the docs to ManagerLost which has been moved to errors.py instead of being within the Interchange. Theoretically, the original way of accessing ManagerLost via Interchange should be fine but doesn't work. Either way hopefully directly referencing errors.py should make it more clear in docs if nothing else. 

# Changed Behaviour

Docs CI should not fail due to missing references anymore.

# Fixes

N/a

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
