### PR TITLE
Revisit docstring of parsl.log_utils

### DIFF
--- a/parsl/log_utils.py
+++ b/parsl/log_utils.py
@@ -1,14 +1,9 @@
-"""Following the general logging philosophy of python libraries, by default
-Parsl doesn't log anything.  However the following helper functions are
-provided for logging:
+"""This module contains helpers for configuring logging. By default,
+`set_file_logger` is invoked by the DataFlowKernel initializer to log
+parsl messages to parsl.log.
 
-1. set_stream_logger
-    This sets the logger to the StreamHandler. This is quite useful when working from
-    a Jupyter notebook.
-
-2. set_file_logger
-    This sets the logging to a file. This is ideal for reporting issues to the dev team.
-
+`set_stream_logger` which by default logs to stderr, can be useful
+when working in a Jupyter notebook.
 """
 import io
 import logging


### PR DESCRIPTION
Prior to this PR, this string claimed that Parsl doesn't log anything by default. However, Parsl has logged by default since commit f4d47eeed6e8783b7c9bc3b9f4f7fd897ba160a4 introduced parsl.log in March 2018.

## Type of change

- Update to human readable text: Documentation/error messages/comments
