### PR TITLE
Use cwd for lsf

### DIFF
--- a/parsl/providers/lsf/template.py
+++ b/parsl/providers/lsf/template.py
@@ -2,8 +2,9 @@ template_string = '''#!/bin/bash
 
 #BSUB -W ${walltime}
 #BSUB -J ${jobname}
-#BSUB -o ${submit_script_dir}/${jobname}.submit.stdout
-#BSUB -e ${submit_script_dir}/${jobname}.submit.stderr
+#BSUB -cwd ${submit_script_dir}
+#BSUB -o ${jobname}.submit.stdout
+#BSUB -e ${jobname}.submit.stderr
 ${scheduler_options}
 
 ${worker_init}


### PR DESCRIPTION
# Description

No functional difference, but make the BSUB commands slightly less redundant, and easier (at least for my brain) to visually parse.

Before:

    #BSUB -o /some/long/cwd/path/job.stdout
    #BSUB -e /some/long/cwd/path/job.stderr

After:

    #BSUB -cwd /some/long/cwd/path
    #BSUB -o job.stdout
    #BSUB -e job.stderr

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup