### PR TITLE
Flesh out multiprocessing queue monitoring radio

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -191,6 +191,7 @@ Monitoring
     parsl.monitoring.radios.filesystem.FilesystemRadio
     parsl.monitoring.radios.htex.HTEXRadio
     parsl.monitoring.radios.udp.UDPRadio
+    parsl.monitoring.radios.multiprocessing.MultiprocessingRadio
 
 
 Internal

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -191,7 +191,7 @@ Monitoring
     parsl.monitoring.radios.filesystem.FilesystemRadio
     parsl.monitoring.radios.htex.HTEXRadio
     parsl.monitoring.radios.udp.UDPRadio
-    parsl.monitoring.radios.multiprocessing.MultiprocessingRadio
+    parsl.monitoring.radios.multiprocessing.MultiprocessingQueueRadio
 
 
 Internal

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -47,7 +47,6 @@ from parsl.monitoring import MonitoringHub
 from parsl.monitoring.errors import RadioRequiredError
 from parsl.monitoring.message_type import MessageType
 from parsl.monitoring.radios.multiprocessing import MultiprocessingQueueRadioSender
-from parsl.monitoring.radios.udp import UDPRadio
 from parsl.monitoring.remote import monitor_wrapper
 from parsl.process_loggers import wrap_with_logs
 from parsl.usage_tracking.usage import UsageTracker
@@ -189,8 +188,7 @@ class DataFlowKernel:
 
         self.data_manager = DataManager(self)
         parsl_internal_executor = ThreadPoolExecutor(max_threads=config.internal_tasks_max_threads,
-                                                     label='_parsl_internal',
-                                                     remote_monitoring_radio=UDPRadio(address='127.0.0.1'))
+                                                     label='_parsl_internal')
         self.add_executors(config.executors)
         self.add_executors([parsl_internal_executor])
 

--- a/parsl/executors/threads.py
+++ b/parsl/executors/threads.py
@@ -8,6 +8,7 @@ from parsl.data_provider.staging import Staging
 from parsl.executors.base import ParslExecutor
 from parsl.executors.errors import InvalidResourceSpecification
 from parsl.monitoring.radios.base import RadioConfig
+from parsl.monitoring.radios.multiprocessing import MultiprocessingQueueRadio
 from parsl.utils import RepresentationMixin
 
 logger = logging.getLogger(__name__)
@@ -41,7 +42,10 @@ class ThreadPoolExecutor(ParslExecutor, RepresentationMixin):
         self.storage_access = storage_access
         self.working_dir = working_dir
 
-        self.remote_monitoring_radio = remote_monitoring_radio
+        if remote_monitoring_radio is not None:
+            self.remote_monitoring_radio = remote_monitoring_radio
+        else:
+            self.remote_monitoring_radio = MultiprocessingQueueRadio()
 
     def start(self):
         self.executor = cf.ThreadPoolExecutor(max_workers=self.max_threads,

--- a/parsl/monitoring/radios/multiprocessing.py
+++ b/parsl/monitoring/radios/multiprocessing.py
@@ -1,6 +1,10 @@
-from multiprocessing.queues import Queue
+from multiprocessing import Queue
 
-from parsl.monitoring.radios.base import MonitoringRadioSender
+from parsl.monitoring.radios.base import (
+    MonitoringRadioReceiver,
+    MonitoringRadioSender,
+    RadioConfig,
+)
 
 
 class MultiprocessingQueueRadioSender(MonitoringRadioSender):
@@ -15,3 +19,19 @@ class MultiprocessingQueueRadioSender(MonitoringRadioSender):
 
     def send(self, message: object) -> None:
         self.queue.put(message)
+
+
+class MultiprocessingQueueRadio(RadioConfig):
+    def create_sender(self) -> MonitoringRadioSender:
+        return MultiprocessingQueueRadioSender(self._queue)
+
+    def create_receiver(self, *, run_dir: str, resource_msgs: Queue) -> MonitoringRadioReceiver:
+        # This object is only for use with an in-process thread-pool so it
+        # is fine to store a reference to the message queue directly.
+        self._queue = resource_msgs
+        return MultiprocessingQueueRadioReceiver()
+
+
+class MultiprocessingQueueRadioReceiver(MonitoringRadioReceiver):
+    def shutdown(self) -> None:
+        pass

--- a/parsl/tests/test_monitoring/test_radio_multiprocessing.py
+++ b/parsl/tests/test_monitoring/test_radio_multiprocessing.py
@@ -1,0 +1,44 @@
+import pytest
+
+from parsl.monitoring.message_type import MessageType
+from parsl.monitoring.radios.multiprocessing import MultiprocessingQueueRadio
+from parsl.multiprocessing import SpawnQueue
+
+
+@pytest.mark.local
+def test_radio(tmpd_cwd):
+    """Test filesystem radio/receiver pair.
+    This test checks that the pair can be started up locally, that a message
+    is conveyed from radio to receiver, and that the receiver process goes
+    away at shutdown.
+    """
+
+    resource_msgs = SpawnQueue()
+
+    radio_config = MultiprocessingQueueRadio()
+
+    # start receiver
+    receiver = radio_config.create_receiver(run_dir=str(tmpd_cwd),
+                                            resource_msgs=resource_msgs)
+
+    # make radio
+
+    radio_sender = radio_config.create_sender()
+
+    # send message into radio
+
+    message = (MessageType.RESOURCE_INFO, {})
+
+    radio_sender.send(message)
+
+    # verify it comes out of the receiver
+
+    m = resource_msgs.get()
+
+    assert m == message, "The sent message should appear in the queue"
+
+    # Shut down router.
+    # In the multiprocessing radio, nothing happens at shutdown, so this
+    # validates that the call executes without raising an exception, but
+    # not much else.
+    receiver.shutdown()


### PR DESCRIPTION
Previously, it was not a proper RadioConfig style radio, but was used ad-hoc to send messages into a multiprocessing queue.

This PR makes it into a real radio which is then used by the ThreadPoolExecutor - allowing monitoring messages to be sent from there within process (rather than the previous UDPRadio default)

# Changed Behaviour

ThreadPoolExecutor will no longer open a UDP listening socket for monitoring. Monitoring messages should flow the same as before.

## Type of change

- New feature
