### PR TITLE
Fix pbspro job statuses

### DIFF
--- a/parsl/providers/torque/torque.py
+++ b/parsl/providers/torque/torque.py
@@ -14,12 +14,17 @@ logger = logging.getLogger(__name__)
 translate_table = {
     'B': JobState.RUNNING,  # This state is returned for running array jobs
     'R': JobState.RUNNING,
-    'C': JobState.COMPLETED,  # Completed after having run
+    'C': JobState.COMPLETED,  # Completed after having run (TORQUE)
     'E': JobState.COMPLETED,  # Exiting after having run
+    'F': JobState.COMPLETED,  # Finished (PBS Pro)
     'H': JobState.HELD,  # Held
     'Q': JobState.PENDING,  # Queued, and eligible to run
     'W': JobState.PENDING,  # Job is waiting for it's execution time (-a option) to be reached
-    'S': JobState.HELD  # Suspended
+    'S': JobState.HELD,  # Suspended
+    'M': JobState.COMPLETED,  # Moved to another server (PBS Pro)
+    'T': JobState.PENDING,  # Transiting (PBS Pro)
+    'U': JobState.HELD,  # User-suspended (PBS Pro)
+    'X': JobState.COMPLETED, # Subjob finished (PBS Pro)
 }
 
 

--- a/parsl/providers/torque/torque.py
+++ b/parsl/providers/torque/torque.py
@@ -24,7 +24,7 @@ translate_table = {
     'M': JobState.COMPLETED,  # Moved to another server (PBS Pro)
     'T': JobState.PENDING,  # Transiting (PBS Pro)
     'U': JobState.HELD,  # User-suspended (PBS Pro)
-    'X': JobState.COMPLETED, # Subjob finished (PBS Pro)
+    'X': JobState.COMPLETED,  # Subjob finished (PBS Pro)
 }
 
 

--- a/parsl/providers/torque/torque.py
+++ b/parsl/providers/torque/torque.py
@@ -21,7 +21,6 @@ translate_table = {
     'Q': JobState.PENDING,  # Queued, and eligible to run
     'W': JobState.PENDING,  # Job is waiting for it's execution time (-a option) to be reached
     'S': JobState.HELD,  # Suspended
-    'M': JobState.COMPLETED,  # Moved to another server (PBS Pro)
     'T': JobState.PENDING,  # Transiting (PBS Pro)
     'U': JobState.HELD,  # User-suspended (PBS Pro)
     'X': JobState.COMPLETED,  # Subjob finished (PBS Pro)


### PR DESCRIPTION
# Description

The PBSProProvider uses qstat -x to retrieve job statuses, which returns PBS Pro-specific job state codes. However, the translate_table (defined in torque.py and shared by PBSProProvider) only contained TORQUE job states. PBS Pro uses 'F' (Finished) instead of TORQUE's 'C' (Completed) for finished jobs, causing completed jobs to be reported as JobState.UNKNOWN.

This PR adds missing PBS Pro job states to translate_table: 'F' (Finished), 'T' (Transiting), 'U' (User-suspended), and 'X' (Subjob finished).

# Changed Behaviour

Jobs run via PBSProProvider that finish and enter the PBS Pro 'F' state will now correctly resolve to JobState.COMPLETED instead of JobState.UNKNOWN. The same applies to jobs in 'T', 'U', or 'X' states which were also previously unrecognised. No change in behaviour for TORQUE users, as these states are not returned by TORQUE's qstat.

## Type of change

- Bug fix

