### PR TITLE
Remove bash app exception return code report that is constant None

### DIFF
--- a/parsl/app/bash.py
+++ b/parsl/app/bash.py
@@ -88,7 +88,7 @@ def remote_side_bash_executor(func, *args, **kwargs):
         raise pe.AppTimeout(f"App {func_name} exceeded walltime: {timeout} seconds")
 
     except Exception as e:
-        raise pe.AppException(f"App {func_name} caught exception with returncode: {returncode}", e)
+        raise pe.AppException(f"App {func_name} caught exception", e)
 
     if returncode != 0:
         raise pe.BashExitFailure(func_name, proc.returncode)


### PR DESCRIPTION
There is no code path where this value gets set and then ends up in the exception block, and this code misleading leads a reader to think the unix return code will be reported here.

The unix return code is actually reported for failing apps a few lines later with a BashExitFailure exception.

# Changed Behaviour

The text "with returncode: None" no longer appears on this exception.

## Type of change

- Update to human readable text: Documentation/error messages/comments
