### PR TITLE
prototype task/manager affinity

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -387,7 +387,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         if resource_specification:
             """HTEX supports the following *Optional* resource specifications:
             priority: lower value is higher priority"""
-            acceptable_fields = {'priority'}  # add new resource spec field names here to make htex accept them
+            acceptable_fields = {'priority', 'manager_affinity'}  # add new resource spec field names here to make htex accept them
             keys = set(resource_specification.keys())
             invalid_keys = keys - acceptable_fields
             if invalid_keys:

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -177,7 +177,7 @@ class Interchange:
 
         logger.info("Platform info: {}".format(self.current_platform))
 
-        self.affinities = {}
+        self.affinities: Dict[Any, Any] = {}
 
     def get_tasks(self, count: int, manager_id: Any) -> Sequence[dict]:
         """ Obtains a batch of tasks from the internal pending_task_queue
@@ -192,7 +192,7 @@ class Interchange:
         List of upto count tasks. May return fewer than count down to an empty list
             eg. [{'task_id':<x>, 'buffer':<buf>} ... ]
         """
-        tasks = []
+        tasks: list[Any] = []
         discards = []
         try:
             while len(tasks) < count:
@@ -207,7 +207,7 @@ class Interchange:
                     tasks.append(task)
                 else:
                     discards.append(e)
-                     
+
         except IndexError:
             # we've run out of tasks in the queue
             pass

--- a/parsl/tests/test_htex/test_manager_affinity.py
+++ b/parsl/tests/test_htex/test_manager_affinity.py
@@ -1,5 +1,6 @@
 import logging
 import random
+
 import pytest
 
 import parsl
@@ -10,14 +11,13 @@ from parsl.executors.high_throughput.manager_selector import RandomManagerSelect
 from parsl.providers import LocalProvider
 from parsl.usage_tracking.levels import LEVEL_1
 
-
 logger = logging.getLogger(__name__)
 
 
 @python_app
 def fake_task(parsl_resource_specification=None):
-    import time
     import os
+    import time
     time.sleep(1)
     # return the worker pid. with only one worker per manager, this will
     # be enough to identify the manager/pool.
@@ -34,7 +34,7 @@ def test_priority_queue(try_assert):
 
     htex = HighThroughputExecutor(
         label="htex_local",
-        max_workers_per_node=1, # needed for correctness
+        max_workers_per_node=1,  # needed for correctness
         provider=provider,
         worker_debug=True,  # needed to instrospect interchange logs
     )
@@ -52,7 +52,7 @@ def test_priority_queue(try_assert):
         # Test fallback behavior with a guaranteed-unsorted priorities
         for i in range(100):
             # 10 different test affinities
-            affinity = random.randint(1,10)
+            affinity = random.randint(1, 10)
             spec = {'manager_affinity': affinity}
             futures.append((affinity, fake_task(parsl_resource_specification=spec)))
 
@@ -64,7 +64,7 @@ def test_priority_queue(try_assert):
 
         def interchange_logs_task_count():
             with open(htex.worker_logdir + "/interchange.log", "r") as f:
-                lines = f.readlines() 
+                lines = f.readlines()
                 for line in lines:
                     if f"Put task {n} onto pending_task_queue" in line:
                         return True

--- a/parsl/tests/test_htex/test_manager_affinity.py
+++ b/parsl/tests/test_htex/test_manager_affinity.py
@@ -1,0 +1,83 @@
+import logging
+import random
+import pytest
+
+import parsl
+from parsl.app.app import python_app
+from parsl.config import Config
+from parsl.executors import HighThroughputExecutor
+from parsl.executors.high_throughput.manager_selector import RandomManagerSelector
+from parsl.providers import LocalProvider
+from parsl.usage_tracking.levels import LEVEL_1
+
+
+logger = logging.getLogger(__name__)
+
+
+@python_app
+def fake_task(parsl_resource_specification=None):
+    import time
+    import os
+    time.sleep(1)
+    # return the worker pid. with only one worker per manager, this will
+    # be enough to identify the manager/pool.
+    return os.getpid()
+
+
+@pytest.mark.local
+def test_priority_queue(try_assert):
+    provider = LocalProvider(
+        init_blocks=5,
+        max_blocks=5,
+        min_blocks=5,
+    )
+
+    htex = HighThroughputExecutor(
+        label="htex_local",
+        max_workers_per_node=1, # needed for correctness
+        provider=provider,
+        worker_debug=True,  # needed to instrospect interchange logs
+    )
+
+    config = Config(
+        executors=[htex],
+        strategy="htex_auto_scale",
+        usage_tracking=LEVEL_1,
+    )
+
+    with parsl.load(config):
+        futures = []
+
+        # Submit tasks with mixed priorities
+        # Test fallback behavior with a guaranteed-unsorted priorities
+        for i in range(100):
+            # 10 different test affinities
+            affinity = random.randint(1,10)
+            spec = {'manager_affinity': affinity}
+            futures.append((affinity, fake_task(parsl_resource_specification=spec)))
+
+        # wait for the interchange to have received all tasks
+        # (which happens asynchronously to the main thread, and is otherwise
+        # a race condition which can cause this test to fail)
+
+        n = len(futures)
+
+        def interchange_logs_task_count():
+            with open(htex.worker_logdir + "/interchange.log", "r") as f:
+                lines = f.readlines() 
+                for line in lines:
+                    if f"Put task {n} onto pending_task_queue" in line:
+                        return True
+            return False
+
+        try_assert(interchange_logs_task_count)
+
+        affinities = {}
+        for (affinity, fut) in futures:
+            p = fut.result()
+            if affinity in affinities:
+                assert p == affinities[affinity]
+            else:
+                affinities[affinity] = p
+
+        logger.info("affinities table: %r", RuntimeError(repr(affinities)))


### PR DESCRIPTION
This is for a thread on #parsl-help

you can make tasks run on the same manager as each other by attaching an opaque affinity key to each task in resource info.

the guarantee is that every task with the same affinity key will run on the same manager. 

this does not exclude tasks from running: two tasks with different affinity keys are allowed to run on the same manager (make sure you understand how that is different from two tasks with the same affinity key will run on the same manager)

this is probably going to give slightly unusual looking workload patterns near the end: its possible for there to be free managers, and tasks that need running, but the tasks are all affinitized to busy managers so no new tasks will start on those free managers.

if a manager goes away (e.g. block ending or crash) the tasks affinitised to that manager will sit in the interchange hung forever (waiting for that manager to request a new task. which it will never do) - that's not intrinsic to the design, just me not implementing any other policy here.

this PR adds a test that demonstrates the use of the manager_affinity resource specification field. the test picks a random number between 1,10. but you can use anything with sensible equality - a string representation of your sub-workflow, a uuid, ...

# Changed Behaviour

as above

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature
