### PR TITLE
Make Globus dependencies optional in test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ mypy: ## run mypy checks
 .PHONY: gce_test
 gce_test: ## Run tests with GlobusComputeExecutor (--config .../globus_compute.py)
 	pytest -v -k "not shared_fs and not issue_3620 and not staging_required" --config parsl/tests/configs/globus_compute.py parsl/tests/ --random-order --durations 10
+	pytest -v -k "not shared_fs and not issue_3620 and not staging_required and globus_compute" --config local --random-order --durations 10
 
 .PHONY: local_thread_test
 local_thread_test: ## run all tests with local_thread config (--config .../local_threads.py)
@@ -86,7 +87,7 @@ radical_local_test:  ## Run the Radical local tests (-m radical --config local)
 .PHONY: config_local_test
 config_local_test:  ## run the config-local tests (--config local)
 	pip3 install ".[monitoring,visualization,proxystore,kubernetes]"
-	pytest parsl/tests/ -k "not cleannet and not workqueue and not taskvine" --config local --random-order --durations 10
+	pytest parsl/tests/ -k "not cleannet and not workqueue and not taskvine and not globus_compute" --config local --random-order --durations 10
 
 .PHONY: site_test
 site_test:  ## Run the site tests

--- a/parsl/tests/configs/local_threads_globus.py
+++ b/parsl/tests/configs/local_threads_globus.py
@@ -9,16 +9,11 @@ from parsl.executors.threads import ThreadPoolExecutor
 #          (i.e., user_opts['swan']['username'] -> 'your_username')
 from .user_opts import user_opts
 
+
 def fresh_config():
+    from parsl.data_provider.globus import GlobusStaging
     opts = user_opts['globus']
 
-    # This user_opts key lookup will implicitly skip the
-    # test when the user has not defined a globus entry,
-    # skipping the rest of configuration construction,
-    # especially the import of GlobusStaging which may
-    # not be importable in non-Globus-user cases.
-
-    from parsl.data_provider.globus import GlobusStaging
     storage_access = default_staging + [GlobusStaging(
                     endpoint_uuid=opts['endpoint'],
                     endpoint_path=opts['path']
@@ -30,8 +25,9 @@ def fresh_config():
                 label='local_threads_globus',
                 working_dir=opts['path'],
                 storage_access=storage_access
-           )
-       ]
+            )
+        ]
     )
+
 
 remote_writeable = user_opts['globus']['remote_writeable']

--- a/parsl/tests/configs/local_threads_globus.py
+++ b/parsl/tests/configs/local_threads_globus.py
@@ -12,18 +12,17 @@ from .user_opts import user_opts
 
 def fresh_config():
     from parsl.data_provider.globus import GlobusStaging
-    opts = user_opts['globus']
 
     storage_access = default_staging + [GlobusStaging(
-                    endpoint_uuid=opts['endpoint'],
-                    endpoint_path=opts['path']
+                    endpoint_uuid=user_opts['globus']['endpoint'],
+                    endpoint_path=user_opts['globus']['path']
                 )]
 
     return Config(
         executors=[
             ThreadPoolExecutor(
                 label='local_threads_globus',
-                working_dir=opts['path'],
+                working_dir=user_opts['globus']['path'],
                 storage_access=storage_access
             )
         ]

--- a/parsl/tests/configs/local_threads_globus.py
+++ b/parsl/tests/configs/local_threads_globus.py
@@ -1,6 +1,5 @@
 from parsl.config import Config
 from parsl.data_provider.data_manager import default_staging
-from parsl.data_provider.globus import GlobusStaging
 from parsl.executors.threads import ThreadPoolExecutor
 
 # If you are a developer running tests, make sure to update parsl/tests/configs/user_opts.py
@@ -10,19 +9,29 @@ from parsl.executors.threads import ThreadPoolExecutor
 #          (i.e., user_opts['swan']['username'] -> 'your_username')
 from .user_opts import user_opts
 
-storage_access = default_staging + [GlobusStaging(
-                endpoint_uuid=user_opts['globus']['endpoint'],
-                endpoint_path=user_opts['globus']['path']
-            )]
+def fresh_config():
+    opts = user_opts['globus']
 
-config = Config(
-    executors=[
-        ThreadPoolExecutor(
-            label='local_threads_globus',
-            working_dir=user_opts['globus']['path'],
-            storage_access=storage_access
-        )
-    ]
-)
+    # This user_opts key lookup will implicitly skip the
+    # test when the user has not defined a globus entry,
+    # skipping the rest of configuration construction,
+    # especially the import of GlobusStaging which may
+    # not be importable in non-Globus-user cases.
+
+    from parsl.data_provider.globus import GlobusStaging
+    storage_access = default_staging + [GlobusStaging(
+                    endpoint_uuid=opts['endpoint'],
+                    endpoint_path=opts['path']
+                )]
+
+    return Config(
+        executors=[
+            ThreadPoolExecutor(
+                label='local_threads_globus',
+                working_dir=opts['path'],
+                storage_access=storage_access
+           )
+       ]
+    )
 
 remote_writeable = user_opts['globus']['remote_writeable']

--- a/parsl/tests/test_python_apps/test_basic.py
+++ b/parsl/tests/test_python_apps/test_basic.py
@@ -14,10 +14,13 @@ def import_square(x):
     return math.pow(x, 2)
 
 
+class CustomException(Exception):
+    pass
+
+
 @python_app
 def custom_exception():
-    from globus_sdk import GlobusError
-    raise GlobusError('foobar')
+    raise CustomException('foobar')
 
 
 def test_simple(n=2):
@@ -41,8 +44,6 @@ def test_parallel_for(n):
 
 
 def test_custom_exception():
-    from globus_sdk import GlobusError
-
     x = custom_exception()
-    with pytest.raises(GlobusError):
+    with pytest.raises(CustomException):
         x.result()

--- a/parsl/tests/test_staging/test_staging_globus.py
+++ b/parsl/tests/test_staging/test_staging_globus.py
@@ -3,9 +3,9 @@ import pytest
 import parsl
 from parsl.app.app import python_app
 from parsl.data_provider.files import File
-from parsl.tests.configs.local_threads_globus import config, remote_writeable
+from parsl.tests.configs.local_threads_globus import fresh_config, remote_writeable
 
-local_config = config
+local_config = fresh_config
 
 
 @python_app

--- a/parsl/tests/unit/test_globus_compute_executor.py
+++ b/parsl/tests/unit/test_globus_compute_executor.py
@@ -16,6 +16,7 @@ def mock_ex():
 
 
 @pytest.mark.local
+@pytest.mark.globus_compute
 def test_gc_executor_mock_spec(mock_ex):
     # a test of tests -- make sure we're using spec= in the mock
     with pytest.raises(AttributeError):
@@ -23,12 +24,14 @@ def test_gc_executor_mock_spec(mock_ex):
 
 
 @pytest.mark.local
+@pytest.mark.globus_compute
 def test_gc_executor_label_default(mock_ex):
     gce = GlobusComputeExecutor(mock_ex)
     assert gce.label == type(gce).__name__, "Expect reasonable default label"
 
 
 @pytest.mark.local
+@pytest.mark.globus_compute
 def test_gc_executor_label(mock_ex, randomstring):
     exp_label = randomstring()
     gce = GlobusComputeExecutor(mock_ex, label=exp_label)
@@ -36,6 +39,7 @@ def test_gc_executor_label(mock_ex, randomstring):
 
 
 @pytest.mark.local
+@pytest.mark.globus_compute
 def test_gc_executor_resets_spec_after_submit(mock_ex, randomstring):
     submit_res = {randomstring(): "some submit res"}
     res = {"some": randomstring(), "spec": randomstring()}
@@ -59,6 +63,7 @@ def test_gc_executor_resets_spec_after_submit(mock_ex, randomstring):
 
 
 @pytest.mark.local
+@pytest.mark.globus_compute
 def test_gc_executor_resets_uep_after_submit(mock_ex, randomstring):
     uep_conf = randomstring()
     res = {"some": randomstring()}
@@ -81,6 +86,7 @@ def test_gc_executor_resets_uep_after_submit(mock_ex, randomstring):
 
 
 @pytest.mark.local
+@pytest.mark.globus_compute
 def test_gc_executor_happy_path(mock_ex, randomstring):
     mock_fn = mock.Mock()
     args = tuple(randomstring() for _ in range(random.randint(0, 3)))
@@ -97,6 +103,7 @@ def test_gc_executor_happy_path(mock_ex, randomstring):
 
 
 @pytest.mark.local
+@pytest.mark.globus_compute
 def test_gc_executor_shuts_down_asynchronously(mock_ex):
     gce = GlobusComputeExecutor(mock_ex)
     gce.shutdown()

--- a/parsl/tests/unit/test_globus_compute_executor.py
+++ b/parsl/tests/unit/test_globus_compute_executor.py
@@ -2,14 +2,16 @@ import random
 from unittest import mock
 
 import pytest
-from globus_compute_sdk import Executor
 
 from parsl.executors import GlobusComputeExecutor
 
 
 @pytest.fixture
 def mock_ex():
-    # Not Parsl's job to test GC's Executor
+    # Not Parsl's job to test GC's Executor, although it
+    # still needs to be importable for these test cases.
+    from globus_compute_sdk import Executor
+
     yield mock.Mock(spec=Executor)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ typeguard>=2.10,!=3.*,<5
 
 
 typing-extensions>=4.6,<5
-globus-sdk
 dill
 tblib
 requests

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ extras_require = {
     'proxystore': ['proxystore'],
     'radical-pilot': ['radical.pilot==1.90', 'radical.utils==1.90'],
     'globus_compute': ['globus_compute_sdk>=2.34.0'],
+    'globus_transfer': ['globus-sdk'],
     # Disabling psi-j since github direct links are not allowed by pypi
     # 'psij': ['psi-j-parsl@git+https://github.com/ExaWorks/psi-j-parsl']
 }

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,7 +10,6 @@ types-mock
 types-python-dateutil
 types-requests
 mpi4py
-globus-compute-sdk>=2.34.0
 
 # sqlalchemy is needed for typechecking, so it's here
 # as well as at runtime for optional monitoring execution


### PR DESCRIPTION
This PR makes Globus dependencies more optional:

In regular install, globus-sdk used by the very abandoned and probably untested GlobusStagingProvider is now no-longer installed, which reduces the dependency footprint some.

In test installs, Globus Compute tests can be picked out or skipped using `-k globus_compute`. This follows the style of `-k workqueue` and `-k taskvine` used to allow Work Queue and Taskvine to not be installed.

As a consequence, the main CI workflow no longer runs the Globus Compute site tests. This PR adds a `-k globus_compute` local test to the Globus-specific workflow, again in the style of the Work Queue and Taskvine tests.

The GlobusStagingProvider uses the older "not configured implies skip implies pass in CI" model of test configuration which I find personally quite distasteful; but I have not peturbed that.

Relevant issues:

Debian bug #1116867 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1116867#30 where @emollier comments on some Globus related packaging impeding the Debian packaging of Parsl.

Parsl issue #2218 

# Changed Behaviour

Dependencies will be loosened both in user installs and test environment installs - this might reveal interesting package incompatibilities although I am not aware of any.

## Type of change

- Code maintenance/cleanup
