### PR TITLE
Tighten up typing of `addresses` in HTEX

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -289,9 +289,9 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         self.loopback_address = loopback_address
 
         if self.address:
-            self.all_addresses = address
+            self.all_addresses = {self.address}
         else:
-            self.all_addresses = ','.join(get_all_addresses())
+            self.all_addresses = get_all_addresses()
 
         self.max_workers_per_node = max_workers_per_node or float("inf")
 
@@ -411,7 +411,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         l_cmd = self.launch_cmd.format(debug=debug_opts,
                                        prefetch_capacity=self.prefetch_capacity,
                                        address_probe_timeout_string=address_probe_timeout_string,
-                                       addresses=self.all_addresses,
+                                       addresses=",".join(self.all_addresses),
                                        worker_port=self.worker_port,
                                        cores_per_worker=self.cores_per_worker,
                                        mem_per_worker=self.mem_per_worker,

--- a/parsl/executors/high_throughput/probe.py
+++ b/parsl/executors/high_throughput/probe.py
@@ -12,16 +12,15 @@ logger = logging.getLogger(__name__)
 
 def probe_addresses(
     zmq_context: curvezmq.ClientContext,
-    addresses: str,
+    addresses: set[str],
     timeout_ms: int = 120_000,
     identity: Optional[bytes] = None,
 ):
     """
-    Given a single-line CSV list of addresses, return the first proven valid address.
+    Given a set of addresses, return the first proven valid address.
 
-    This function will connect to each address in ``addresses`` (a comma-separated
-    list of URLs) and attempt to send a CONNECTION_PROBE packet.  Returns the first
-    address that receives a response.
+    This function will connect to each address in ``addresses`` and attempt to send a
+    CONNECTION_PROBE packet.  Returns the first address that receives a response.
 
     If no address receives a response within the ``timeout_ms`` (specified in
     milliseconds), then raise ``ConnectionError``.
@@ -29,8 +28,8 @@ def probe_addresses(
     :param zmq_context: A ZMQ Context; the call-site may provide an encrypted ZMQ
         context for assurance that the returned address is the expected and correct
         endpoint
-    :param addresses: a comma-separated string of addresses to attempt.  Example:
-        ``tcp://127.0.0.1:1234,tcp://[3812::03aa]:5678``
+    :param addresses: a set of addresses to attempt.  Example:
+        ``{"tcp://127.0.0.1:1234", "tcp://[3812::03aa]:5678"}``
     :param timeout_ms: how long to wait for a response from the probes.  The probes
         are initiated and await concurrently, so this timeout will be the total wall
         time in the worst case of "no addresses are valid."
@@ -43,10 +42,9 @@ def probe_addresses(
         raise ValueError("No address to probe!")
 
     sock_map = {}
-    urls = addresses.split(",")
     with ExitStack() as stk:
         poller = zmq.Poller()
-        for url in urls:
+        for url in addresses:
             logger.debug("Testing ZMQ connection to url: %s", url)
             s: zmq.Socket = stk.enter_context(zmq_context.socket(zmq.DEALER))
             s.setsockopt(zmq.LINGER, 0)
@@ -63,7 +61,7 @@ def probe_addresses(
             sock.recv()  # clear the buffer for good netizenry
             return sock_map.get(sock)
 
-    addys = ", ".join(urls)  # just slightly more human friendly
+    addys = ", ".join(addresses)  # just slightly more human friendly
     raise ConnectionError(f"No viable ZMQ url from: {addys}")
 
 

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -164,7 +164,7 @@ class Manager:
         self.cert_dir = cert_dir
         self.zmq_context = curvezmq.ClientContext(self.cert_dir)
 
-        addresses = ','.join(tcp_url(a, port) for a in addresses.split(','))
+        addresses = {tcp_url(a, port) for a in addresses.split(',')}
         try:
             self._ix_url = probe_addresses(
                 self.zmq_context,


### PR DESCRIPTION
# Description

Cleans up a couple instances of "stringly-typed" variables in the HTEX internal code, which previously passed the list of candidate addresses as a comma-separated string. While that can't be avoided in between `executor.py` and `process_worker_pool.py` (since the latter is started up as a shell command), it *can* be avoided within the executor class and in the `get_all_addresses` function, freeing us of one call each of `str.split` and `str.join`.

# Changed Behaviour

None

## Type of change

- Code maintenance/cleanup
