### PR TITLE
Reduce SizedQueue to a regular Queue in monitoring radios

### DIFF
--- a/parsl/monitoring/radios/udp_router.py
+++ b/parsl/monitoring/radios/udp_router.py
@@ -21,9 +21,9 @@ from parsl.monitoring.errors import MonitoringRouterStartError
 from parsl.monitoring.radios.base import MonitoringRadioReceiver
 from parsl.monitoring.radios.multiprocessing import MultiprocessingQueueRadioSender
 from parsl.multiprocessing import (
-    SizedQueue,
     SpawnEvent,
     SpawnProcess,
+    SpawnQueue,
     join_terminate_close_proc,
 )
 from parsl.process_loggers import wrap_with_logs
@@ -198,7 +198,7 @@ def start_udp_receiver(*,
                        hmac_digest: str) -> UDPRadioReceiver:
 
     udp_comm_q: Queue[Union[int, str]]
-    udp_comm_q = SizedQueue(maxsize=10)
+    udp_comm_q = SpawnQueue(maxsize=10)
 
     router_exit_event = SpawnEvent()
 

--- a/parsl/monitoring/radios/zmq_router.py
+++ b/parsl/monitoring/radios/zmq_router.py
@@ -19,9 +19,9 @@ from parsl.monitoring.errors import MonitoringRouterStartError
 from parsl.monitoring.radios.multiprocessing import MultiprocessingQueueRadioSender
 from parsl.monitoring.types import TaggedMonitoringMessage
 from parsl.multiprocessing import (
-    SizedQueue,
     SpawnEvent,
     SpawnProcess,
+    SpawnQueue,
     join_terminate_close_proc,
 )
 from parsl.process_loggers import wrap_with_logs
@@ -158,7 +158,7 @@ def start_zmq_receiver(*,
                        port_range: Tuple[int, int],
                        logdir: str,
                        worker_debug: bool) -> ZMQRadioReceiver:
-    comm_q = SizedQueue(maxsize=10)
+    comm_q = SpawnQueue(maxsize=10)
 
     router_exit_event = SpawnEvent()
 


### PR DESCRIPTION
The radios do not make use of the .qsize() functionality of queues, and so th (broken, see #3856) platform-specific sized queue functionality is not necessary.

This is part of a series of PRs to remove that platform-specific functionality entirely - see PR #3932.

# Changed Behaviour

This code is part of broken behaviour on Macs. The behaviour will be slightly better but still broken after this PR on that platform.

Otherwise, the queue should not behave any differently.

## Type of change

- Code maintenance/cleanup
