### PR TITLE
Implement parsl-perf explicit batch size iteration mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ site_test:  ## Run the site tests
 .PHONY: perf_test
 perf_test:  ## Run `parsl-perf` (--config .../local_threads.py)
 	parsl-perf --time 5 --config parsl/tests/configs/local_threads.py
+	parsl-perf --iterate 1,2,3 --config parsl/tests/configs/local_threads.py
 
 .PHONY: test ## run all tests with all config types
 test: clean_coverage isort lint flake8 mypy local_thread_test htex_local_test htex_local_alternate_test config_local_test perf_test ## run all tests

--- a/docs/userguide/advanced/parsl_perf.rst
+++ b/docs/userguide/advanced/parsl_perf.rst
@@ -38,6 +38,13 @@ decide when to stop, use the ``--iterate`` parameter:
    which is sometimes sub-linear, and to get more consistent batch sizes across
    runs of ``parsl-perf``.
 
+ * ``--iterate=10,10000,10000`` (or any other sequence of batch sizes) will run a
+   fixed sequence of batches: in this example, first a batch of 10 tasks, then
+   two batches of 10000 tasks. This is useful for making tests that compare
+   fixed batch sizes along with warmup steps between different configurations,
+   without the additional batches of ``estimate`` and ``exponential`` to discover
+   time-sized (rather than count-sized) batch sizes.
+
 For example:
 
 .. code-block:: bash


### PR DESCRIPTION
For example:

  parsl-perf --iterate=1,10000,10000

See documentation in this PR for justification.

# Changed Behaviour

existing modes should behave as before

## Type of change

- New feature
