### PR TITLE
Fix bad global default provider in several executors

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -237,7 +237,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
     @typeguard.typechecked
     def __init__(self,
                  label: str = 'HighThroughputExecutor',
-                 provider: ExecutionProvider = LocalProvider(),
+                 provider: Optional[ExecutionProvider] = None,
                  launch_cmd: Optional[str] = None,
                  interchange_launch_cmd: Optional[Sequence[str]] = None,
                  address: Optional[str] = None,
@@ -267,7 +267,9 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
 
         logger.debug("Initializing HighThroughputExecutor")
 
-        BlockProviderExecutor.__init__(self, provider=provider, block_error_handler=block_error_handler)
+        BlockProviderExecutor.__init__(self,
+                                       provider=provider if provider else LocalProvider(),
+                                       block_error_handler=block_error_handler)
         self.label = label
         self.worker_debug = worker_debug
         self.storage_access = storage_access

--- a/parsl/executors/high_throughput/mpi_executor.py
+++ b/parsl/executors/high_throughput/mpi_executor.py
@@ -16,7 +16,6 @@ from parsl.executors.status_handling import BlockProviderExecutor
 from parsl.jobs.states import JobStatus
 from parsl.launchers import SimpleLauncher
 from parsl.monitoring.radios.base import RadioConfig
-from parsl.providers import LocalProvider
 from parsl.providers.base import ExecutionProvider
 
 
@@ -47,7 +46,7 @@ class MPIExecutor(HighThroughputExecutor):
     @typeguard.typechecked
     def __init__(self,
                  label: str = 'MPIExecutor',
-                 provider: ExecutionProvider = LocalProvider(),
+                 provider: Optional[ExecutionProvider] = None,
                  launch_cmd: Optional[str] = None,
                  interchange_launch_cmd: Optional[str] = None,
                  address: Optional[str] = None,

--- a/parsl/executors/taskvine/executor.py
+++ b/parsl/executors/taskvine/executor.py
@@ -107,13 +107,17 @@ class TaskVineExecutor(BlockProviderExecutor, putils.RepresentationMixin):
                  function_exec_mode: Union[Literal['regular'], Literal['serverless']] = 'regular',
                  manager_config: TaskVineManagerConfig = TaskVineManagerConfig(),
                  factory_config: TaskVineFactoryConfig = TaskVineFactoryConfig(),
-                 provider: Optional[ExecutionProvider] = LocalProvider(init_blocks=1),
+                 provider: Optional[ExecutionProvider] = None,
                  storage_access: Optional[List[Staging]] = None,
                  remote_monitoring_radio: Optional[RadioConfig] = None):
 
         # Set worker launch option for this executor
         if worker_launch_method == 'factory' or worker_launch_method == 'manual':
             provider = None
+        elif worker_launch_method == 'provider' and provider is None:
+            # provider method chosen, but no explicit provider supplied to __init__
+            # so default to LocalProvider
+            provider = LocalProvider(init_blocks=1)
 
         # Initialize the parent class with the execution provider and block error handling enabled.
         # If provider is None, then no worker is launched via the provider method.

--- a/parsl/tests/configs/taskvine_ex.py
+++ b/parsl/tests/configs/taskvine_ex.py
@@ -7,4 +7,4 @@ from parsl.executors.taskvine import TaskVineExecutor, TaskVineManagerConfig
 
 def fresh_config():
     return Config(executors=[TaskVineExecutor(manager_config=TaskVineManagerConfig(port=9000),
-                                              worker_launch_method='factory')])
+                                              worker_launch_method='provider')])

--- a/parsl/tests/test_regression/test_3874.py
+++ b/parsl/tests/test_regression/test_3874.py
@@ -1,0 +1,47 @@
+import shutil
+
+import pytest
+
+import parsl
+from parsl.app.app import python_app
+from parsl.config import Config
+from parsl.executors import HighThroughputExecutor
+
+
+@python_app
+def noop():
+    pass
+
+
+@pytest.mark.local
+def test_regression_3874(tmpd_cwd_session):
+    # HTEX run 1
+
+    rundir_1 = str(tmpd_cwd_session / "1")
+
+    config = Config(executors=[HighThroughputExecutor()], strategy_period=0.5)
+    config.run_dir = rundir_1
+
+    with parsl.load(config):
+        noop().result()
+
+    # It is necessary to delete this rundir to exercise the bug. Otherwise,
+    # the next run will be able to continue looking at this directory - the
+    # bug manifests when it cannot.
+
+    shutil.rmtree(rundir_1)
+
+    # HTEX run 2
+    # In the case of issue 3874, this run hangs (rather than failing) as the
+    # JobStatusPoller fails to collect status of all of its managed tasks
+    # every iteration, without converging towards failure.
+
+    rundir_2 = str(tmpd_cwd_session / "2")
+
+    config = Config(executors=[HighThroughputExecutor()], strategy_period=0.5)
+    config.run_dir = rundir_2
+
+    with parsl.load(config):
+        noop().result()
+
+    shutil.rmtree(rundir_2)


### PR DESCRIPTION
This affects the High Throughput Executor, the MPI Executor and Task Vine.

Mutable objects should not be used as default values, and in this case, a mutable LocalProvider is used as the default provider.

This PR changes that to use a `None` default value and makes a new LocalProvider whenever a new High Throughput Executor is made.

See issue #1662 for broader context around mutable defaults.

This PR adds a regression test based on the reproducer supplied by @d33bs in issue #3874.

# Fixes

Fixes issue #3874.

## Type of change

- Bug fix
