### PR TITLE
Detach log handler at shutdown of DFK

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -91,8 +91,11 @@ class DataFlowKernel:
         self._config = config
         self.run_dir = make_rundir(config.run_dir)
 
+        self._logging_unregister_callback: Optional[Callable[[], None]]
         if config.initialize_logging:
-            parsl.set_file_logger("{}/parsl.log".format(self.run_dir), level=logging.DEBUG)
+            self._logging_unregister_callback = parsl.set_file_logger("{}/parsl.log".format(self.run_dir), level=logging.DEBUG)
+        else:
+            self._logging_unregister_callback = None
 
         logger.info("Starting DataFlowKernel with config\n{}".format(config))
 
@@ -1255,6 +1258,13 @@ class DataFlowKernel:
         else:
             logger.debug("Cleaning up non-default DFK - not unregistering")
 
+        if self._logging_unregister_callback:
+            logger.info("Unregistering log handler")
+            self._logging_unregister_callback()
+            logger.info("Unregistered log handler")
+
+        # This message won't go to the default parsl.log, but other handlers
+        # should still see it.
         logger.info("DFK cleanup complete")
 
     def checkpoint(self, tasks: Optional[Sequence[TaskRecord]] = None) -> str:

--- a/parsl/log_utils.py
+++ b/parsl/log_utils.py
@@ -7,7 +7,7 @@ when working in a Jupyter notebook.
 """
 import io
 import logging
-from typing import Optional
+from typing import Callable, Optional
 
 import typeguard
 
@@ -22,7 +22,7 @@ DEFAULT_FORMAT = (
 def set_stream_logger(name: str = 'parsl',
                       level: int = logging.DEBUG,
                       format_string: Optional[str] = None,
-                      stream: Optional[io.TextIOWrapper] = None) -> None:
+                      stream: Optional[io.TextIOBase] = None) -> Callable[[], None]:
     """Add a stream log handler.
 
     Args:
@@ -50,12 +50,18 @@ def set_stream_logger(name: str = 'parsl',
     futures_logger = logging.getLogger("concurrent.futures")
     futures_logger.addHandler(handler)
 
+    def unregister_callback():
+        logger.removeHandler(handler)
+        futures_logger.removeHandler(handler)
+
+    return unregister_callback
+
 
 @typeguard.typechecked
 def set_file_logger(filename: str,
                     name: str = 'parsl',
                     level: int = logging.DEBUG,
-                    format_string: Optional[str] = None) -> None:
+                    format_string: Optional[str] = None) -> Callable[[], None]:
     """Add a file log handler.
 
     Args:
@@ -63,6 +69,12 @@ def set_file_logger(filename: str,
         - name (string): Logger name
         - level (logging.LEVEL): Set the logging level.
         - format_string (string): Set the format string
+
+    Returns:
+        - a callable which, when invoked, will reverse the log handler
+          attachments made by this call. (compare to how object based pieces
+          of parsl model this as a close/shutdown/cleanup method on the
+          object))
     """
     if format_string is None:
         format_string = DEFAULT_FORMAT
@@ -79,3 +91,9 @@ def set_file_logger(filename: str,
     # concurrent.futures
     futures_logger = logging.getLogger("concurrent.futures")
     futures_logger.addHandler(handler)
+
+    def unregister_callback():
+        logger.removeHandler(handler)
+        futures_logger.removeHandler(handler)
+
+    return unregister_callback

--- a/parsl/tests/test_utils/test_logutils.py
+++ b/parsl/tests/test_utils/test_logutils.py
@@ -1,0 +1,70 @@
+import io
+import logging
+
+import pytest
+
+from parsl.log_utils import set_file_logger, set_stream_logger
+
+
+@pytest.mark.local
+def test_stream_close():
+    """Tests that set_stream_logger callback detaches log handler.
+    """
+
+    logger = logging.getLogger("parsl")
+
+    s1 = io.StringIO()
+    close_callback_1 = set_stream_logger(stream=s1)
+    logger.info("AAA")
+    close_callback_1()
+
+    s2 = io.StringIO()
+    close_callback_2 = set_stream_logger(stream=s2)
+    logger.info("BBB")
+    close_callback_2()
+
+    logger.info("CCC")
+
+    assert "AAA" in s1.getvalue()
+    assert "AAA" not in s2.getvalue()
+
+    assert "BBB" not in s1.getvalue()
+    assert "BBB" in s2.getvalue()
+
+    assert "CCC" not in s1.getvalue()
+    assert "CCC" not in s2.getvalue()
+
+
+@pytest.mark.local
+def test_file_close(tmpd_cwd):
+    """Tests that set_file_Logger callback detaches log handler.
+    """
+
+    logger = logging.getLogger("parsl")
+
+    f1 = str(tmpd_cwd / "log1")
+    close_callback_1 = set_file_logger(filename=f1)
+    logger.info("AAA")
+    close_callback_1()
+
+    f2 = str(tmpd_cwd / "log2")
+    close_callback_2 = set_file_logger(filename=f2)
+    logger.info("BBB")
+    close_callback_2()
+
+    logger.info("CCC")
+
+    with open(f1, "r") as f:
+        s1 = f.read()
+
+    with open(f2, "r") as f:
+        s2 = f.read()
+
+    assert "AAA" in s1
+    assert "AAA" not in s2
+
+    assert "BBB" not in s1
+    assert "BBB" in s2
+
+    assert "CCC" not in s1
+    assert "CCC" not in s2


### PR DESCRIPTION
Prior to this PR, the automatic parsl.log handlers for each DFK will accumulate on the "parsl" log topic as new DFKs in one process are created, so for example the first created parsl.log will contain the log messages for every parsl workflow run in that process.

This is especially noticeable in pytest tests, but real world users also occasionally want to run multiple DFKs in one process.

For multiple DFKs in a process that exist completely serially, with one being shut down completely before the next starts, this should separate the logs from the two DFKs (and components) entirely.

For DFKs that exist concurrently, this PR does not stop overlapping logs. The current approach of per-module loggers (rather than per-DFK/per-object) makes that hard and this PR does not attempt to solve that.

# Changed Behaviour

less logging when using multiple DFKs - mostly that will be a good thing, but users relying on parsl.log being written to all the way to the end of the process (rather than until the DFK is closed) will have to change.

## Type of change

- New feature
