### PR TITLE
Remove HTEX custom implementations of file logging

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -18,7 +18,7 @@ from parsl.app.errors import RemoteExceptionWrapper
 from parsl.executors.high_throughput.errors import ManagerLost, VersionMismatch
 from parsl.executors.high_throughput.manager_record import ManagerRecord
 from parsl.executors.high_throughput.manager_selector import ManagerSelector
-from parsl.log_utils import DEFAULT_FORMAT
+from parsl.log_utils import set_file_logger
 from parsl.monitoring.message_type import MessageType
 from parsl.monitoring.radios.base import MonitoringRadioSender
 from parsl.monitoring.radios.zmq import ZMQRadioSender
@@ -109,7 +109,7 @@ class Interchange:
         self.logdir = logdir
         os.makedirs(self.logdir, exist_ok=True)
 
-        start_file_logger("{}/interchange.log".format(self.logdir), level=logging_level)
+        set_file_logger("{}/interchange.log".format(self.logdir), level=logging_level)
         logger.debug("Initializing Interchange process")
 
         self.client_address = client_address
@@ -597,36 +597,6 @@ class Interchange:
             self._ready_managers.pop(manager_id, 'None')
             if manager_id in interesting_managers:
                 interesting_managers.remove(manager_id)
-
-
-def start_file_logger(filename: str, name: str = 'parsl', level: int = logging.DEBUG, format_string: Optional[str] = None) -> None:
-    """Add a stream log handler.
-
-    Parameters
-    ---------
-
-    filename: string
-        Name of the file to write logs to. Required.
-    level: logging.LEVEL
-        Set the logging level. Default=logging.DEBUG
-        - format_string (string): Set the format string
-    format_string: string
-        Format string to use.
-
-    Returns
-    -------
-        None.
-    """
-    if format_string is None:
-        format_string = DEFAULT_FORMAT
-
-    logger = logging.getLogger(name)
-    logger.setLevel(level)
-    handler = logging.FileHandler(filename)
-    handler.setLevel(level)
-    formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
 
 
 if __name__ == "__main__":

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -37,7 +37,7 @@ from parsl.executors.high_throughput.mpi_resource_management import (
     TaskScheduler,
 )
 from parsl.executors.high_throughput.probe import probe_addresses
-from parsl.log_utils import DEFAULT_FORMAT
+from parsl.log_utils import set_file_logger
 from parsl.multiprocessing import SpawnContext
 from parsl.process_loggers import wrap_with_logs
 from parsl.serialize import serialize
@@ -644,8 +644,8 @@ def worker(
     debug: bool,
     mpi_launcher: str,
 ):
-    start_file_logger('{}/block-{}/{}/worker_{}.log'.format(logdir, block_id, pool_id, worker_id),
-                      level=logging.DEBUG if debug else logging.INFO)
+    set_file_logger('{}/block-{}/{}/worker_{}.log'.format(logdir, block_id, pool_id, worker_id),
+                    level=logging.DEBUG if debug else logging.INFO)
 
     # Store worker ID as an environment variable
     os.environ['PARSL_WORKER_RANK'] = str(worker_id)
@@ -818,30 +818,6 @@ def worker(
         logger.info("All processing finished for executor task {}".format(tid))
 
 
-def start_file_logger(filename, name='parsl', level=logging.DEBUG, format_string=None):
-    """Add a stream log handler.
-
-    Args:
-        - filename (string): Name of the file to write logs to
-        - name (string): Logger name
-        - level (logging.LEVEL): Set the logging level.
-        - format_string (string): Set the format string
-
-    Returns:
-       -  None
-    """
-    if format_string is None:
-        format_string = DEFAULT_FORMAT
-
-    logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG)
-    handler = logging.FileHandler(filename)
-    handler.setLevel(level)
-    formatter = logging.Formatter(format_string, datefmt='%Y-%m-%d %H:%M:%S')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-
-
 def get_arg_parser() -> argparse.ArgumentParser:
 
     def strategyorlist(s: str):
@@ -966,7 +942,7 @@ if __name__ == "__main__":
 
     os.makedirs(os.path.join(args.logdir, "block-{}".format(args.block_id), args.uid), exist_ok=True)
 
-    start_file_logger(
+    set_file_logger(
         f'{args.logdir}/block-{args.block_id}/{args.uid}/manager.log',
         level=logging.DEBUG if args.debug is True else logging.INFO
     )


### PR DESCRIPTION
The interchange and worker pool now use the same initialier as parsl.log

Previous PRs have addressed the big changes caused by this refactoring, but a few remain:

* parsl.log logging also logs concurrent.futures. If concurrent futures are used (for example in user app code) then their log messages will now appear in the relevant log file.

* the interchange logger set the logger log level to the specified level rather than DEBUG. This should not have any practical effect in the fairly closed interchange environment.

# Changed Behaviour

see above

## Type of change

- Code maintenance/cleanup
