### PR TITLE
Make slurm test container use virtualenv

### DIFF
--- a/.github/workflows/parsl+slurm.yaml
+++ b/.github/workflows/parsl+slurm.yaml
@@ -25,8 +25,7 @@ jobs:
 
       - name: Install Dependencies and Parsl
         run: |
-          apt install -y python3-virtualenv
-          virtualenv ./venv
+          python3 -m venv ./venv
           . ./venv/bin/activate
           CC=/usr/lib64/openmpi/bin/mpicc pip3 install . -r test-requirements.txt
 

--- a/.github/workflows/parsl+slurm.yaml
+++ b/.github/workflows/parsl+slurm.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install Dependencies and Parsl
         run: |
-          apt install python3.13-venv
+          apt install -y python3.13-venv
           python3 -m venv ./venv
           . ./venv/bin/activate
           CC=/usr/lib64/openmpi/bin/mpicc pip3 install . -r test-requirements.txt

--- a/.github/workflows/parsl+slurm.yaml
+++ b/.github/workflows/parsl+slurm.yaml
@@ -25,12 +25,17 @@ jobs:
 
       - name: Install Dependencies and Parsl
         run: |
+          apt install -y python3-virtualenv
+          virtualenv ./venv
+          . ./venv/bin/activate
           CC=/usr/lib64/openmpi/bin/mpicc pip3 install . -r test-requirements.txt
 
       - name: Verify Parsl Installation
         run: |
+          . venv/bin/activate
           pytest parsl/tests/ -k "not cleannet and not unix_filesystem_permissions_required" --config parsl/tests/configs/local_threads.py --random-order --durations 10
 
       - name: Test Parsl with Slurm Config
         run: |
+          . venv/bin/activate
           ./parsl/tests/slurm-entrypoint.sh  pytest parsl/tests/ -k "not cleannet and not unix_filesystem_permissions_required" --config parsl/tests/configs/slurm_local.py --random-order --durations 10

--- a/.github/workflows/parsl+slurm.yaml
+++ b/.github/workflows/parsl+slurm.yaml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Install Dependencies and Parsl
         run: |
+          apt install python3.13-venv
           python3 -m venv ./venv
           . ./venv/bin/activate
           CC=/usr/lib64/openmpi/bin/mpicc pip3 install . -r test-requirements.txt


### PR DESCRIPTION
As part of removing support for Python 3.9, the slurm test container was updated (not in this repo) to use a more recent OS/Python version. That more recent version is more aggressive about protecting against root-level global installation of software using `pip` rather than using the OS-native package manager.

This PR fixes that by using a virtualenv, which is consistent with the behaviour in the main CI environment.

## Type of change

- Code maintenance/cleanup
