### PR TITLE
Revisit per-task resource monitoring enabling

### DIFF
--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -108,8 +108,9 @@ class ParslExecutor(metaclass=ABCMeta):
     def monitor_resources(self) -> bool:
         """Should resource monitoring happen for tasks on running on this executor?
 
-        Parsl resource monitoring conflicts with execution styles which use threads, and
-        can deadlock while running.
+        Parsl resource monitoring conflicts with execution styles which do
+        not directly use a process tree - for example, the ThreadPoolExecutor
+        and the MPIExecutor.
 
         This function allows resource monitoring to be disabled per executor implementation.
         """

--- a/parsl/executors/high_throughput/mpi_executor.py
+++ b/parsl/executors/high_throughput/mpi_executor.py
@@ -111,3 +111,10 @@ class MPIExecutor(HighThroughputExecutor):
 
     def validate_resource_spec(self, resource_specification: dict):
         return validate_resource_spec(resource_specification)
+
+    def monitor_resources(self):
+        """Resource monitoring does not make sense when using the
+        MPIExecutor, as the process tree launched for each task is spread
+        across multiple OS images/worker nodes.
+        """
+        return False

--- a/parsl/executors/threads.py
+++ b/parsl/executors/threads.py
@@ -79,6 +79,12 @@ class ThreadPoolExecutor(ParslExecutor, RepresentationMixin):
         logger.debug("Done with executor shutdown")
 
     def monitor_resources(self):
-        """Resource monitoring sometimes deadlocks when using threads, so this function
-        returns false to disable it."""
+        """Resource monitoring does not make sense when using the
+        ThreadPoolExecutor, as there is no per-task process tree: all tasks
+        run inside the same single submitting process.
+
+        In addition, the use of fork-based multiprocessing in the remote
+        wrapper in parsl/monitoring/remote.py was especially prone to deadlock
+        with this executor.
+        """
         return False


### PR DESCRIPTION
This PR disables MPIExecutor per task monitoring because it doesn't make sense, and rephrases documentation around this option for my updated understanding of the situation.

# Changed Behaviour

MPI executor won't monitor resource usage of its task process. But this was probably useless anyway: it would have been monitoring the launcher process, not the actual work processes.

## Type of change

- New feature
- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
