### PR TITLE
apt update before installing slurm ci dependencies

### DIFF
--- a/.github/workflows/parsl+slurm.yaml
+++ b/.github/workflows/parsl+slurm.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install Dependencies and Parsl
         run: |
-          apt install -y python3.13-venv
+          apt update && apt install -y python3.13-venv
           python3 -m venv ./venv
           . ./venv/bin/activate
           CC=/usr/lib64/openmpi/bin/mpicc pip3 install . -r test-requirements.txt


### PR DESCRIPTION
Prior to this PR, the SLURM CI build installed some dependencies via `apt`, but the base container could become out of date wrt the live repos. This PR does an `apt update` before that install. That's the pattern I use in my own containers to address this drift.

The SLURM CI test is broken right now because of this drift - this PR fixes it. (compare the red vs green test results on this PR vs on other recent PRs).

cc @tylern4 for opinion as original contributor

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
