### PR TITLE
Add conference proceedings paper references to `CITATION.cff` and `README.rst`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 1.1.0
+cff-version: 1.2.0
 message: "If you use this software in your work, please cite it using the following metadata."
 authors:
 - family-names: "Nand Babuji"
@@ -113,7 +113,8 @@ authors:
 - family-names: "Bilke"
   given-names: "Lars"
 title: "parsl"
-version: 1.1.0
-date-released: 2021-04-26
-
+identifiers:
+  - description: Conference proceedings paper
+    type: doi
+    value: "10.1145/3307681.3325400"
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 Parsl - Parallel Scripting Library
 ==================================
-|licence| |docs| |NSF-1550588| |NSF-1550476| |NSF-1550562| |NSF-1550528| |NumFOCUS| |CZI-EOSS| 
+|licence| |docs| |NSF-1550588| |NSF-1550476| |NSF-1550562| |NSF-1550528| |NumFOCUS| |CZI-EOSS| |paper| 
 
 Parsl extends parallelism in Python beyond a single computer.
 
@@ -67,6 +67,9 @@ then explore the `parallel computing patterns <https://parsl.readthedocs.io/en/s
 .. |NumFOCUS| image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
     :target: https://numfocus.org
     :alt: Powered by NumFOCUS
+.. |paper| image:: https://img.shields.io/badge/Software_DOI-10.1145/3307681.3325400-blue
+    :target: https://doi.org/10.1145/3307681.3325400
+    :alt: Conference proceedings paper
 
    
 Quickstart


### PR DESCRIPTION
# Description

This PR adds the conference proceedings paper on Parsl to the `CITATION.cff` file and also adds a badge to the project to make the paper more visible to others. I recognize there is also a `CITATION.md` with this information but thought it could be helpful to raise further awareness through more direct integration.

# Changed Behaviour

People can reference the `CIATION.cff` or the `README.rst` to find the paper.

# Fixes

Closes #3857 

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Update to human readable text: Documentation/error messages/comments

