### PR TITLE
Make executors call superclass shutdown

### DIFF
--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -99,6 +99,9 @@ class ParslExecutor(metaclass=ABCMeta):
         """Shutdown the executor.
 
         This includes all attached resources such as workers and controllers.
+
+        Executors should call super().shutdown() as part of their overridden
+        implementation.
         """
         pass
 

--- a/parsl/executors/flux/executor.py
+++ b/parsl/executors/flux/executor.py
@@ -248,6 +248,8 @@ class FluxExecutor(ParslExecutor, RepresentationMixin):
         if wait:
             self._submission_thread.join()
 
+        super().shutdown()
+
     def submit(
         self,
         func: Callable,

--- a/parsl/executors/globus_compute.py
+++ b/parsl/executors/globus_compute.py
@@ -134,3 +134,5 @@ class GlobusComputeExecutor(ParslExecutor, RepresentationMixin):
         self.executor.shutdown(wait=False, cancel_futures=True)
         result_watcher = self.executor._get_result_watcher()
         result_watcher.shutdown(wait=False, cancel_futures=True)
+
+        super().shutdown()

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -881,6 +881,8 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         if self.zmq_monitoring:
             self.zmq_monitoring.close()
 
+        super().shutdown()
+
         logger.info("Finished HighThroughputExecutor shutdown attempt")
 
     def get_usage_information(self):

--- a/parsl/executors/radical/executor.py
+++ b/parsl/executors/radical/executor.py
@@ -601,6 +601,9 @@ class RadicalPilotExecutor(ParslExecutor, RepresentationMixin):
             self._bulk_thread.join()
 
         self.session.close(download=True)
+
+        super().shutdown()
+
         logger.info("RadicalPilotExecutor is terminated.")
 
         return True

--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -601,6 +601,8 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         self._finished_task_queue.close()
         self._finished_task_queue.join_thread()
 
+        super().shutdown()
+
         logger.debug("TaskVine shutdown completed")
 
     @wrap_with_logs

--- a/parsl/executors/threads.py
+++ b/parsl/executors/threads.py
@@ -73,6 +73,9 @@ class ThreadPoolExecutor(ParslExecutor, RepresentationMixin):
         """
         logger.debug("Shutting down executor, which involves waiting for running tasks to complete")
         self.executor.shutdown(wait=block)
+
+        super().shutdown()
+
         logger.debug("Done with executor shutdown")
 
     def monitor_resources(self):

--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -714,6 +714,8 @@ class WorkQueueExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         self.collector_queue.close()
         self.collector_queue.join_thread()
 
+        super().shutdown()
+
         logger.debug("Work Queue shutdown completed")
 
     @wrap_with_logs


### PR DESCRIPTION
As of this PR, this doesn't lead to anything of substance being invoked, but an upcoming PR will move monitoring shutdown into the base ParslExecutor (as part of making monitoring radios be per-executor) and this PR provides infrastructure for that. See overarching PR #3315 for more context.

## Type of change

- New feature
