### PR TITLE
Rationalise monitoring radio logging in a post-fork world

### DIFF
--- a/parsl/monitoring/radios/filesystem_router.py
+++ b/parsl/monitoring/radios/filesystem_router.py
@@ -16,12 +16,13 @@ from parsl.multiprocessing import SpawnEvent, join_terminate_close_proc
 from parsl.process_loggers import wrap_with_logs
 from parsl.utils import setproctitle
 
+logger = logging.getLogger(__name__)
+
 
 @wrap_with_logs
 def filesystem_router_starter(*, q: Queue[TaggedMonitoringMessage], run_dir: str, exit_event: Event) -> None:
-    logger = set_file_logger(f"{run_dir}/monitoring_filesystem_radio.log",
-                             name="monitoring_filesystem_radio",
-                             level=logging.INFO)
+    set_file_logger(f"{run_dir}/monitoring_filesystem_radio.log",
+                    level=logging.INFO)
 
     logger.info("Starting filesystem radio receiver")
     setproctitle("parsl: monitoring filesystem receiver")

--- a/parsl/monitoring/radios/zmq_router.py
+++ b/parsl/monitoring/radios/zmq_router.py
@@ -61,10 +61,9 @@ class MonitoringRouter:
             An event that the main Parsl process will set to signal that the monitoring router should shut down.
         """
         os.makedirs(run_dir, exist_ok=True)
-        self.logger = set_file_logger(f"{run_dir}/monitoring_zmq_router.log",
-                                      name="zmq_monitoring_router",
-                                      level=logging_level)
-        self.logger.debug("Monitoring router starting")
+        set_file_logger(f"{run_dir}/monitoring_zmq_router.log",
+                        level=logging_level)
+        logger.debug("Monitoring router starting")
 
         self.address = address
 
@@ -75,7 +74,7 @@ class MonitoringRouter:
         self.zmq_receiver_channel.setsockopt(zmq.LINGER, 0)
         self.zmq_receiver_channel.set_hwm(0)
         self.zmq_receiver_channel.RCVTIMEO = int(self.loop_freq)  # in milliseconds
-        self.logger.debug("address: {}. port_range {}".format(address, port_range))
+        logger.debug("address: {}. port_range {}".format(address, port_range))
         self.zmq_receiver_port = self.zmq_receiver_channel.bind_to_random_port(tcp_url(address),
                                                                                min_port=port_range[0],
                                                                                max_port=port_range[1])
@@ -83,9 +82,9 @@ class MonitoringRouter:
         self.target_radio = MultiprocessingQueueRadioSender(resource_msgs)
         self.exit_event = exit_event
 
-    @wrap_with_logs(target="zmq_monitoring_router")
+    @wrap_with_logs
     def start(self) -> None:
-        self.logger.info("Starting ZMQ listener")
+        logger.info("Starting ZMQ listener")
         try:
             while not self.exit_event.is_set():
                 try:
@@ -107,11 +106,11 @@ class MonitoringRouter:
                     # channel is broken in such a way that it always raises
                     # an exception? Looping on this would maybe be the wrong
                     # thing to do.
-                    self.logger.warning("Failure processing a ZMQ message", exc_info=True)
+                    logger.warning("Failure processing a ZMQ message", exc_info=True)
 
-            self.logger.info("ZMQ listener finishing normally")
+            logger.info("ZMQ listener finishing normally")
         finally:
-            self.logger.info("ZMQ listener finished")
+            logger.info("ZMQ listener finished")
 
 
 @wrap_with_logs


### PR DESCRIPTION
Prior to PR #3817, router processes were launched with multiprocessing fork-no-exec. This carried log configuration into the new process, and made the direction of logs to a log file for the new process vs the other process awkward and confusing.

Post-#3817, router processes start with a clean logging environment. So, this PR makes those processes log to `parsl.*`, following logging conventions, and directs all of `parsl.*` in those processes to the relevant per-process log file.

See issue #3723 for the overarching issue about moving away from fork-no-exec.

# Changed Behaviour

This will make log files longer per-entry because, like parsl.log, the fully qualified module name is now recorded.

This will allow parsl.* log lines from any helper functions to be recorded into the relevant process log - prior to this PR, in that situation, those lines would be discarded - for example, there is now one more log line in the zmq router log, from `wrap_with_logs`.


## Type of change

- Code maintenance/cleanup
