### PR TITLE
Make interchange log all of parsl.* like other components

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -598,7 +598,7 @@ class Interchange:
                 interesting_managers.remove(manager_id)
 
 
-def start_file_logger(filename: str, name: str='parsl', level: int = logging.DEBUG, format_string: Optional[str] = None) -> None:
+def start_file_logger(filename: str, name: str = 'parsl', level: int = logging.DEBUG, format_string: Optional[str] = None) -> None:
     """Add a stream log handler.
 
     Parameters


### PR DESCRIPTION
Parsl.log and the worker pool log all of parsl.* in their respective processes.

Since recent PR #4064, the interchange now logs into parsl.* and doesn't need to restrict its logging to the module specific logger.

This makes the interchange log configuration more consistent with parsl.log and the process worker pool log initialization, as part of moving towards a single implementation of that, and ultimately more user configurability.

For comparison, look at set_file_logger in parsl/log_utils.py for parsl.log and start_file_logger in the htex process worker pool.

I used wc to compare log sizes before and after in pytest runs and they differed in size by 1 byte and had identical line counts.

# Changed Behaviour

potentially parsl helper function logging might now be visible in interchange.log. This is probably desirable. I don't think any such helper functions do so, though.

## Type of change

- Code maintenance/cleanup
