### PR TITLE
Correct type annotation on monitoring _migrate_logs_to_internal

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -554,7 +554,7 @@ class DatabaseManager:
             raise RuntimeError("An exception happened sometime during database processing and should have been logged in database_manager.log")
 
     @wrap_with_logs(target="database_manager")
-    def _migrate_logs_to_internal(self, logs_queue: queue.Queue, kill_event: threading.Event) -> None:
+    def _migrate_logs_to_internal(self, logs_queue: mpq.Queue, kill_event: threading.Event) -> None:
         logger.info("Starting _migrate_logs_to_internal")
 
         while not kill_event.is_set() or logs_queue.qsize() != 0:


### PR DESCRIPTION
This isn't type-checked by mypy on invocation because the invocation is via a Thread() object rather than a regular function call.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
