### PR TITLE
Make explicit checkpoint calls on memoizer, not DFK

### DIFF
--- a/docs/userguide/workflows/checkpoints.rst
+++ b/docs/userguide/workflows/checkpoints.rst
@@ -193,12 +193,16 @@ parameter to ``memoizer=BasicMemoizer(...)``
       BasicMemoizer(checkpoint_mode = 'dfk_exit')
 
 4. ``manual``: in addition to these automated checkpointing modes, it is also possible
-   to manually initiate a checkpoint by calling ``DataFlowKernel.checkpoint()`` in the
-   Parsl program code.
+   to manually initiate a checkpoint by calling ``checkpoint()`` on the
+   `BasicMemoizer` in the Parsl program code.
 
    .. code-block:: python
 
-      dfk.checkpoint()
+      m = BasicMemoizer(checkpoint_mode = 'manual')
+      ...
+      with parsl.load(Config(memoizer=m, ...)):
+         ...
+         m.checkpoint()
 
 In all cases the checkpoint file is written out to the ``runinfo/RUN_ID/checkpoint/`` directory.
 
@@ -238,7 +242,7 @@ each invocation of the ``slow_double`` app will be stored in the checkpoint file
 
 Alternatively, manual checkpointing can be used to explictly specify when the checkpoint
 file should be saved. The following example shows how manual checkpointing can be used.
-Here, the ``dfk.checkpoint()`` function will save the results of the prior invocations 
+Here, the ``checkpoint()`` method will save the results of the prior invocations 
 of the ``slow_double`` app.
 
 .. code-block:: python
@@ -263,7 +267,7 @@ of the ``slow_double`` app.
     # Wait for the results
     [i.result() for i in d]
 
-    dfk.checkpoint()
+    dfk.memoizer.checkpoint()
 
 
 Resuming from a checkpoint

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1190,9 +1190,6 @@ class DataFlowKernel:
         # should still see it.
         logger.info("DFK cleanup complete")
 
-    def checkpoint(self) -> None:
-        self.memoizer.checkpoint_queue()
-
     @staticmethod
     def _log_std_streams(task_record: TaskRecord) -> None:
         tid = task_record['id']

--- a/parsl/dataflow/memoization.py
+++ b/parsl/dataflow/memoization.py
@@ -191,14 +191,6 @@ class Memoizer(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def checkpoint_queue(self) -> None:
-        """Called by the DFK when the user calls dfk.checkpoint(). This
-        indicates that the checkpoint system should explicitly process any
-        outstanding checkpoint writes.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
     def check_memo(self, task: TaskRecord) -> Optional[Future[Any]]:
         """Asks the checkpoint system for a result recorded for the described
         task. ``check_memo`` should return a `Future` that will be used as
@@ -536,6 +528,11 @@ class BasicMemoizer(Memoizer):
         with self._checkpoint_lock:
             self._checkpoint_these_tasks(self.checkpointable_tasks)
             self.checkpointable_tasks = []
+
+    def checkpoint(self) -> None:
+        """This is the user-facing interface to manual checkpointing.
+        """
+        self.checkpoint_queue()
 
     def _checkpoint_these_tasks(self, checkpoint_queue: List[CheckpointCommand]) -> None:
         """Play a sequence of CheckpointCommands into a checkpoint file.


### PR DESCRIPTION
This is a checkpointer-specific behaviour, just like periodic checkpointing. For example, the upcoming SQLite checkpointer has no notion of deferring checkpoint updates to later than task completion.

This PR modifies a test case to show how manual checkpointing should be done now.

# Changed Behaviour

breaks interface for users who do explicit checkpointing. they already got related breakage from #4042 and here is more for them.

## Type of change

- New feature
