### PR TITLE
Remove manual checkpoint() directory return value

### DIFF
--- a/docs/userguide/workflows/checkpoints.rst
+++ b/docs/userguide/workflows/checkpoints.rst
@@ -264,8 +264,7 @@ of the ``slow_double`` app.
     # Wait for the results
     [i.result() for i in d]
 
-    cpt_dir = dfk.checkpoint()
-    print(cpt_dir)  # Prints the checkpoint dir
+    dfk.checkpoint()
 
 
 Resuming from a checkpoint

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1267,7 +1267,7 @@ class DataFlowKernel:
         # should still see it.
         logger.info("DFK cleanup complete")
 
-    def checkpoint(self, tasks: Optional[Sequence[TaskRecord]] = None) -> str:
+    def checkpoint(self, tasks: Optional[Sequence[TaskRecord]] = None) -> None:
         """Checkpoint the dfk incrementally to a checkpoint file.
 
         When called, every task that has been completed yet not
@@ -1327,8 +1327,6 @@ class DataFlowKernel:
                     logger.debug("No tasks checkpointed in this pass.")
             else:
                 logger.info("Done checkpointing {} tasks".format(count))
-
-            return checkpoint_dir
 
     @staticmethod
     def _log_std_streams(task_record: TaskRecord) -> None:

--- a/parsl/tests/test_checkpointing/test_python_checkpoint_1.py
+++ b/parsl/tests/test_checkpointing/test_python_checkpoint_1.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import pytest
 
@@ -20,12 +21,14 @@ def uuid_app():
 
 
 @pytest.mark.local
-def test_initial_checkpoint_write():
+def test_initial_checkpoint_write() -> None:
     """1. Launch a few apps and write the checkpoint once a few have completed
     """
     uuid_app().result()
 
-    cpt_dir = parsl.dfk().checkpoint()
+    parsl.dfk().checkpoint()
 
-    cptpath = cpt_dir + '/tasks.pkl'
+    cpt_dir = Path(parsl.dfk().run_dir) / 'checkpoint'
+
+    cptpath = cpt_dir / 'tasks.pkl'
     assert os.path.exists(cptpath), f"Tasks checkpoint missing: {cptpath}"


### PR DESCRIPTION
Prior to this PR, a manual checkpoint() call returned the directory that the checkpoint was written to.

This isn't really needed, so this PR removes it as part of removing cruft around the checkpoint API, as part of refactoring towards pluggable checkpointing.

The checkpoint directory isn't specific to manually-invoked checkpointing so this is not the right way to be informing the user of the directory.

The only use is in a test case, which this PR rewrites.

# Changed Behaviour

Anyone who expects to get the directory from a manual checkpoint call will have to do so in some other way. See the changed test in this PR for an example.

## Type of change

- Code maintenance/cleanup
