### PR TITLE
Fix YAML type error in flux test github action

### DIFF
--- a/.github/workflows/parsl+flux.yaml
+++ b/.github/workflows/parsl+flux.yaml
@@ -1,6 +1,6 @@
 name: Test Flux Scheduler
 on:
-  pull_request: []
+  pull_request:
   merge_group:
 
 jobs:


### PR DESCRIPTION
At some point, this error started happening:

```
(Line: 3, Col: 17): A sequence was not expected
```

when GitHub tries to run the flux test.

The other platform tests do not have `[]` after pull_request: so this PR makes the flux workflow consistent with the others.

This PR will either make the flux tests work again, or reveal some other breakage.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
