### PR TITLE
Use parsl hierarchical name for interchange logger

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -28,8 +28,7 @@ from parsl.version import VERSION as PARSL_VERSION
 PKL_HEARTBEAT_CODE = pickle.dumps((2 ** 32) - 1)
 PKL_DRAINED_CODE = pickle.dumps((2 ** 32) - 2)
 
-LOGGER_NAME = "interchange"
-logger = logging.getLogger(LOGGER_NAME)
+logger = logging.getLogger("parsl.executors.high_throughput.interchange")
 
 
 class Interchange:


### PR DESCRIPTION
Prior to this PR, the interchange process used a logger called "interchange". This is against the convention of using the module name.

This doesn't really matter in the current codebase, as the only code that cares about this is contained within the interchange. However, I'm working to make logging more configurable across the whole stack of Parsl processes and in that situation, it is more important that the interchange appears under parsl.*

I compared pytest logs using `wc` before and after this PR. The number of lines stays roughly the same, but the byte count increases by about 25% as a result of the longer full module name on each log line.

Before PR: 686568 bytes
After PR: 835033 bytes

# Changed Behaviour

bigger interchange log files

## Type of change

- Code maintenance/cleanup
