### PR TITLE
Make task state helper log state changes.

### DIFF
--- a/parsl/tests/test_logging/test_dfk_states.py
+++ b/parsl/tests/test_logging/test_dfk_states.py
@@ -1,0 +1,33 @@
+import pytest
+
+import parsl
+
+
+@parsl.python_app
+def noop():
+    pass
+
+
+@parsl.python_app
+def fail():
+    raise RuntimeError()
+
+
+@pytest.mark.local
+def test_state_logs_success(caplog):
+    with parsl.load():
+        noop().result()
+
+    # from the DFK logs, we wouldn't expect to see running or
+    # running_done states as those exist only in the worker.
+    for s in ("pending", "launched", "exec_done", ):
+        assert s in caplog.text, f"Expected state {s} to be logged"
+
+
+@pytest.mark.local
+def test_state_logs_fail(caplog):
+    with parsl.load():
+        noop().result()
+
+    for s in ("pending", "launched", "failed", ):
+        assert s in caplog.text, f"Expected state {s} to be logged"


### PR DESCRIPTION
Prior to this PR, logs were done separately on each state change. This follows on from e.g. PR #4034 consolidating task state behaviour.

This gives about 6% more log lines - because some state transitions are now logged when they weren't before. That is overall a good thing, I think.

The ad-hoc phrasing of different state related messages prior to this PR instead will now only use state names from parsl.dataflow.states.


# Changed Behaviour

log messages will now look different

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
