### PR TITLE
Don't try pickle before dill in parsl.serialize

### DIFF
--- a/parsl/serialize/facade.py
+++ b/parsl/serialize/facade.py
@@ -26,7 +26,6 @@ def register_method_for_data(s: SerializerBase) -> None:
     methods_for_data[s.identifier] = s
 
 
-register_method_for_data(concretes.PickleSerializer())
 register_method_for_data(concretes.DillSerializer())
 
 


### PR DESCRIPTION
In many cases, dill uses pickle default behaviour anyway.

In other cases, pickle will fail, and then parsl.serialize will try using dill. After this PR, there won't be the pickle failed step and the code will go directly to using the dill-provided method.

In one other case, pickle and dill generate divergent serializations: if serializing a definition (such as a function) in the `__main__` module, pickle will serialize it by name (`__name__.whatever`) which is usually the wrong thing to do in a Parsl context: it is likely that on deserialization, the `__main__` module will be something else: for example, the htex process worker pool, and the import of the name reference will fail.

Dill will regard `__main__` module functions as send-by-bytecode, the same as for other definitions which don't have a globally importable name.

This PR makes `__main__` definitions be sent this way, because plain pickle now no longer intervenes.

Here is an example that fails before this PR and passes after the PR:

```
import parsl
from parsl.tests.configs.htex_local import fresh_config

def add(x,y):
    return x+y

@parsl.python_app
def apply(f, x,y):
    return f(x,y)

with parsl.load(fresh_config()):
    fut = apply(add, 2, 1)
    assert fut.result() == 3
    print("ok")
```

Some simple timings, which I think show there isn't a big change here for the kind of data structures parsl-perf generates:

parsl-perf --config pickleperf.py --iterate=1,2000,56799

pre-PR:

Tasks per second: 1965.237
Tasks per second: 1667.093
Tasks per second: 1974.990

with --argsize 64000
Tasks per second: 321.715
Tasks per second: 311.608
Tasks per second: 271.616


post-PR:

Tasks per second: 2017.673
Tasks per second: 1986.249
Tasks per second: 1635.260

with --argsize 64000

Tasks per second: 332.174
Tasks per second: 394.349
Tasks per second: 314.141

The current pickle-before-dill behaviour was introduced in PR #1806 as a Contribution (in the Capitalised sense) from the funcX codebase, without much explanation - but I know that there was a lot of Magical Thinking around object serialization at that time.

# Changed Behaviour

serialization of some structures will be a bit different. hopefully always for the better.

## Type of change

- Bug fix
