### PR TITLE
Add HMAC to UDP monitoring messages

### DIFF
--- a/parsl/tests/test_monitoring/test_radio_udp.py
+++ b/parsl/tests/test_monitoring/test_radio_udp.py
@@ -24,6 +24,10 @@ def test_udp(tmpd_cwd):
     udp_receiver = radio_config.create_receiver(run_dir=str(tmpd_cwd),
                                                 resource_msgs=resource_msgs)
 
+    # check hash properties
+
+    assert len(radio_config.hmac_key) == 64, "With default hash, should expect 64 byte key"
+
     # make radio
 
     radio_sender = radio_config.create_sender()


### PR DESCRIPTION
This is intended to stop spoofing and other misdelivery of UDP messages.

Each UDP receiver generates a new HMAC key, which is then conveyed to the relevant senders using the config mechanism introduced in PR #3892. That makes key lifetime roughly as long as the DFK/executor lifetime - or around the length of the workflow run.

This PR adds two tests around failing validation:
 i) when an incorrect HMAC key is used
 ii) when the message is so short it cannot be parsed into an HMAC+data

## Type of change

- New feature
