### PR TITLE
Remove a TODO that seems irrelevant

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -501,8 +501,6 @@ class Manager:
 
     def start(self):
         """ Start the worker processes.
-
-        TODO: Move task receiving to a thread
         """
         procs: dict[int, SpawnProcess] = {}
         for worker_id in range(self.worker_count):


### PR DESCRIPTION
This was introduced in f8d35eb69dc63ce1a0e1b6ee730662d94bf07b6a in the initial addition of the MPIX executor to Parsl in 2018.

It has subsequently been copy-pasted into the fabric code of MPIX, and from one of those two sources been copy pasted into both the interchange and worker pool components of the high throughput executor.

The interchange copy was removed in PR #2244.

# Changed Behaviour

none

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
