### PR TITLE
Remove Mac global fork process overrides

### DIFF
--- a/parsl/__init__.py
+++ b/parsl/__init__.py
@@ -15,7 +15,6 @@ AUTO_LOGNAME
 
 """
 import logging
-import multiprocessing as _multiprocessing
 import os
 import platform
 
@@ -31,9 +30,6 @@ from parsl.executors import (
 from parsl.log_utils import set_file_logger, set_stream_logger
 from parsl.monitoring import MonitoringHub
 from parsl.version import VERSION
-
-if platform.system() == 'Darwin':
-    _multiprocessing.set_start_method('fork', force=True)
 
 __author__ = 'The Parsl Team'
 __version__ = VERSION


### PR DESCRIPTION
These were introduced a long time ago to support using `fork` multiprocessing on Macs, despite the Mac side of things pushing back on doing this. More recently, it became clear (issue #2343) that `fork` was a bad idea on all platforms, not just Mac, and subsequent work has happened in Parsl to move most processes to `spawn` multiprocessing explicitly labelled as `parsl.multiprocessing.SpawnProcess`, and label the remaining fork processes explicitly as `parsl.multiprocessing.ForkProcess`.

Because of that explicit labelling, the default multiprocessing set by this removed code now no longer affects how Parsl launches processes on macs, and can be removed.

# Changed Behaviour

Users who launch their own processes on a Mac and were relying implicitly on those being `fork` processes will have to make this global reconfiguration themselves.

## Type of change

- Code maintenance/cleanup
