### PR TITLE
Make executor.connected_workers a regular method

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -626,7 +626,6 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         and managers"""
         return len(self.tasks)
 
-    @property
     def connected_workers(self) -> int:
         """Returns the count of workers across all connected managers"""
         return self.command_client.run("WORKERS")

--- a/parsl/jobs/strategy.py
+++ b/parsl/jobs/strategy.py
@@ -215,7 +215,7 @@ class Strategy:
 
             if hasattr(executor, 'connected_workers'):
                 logger.debug('Executor {} has {} active tasks, {}/{} running/pending blocks, and {} connected workers'.format(
-                    label, active_tasks, running, pending, executor.connected_workers))
+                    label, active_tasks, running, pending, executor.connected_workers()))
             else:
                 logger.debug('Executor {} has {} active tasks and {}/{} running/pending blocks'.format(
                     label, active_tasks, running, pending))

--- a/parsl/tests/manual_tests/test_memory_limits.py
+++ b/parsl/tests/manual_tests/test_memory_limits.py
@@ -53,7 +53,7 @@ def test_simple(mem_per_worker):
     # Prime a worker
     double(5).result()
     dfk = parsl.dfk()
-    connected = dfk.executors['htex_local'].connected_workers
+    connected = dfk.executors['htex_local'].connected_workers()
     print("Connected : ", connected)
     assert expected_workers == connected, "Expected {} workers, instead got {} workers".format(expected_workers,
                                                                                                connected)

--- a/parsl/tests/site_tests/test_site.py
+++ b/parsl/tests/site_tests/test_site.py
@@ -35,7 +35,7 @@ def test_platform(n=2, sleep_dur=10):
     print([i.result() for i in x])
 
     print("Executor : ", dfk.executors[name])
-    print("Connected   : ", dfk.executors[name].connected_workers)
+    print("Connected   : ", dfk.executors[name].connected_workers())
     print("Outstanding : ", dfk.executors[name].outstanding())
 
     d = []


### PR DESCRIPTION
See PR #3915 for related justification on the same change for executor.outstanding()

In the connected_workers case, for High Throughput Executor, an RPC to the interchange is made when this attribute is accessed, which is execptionally high failure risk and has personally caused me a lot of trouble in understanding previously.

# Changed Behaviour

User code that is accessing connected workers will have to switch to method syntax, from attribute syntax.

## Type of change

- Code maintenance/cleanup
