### PR TITLE
Set HighThroughputExecutor to encrypted mode by default

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -151,7 +151,7 @@ GENERAL_HTEX_PARAM_DOCS = """provider : :class:`~parsl.providers.base.ExecutionP
         In case of a remote file system, specify the path to where logs will be kept.
 
     encrypted : bool
-        Flag to enable/disable encryption (CurveZMQ). Default is False.
+        Flag to enable/disable encryption (CurveZMQ). Default is True.
 
     manager_selector: ManagerSelector
         Determines what strategy the interchange uses to select managers during task distribution.
@@ -268,7 +268,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
                  worker_logdir_root: Optional[str] = None,
                  manager_selector: ManagerSelector = RandomManagerSelector(),
                  block_error_handler: Union[bool, Callable[[BlockProviderExecutor, Dict[str, JobStatus]], None]] = True,
-                 encrypted: bool = False,
+                 encrypted: bool = True,
                  remote_monitoring_radio: Optional[RadioConfig] = None):
 
         logger.debug("Initializing HighThroughputExecutor")


### PR DESCRIPTION
Most tests run this way, and Globus Compute has defaulted to this since early 2024 in
https://github.com/globus/globus-compute/commit/40d848eb265e89c81c157807c2c05fc2b8456ae0

I think this was initially not enabled in pure Parsl because of concerns over performance. Subsequent performance measurement has suggested that this isn't really a problem.

# Changed Behaviour

Encrypted behaviour has a stronger requirement for a shared filesystem for the run directory, so that the shared key material can be shared. If you're running your workers in isolated environments, you will need to take this into account.

## Type of change

- New feature
