### PR TITLE
Remove redundant argument from update_memo

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -561,7 +561,7 @@ class DataFlowKernel:
         if not task_record['app_fu'] == future:
             logger.error("Internal consistency error: callback future is not the app_fu in task structure, for task {}".format(task_id))
 
-        self.memoizer.update_memo(task_record, future)
+        self.memoizer.update_memo(task_record)
 
         # Cover all checkpointing cases here:
         # Do we need to checkpoint now, or queue for later,

--- a/parsl/dataflow/memoization.py
+++ b/parsl/dataflow/memoization.py
@@ -242,16 +242,14 @@ class Memoizer:
         assert isinstance(result, Future) or result is None
         return result
 
-    def update_memo(self, task: TaskRecord, r: Future[Any]) -> None:
+    def update_memo(self, task: TaskRecord) -> None:
         """Updates the memoization lookup table with the result from a task.
+        This doesn't move any values around but associates the memoization
+        hashsum with the completed (by success or failure) AppFuture.
 
         Args:
-             - task (dict) : A task dict from dfk.tasks
-             - r (Result future): Result future
+             - task (TaskRecord) : A task record from dfk.tasks
         """
-        # TODO: could use typeguard
-        assert isinstance(r, Future)
-
         task_id = task['id']
 
         if not self.memoize or not task['memoize'] or 'hashsum' not in task:
@@ -265,7 +263,7 @@ class Memoizer:
             logger.info(f"Replacing app cache entry {task['hashsum']} with result from task {task_id}")
         else:
             logger.debug(f"Storing app cache entry {task['hashsum']} with result from task {task_id}")
-        self.memo_lookup_table[task['hashsum']] = r
+        self.memo_lookup_table[task['hashsum']] = task['app_fu']
 
     def _load_checkpoints(self, checkpointDirs: Sequence[str]) -> Dict[str, Future[Any]]:
         """Load a checkpoint file into a lookup table.


### PR DESCRIPTION
update_memo is given the whole task record, which contains the relevant Future to be memoizing.

The memoizer should never be being updated with a future that is not coming from a coherent task record with aligned hash sum and future.


# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
