### PR TITLE
Only run GCE test if setup exists

### DIFF
--- a/.github/workflows/gce_test.yaml
+++ b/.github/workflows/gce_test.yaml
@@ -10,8 +10,25 @@ env:
   PYTHON_VERSION: 3.11
 
 jobs:
+  check-secret:
+    runs-on: ubuntu-latest
+    outputs:
+      has_secret: ${{ steps.check-secret.outputs.has_secret }}
+    steps:
+      - name: Collect secret
+        id: check-secret
+        run: |
+          if [ -n "${{ secrets.GLOBUS_COMPUTE_SECRET_KEY }}" ]; then
+            echo "has_secret=1" >> $GITHUB_OUTPUT
+          else
+            echo "has_secret=0" >> $GITHUB_OUTPUT
+          fi
+
   main-test-suite:
     runs-on: ubuntu-24.04
+    needs: check-secret
+    if: needs.check-secret.outputs.has_secret == '1'
+
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
# Description

In practice, this means only PRs created by maintainers will have this test run.  This should hopefully stop the scary failure for external contributors since they will not have access to the repository secrets.

# Changed Behaviour

No product behavior change.

## Type of change

- Code maintenance/cleanup