### PR TITLE
Fix RepresentationMixin PEP3102 keyword-only arguments

### DIFF
--- a/parsl/tests/test_utils/test_representation_mixin.py
+++ b/parsl/tests/test_utils/test_representation_mixin.py
@@ -15,6 +15,12 @@ class GoodReprDefaults(RepresentationMixin):
         self.y = y
 
 
+class GoodReprKeywordOnly(RepresentationMixin):
+    def __init__(self, *, x, y):
+        self.x = x
+        self.y = y
+
+
 class BadRepr(RepresentationMixin):
     """This class incorrectly subclasses RepresentationMixin.
     It does not store the parameter x on self.
@@ -62,6 +68,20 @@ def test_repr_good_defaults_defaulted():
     # at object creation, and the other defaulted.
     assert p1 in r
     assert "default 2" in r
+
+
+@pytest.mark.local
+def test_repr_good_keyword_only():
+    p1 = "parameter 1"
+    p2 = "the second parameter"
+
+    # repr should not raise an exception
+    r = repr(GoodReprKeywordOnly(x=p1, y=p2))
+
+    # representation should contain both values supplied
+    # at object creation.
+    assert p1 in r
+    assert p2 in r
 
 
 @pytest.mark.local

--- a/parsl/utils.py
+++ b/parsl/utils.py
@@ -250,6 +250,9 @@ class RepresentationMixin:
             args = [getattr(self, a, default) for a in argspec.args[1:]]
         kwargs = {key: getattr(self, key, default) for key in defaults}
 
+        kwonlyargs = {key: getattr(self, key, default) for key in argspec.kwonlyargs}
+        kwargs.update(kwonlyargs)
+
         def assemble_multiline(args: List[str], kwargs: Dict[str, object]) -> str:
             def indent(text: str) -> str:
                 lines = text.splitlines()


### PR DESCRIPTION
# Changed Behaviour

Prior to this PR, keyword-only arguments (those appearing after a `*`) such as z in:

```python
def f(x, y, *, z):
```

would not be output by the representation mixin.

This PR makes `RepresentationMixin` output those.

## Type of change

- Bug fix