### PR TITLE
Remove special-case checkpoint case from garbage collector test

### DIFF
--- a/parsl/tests/test_python_apps/test_garbage_collect.py
+++ b/parsl/tests/test_python_apps/test_garbage_collect.py
@@ -27,10 +27,5 @@ def test_garbage_collect():
 
     evt.set()
     assert x.result() == 10 * 4
-    if parsl.dfk().checkpoint_mode is not None:
-        # We explicit call checkpoint if checkpoint_mode is enabled covering
-        # cases like manual/periodic where checkpointing may be deferred.
-        parsl.dfk().checkpoint()
-
-    time.sleep(0.01)  # Give enough time for task wipes to work
+    time.sleep(0.01)  # Give enough time for task wipes to work - see issue #1279
     assert x.tid not in parsl.dfk().tasks, "Task record should be wiped after task completion"


### PR DESCRIPTION
Prior to PR #2514, tasks were removed at checkpoint-completion when checkpointed, rather than when completed, in the case that checkpointing was enabled.

This was race-y behaviour and was removed in PR #2414.

This test also looks like it is subject to a related race condition around task completion, described in issue #1279, for which there is a sleep statement - this PR does not modify that but does add a reference to the issue.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
