### PR TITLE
Make try_assert exponential backoff smoother

### DIFF
--- a/parsl/tests/conftest.py
+++ b/parsl/tests/conftest.py
@@ -406,13 +406,15 @@ def try_assert():
         timeout_ms: float = 5000,
         attempts: int = 0,
         check_period_ms: int = 20,
+        factor: float = 2,
     ):
         tb = create_traceback(start=1)
         check_period_s = abs(check_period_ms) / 1000.0
         if attempts > 0:
             for _attempt_no in range(attempts):
-                time.sleep(random.random() * check_period_s)  # jitter
-                check_period_s *= 2
+                fraction = random.random()
+                time.sleep(fraction * check_period_s)  # jitter
+                check_period_s *= factor ** fraction
                 if test_func():
                     return
             else:
@@ -427,9 +429,10 @@ def try_assert():
             timeout_s = abs(timeout_ms) / 1000.0
             end = time.monotonic() + timeout_s
             while time.monotonic() < end:
-                wait_for = random.random() * check_period_s  # jitter
+                fraction = random.random()
+                wait_for = fraction * check_period_s  # jitter
                 time.sleep(min(wait_for, end - time.monotonic()))
-                check_period_s *= 2
+                check_period_s *= factor ** fraction
                 if test_func():
                     return
             att_fail = (


### PR DESCRIPTION
Before this PR, a sequence of small random number choices could make doublings happen quite fast, pushing the delay time to be quite high faster than exponential rate and then causing later iterations to wait for longer than might be expected.

This PR makes the delay time increase according to the chosen delay for each iteration.

See issue #3350 for an example of where this happened and was part of a non-deterministic test failure.

This PR should make (by default) try_assert wait up to 2x as long as it takes for the assert condition to become true. This is now parameterised by `factor`, so that it might be set to 1.1 to make the assert wait for up to 1.1x the time it takes for the assert condition to become true.

# Changed Behaviour

Exponential backoff should now be more smoothly exponential.

## Type of change

- Bug fix
