### PR TITLE
Add buffer for signal to affect parent process

### DIFF
--- a/parsl/tests/test_serialization/test_3495_deserialize_managerlost.py
+++ b/parsl/tests/test_serialization/test_3495_deserialize_managerlost.py
@@ -18,9 +18,12 @@ def get_manager_pgid():
 def lose_manager():
     import os
     import signal
+    import time
 
     manager_pid = os.getppid()
     os.kill(manager_pid, signal.SIGSTOP)
+
+    time.sleep(5)  # approximate "forever"; if not enough, something's awry
 
 
 @pytest.mark.local


### PR DESCRIPTION
In response to [the comment in 4056](https://github.com/Parsl/parsl/pull/4056#issuecomment-3767568783):

> my hypothesis (without further investigation) for that failed test is that
> there's a race condition between signal delivery/suspend having an effect vs
> task completion, and that the task managed to complete before the task was
> suspended.

Approximate forever as 5 seconds.

# Changed Behaviour

None user-facing; hopefully more robust test case

## Type of change

- Bug fix (test case)