### PR TITLE
Remove set_*_logger return values

### DIFF
--- a/parsl/log_utils.py
+++ b/parsl/log_utils.py
@@ -27,7 +27,7 @@ DEFAULT_FORMAT = (
 def set_stream_logger(name: str = 'parsl',
                       level: int = logging.DEBUG,
                       format_string: Optional[str] = None,
-                      stream: Optional[io.TextIOWrapper] = None) -> logging.Logger:
+                      stream: Optional[io.TextIOWrapper] = None) -> None:
     """Add a stream log handler.
 
     Args:
@@ -36,9 +36,6 @@ def set_stream_logger(name: str = 'parsl',
          - format_string (string) : Set to None by default.
          - stream (io.TextIOWrapper) : Specify sys.stdout or sys.stderr for stream.
             If not specified, the default stream for logging.StreamHandler is used.
-
-    Returns:
-         - logger for specified name
     """
     if format_string is None:
         # format_string = "%(asctime)s %(name)s [%(levelname)s] Thread:%(thread)d %(message)s"
@@ -58,14 +55,12 @@ def set_stream_logger(name: str = 'parsl',
     futures_logger = logging.getLogger("concurrent.futures")
     futures_logger.addHandler(handler)
 
-    return logger
-
 
 @typeguard.typechecked
 def set_file_logger(filename: str,
                     name: str = 'parsl',
                     level: int = logging.DEBUG,
-                    format_string: Optional[str] = None) -> logging.Logger:
+                    format_string: Optional[str] = None) -> None:
     """Add a file log handler.
 
     Args:
@@ -73,9 +68,6 @@ def set_file_logger(filename: str,
         - name (string): Logger name
         - level (logging.LEVEL): Set the logging level.
         - format_string (string): Set the format string
-
-    Returns:
-       - logger for specified name
     """
     if format_string is None:
         format_string = DEFAULT_FORMAT
@@ -92,5 +84,3 @@ def set_file_logger(filename: str,
     # concurrent.futures
     futures_logger = logging.getLogger("concurrent.futures")
     futures_logger.addHandler(handler)
-
-    return logger


### PR DESCRIPTION
These return values are unused in the codebase.

Generally code uses a sub-logger of the logger used by these two set_*_logger functions, mirroring the module hierarchy.

So it would be unusual for this logger return value to be used ...

... but this value *was* used in PR #3254 as part of ongoing refactoring of logging helpers in other processes, until PR #3891, which rationalised those other process logging to also be module hierarchy based meaning the return value is not needed any more.

This is a tidyup to allow a future commit to return a different value as part of work to shut down parsl logging at DFK shutdown.

# Changed Behaviour

Users making use of this return value in their own code will have to acquire the relevant `logger` through some other means - for example, using the usual `logging.getLogger` idiom.

## Type of change

- Code maintenance/cleanup
