### PR TITLE
Do not inhibit log propagation in monitoring db manager

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -293,8 +293,6 @@ class DatabaseManager:
         self.run_dir = run_dir
         os.makedirs(self.run_dir, exist_ok=True)
 
-        logger.propagate = False
-
         set_file_logger(f"{self.run_dir}/database_manager.log", level=logging_level,
                         format_string="%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s] [%(threadName)s %(thread)d] %(message)s",
                         name="database_manager")


### PR DESCRIPTION
See PR #3644 for the same change and justification on the htex interchange. This has been unneeded since the database manager moved to using spawn multiprocessing in PR #3817.

# Changed Behaviour

This should not change any log output right now but makes the behaviour more consistent and easier to understand.

## Type of change

- Code maintenance/cleanup
