### PR TITLE
Rework memoizer vs exception tests to use fixed config

### DIFF
--- a/parsl/tests/test_python_apps/test_memoize_exception.py
+++ b/parsl/tests/test_python_apps/test_memoize_exception.py
@@ -1,5 +1,17 @@
+import pytest
+
 import parsl
 from parsl.app.app import python_app
+from parsl.config import Config
+from parsl.dataflow.memoization import BasicMemoizer
+from parsl.executors.threads import ThreadPoolExecutor
+
+
+def local_config():
+    return Config(
+        executors=[ThreadPoolExecutor()],
+        memoizer=BasicMemoizer()
+    )
 
 
 @python_app(cache=True)
@@ -12,8 +24,9 @@ def raise_exception_nocache(x, cache=True):
     raise RuntimeError("exception from raise_exception_nocache")
 
 
+@pytest.mark.local
 def test_python_memoization(n=2):
-    """Test Python memoization of exceptions, with cache=True"""
+    """Test BasicMemoizer memoization of exceptions, with cache=True"""
     x = raise_exception_cache(0)
 
     # wait for x to be done
@@ -27,8 +40,9 @@ def test_python_memoization(n=2):
         assert fut.exception() is x.exception(), "Memoized exception should have been memoized"
 
 
+@pytest.mark.local
 def test_python_no_memoization(n=2):
-    """Test Python non-memoization of exceptions, with cache=False"""
+    """Test BasicMemoizer non-memoization of exceptions, with cache=False"""
     x = raise_exception_nocache(0)
 
     # wait for x to be done


### PR DESCRIPTION
Upcoming pull requests will change semantics around exception vs memoizer behaviour, and when those PRs happen, these tests will not correctly assert the behaviour of all different memoizer configurations.

Instead they assert the behaviour of a "traditionally configured" BasicMemoizer. This PR changes the tests to test only that traditionally configured BasicMemoizer.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
