### PR TITLE
Use one logging format string across DFK and HTEX

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -18,6 +18,7 @@ from parsl.app.errors import RemoteExceptionWrapper
 from parsl.executors.high_throughput.errors import ManagerLost, VersionMismatch
 from parsl.executors.high_throughput.manager_record import ManagerRecord
 from parsl.executors.high_throughput.manager_selector import ManagerSelector
+from parsl.log_utils import DEFAULT_FORMAT
 from parsl.monitoring.message_type import MessageType
 from parsl.monitoring.radios.base import MonitoringRadioSender
 from parsl.monitoring.radios.zmq import ZMQRadioSender
@@ -617,13 +618,7 @@ def start_file_logger(filename: str, name: str = 'parsl', level: int = logging.D
         None.
     """
     if format_string is None:
-        format_string = (
-
-            "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d "
-            "%(processName)s(%(process)d) %(threadName)s "
-            "%(funcName)s [%(levelname)s] %(message)s"
-
-        )
+        format_string = DEFAULT_FORMAT
 
     logger = logging.getLogger(name)
     logger.setLevel(level)

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -37,6 +37,7 @@ from parsl.executors.high_throughput.mpi_resource_management import (
     TaskScheduler,
 )
 from parsl.executors.high_throughput.probe import probe_addresses
+from parsl.log_utils import DEFAULT_FORMAT
 from parsl.multiprocessing import SpawnContext
 from parsl.process_loggers import wrap_with_logs
 from parsl.serialize import serialize
@@ -830,9 +831,7 @@ def start_file_logger(filename, name='parsl', level=logging.DEBUG, format_string
        -  None
     """
     if format_string is None:
-        format_string = "%(asctime)s.%(msecs)03d %(name)s:%(lineno)d " \
-                        "%(process)d %(threadName)s " \
-                        "[%(levelname)s]  %(message)s"
+        format_string = DEFAULT_FORMAT
 
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
This makes the two htex process components use the same log format as used for parsl.log

The affected log files now have longer log lines, because parsl.log lines are long.

This is part of work to factor away the htex-specific start_file_logger functions and eventually make this all more user configurable.

# Changed Behaviour

bigger log files

## Type of change

- Update to human readable text: Documentation/error messages/comments
