### PR TITLE
Increase log level for binding between WQ and executor ID namespaces

### DIFF
--- a/parsl/executors/workqueue/executor.py
+++ b/parsl/executors/workqueue/executor.py
@@ -983,7 +983,7 @@ def _work_queue_submit_wait(*,
                 continue
             # When a task is found:
             executor_task_id = t.tag
-            logger.debug("Completed Work Queue task {}, executor task {}".format(t.id, t.tag))
+            logger.info("Completed Work Queue task {}, executor task {}".format(t.id, t.tag))
             result_file = result_file_of_task_id.pop(t.tag)
 
             # A tasks completes 'succesfully' if it has result file.


### PR DESCRIPTION
This is to help understand the connection between Work Queue and executor level tasks when looking through logs.

Awkardly this binding is only logged at the end of a task execution, but this is intended to be a minimal PR.

See for example #2313 for similar binding work in the DataFlowKernel.

# Changed Behaviour

one extra log line per task when running at INFO log level and using the Work Queue executor.

## Type of change

- Update to human readable text: Documentation/error messages/comments
