### PR TITLE
Remove outdated executor shutdown description

### DIFF
--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -98,8 +98,6 @@ class ParslExecutor(metaclass=ABCMeta):
     def shutdown(self) -> None:
         """Shutdown the executor.
 
-        This includes all attached resources such as workers and controllers.
-
         Executors should call super().shutdown() as part of their overridden
         implementation.
         """


### PR DESCRIPTION
Executor shutdown does not shutdown workers in most current executors: instead, the DFK drives scale in via the JobStatusPoller.

Controllers do not exist as a named concept in Parsl. They did exist in the days of the IPyParallel executor, but that was removed in PR #1565.

## Type of change

- Update to human readable text: Documentation/error messages/comments
