### PR TITLE
Move wipe_task into task completion helpers, remove AppFuture callback

### DIFF
--- a/parsl/tests/test_python_apps/test_garbage_collect.py
+++ b/parsl/tests/test_python_apps/test_garbage_collect.py
@@ -27,5 +27,4 @@ def test_garbage_collect():
 
     evt.set()
     assert x.result() == 10 * 4
-    time.sleep(0.01)  # Give enough time for task wipes to work - see issue #1279
     assert x.tid not in parsl.dfk().tasks, "Task record should be wiped after task completion"


### PR DESCRIPTION
wipe_task now happens in complete task, the moral successor of handle_app_update, but now happening before the user can observe a task completing.

Previously: a user might or might not see the task table entry for a task at the point that completion is observed, as the handle_app_update future might happen before or after that observation. After this PR, the task table entry will always be removed before the user can observe task completion.

Test parsl/tests/test_python_apps/test_garbage_collect.py was very slightly racey before this PR - thats why it contains a sleep statement. This could be observed by putting a long delay at the start of handle_app_update. This PR should fix that. See issue #1279.

# Changed Behaviour

changes in observed wipe task  vs AppFuture completion order described above

## Type of change

- Bug fix
