### PR TITLE
Log executor label, not repr of whole executor

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1142,7 +1142,7 @@ class DataFlowKernel:
                 executor.monitoring_messages = self.monitoring.resource_msgs
                 logger.debug("Starting monitoring receiver for executor %s "
                              "with remote monitoring radio config %s",
-                             executor, executor.remote_monitoring_radio)
+                             executor.label, executor.remote_monitoring_radio)
 
                 executor.monitoring_receiver = executor.remote_monitoring_radio.create_receiver(resource_msgs=executor.monitoring_messages,
                                                                                                 run_dir=executor.run_dir)


### PR DESCRIPTION
This log line was introduced in PR #3892 along with the monitoring radio configuration interface.

# Changed Behaviour

Before this PR:

1754833001.826854 2025-08-10 13:36:41 MainProcess-19435 MainThread-140433663899456 parsl.dataflow.dflow:1143 add_executors DEBUG: Starting monitoring receiver for executor HighThroughputExecutor(
    address='127.0.0.1',
    address_probe_timeout=None,
    available_accelerators=[],
    block_error_handler=<function noop_error_handler at 0x7fb93cd74720>,
    cores_per_worker=1,
    cpu_affinity='none',
    drain_period=None,
    encrypted=True,
    heartbeat_period=2,
    heartbeat_threshold=5,
    interchange_launch_cmd=['interchange.py'],
    interchange_port_range=(55000, 56000),
    label='htex_Local',
    launch_cmd='process_worker_pool.py {debug} {max_workers_per_node} -a {addresses} -p {prefetch_capacity} -c {cores_per_worker} -m {mem_per_worker} --poll {poll_period} --port={worker_port} --cert_dir {cert_dir} --logdir={logdir} --block_id={{block_id}} --hb_period={heartbeat_period} {address_probe_timeout_string} --hb_threshold={heartbeat_threshold} --drain_period={drain_period} --cpu-affinity {cpu_affinity} {enable_mpi_mode} --mpi-launcher={mpi_launcher} --available-accelerators {accelerators}',
    loopback_address='127.0.0.1',
    manager_selector=<parsl.executors.high_throughput.manager_selector.RandomManagerSelector object at 0x7fb93dc5fb30>,
    max_workers_per_node=inf,
    mem_per_worker=None,
    poll_period=100,
    prefetch_capacity=0,
    provider=LocalProvider(
        cmd_timeout=30,
        init_blocks=0,
        launcher=SingleNodeLauncher(debug=True, fail_on_any=False),
        max_blocks=5,
        min_blocks=0,
        nodes_per_block=1,
        parallelism=1,
        worker_init=''
    ),
    remote_monitoring_radio=<parsl.monitoring.radios.htex.HTEXRadio object at 0x7fb921b880b0>,
    storage_access=[<parsl.data_provider.zip.ZipFileStaging object at 0x7fb921969100>, FTPInTaskStaging(), HTTPInTaskStaging(), NoOpFileStaging()],
    worker_debug=True,
    worker_logdir_root=None,
    worker_port=None,
    worker_port_range=(54000, 55000),
    working_dir='/home/benc/parsl/src/parsl/test_htex_alternate'
) with remote monitoring radio config <parsl.monitoring.radios.htex.HTEXRadio object at 0x7fb921b880b0>

After this PR:

1754833115.230316 2025-08-10 13:38:35 MainProcess-22207 MainThread-140347870947136 parsl.dataflow.dflow:1143 add_executors DEBUG: Starting monitoring receiver for executor htex_Local with remote monitoring radio config <parsl.monitoring.radios.htex.HTEXRadio object at 0x7fa53b956db0>

## Type of change

- Update to human readable text: Documentation/error messages/comments
