### PR TITLE
Fix memoization-disabled test

### DIFF
--- a/parsl/tests/test_python_apps/test_memoize_2.py
+++ b/parsl/tests/test_python_apps/test_memoize_2.py
@@ -17,7 +17,7 @@ def local_config():
     )
 
 
-@python_app
+@python_app(cache=True)
 def random_uuid(x):
     import uuid
     return str(uuid.uuid4())
@@ -28,6 +28,13 @@ def test_python_memoization(n=2):
     """Testing python memoization disable via DFK call
     """
     x = random_uuid(0)
+
+    # Force x to completion before running other tests that will
+    # potentially re-use (or not-re-use) the result of x. Otherwise,
+    # results might not be reused because x is not completed, rather
+    # than because app-caching is disabled.
+
+    x.result()
 
     for i in range(0, n):
         foo = random_uuid(0)


### PR DESCRIPTION
Prior to this PR, this test would still (usually) pass when modified to set app_cache=True. It is supposed to fail in such situations.

This PR fixes this in two ways:

- the python_app under test was not set to cache its results, so its results would be ignored for caching.
- the test runs all the apps with the same parameter potentially simultaneously. Those apps would not be considered for memoization reuse, because results are only memoized after completion.

After this PR, manually changing app_cache=True in this test causes the test to fail, as I expect.

I think this test was probably broken by
f0f592ac56bdef42fac899e041eef66fb2d8ee3c as part of issue #43
which introduced the per-app cache parameter, set off by default.

# Changed Behaviour

test should test better. no user facing changes.

## Type of change

- Bug fix
