### PR TITLE
Remove "monitoring is htex only" statement

### DIFF
--- a/docs/userguide/advanced/monitoring.rst
+++ b/docs/userguide/advanced/monitoring.rst
@@ -15,8 +15,6 @@ SQLite tools.
 Monitoring configuration
 ------------------------
 
-Parsl monitoring is only supported with the `parsl.executors.HighThroughputExecutor`. 
-
 The following example shows how to enable monitoring in the Parsl
 configuration. Here the `parsl.monitoring.MonitoringHub` is specified to use port
 55055 to receive monitoring messages from workers every 10 seconds.


### PR DESCRIPTION
Monitoring has been used for years with WorkQueueExecutor within DESC.

## Type of change

- Update to human readable text: Documentation/error messages/comments

