### PR TITLE
Don't hide original exception

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -501,10 +501,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
             else:
 
                 for serialized_msg in msgs:
-                    try:
-                        msg = pickle.loads(serialized_msg)
-                    except pickle.UnpicklingError:
-                        raise BadMessage("Message received could not be unpickled")
+                    msg = pickle.loads(serialized_msg)
 
                     if msg['type'] == 'result':
                         try:


### PR DESCRIPTION
# Description

The caught exception provided negligible value.  Just remove it -- which is, pragmatically speaking, the same behavior (we were already throwing!), but now let the raw exception bubble rather hiding the origin.

# Changed Behaviour

Pragmatically no difference, but in the case of inter-component serde mismatch or bitrot, now emit a full traceback rather than only a partial one with an unhelpful summarization.

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup