### PR TITLE
Move more UDP receiver code to own class/file

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -3,16 +3,14 @@ from __future__ import annotations
 import logging
 import multiprocessing.synchronize as ms
 import os
-import queue
 import warnings
 from multiprocessing.queues import Queue
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import Any, Optional, Union
 
 import typeguard
 
-from parsl.monitoring.errors import MonitoringHubStartError
 from parsl.monitoring.radios.filesystem_router import filesystem_router_starter
-from parsl.monitoring.radios.udp_router import udp_router_starter
+from parsl.monitoring.radios.udp_router import start_udp_receiver
 from parsl.monitoring.types import TaggedMonitoringMessage
 from parsl.multiprocessing import (
     SizedQueue,
@@ -119,39 +117,17 @@ class MonitoringHub(RepresentationMixin):
 
         self.monitoring_hub_active = True
 
-        # This annotation is incompatible with typeguard 4.x instrumentation
-        # of local variables: Queue is not subscriptable at runtime, as far
-        # as typeguard is concerned. The more general Queue annotation works,
-        # but does not restrict the contents of the Queue. Using TYPE_CHECKING
-        # here allows the stricter definition to be seen by mypy, and the
-        # simpler definition to be seen by typeguard. Hopefully at some point
-        # in the future, Queue will allow runtime subscripts.
-
-        if TYPE_CHECKING:
-            udp_comm_q: Queue[Union[int, str]]
-        else:
-            udp_comm_q: Queue
-
-        udp_comm_q = SizedQueue(maxsize=10)
-
         self.resource_msgs: Queue[TaggedMonitoringMessage]
         self.resource_msgs = SizedQueue()
 
         self.router_exit_event: ms.Event
         self.router_exit_event = SpawnEvent()
 
-        self.udp_router_proc = SpawnProcess(target=udp_router_starter,
-                                            kwargs={"comm_q": udp_comm_q,
-                                                    "resource_msgs": self.resource_msgs,
-                                                    "exit_event": self.router_exit_event,
-                                                    "udp_port": self.hub_port,
-                                                    "run_dir": dfk_run_dir,
-                                                    "logging_level": logging.DEBUG if self.monitoring_debug else logging.INFO,
-                                                    },
-                                            name="Monitoring-UDP-Router-Process",
-                                            daemon=True,
-                                            )
-        self.udp_router_proc.start()
+        self.udp_receiver = start_udp_receiver(debug=self.monitoring_debug,
+                                               logdir=dfk_run_dir,
+                                               monitoring_messages=self.resource_msgs,
+                                               port=self.hub_port
+                                               )
 
         self.dbm_exit_event: ms.Event
         self.dbm_exit_event = SpawnEvent()
@@ -168,7 +144,7 @@ class MonitoringHub(RepresentationMixin):
                                      )
         self.dbm_proc.start()
         logger.info("Started UDP router process %s and DBM process %s",
-                    self.udp_router_proc.pid, self.dbm_proc.pid)
+                    self.udp_receiver.process.pid, self.dbm_proc.pid)
 
         self.filesystem_proc = SpawnProcess(target=filesystem_router_starter,
                                             kwargs={"q": self.resource_msgs,
@@ -180,20 +156,7 @@ class MonitoringHub(RepresentationMixin):
         self.filesystem_proc.start()
         logger.info("Started filesystem radio receiver process %s", self.filesystem_proc.pid)
 
-        try:
-            udp_comm_q_result = udp_comm_q.get(block=True, timeout=120)
-            udp_comm_q.close()
-            udp_comm_q.join_thread()
-        except queue.Empty:
-            logger.error("Monitoring UDP router has not reported port in 120s. Aborting")
-            raise MonitoringHubStartError()
-
-        if isinstance(udp_comm_q_result, str):
-            logger.error("MonitoringRouter sent an error message: %s", udp_comm_q_result)
-            raise RuntimeError(f"MonitoringRouter failed to start: {udp_comm_q_result}")
-
-        udp_port = udp_comm_q_result
-        self.monitoring_hub_url = "udp://{}:{}".format(self.hub_address, udp_port)
+        self.monitoring_hub_url = "udp://{}:{}".format(self.hub_address, self.udp_receiver.port)
 
         logger.info("Monitoring Hub initialized")
 
@@ -205,7 +168,7 @@ class MonitoringHub(RepresentationMixin):
             self.router_exit_event.set()
 
             logger.info("Waiting for UDP router to terminate")
-            join_terminate_close_proc(self.udp_router_proc)
+            self.udp_receiver.close()
 
             logger.debug("Finished waiting for router termination")
             logger.debug("Waiting for DB termination")

--- a/parsl/tests/test_monitoring/test_radio_udp.py
+++ b/parsl/tests/test_monitoring/test_radio_udp.py
@@ -1,0 +1,53 @@
+import pytest
+
+from parsl.monitoring.message_type import MessageType
+from parsl.monitoring.radios.udp import UDPRadioSender
+from parsl.monitoring.radios.udp_router import start_udp_receiver
+from parsl.multiprocessing import SpawnQueue
+
+
+@pytest.mark.local
+def test_udp(tmpd_cwd):
+    """Test UDP radio/receiver pair.
+    This test checks that the pair can be started up locally, that a message
+    is conveyed from radio to receiver, and that the receiver process goes
+    away at shutdown.
+    """
+
+    resource_msgs = SpawnQueue()
+
+    # start receiver
+    udp_receiver = start_udp_receiver(debug=True,
+                                      logdir=str(tmpd_cwd),
+                                      monitoring_messages=resource_msgs,
+                                      port=None
+                                      )
+
+    # make radio
+
+    # this comes from monitoring.py:
+    url = "udp://{}:{}".format("localhost", udp_receiver.port)
+
+    radio_sender = UDPRadioSender(url)
+
+    # send message into radio
+
+    message = (MessageType.RESOURCE_INFO, {})
+
+    radio_sender.send(message)
+
+    # verify it comes out of the receiver
+
+    m = resource_msgs.get()
+
+    assert m == message, "The sent message should appear in the queue"
+
+    # shut down router
+
+    udp_receiver.close()
+
+    # we can't inspect the process if it has been closed properly, but
+    # we can verify that it raises the expected ValueError the closed
+    # processes raise on access.
+    with pytest.raises(ValueError):
+        udp_receiver.process.exitcode

--- a/parsl/tests/test_shutdown/test_kill_monitoring.py
+++ b/parsl/tests/test_shutdown/test_kill_monitoring.py
@@ -30,7 +30,7 @@ def test_no_kills():
 
 @pytest.mark.local
 @pytest.mark.parametrize("sig", [signal.SIGINT, signal.SIGTERM, signal.SIGKILL, signal.SIGQUIT])
-@pytest.mark.parametrize("process_attr", ["udp_router_proc", "dbm_proc", "filesystem_proc"])
+@pytest.mark.parametrize("process_attr", ["dbm_proc", "filesystem_proc"])
 def test_kill_monitoring_helper_process(sig, process_attr, try_assert):
     """This tests that we can kill a monitoring process and still have successful shutdown.
     SIGINT emulates some racy behaviour when ctrl-C is pressed: that


### PR DESCRIPTION
This is part of making radios more pluggable.

After this PR, there is a UDPRadioReceiver, patterned after ZMQRadioReceiver which contains process state and can be asked to close.

One MonitoringHub shutdown test no longer tests the UDP receiver process being killed -- the MonitoringHub is no longer directly aware of that process because of the new UDPRadioReceiver class.

There is a new test that is more focused on the UDP code starting and exiting correctly, without involving the MonitoringHub, and which runs much faster.

## Type of change

- Code maintenance/cleanup
