### PR TITLE
Split memoizer.checkpoint() into two different functions

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1228,7 +1228,7 @@ class DataFlowKernel:
         logger.info("DFK cleanup complete")
 
     def checkpoint(self) -> None:
-        self.memoizer.checkpoint()
+        self.memoizer.checkpoint_queue()
 
     @staticmethod
     def _log_std_streams(task_record: TaskRecord) -> None:


### PR DESCRIPTION
This method is used in two clearly distinct places:

* checkpointing one task that we are handling the end of right now

* checkpointing a previously stored queue of tasks, which were enqueued at the end of the relevant task.

These become checkpoint_one and checkpoint_queue: the first works on a single task supplied as an argument and does not mutate the checkpoint queue; the other takes no arguments and works with the checkpoint queue.

The actual file access is moved into _checkpoint_these_tasks: sharing that code was probably the reason for a single multifunction checkpoint() method originally.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
