### PR TITLE
Don't instantiate variable unless necessary

### DIFF
--- a/parsl/executors/high_throughput/mpi_resource_management.py
+++ b/parsl/executors/high_throughput/mpi_resource_management.py
@@ -168,9 +168,8 @@ class MPITaskScheduler(TaskScheduler):
         """Schedule task if resources are available otherwise backlog the task"""
         resource_spec = task_package.get("resource_spec", {})
 
-        nodes_needed = resource_spec.get("num_nodes")
-        tid = task_package["task_id"]
-        if nodes_needed:
+        if nodes_needed := resource_spec.get("num_nodes"):
+            tid = task_package["task_id"]
             try:
                 allocated_nodes = self._get_nodes(nodes_needed)
             except MPINodesUnavailable:


### PR DESCRIPTION
# Description

The walrus operator (`:=`) entered [Python's syntax in v3.8](https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions).

# Changed Behaviour

No changes.

## Type of change

- Code maintenance/cleanup