### PR TITLE
Use RepresentationMixin for monitoring radios

### DIFF
--- a/parsl/monitoring/radios/filesystem.py
+++ b/parsl/monitoring/radios/filesystem.py
@@ -10,11 +10,12 @@ from parsl.monitoring.radios.base import (
     RadioConfig,
 )
 from parsl.monitoring.radios.filesystem_router import FilesystemRadioReceiver
+from parsl.utils import RepresentationMixin
 
 logger = logging.getLogger(__name__)
 
 
-class FilesystemRadio(RadioConfig):
+class FilesystemRadio(RadioConfig, RepresentationMixin):
     """A MonitoringRadioSender that sends messages over a shared filesystem.
 
     The messsage directory structure is based on maildir,

--- a/parsl/monitoring/radios/htex.py
+++ b/parsl/monitoring/radios/htex.py
@@ -7,11 +7,12 @@ from parsl.monitoring.radios.base import (
     MonitoringRadioSender,
     RadioConfig,
 )
+from parsl.utils import RepresentationMixin
 
 logger = logging.getLogger(__name__)
 
 
-class HTEXRadio(RadioConfig):
+class HTEXRadio(RadioConfig, RepresentationMixin):
     def create_sender(self) -> MonitoringRadioSender:
         return HTEXRadioSender()
 

--- a/parsl/monitoring/radios/multiprocessing.py
+++ b/parsl/monitoring/radios/multiprocessing.py
@@ -5,9 +5,10 @@ from parsl.monitoring.radios.base import (
     MonitoringRadioSender,
     RadioConfig,
 )
+from parsl.utils import RepresentationMixin
 
 
-class MultiprocessingQueueRadioSender(MonitoringRadioSender):
+class MultiprocessingQueueRadioSender(MonitoringRadioSender, RepresentationMixin):
     """A monitoring radio which connects over a multiprocessing Queue.
     This radio is intended to be used on the submit side, where components
     in the submit process, or processes launched by multiprocessing, will have

--- a/parsl/monitoring/radios/udp.py
+++ b/parsl/monitoring/radios/udp.py
@@ -13,11 +13,12 @@ from parsl.monitoring.radios.base import (
     RadioConfig,
 )
 from parsl.monitoring.radios.udp_router import start_udp_receiver
+from parsl.utils import RepresentationMixin
 
 logger = logging.getLogger(__name__)
 
 
-class UDPRadio(RadioConfig):
+class UDPRadio(RadioConfig, RepresentationMixin):
     def __init__(self, *, port: Optional[int] = None, atexit_timeout: int = 3, address: str, debug: bool = False, hmac_digest: str = 'sha512'):
         self.port = port
         self.atexit_timeout = atexit_timeout


### PR DESCRIPTION
Example log line before this PR:

```
1754833115.230316 2025-08-10 13:38:35 MainProcess-22207 MainThread-140347870947136
 parsl.dataflow.dflow:1143 add_executors DEBUG: Starting monitoring receiver for executor
 htex_Local with remote monitoring radio config <parsl.monitoring.radios.htex.HTEXRadio object at 0x7fa53b956db0>
```

After this PR:

```
1754833488.999064 2025-08-10 13:44:48 MainProcess-25293 MainThread-139640816629568
 parsl.dataflow.dflow:1143 add_executors DEBUG: Starting monitoring receiver for executor
 htex_Local with remote monitoring radio config HTEXRadio()
```

# Changed Behaviour

clearer log output

## Type of change

- Update to human readable text: Documentation/error messages/comments