### PR TITLE
Reapply PR #3791 accidentally unapplied in #3796

### DIFF
--- a/parsl/monitoring/radios/udp_router.py
+++ b/parsl/monitoring/radios/udp_router.py
@@ -25,8 +25,6 @@ class MonitoringRouter:
                  *,
                  hub_address: str,
                  udp_port: Optional[int] = None,
-
-                 monitoring_hub_address: str = "127.0.0.1",
                  run_dir: str = ".",
                  logging_level: int = logging.INFO,
                  atexit_timeout: int = 3,   # in seconds


### PR DESCRIPTION
PR #3791 removed an unused argument. PR #3796 was a source code move that was prepared around the same time, and did not do that move cleanly.

# Fixes

nothing was broken by the reversion, so nothing is fixed

## Type of change

- Code maintenance/cleanup
