### PR TITLE
Remove a done TODO in monitoring database work

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -509,7 +509,7 @@ class DatabaseManager:
                             msg['task_status_name'] = States.running.name
                             msg['task_try_time_running'] = msg['timestamp']
 
-                            if task_try_id in inserted_tries:  # TODO: needs to become task_id and try_id, and check against inserted_tries
+                            if task_try_id in inserted_tries:
                                 reprocessable_first_resource_messages.append(msg)
                             else:
                                 if task_try_id in deferred_resource_messages:


### PR DESCRIPTION
This TODO was introduced in #1808 in the same PR that actually did what the TODO was for - it was leftover from development work.

## Type of change

- Update to human readable text: Documentation/error messages/comments
