### PR TITLE
Remove unnecessary test wait

### DIFF
--- a/parsl/tests/test_htex/test_priority_queue.py
+++ b/parsl/tests/test_htex/test_priority_queue.py
@@ -46,6 +46,7 @@ def test_priority_queue():
             futures[(priority, i)] = fake_task(parsl_resource_specification=spec)
 
         provider.max_blocks = 1
+        htex.scale_out_facade(1)  # don't wait for the JSP to catch up
 
         # Wait for completion
         results = {


### PR DESCRIPTION
# Description

Remove an unnecessary test wait while the JSP catches up.

# Changed Behaviour

No user functionality changes; a simple test performance update.

## Type of change

- Code maintenance/cleanup