### PR TITLE
Refactor failure states collection

### DIFF
--- a/parsl/dataflow/states.py
+++ b/parsl/dataflow/states.py
@@ -67,10 +67,10 @@ class States(IntEnum):
         return self.__class__.__name__ + "." + self.name
 
 
-FINAL_STATES = [States.exec_done, States.memo_done, States.failed, States.dep_fail]
-"""States from which we will never move to another state, because the job has
-either definitively completed or failed."""
-
-FINAL_FAILURE_STATES = [States.failed, States.dep_fail]
+FINAL_FAILURE_STATES = {States.failed, States.dep_fail}
 """States which are final and which indicate a failure. This must
 be a subset of FINAL_STATES"""
+
+FINAL_STATES = {States.exec_done, States.memo_done, *FINAL_FAILURE_STATES}
+"""States from which we will never move to another state, because the job has
+either definitively completed or failed."""


### PR DESCRIPTION
# Description

Reviewing PR #4006 brought up the fact that the `FINAL_FAILURE_STATES` is a strict subset of `FINAL_STATES`.  The thrust of this commit is to create `FINAL_STATES` as a superset of `FINAL_FAILURE_STATES`.

While here, favor a Python `set()` (`{...}`) for the existence criteria over `list()` (`[...]`).  I do not intend this as any sort of performance improvement but as a matter of correctness: these objects are about existence, so (unique) sets make more natural sense.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup