### PR TITLE
Remove spurious double set of task time_returned

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -397,7 +397,6 @@ class DataFlowKernel:
             else:
                 logger.exception("Task {} failed after {} retry attempts".format(task_id,
                                                                                  task_record['try_id']))
-                task_record['time_returned'] = datetime.datetime.now()
                 self.update_task_state(task_record, States.failed)
                 task_record['time_returned'] = datetime.datetime.now()
                 self._send_task_log_info(task_record)


### PR DESCRIPTION
This is set again 2 lines later, and the only potential for use is a call to update_task_state, which does not use time_returned. The time is set for the purposes of the subsequent _send_task_log_info.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
