### PR TITLE
Put executor label in ThreadPoolExecutor thread name

### DIFF
--- a/parsl/executors/threads.py
+++ b/parsl/executors/threads.py
@@ -29,12 +29,15 @@ class ThreadPoolExecutor(ParslExecutor, RepresentationMixin):
 
     @typeguard.typechecked
     def __init__(self, label: str = 'threads', max_threads: Optional[int] = 2,
-                 thread_name_prefix: str = '', storage_access: Optional[List[Staging]] = None,
+                 thread_name_prefix: str | None = None, storage_access: Optional[List[Staging]] = None,
                  working_dir: Optional[str] = None, remote_monitoring_radio: Optional[RadioConfig] = None):
         ParslExecutor.__init__(self)
         self.label = label
         self.max_threads = max_threads
-        self.thread_name_prefix = thread_name_prefix
+        if thread_name_prefix is None:
+            self.thread_name_prefix = "ThreadPoolExecutor-" + label
+        else:
+            self.thread_name_prefix = thread_name_prefix
 
         # we allow storage_access to be None now, which means something else to [] now
         # None now means that a default storage access list will be used, while


### PR DESCRIPTION
That means it propagates to (for example) logs, turning:

```
1762357807.564501 2025-11-05 15:50:07 MainProcess-5592 ThreadPoolExecutor-0_0-140031293384384 parsl.dataflow.dflow:539 _complete_task_result INFO: Task 8 completed (launched -> exec_done)
```

into

```
1762357864.299480 2025-11-05 15:51:04 MainProcess-5748 ThreadPoolExecutor-threads_0-139755945715392 parsl.dataflow.dflow:539 _complete_task_result INFO: Task 8 completed (launched -> exec_done)
```

when the executor is called `threads`.

# Changed Behaviour

places where the thread name is displayed will change to be more informative

## Type of change

- Update to human readable text: Documentation/error messages/comments
