### PR TITLE
Use usual __name__ idiom for monitoring DB manager logging

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -18,7 +18,7 @@ from parsl.monitoring.types import MonitoringMessage, TaggedMonitoringMessage
 from parsl.process_loggers import wrap_with_logs
 from parsl.utils import setproctitle
 
-logger = logging.getLogger("database_manager")
+logger = logging.getLogger(__name__)
 
 X = TypeVar('X')
 
@@ -294,8 +294,7 @@ class DatabaseManager:
         os.makedirs(self.run_dir, exist_ok=True)
 
         set_file_logger(f"{self.run_dir}/database_manager.log", level=logging_level,
-                        format_string="%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s] [%(threadName)s %(thread)d] %(message)s",
-                        name="database_manager")
+                        format_string="%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s] [%(threadName)s %(thread)d] %(message)s")
 
         logger.debug("Initializing Database Manager process")
 
@@ -551,7 +550,7 @@ class DatabaseManager:
         if exception_happened:
             raise RuntimeError("An exception happened sometime during database processing and should have been logged in database_manager.log")
 
-    @wrap_with_logs(target="database_manager")
+    @wrap_with_logs
     def _migrate_logs_to_internal(self, logs_queue: mpq.Queue, kill_event: threading.Event) -> None:
         logger.info("Starting _migrate_logs_to_internal")
 
@@ -680,7 +679,7 @@ class DatabaseManager:
         self._kill_event.set()
 
 
-@wrap_with_logs(target="database_manager")
+@wrap_with_logs
 @typeguard.typechecked
 def dbm_starter(resource_msgs: mpq.Queue,
                 db_url: str,


### PR DESCRIPTION
Since PR #3817, the database manager has been started using multiprocessing spawn, rather than fork, as part of issue #3723, and since then, this special logger naming has been unnecessary.

See PR #3644 for the same change on the htex interchange, including more detailed explanation/justification.


# Changed Behaviour

This PR probably doesn't change which log lines are logged now. It does open up the opportunity for Parsl helper functions to log things into the database manager log now. And log lines are now longer, because their topic is now "parsl.monitoring.db_manager", not "database_manager".

## Type of change

- Code maintenance/cleanup
