### PR TITLE
Replace SizedQueue use in monitoring with regular Queue

### DIFF
--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -11,9 +11,9 @@ import typeguard
 
 from parsl.monitoring.types import TaggedMonitoringMessage
 from parsl.multiprocessing import (
-    SizedQueue,
     SpawnEvent,
     SpawnProcess,
+    SpawnQueue,
     join_terminate_close_proc,
 )
 from parsl.utils import RepresentationMixin
@@ -126,7 +126,7 @@ class MonitoringHub(RepresentationMixin):
         self.monitoring_hub_active = True
 
         self.resource_msgs: Queue[TaggedMonitoringMessage]
-        self.resource_msgs = SizedQueue()
+        self.resource_msgs = SpawnQueue()
 
         self.dbm_exit_event: ms.Event
         self.dbm_exit_event = SpawnEvent()


### PR DESCRIPTION
Since PR #3937, no .qsize() has been used in monitoring.

This leaves MacSafeQueue, the Mac implementation of SizedQueue, unused. It will be removed in a subsequent PR. See PR #3932 for over-arching work

# Changed Behaviour

Monitoring should now work on Mac.

# Fixes

Fixes #3856 - hopefully. @d33bs has tested an approximately-equal change in #3932 on Mac, but that is not an auto-tested platform.

## Type of change

- Bug fix