### PR TITLE
Introduce a task context in HTEX

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -709,7 +709,11 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         except TypeError:
             raise SerializationError(func.__name__)
 
-        msg = {"task_id": task_id, "resource_spec": resource_specification, "buffer": fn_buf}
+        context = {}
+        if resource_specification:
+            context["resource_spec"] = resource_specification
+
+        msg = {"task_id": task_id, "context": context, "buffer": fn_buf}
 
         # Post task to the outgoing queue
         self.outgoing_q.put(msg)

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -332,7 +332,7 @@ class Interchange:
             msg = self.task_incoming.recv_pyobj()
 
             # Process priority, higher number = lower priority
-            resource_spec = msg.get('resource_spec', {})
+            resource_spec = msg['context'].get('resource_spec', {})
             priority = resource_spec.get('priority', float('inf'))
             queue_entry = (-priority, -self.task_counter, msg)
 

--- a/parsl/executors/high_throughput/mpi_resource_management.py
+++ b/parsl/executors/high_throughput/mpi_resource_management.py
@@ -166,7 +166,7 @@ class MPITaskScheduler(TaskScheduler):
 
     def put_task(self, task_package: dict):
         """Schedule task if resources are available otherwise backlog the task"""
-        resource_spec = task_package.get("resource_spec", {})
+        resource_spec = task_package.get("context", {}).get("resource_spec", {})
 
         if nodes_needed := resource_spec.get("num_nodes"):
             tid = task_package["task_id"]

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -773,7 +773,10 @@ def worker(
             ready_worker_count.value -= 1
         worker_enqueued = False
 
-        _init_mpi_env(mpi_launcher=mpi_launcher, resource_spec=req["resource_spec"])
+        ctxt = req["context"]
+        res_spec = ctxt.get("resource_spec", {})
+
+        _init_mpi_env(mpi_launcher=mpi_launcher, resource_spec=res_spec)
 
         try:
             result = execute_task(req['buffer'])


### PR DESCRIPTION
# Description

Introduce a `context` side-along variable for HTEX tasks.  `resource_spec` is an entry within this new dictionary.  For the moment, they serve the same purpose, but I expect `context` to become a more general concept.

Functionally, the only difference currently is a one-layer-deeper nest of dictionaries:

```diff
- msg = {..., "resource_spec": {...}}
+ msg = {..., "context": {"resource_spec": {...}}}
```

# Changed Behaviour

None.

## Type of change

- (Infrastructure for a) new feature