### PR TITLE
Move DB manager exit check happen to main thread

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -548,6 +548,10 @@ class DatabaseManager:
                     "or some other error. monitoring data may have been lost"
                 )
                 exception_happened = True
+
+            if self.external_exit_event.is_set():
+                self.close()
+
         if exception_happened:
             raise RuntimeError("An exception happened sometime during database processing and should have been logged in database_manager.log")
 
@@ -558,9 +562,6 @@ class DatabaseManager:
         while not kill_event.is_set() or logs_queue.qsize() != 0:
             logger.debug("Checking STOP conditions: kill event: %s, queue has entries: %s",
                          kill_event.is_set(), logs_queue.qsize() != 0)
-
-            if self.external_exit_event.is_set():
-                self.close()
 
             try:
                 x = logs_queue.get(timeout=0.1)


### PR DESCRIPTION
Prior to this PR, self.close() was called inside the message migration thread. But self.close() does database stuff, which should all happen in one thread: the main thread.

The historical reason is that self.close was originally triggered by a special stop message in what was previously many threads all running this migrate code. That stop message was removed in PR #3807 and replaced by a multiprocessing Event.

This addresses some exceptions at shutdown when both the main thread and the message migration close() attempt to write to the database at the same time.

This PR does not address the possibility of outstanding messages which have not reached the database manager at the time of shutdown.

The message migration thread now does only message routing.

## Type of change

- Bug fix
