### PR TITLE
Add type annotations and stronger mypy for parsl-perf

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -27,6 +27,9 @@ disallow_any_decorated = True
 [mypy-parsl.app.app.*]
 disallow_untyped_defs = True
 
+[mypy-parsl.benchmark.*]
+disallow_untyped_defs = True
+
 [mypy-parsl.dataflow.errors.*]
 disallow_untyped_defs = True
 disallow_any_expr = True

--- a/parsl/benchmark/perf.py
+++ b/parsl/benchmark/perf.py
@@ -2,15 +2,28 @@ import argparse
 import concurrent.futures
 import importlib
 import time
+from typing import Any, Dict
 
 import parsl
+from parsl.dataflow.dflow import DataFlowKernel
 
 min_iterations = 2
 
 
 # TODO: factor with conftest.py where this is copy/pasted from?
-def load_dfk_from_config(filename):
+def load_dfk_from_config(filename: str) -> DataFlowKernel:
     spec = importlib.util.spec_from_file_location('', filename)
+
+    if spec is None:
+        raise RuntimeError("Could not import configuration")
+
+    module = importlib.util.module_from_spec(spec)
+
+    if spec.loader is None:
+        raise RuntimeError("Could not load configuration")
+
+    spec.loader.exec_module(module)
+
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
@@ -23,11 +36,11 @@ def load_dfk_from_config(filename):
 
 
 @parsl.python_app
-def app(extra_payload, parsl_resource_specification={}):
+def app(extra_payload: Any, parsl_resource_specification: Dict = {}) -> int:
     return 7
 
 
-def performance(*, resources: dict, target_t: float, args_extra_size: int):
+def performance(*, resources: dict, target_t: float, args_extra_size: int) -> None:
     n = 10
 
     delta_t: float


### PR DESCRIPTION
# Changed Behaviour

A couple of errors around config loading, which previously manifested as attribute-related errors, are now more explicitly checked and reported.

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
