### PR TITLE
Add pluggable API for monitoring radios

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -13,7 +13,6 @@ Core
     parsl.app.app.join_app
     parsl.dataflow.futures.AppFuture
     parsl.dataflow.dflow.DataFlowKernelLoader
-    parsl.monitoring.MonitoringHub
     parsl.dataflow.dependency_resolvers.DependencyResolver
     parsl.dataflow.dependency_resolvers.DEEP_DEPENDENCY_RESOLVER
     parsl.dataflow.dependency_resolvers.SHALLOW_DEPENDENCY_RESOLVER
@@ -176,6 +175,23 @@ Exceptions
     parsl.executors.high_throughput.errors.ManagerLost
     parsl.serialize.errors.DeserializationError
     parsl.serialize.errors.SerializationError
+
+
+Monitoring
+==========
+
+.. autosummary::
+    :toctree: stubs
+    :nosignatures:
+
+    parsl.monitoring.MonitoringHub
+    parsl.monitoring.radios.base.RadioConfig
+    parsl.monitoring.radios.base.RadioSender
+    parsl.monitoring.radios.base.RadioReceiver
+    parsl.monitoring.radios.filesystem.FilesystemRadio
+    parsl.monitoring.radios.htex.HTEXRadio
+    parsl.monitoring.radios.udp.UDPRadio
+
 
 Internal
 ========

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -44,6 +44,7 @@ from parsl.executors.status_handling import BlockProviderExecutor
 from parsl.executors.threads import ThreadPoolExecutor
 from parsl.jobs.job_status_poller import JobStatusPoller
 from parsl.monitoring import MonitoringHub
+from parsl.monitoring.errors import RadioRequiredError
 from parsl.monitoring.message_type import MessageType
 from parsl.monitoring.radios.multiprocessing import MultiprocessingQueueRadioSender
 from parsl.monitoring.remote import monitor_wrapper
@@ -736,17 +737,19 @@ class DataFlowKernel:
         try_id = task_record['fail_count']
 
         if self.monitoring is not None and self.monitoring.resource_monitoring_enabled:
+            if executor.remote_monitoring_radio is None:
+                raise RadioRequiredError()
+
             wrapper_logging_level = logging.DEBUG if self.monitoring.monitoring_debug else logging.INFO
             (function, args, kwargs) = monitor_wrapper(f=function,
                                                        args=args,
                                                        kwargs=kwargs,
                                                        x_try_id=try_id,
                                                        x_task_id=task_id,
-                                                       monitoring_hub_url=self.monitoring.monitoring_hub_url,
+                                                       radio_config=executor.remote_monitoring_radio,
                                                        run_id=self.run_id,
                                                        logging_level=wrapper_logging_level,
                                                        sleep_dur=self.monitoring.resource_monitoring_interval,
-                                                       radio_mode=executor.radio_mode,
                                                        monitor_resources=executor.monitor_resources(),
                                                        run_dir=self.run_dir)
 
@@ -1131,8 +1134,14 @@ class DataFlowKernel:
         for executor in executors:
             executor.run_id = self.run_id
             executor.run_dir = self.run_dir
-            if self.monitoring:
+            if self.monitoring and executor.remote_monitoring_radio is not None:
                 executor.monitoring_messages = self.monitoring.resource_msgs
+                logger.debug("Starting monitoring receiver for executor %s "
+                             "with remote monitoring radio config %s",
+                             executor, executor.remote_monitoring_radio)
+
+                executor.monitoring_receiver = executor.remote_monitoring_radio.create_receiver(resource_msgs=executor.monitoring_messages,
+                                                                                                run_dir=executor.run_dir)
             if hasattr(executor, 'provider'):
                 if hasattr(executor.provider, 'script_dir'):
                     executor.provider.script_dir = os.path.join(self.run_dir, 'submit_scripts')

--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -29,6 +29,8 @@ from parsl.executors.high_throughput.manager_selector import (
 )
 from parsl.executors.status_handling import BlockProviderExecutor
 from parsl.jobs.states import TERMINAL_STATES, JobState, JobStatus
+from parsl.monitoring.radios.base import RadioConfig
+from parsl.monitoring.radios.htex import HTEXRadio
 from parsl.monitoring.radios.zmq_router import ZMQRadioReceiver, start_zmq_receiver
 from parsl.process_loggers import wrap_with_logs
 from parsl.providers import LocalProvider
@@ -261,7 +263,8 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
                  worker_logdir_root: Optional[str] = None,
                  manager_selector: ManagerSelector = RandomManagerSelector(),
                  block_error_handler: Union[bool, Callable[[BlockProviderExecutor, Dict[str, JobStatus]], None]] = True,
-                 encrypted: bool = False):
+                 encrypted: bool = False,
+                 remote_monitoring_radio: Optional[RadioConfig] = None):
 
         logger.debug("Initializing HighThroughputExecutor")
 
@@ -310,6 +313,12 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
             self._workers_per_node = 1  # our best guess-- we do not have any provider hints
 
         self._task_counter = 0
+
+        if remote_monitoring_radio is not None:
+            self.remote_monitoring_radio = remote_monitoring_radio
+        else:
+            self.remote_monitoring_radio = HTEXRadio()
+
         self.worker_ports = worker_ports
         self.worker_port_range = worker_port_range
         self.interchange_proc: Optional[subprocess.Popen] = None
@@ -339,7 +348,6 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         self.zmq_monitoring = None
         self.hub_zmq_port = None
 
-    radio_mode = "htex"
     enable_mpi_mode: bool = False
     mpi_launcher: str = "mpiexec"
 

--- a/parsl/executors/high_throughput/mpi_executor.py
+++ b/parsl/executors/high_throughput/mpi_executor.py
@@ -15,6 +15,7 @@ from parsl.executors.high_throughput.mpi_prefix_composer import (
 from parsl.executors.status_handling import BlockProviderExecutor
 from parsl.jobs.states import JobStatus
 from parsl.launchers import SimpleLauncher
+from parsl.monitoring.radios.base import RadioConfig
 from parsl.providers import LocalProvider
 from parsl.providers.base import ExecutionProvider
 
@@ -67,7 +68,8 @@ class MPIExecutor(HighThroughputExecutor):
                  worker_logdir_root: Optional[str] = None,
                  mpi_launcher: str = "mpiexec",
                  block_error_handler: Union[bool, Callable[[BlockProviderExecutor, Dict[str, JobStatus]], None]] = True,
-                 encrypted: bool = False):
+                 encrypted: bool = False,
+                 remote_monitoring_radio: Optional[RadioConfig] = None):
         super().__init__(
             # Hard-coded settings
             cores_per_worker=1e-9,  # Ensures there will be at least an absurd number of workers
@@ -94,7 +96,8 @@ class MPIExecutor(HighThroughputExecutor):
             address_probe_timeout=address_probe_timeout,
             worker_logdir_root=worker_logdir_root,
             block_error_handler=block_error_handler,
-            encrypted=encrypted
+            encrypted=encrypted,
+            remote_monitoring_radio=remote_monitoring_radio
         )
         self.enable_mpi_mode = True
         self.mpi_launcher = mpi_launcher

--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -40,6 +40,8 @@ from parsl.executors.taskvine.factory_config import TaskVineFactoryConfig
 from parsl.executors.taskvine.manager import _taskvine_submit_wait
 from parsl.executors.taskvine.manager_config import TaskVineManagerConfig
 from parsl.executors.taskvine.utils import ParslFileToVine, ParslTaskToVine
+from parsl.monitoring.radios.base import RadioConfig
+from parsl.monitoring.radios.filesystem import FilesystemRadio
 from parsl.multiprocessing import SpawnContext
 from parsl.process_loggers import wrap_with_logs
 from parsl.providers import CondorProvider, LocalProvider
@@ -98,8 +100,6 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
             Default is None.
     """
 
-    radio_mode = "filesystem"
-
     @typeguard.typechecked
     def __init__(self,
                  label: str = "TaskVineExecutor",
@@ -108,7 +108,8 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
                  manager_config: TaskVineManagerConfig = TaskVineManagerConfig(),
                  factory_config: TaskVineFactoryConfig = TaskVineFactoryConfig(),
                  provider: Optional[ExecutionProvider] = LocalProvider(init_blocks=1),
-                 storage_access: Optional[List[Staging]] = None):
+                 storage_access: Optional[List[Staging]] = None,
+                 remote_monitoring_radio: Optional[RadioConfig] = None):
 
         # Set worker launch option for this executor
         if worker_launch_method == 'factory' or worker_launch_method == 'manual':
@@ -133,6 +134,11 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
         self.manager_config = manager_config
         self.factory_config = factory_config
         self.storage_access = storage_access
+
+        if remote_monitoring_radio is not None:
+            self.remote_monitoring_radio = remote_monitoring_radio
+        else:
+            self.remote_monitoring_radio = FilesystemRadio()
 
         # Queue to send ready tasks from TaskVine executor process to TaskVine manager process
         self._ready_task_queue: multiprocessing.Queue = SpawnContext.Queue()

--- a/parsl/executors/threads.py
+++ b/parsl/executors/threads.py
@@ -7,6 +7,7 @@ import typeguard
 from parsl.data_provider.staging import Staging
 from parsl.executors.base import ParslExecutor
 from parsl.executors.errors import InvalidResourceSpecification
+from parsl.monitoring.radios.base import RadioConfig
 from parsl.utils import RepresentationMixin
 
 logger = logging.getLogger(__name__)
@@ -28,7 +29,7 @@ class ThreadPoolExecutor(ParslExecutor, RepresentationMixin):
     @typeguard.typechecked
     def __init__(self, label: str = 'threads', max_threads: Optional[int] = 2,
                  thread_name_prefix: str = '', storage_access: Optional[List[Staging]] = None,
-                 working_dir: Optional[str] = None):
+                 working_dir: Optional[str] = None, remote_monitoring_radio: Optional[RadioConfig] = None):
         ParslExecutor.__init__(self)
         self.label = label
         self.max_threads = max_threads
@@ -39,6 +40,8 @@ class ThreadPoolExecutor(ParslExecutor, RepresentationMixin):
         # [] is a list with no storage access in it at all
         self.storage_access = storage_access
         self.working_dir = working_dir
+
+        self.remote_monitoring_radio = remote_monitoring_radio
 
     def start(self):
         self.executor = cf.ThreadPoolExecutor(max_workers=self.max_threads,

--- a/parsl/monitoring/errors.py
+++ b/parsl/monitoring/errors.py
@@ -4,3 +4,8 @@ from parsl.errors import ParslError
 class MonitoringRouterStartError(ParslError):
     def __str__(self) -> str:
         return "Monitoring router failed to start"
+
+
+class RadioRequiredError(ParslError):
+    def __str__(self) -> str:
+        return "A radio must be configured for remote task monitoring"

--- a/parsl/monitoring/radios/base.py
+++ b/parsl/monitoring/radios/base.py
@@ -1,10 +1,71 @@
-import logging
 from abc import ABCMeta, abstractmethod
+from multiprocessing.queues import Queue
 
-logger = logging.getLogger(__name__)
+
+class MonitoringRadioReceiver(metaclass=ABCMeta):
+    @abstractmethod
+    def shutdown(self) -> None:
+        pass
 
 
 class MonitoringRadioSender(metaclass=ABCMeta):
     @abstractmethod
     def send(self, message: object) -> None:
+        pass
+
+
+class RadioConfig(metaclass=ABCMeta):
+    """Base class for radio plugin configuration.
+
+    This provides the configuration for a particular way of sending monitoring
+    messages from a source of monitoring messages into the submit side
+    monitoring database.
+
+    This uses staged initialization like lots of Parsl configuration, but in
+    a slightly different form.
+
+    A RadioConfig object must be pickleable, because it will be sent to remote
+    workers to configure senders. The MonitoringRadioSender and
+    MonitoringRadioReceiver objects do not need to be pickleable (and often
+    will not be - for example, when they hold references to other processes).
+
+    The RadioConfig object will be use by Parsl in this sequence:
+
+    * A user creates a RadioConfig object from the appropriate subclass for
+      radio mechanism they want to use, and specifies it as part of their
+      executor configuration.
+
+    Methods on the RadioConfig will then be invoked by Parsl like this:
+
+     * one create_receiver call, on the submit side
+        - this call can modify the state of radioconfig to contain information
+          about how a sender can connect back to the receiver. for example,
+          after binding to a particular port, can store that port so that the
+          sender knows which port to connect to.
+
+     * Possibly many serializations to get the RadioConfig to remote workers
+
+     * Many (0 or more) create_sender calls, possibly on remote workers, to
+       create the sending side of the radio (MonitoringRadioSender instances)
+
+     * Those senders are used to send messages
+
+     * At executor shutdown, the receiver is shut down.
+
+    This object cannot be re-used across parsl configurations - like many other
+    pieces of parsl config it is single use in that respect.
+    """
+
+    @abstractmethod
+    def create_receiver(self, *, run_dir: str, resource_msgs: Queue) -> MonitoringRadioReceiver:
+        """Create a receiver for this RadioConfig, and update this RadioConfig
+        with enough context to create senders.
+        """
+        pass
+
+    @abstractmethod
+    def create_sender(self) -> MonitoringRadioSender:
+        """Create a sender to connect to the receiver created by an
+        earlier call to create_receiver.
+        """
         pass

--- a/parsl/monitoring/radios/filesystem.py
+++ b/parsl/monitoring/radios/filesystem.py
@@ -2,13 +2,19 @@ import logging
 import os
 import pickle
 import uuid
+from multiprocessing.queues import Queue
 
-from parsl.monitoring.radios.base import MonitoringRadioSender
+from parsl.monitoring.radios.base import (
+    MonitoringRadioReceiver,
+    MonitoringRadioSender,
+    RadioConfig,
+)
+from parsl.monitoring.radios.filesystem_router import FilesystemRadioReceiver
 
 logger = logging.getLogger(__name__)
 
 
-class FilesystemRadioSender(MonitoringRadioSender):
+class FilesystemRadio(RadioConfig):
     """A MonitoringRadioSender that sends messages over a shared filesystem.
 
     The messsage directory structure is based on maildir,
@@ -26,7 +32,16 @@ class FilesystemRadioSender(MonitoringRadioSender):
     the UDP radio, but should be much more reliable.
     """
 
-    def __init__(self, *, monitoring_url: str, timeout: int = 10, run_dir: str):
+    def create_sender(self) -> MonitoringRadioSender:
+        return FilesystemRadioSender(run_dir=self.run_dir)
+
+    def create_receiver(self, *, run_dir: str, resource_msgs: Queue) -> MonitoringRadioReceiver:
+        self.run_dir = run_dir
+        return FilesystemRadioReceiver(resource_msgs, run_dir)
+
+
+class FilesystemRadioSender(MonitoringRadioSender):
+    def __init__(self, *, run_dir: str):
         logger.info("filesystem based monitoring radio initializing")
         self.base_path = f"{run_dir}/monitor-fs-radio/"
         self.tmp_path = f"{self.base_path}/tmp"

--- a/parsl/monitoring/radios/htex.py
+++ b/parsl/monitoring/radios/htex.py
@@ -1,24 +1,29 @@
 import logging
 import pickle
+from multiprocessing.queues import Queue
 
-from parsl.monitoring.radios.base import MonitoringRadioSender
+from parsl.monitoring.radios.base import (
+    MonitoringRadioReceiver,
+    MonitoringRadioSender,
+    RadioConfig,
+)
 
 logger = logging.getLogger(__name__)
 
 
+class HTEXRadio(RadioConfig):
+    def create_sender(self) -> MonitoringRadioSender:
+        return HTEXRadioSender()
+
+    def create_receiver(self, *, run_dir: str, resource_msgs: Queue) -> MonitoringRadioReceiver:
+        return HTEXRadioReceiver()
+
+
 class HTEXRadioSender(MonitoringRadioSender):
 
-    def __init__(self, monitoring_url: str, timeout: int = 10):
-        """
-        Parameters
-        ----------
-
-        monitoring_url : str
-            URL of the form <scheme>://<IP>:<PORT>
-        timeout : int
-            timeout, default=10s
-        """
-        logger.info("htex-based monitoring radio initialising")
+    def __init__(self) -> None:
+        # there is nothing to initialize
+        pass
 
     def send(self, message: object) -> None:
         """ Sends a message to the UDP receiver
@@ -54,4 +59,8 @@ class HTEXRadioSender(MonitoringRadioSender):
         else:
             logger.error("result_queue is uninitialized - cannot put monitoring message")
 
-        return
+
+class HTEXRadioReceiver(MonitoringRadioReceiver):
+    def shutdown(self) -> None:
+        # there is nothing to shut down
+        pass

--- a/parsl/monitoring/radios/udp.py
+++ b/parsl/monitoring/radios/udp.py
@@ -1,29 +1,42 @@
 import logging
 import pickle
 import socket
+from multiprocessing.queues import Queue
+from typing import Any, Optional, Union
 
-from parsl.monitoring.radios.base import MonitoringRadioSender
+from parsl.monitoring.radios.base import MonitoringRadioSender, RadioConfig
+from parsl.monitoring.radios.udp_router import start_udp_receiver
+
+logger = logging.getLogger(__name__)
+
+
+class UDPRadio(RadioConfig):
+    def __init__(self, *, port: Optional[int] = None, atexit_timeout: Union[int, float] = 3, address: str, debug: bool = False):
+        self.port = port
+        self.atexit_timeout = atexit_timeout
+        self.address = address
+        self.debug = debug
+
+    def create_sender(self) -> MonitoringRadioSender:
+        assert self.port is not None, "self.port should have been initialized by create_receiver"
+        return UDPRadioSender(self.address, self.port)
+
+    def create_receiver(self, run_dir: str, resource_msgs: Queue) -> Any:
+        udp_receiver = start_udp_receiver(logdir=run_dir,
+                                          monitoring_messages=resource_msgs,
+                                          port=self.port,
+                                          debug=self.debug
+                                          )
+        self.port = udp_receiver.port
+        return udp_receiver
 
 
 class UDPRadioSender(MonitoringRadioSender):
 
-    def __init__(self, monitoring_url: str, timeout: int = 10):
-        """
-        Parameters
-        ----------
-
-        monitoring_url : str
-            URL of the form <scheme>://<IP>:<PORT>
-        timeout : int
-            timeout, default=10s
-        """
-        self.monitoring_url = monitoring_url
+    def __init__(self, address: str, port: int, timeout: int = 10) -> None:
         self.sock_timeout = timeout
-        try:
-            self.scheme, self.ip, port = (x.strip('/') for x in monitoring_url.split(':'))
-            self.port = int(port)
-        except Exception:
-            raise Exception("Failed to parse monitoring url: {}".format(monitoring_url))
+        self.address = address
+        self.port = port
 
         self.sock = socket.socket(socket.AF_INET,
                                   socket.SOCK_DGRAM,
@@ -42,6 +55,7 @@ class UDPRadioSender(MonitoringRadioSender):
         Returns:
             None
         """
+        logger.info("Starting UDP radio message send")
         try:
             buffer = pickle.dumps(message)
         except Exception:
@@ -49,8 +63,9 @@ class UDPRadioSender(MonitoringRadioSender):
             return
 
         try:
-            self.sock.sendto(buffer, (self.ip, self.port))
+            self.sock.sendto(buffer, (self.address, self.port))
         except socket.timeout:
             logging.error("Could not send message within timeout limit")
             return
+        logger.info("Normal ending for UDP radio message send")
         return

--- a/parsl/monitoring/radios/udp_router.py
+++ b/parsl/monitoring/radios/udp_router.py
@@ -155,7 +155,7 @@ class UDPRadioReceiver():
         self.exit_event = exit_event
         self.port = port
 
-    def close(self) -> None:
+    def shutdown(self) -> None:
         self.exit_event.set()
         join_terminate_close_proc(self.process)
 

--- a/parsl/monitoring/remote.py
+++ b/parsl/monitoring/remote.py
@@ -7,10 +7,7 @@ from multiprocessing import Event
 from typing import Any, Callable, Dict, List, Sequence, Tuple
 
 from parsl.monitoring.message_type import MessageType
-from parsl.monitoring.radios.base import MonitoringRadioSender
-from parsl.monitoring.radios.filesystem import FilesystemRadioSender
-from parsl.monitoring.radios.htex import HTEXRadioSender
-from parsl.monitoring.radios.udp import UDPRadioSender
+from parsl.monitoring.radios.base import RadioConfig
 from parsl.multiprocessing import ForkProcess
 from parsl.process_loggers import wrap_with_logs
 
@@ -23,11 +20,10 @@ def monitor_wrapper(*,
                     kwargs: Dict,     # per invocation
                     x_try_id: int,    # per invocation
                     x_task_id: int,   # per invocation
-                    monitoring_hub_url: str,   # per workflow
+                    radio_config: RadioConfig,   # per executor
                     run_id: str,      # per workflow
                     logging_level: int,  # per workflow
                     sleep_dur: float,  # per workflow
-                    radio_mode: str,   # per executor
                     monitor_resources: bool,  # per workflow
                     run_dir: str) -> Tuple[Callable, Sequence, Dict]:
     """Wrap the Parsl app with a function that will call the monitor function and point it at the correct pid when the task begins.
@@ -41,9 +37,8 @@ def monitor_wrapper(*,
         # Send first message to monitoring router
         send_first_message(try_id,
                            task_id,
-                           monitoring_hub_url,
+                           radio_config,
                            run_id,
-                           radio_mode,
                            run_dir)
 
         if monitor_resources and sleep_dur > 0:
@@ -52,9 +47,8 @@ def monitor_wrapper(*,
                              args=(os.getpid(),
                                    try_id,
                                    task_id,
-                                   monitoring_hub_url,
+                                   radio_config,
                                    run_id,
-                                   radio_mode,
                                    logging_level,
                                    sleep_dur,
                                    run_dir,
@@ -87,9 +81,9 @@ def monitor_wrapper(*,
 
             send_last_message(try_id,
                               task_id,
-                              monitoring_hub_url,
+                              radio_config,
                               run_id,
-                              radio_mode, run_dir)
+                              run_dir)
 
     new_kwargs = kwargs.copy()
     new_kwargs['_parsl_monitoring_task_id'] = x_task_id
@@ -98,47 +92,33 @@ def monitor_wrapper(*,
     return (wrapped, args, new_kwargs)
 
 
-def get_radio(radio_mode: str, monitoring_hub_url: str, task_id: int, run_dir: str) -> MonitoringRadioSender:
-    radio: MonitoringRadioSender
-    if radio_mode == "udp":
-        radio = UDPRadioSender(monitoring_hub_url)
-    elif radio_mode == "htex":
-        radio = HTEXRadioSender(monitoring_hub_url)
-    elif radio_mode == "filesystem":
-        radio = FilesystemRadioSender(monitoring_url=monitoring_hub_url,
-                                      run_dir=run_dir)
-    else:
-        raise RuntimeError(f"Unknown radio mode: {radio_mode}")
-    return radio
-
-
 @wrap_with_logs
 def send_first_message(try_id: int,
                        task_id: int,
-                       monitoring_hub_url: str,
-                       run_id: str, radio_mode: str, run_dir: str) -> None:
-    send_first_last_message(try_id, task_id, monitoring_hub_url, run_id,
-                            radio_mode, run_dir, False)
+                       radio_config: RadioConfig,
+                       run_id: str, run_dir: str) -> None:
+    send_first_last_message(try_id, task_id, radio_config, run_id,
+                            run_dir, False)
 
 
 @wrap_with_logs
 def send_last_message(try_id: int,
                       task_id: int,
-                      monitoring_hub_url: str,
-                      run_id: str, radio_mode: str, run_dir: str) -> None:
-    send_first_last_message(try_id, task_id, monitoring_hub_url, run_id,
-                            radio_mode, run_dir, True)
+                      radio_config: RadioConfig,
+                      run_id: str, run_dir: str) -> None:
+    send_first_last_message(try_id, task_id, radio_config, run_id,
+                            run_dir, True)
 
 
 def send_first_last_message(try_id: int,
                             task_id: int,
-                            monitoring_hub_url: str,
-                            run_id: str, radio_mode: str, run_dir: str,
+                            radio_config: RadioConfig,
+                            run_id: str, run_dir: str,
                             is_last: bool) -> None:
     import os
     import platform
 
-    radio = get_radio(radio_mode, monitoring_hub_url, task_id, run_dir)
+    radio = radio_config.create_sender()
 
     msg = (MessageType.RESOURCE_INFO,
            {'run_id': run_id,
@@ -158,9 +138,8 @@ def send_first_last_message(try_id: int,
 def monitor(pid: int,
             try_id: int,
             task_id: int,
-            monitoring_hub_url: str,
+            radio_config: RadioConfig,
             run_id: str,
-            radio_mode: str,
             logging_level: int,
             sleep_dur: float,
             run_dir: str,
@@ -184,7 +163,7 @@ def monitor(pid: int,
 
     setproctitle("parsl: task resource monitor")
 
-    radio = get_radio(radio_mode, monitoring_hub_url, task_id, run_dir)
+    radio = radio_config.create_sender()
 
     logging.debug("start of monitor")
 

--- a/parsl/tests/configs/htex_local_alternate.py
+++ b/parsl/tests/configs/htex_local_alternate.py
@@ -59,7 +59,6 @@ def fresh_config():
         app_cache=True, checkpoint_mode='task_exit',
         retries=2,
         monitoring=MonitoringHub(
-                        hub_address="localhost",
                         monitoring_debug=False,
                         resource_monitoring_interval=1,
         ),

--- a/parsl/tests/test_monitoring/test_htex_init_blocks_vs_monitoring.py
+++ b/parsl/tests/test_monitoring/test_htex_init_blocks_vs_monitoring.py
@@ -34,7 +34,6 @@ def fresh_config(run_dir, strategy, db_url):
         strategy=strategy,
         strategy_period=0.1,
         monitoring=MonitoringHub(
-                        hub_address="localhost",
                         logging_endpoint=db_url
         )
     )

--- a/parsl/tests/test_monitoring/test_radio_filesystem.py
+++ b/parsl/tests/test_monitoring/test_radio_filesystem.py
@@ -1,8 +1,7 @@
 import pytest
 
 from parsl.monitoring.message_type import MessageType
-from parsl.monitoring.radios.filesystem import FilesystemRadioSender
-from parsl.monitoring.radios.filesystem_router import start_filesystem_receiver
+from parsl.monitoring.radios.filesystem import FilesystemRadio
 from parsl.multiprocessing import SpawnQueue
 
 
@@ -16,16 +15,15 @@ def test_filesystem(tmpd_cwd):
 
     resource_msgs = SpawnQueue()
 
+    radio_config = FilesystemRadio()
+
     # start receiver
-    receiver = start_filesystem_receiver(debug=True,
-                                         logdir=str(tmpd_cwd),
-                                         monitoring_messages=resource_msgs,
-                                         )
+    receiver = radio_config.create_receiver(run_dir=str(tmpd_cwd),
+                                            resource_msgs=resource_msgs)
 
     # make radio
 
-    radio_sender = FilesystemRadioSender(run_dir=str(tmpd_cwd),
-                                         monitoring_url="irrelevant:")
+    radio_sender = radio_config.create_sender()
 
     # send message into radio
 
@@ -41,7 +39,7 @@ def test_filesystem(tmpd_cwd):
 
     # shut down router
 
-    receiver.close()
+    receiver.shutdown()
 
     # we can't inspect the process if it has been closed properly, but
     # we can verify that it raises the expected ValueError the closed

--- a/parsl/tests/test_monitoring/test_radio_udp.py
+++ b/parsl/tests/test_monitoring/test_radio_udp.py
@@ -1,8 +1,7 @@
 import pytest
 
 from parsl.monitoring.message_type import MessageType
-from parsl.monitoring.radios.udp import UDPRadioSender
-from parsl.monitoring.radios.udp_router import start_udp_receiver
+from parsl.monitoring.radios.udp import UDPRadio
 from parsl.multiprocessing import SpawnQueue
 
 
@@ -16,19 +15,15 @@ def test_udp(tmpd_cwd):
 
     resource_msgs = SpawnQueue()
 
+    radio_config = UDPRadio(address="localhost")
+
     # start receiver
-    udp_receiver = start_udp_receiver(debug=True,
-                                      logdir=str(tmpd_cwd),
-                                      monitoring_messages=resource_msgs,
-                                      port=None
-                                      )
+    udp_receiver = radio_config.create_receiver(run_dir=str(tmpd_cwd),
+                                                resource_msgs=resource_msgs)
 
     # make radio
 
-    # this comes from monitoring.py:
-    url = "udp://{}:{}".format("localhost", udp_receiver.port)
-
-    radio_sender = UDPRadioSender(url)
+    radio_sender = radio_config.create_sender()
 
     # send message into radio
 
@@ -44,7 +39,7 @@ def test_udp(tmpd_cwd):
 
     # shut down router
 
-    udp_receiver.close()
+    udp_receiver.shutdown()
 
     # we can't inspect the process if it has been closed properly, but
     # we can verify that it raises the expected ValueError the closed

--- a/parsl/tests/test_monitoring/test_stdouterr.py
+++ b/parsl/tests/test_monitoring/test_stdouterr.py
@@ -35,9 +35,7 @@ def fresh_config(run_dir):
         ],
         strategy='simple',
         strategy_period=0.1,
-        monitoring=MonitoringHub(
-                        hub_address="localhost",
-        )
+        monitoring=MonitoringHub(),
     )
 
 


### PR DESCRIPTION
Prior to this, the set of radios available for sending results from in-task monitoring back to the submit side was fixed in a hard-coded if statement, identified by name.

This PR changes that to a config-object style, along the lines of other pieces of Parsl pluggable configurability.

This PR also changes the way in which the receiving side of radios is started: rather than starting all possible receivers (which is not possible in the new open-world model of radios), it only starts receivers for the configured radios. This now happens one-per-executor, which means in some situations there may be more, rather than fewer, executor receiver processes.

User facing configuration changes:

Executors now have a remote_monitoring_radio configuration parameter, for this new configuration. In most existing executors, this is optional, with the executors using the same default radio as they did before.

The ThreadPoolExecutor no longer has a default, as it previously used the UDP radio, which is now configured differently. A follow-on PR will introduce a new thread pool radio to allow the ThreadPoolExecutor to have a default.

On the MonitoringHub, the hub_address and hub_port parameters will be ignored after this PR. Before this PR, they were used to configure the destination for the UDP radio. That is now configured on the new UDPRadio object directly.

The UDPRadio now exposes its atexit_timeout parameter. This was previously implemented, but not exposed for user configuration

## Type of change

- New feature
