### PR TITLE
Fixup parsl.concurrent map types for Python 3.14

### DIFF
--- a/parsl/concurrent/__init__.py
+++ b/parsl/concurrent/__init__.py
@@ -100,9 +100,9 @@ class ParslPoolExecutor(Executor, AbstractContextManager):
             timeout: The maximum number of seconds to wait. If None, then there
                 is no limit on the wait time.
             chunksize: This parameter is ignored. Caution should be exercised
-                if expecting behaviour as documented in the base `Executor` class.
+                if expecting behaviour as documented in the base `concurrent.futures.Executor` class.
             buffersize: This parameter is ignored. Caution should be exercised
-                if expecting behaviour as documented in the base `Executor` class.
+                if expecting behaviour as documented in the base `concurrent.futures.Executor` class.
 
         Returns:
             An iterator equivalent to: map(func, ``*iterables``) but the calls may


### PR DESCRIPTION
Prior to this PR, this code would not typecheck on Python 3.14.

Python 3.14 introduces a new parameter, buffersize.

This would also cause a runtime failure if any user attempted to use that parameter.

After this PR, buffersize is defined and then ignored, which is the same behaviour as for the chunksize parameter.

This PR also adds in a tighter type variable relating the callable and the return type, coming from mypy's type definition for map, and clarifies that chunksize and buffersize are ignored.

# Changed Behaviour

Before Python 3.14, no change. After and including Python 3.14, use of unimplemented buffersize parameter will now be handled differently (but still unimplemented). Type checking on Python 3.14 with mypy will work.

## Type of change

- Bug fix
