### PR TITLE
Remove requirement that executors implement their own .start()

### DIFF
--- a/parsl/executors/base.py
+++ b/parsl/executors/base.py
@@ -80,11 +80,11 @@ class ParslExecutor(metaclass=ABCMeta):
         self.shutdown()
         return False
 
-    @abstractmethod
     def start(self) -> None:
         """Start the executor.
 
-        Any spin-up operations (for example: starting thread pools) should be performed here.
+        By default, this does nothing, but this method should be overridden to
+        perform any spin-up operations (for example: starting thread pools).
         """
         pass
 

--- a/parsl/executors/globus_compute.py
+++ b/parsl/executors/globus_compute.py
@@ -76,10 +76,6 @@ class GlobusComputeExecutor(ParslExecutor, RepresentationMixin):
         self.storage_access = storage_access
         self.working_dir = working_dir
 
-    def start(self) -> None:
-        """ Start the Globus Compute Executor """
-        super().start()
-
     def submit(self, func: Callable, resource_specification: Dict[str, Any], *args: Any, **kwargs: Any) -> Future:
         """ Submit func to globus-compute
 


### PR DESCRIPTION
This is most immediately driven by my work to upgrade to mypy 1.18.2 from mypy 1.5.1. In that change, mypy now raises an error if a class calls the abstract-decorated superclass method:

```
parsl/executors/globus_compute.py:81: error: Call to abstract method
"start" of "ParslExecutor" with trivial body via super() is unsafe  [safe-super]
```

This happens elsewhere in the codebase too, but mypy doesn't notice those occurences.

As demonstrated by the GlobusComputeExecutor, it isn't actually mandatory for executor-specific start behaviour to exist.

So, this PR removes the @abstractmethod decorator from the executor.start() method. It is no longer mandatory to implement; the existing no-op default implementation remains but no longer upsets more recent mypy. The .start method remains as an optional hook which most executors still choose to use.

This PR also removes the stub in GlobusComputeExecutor which was there only to satisfy the now-removed @abstractmethod requirement.

# Changed Behaviour

Shouldn't change user experience. Developers of new executors will no longer be forced to implement start and will have to discover it (if they want it) by reading.

## Type of change

- Code maintenance/cleanup
