### PR TITLE
Remove commented dead code

### DIFF
--- a/parsl/tests/test_checkpointing/test_regression_233.py
+++ b/parsl/tests/test_checkpointing/test_regression_233.py
@@ -5,7 +5,6 @@ from parsl.dataflow.dflow import DataFlowKernel
 
 
 def run_checkpointed(checkpoints):
-    # set_stream_logger()
     from parsl.tests.configs.local_threads_checkpoint_task_exit import config
     config.checkpoint_files = checkpoints
     dfk = DataFlowKernel(config=config)


### PR DESCRIPTION
This was introduced in 2018 in commit
fd8ce2ed03f570952348b3150742ce160122d41b
already commented-out.


# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
