### PR TITLE
Update htex/monitoring fuzz test after PR #3813

### DIFF
--- a/parsl/tests/test_monitoring/test_htex_fuzz_zmq.py
+++ b/parsl/tests/test_monitoring/test_htex_fuzz_zmq.py
@@ -17,7 +17,12 @@ def this_app():
 
 
 @pytest.mark.local
-def test_row_counts():
+def test_fuzz():
+    """This test sends fuzz into the ZMQ radio receiver that HTEX starts
+    for receiving monitoring messages from the interchange, and checks
+    that monitoring still records things ok.
+    """
+
     import sqlalchemy
     from sqlalchemy import text
 
@@ -44,7 +49,7 @@ def test_row_counts():
     #   the latter is what i'm most suspicious of in my present investigation
 
     # dig out the interchange port...
-    hub_address = parsl.dfk().monitoring.hub_address
+    hub_address = parsl.dfk().executors["htex_Local"].loopback_address
     hub_zmq_port = parsl.dfk().executors["htex_Local"].hub_zmq_port
 
     # this will send a string to a new socket connection


### PR DESCRIPTION
PR #3813 made it clearer that monitoring over ZMQ is an HTEX+monitoring feature, not a general monitoring feature.

This PR renames and rephrases that test in that new context.

PR #3813 also changes that ZMQ channel to listen only on the loopback address. This PR updates the test to use that address rather than the previous hub_address attribute.

## Type of change

- Code maintenance/cleanup
