### PR TITLE
Introduce LogConfig class and use it for the DFK

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -187,6 +187,14 @@ Exceptions
     parsl.serialize.errors.DeserializationError
     parsl.serialize.errors.SerializationError
 
+Logging
+=======
+
+.. autosummary::
+    :toctree: stubs
+    :nosignatures:
+
+    parsl.logconfigs.base.LogConfig
 
 Monitoring
 ==========

--- a/docs/userguide/advanced/plugins.rst
+++ b/docs/userguide/advanced/plugins.rst
@@ -102,6 +102,14 @@ This plugin interface might be used to interface other task-like or future-like
 objects to the Parsl dependency mechanism, by describing how they can be
 interpreted as a Future.
 
+Log configuration
+-----------------
+
+The `LogConfig` class provides a place for log configuration, which is planned
+to extend across the various Python processes involved in a workflow
+execution.  Right now, it is only used by the initialize_logging parameter of
+the `DataFlowKernel`.
+
 Removed interfaces
 ------------------
 

--- a/docs/userguide/advanced/plugins.rst
+++ b/docs/userguide/advanced/plugins.rst
@@ -107,7 +107,7 @@ Log configuration
 
 The `LogConfig` class provides a place for log configuration, which is planned
 to extend across the various Python processes involved in a workflow
-execution.  Right now, it is only used by the initialize_logging parameter of
+execution.  Right now, it is only used by the ``initialize_logging`` parameter of
 the `DataFlowKernel`.
 
 Removed interfaces

--- a/parsl/config.py
+++ b/parsl/config.py
@@ -10,6 +10,7 @@ from parsl.dataflow.taskrecord import TaskRecord
 from parsl.errors import ConfigurationError
 from parsl.executors.base import ParslExecutor
 from parsl.executors.threads import ThreadPoolExecutor
+from parsl.logconfigs.base import LogConfig
 from parsl.monitoring import MonitoringHub
 from parsl.usage_tracking.api import UsageInformation
 from parsl.usage_tracking.levels import DISABLED as USAGE_TRACKING_DISABLED
@@ -76,7 +77,7 @@ class Config(RepresentationMixin, UsageInformation):
     project_name: str, optional
         Option to deanonymize usage tracking data.
         If set, this value will be used as the project name in the usage tracking data and placed on the leaderboard.
-    initialize_logging : bool, optional
+    initialize_logging : bool or log config, optional
         Make DFK optionally not initialize any logging. Log messages
         will still be passed into the python logging system under the
         ``parsl`` logger name, but the logging system will not by default
@@ -105,7 +106,7 @@ class Config(RepresentationMixin, UsageInformation):
                  monitoring: Optional[MonitoringHub] = None,
                  usage_tracking: int = 0,
                  project_name: Optional[str] = None,
-                 initialize_logging: bool = True) -> None:
+                 initialize_logging: Union[bool, LogConfig] = True) -> None:
 
         executors = tuple(executors or [])
         if not executors:

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -42,6 +42,8 @@ from parsl.executors.base import ParslExecutor
 from parsl.executors.status_handling import BlockProviderExecutor
 from parsl.executors.threads import ThreadPoolExecutor
 from parsl.jobs.job_status_poller import JobStatusPoller
+from parsl.logconfigs.base import LogConfig
+from parsl.logconfigs.file import FileLogging
 from parsl.monitoring import MonitoringHub
 from parsl.monitoring.errors import RadioRequiredError
 from parsl.monitoring.message_type import MessageType
@@ -91,10 +93,22 @@ class DataFlowKernel:
         self.run_dir = make_rundir(config.run_dir)
 
         self._logging_unregister_callback: Optional[Callable[[], None]]
-        if config.initialize_logging:
-            self._logging_unregister_callback = parsl.set_file_logger("{}/parsl.log".format(self.run_dir), level=logging.DEBUG)
-        else:
+
+        self.log_config: Optional[LogConfig]
+
+        if config.initialize_logging is True:
+            # This legacy behaviour deliberately does not pass log configuration
+            # to other components, so that they can preserve their own legacy
+            # logging behaviour.
+            self.log_config = None
+            dfk_log_config = FileLogging(level=logging.DEBUG)
+            self._logging_unregister_callback = dfk_log_config.initialize_logging(log_dir=self.run_dir, log_name="parsl")
+        elif config.initialize_logging is False:
+            self.log_config = None
             self._logging_unregister_callback = None
+        else:
+            self.log_config = config.initialize_logging
+            self._logging_unregister_callback = self.log_config.initialize_logging(log_dir=self.run_dir, log_name="parsl")
 
         logger.info("Starting DataFlowKernel with config\n{}".format(config))
 

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -6,6 +6,7 @@ import datetime
 import inspect
 import logging
 import os
+import pathlib
 import random
 import sys
 import threading
@@ -102,13 +103,13 @@ class DataFlowKernel:
             # logging behaviour.
             self.log_config = None
             dfk_log_config = FileLogging(level=logging.DEBUG)
-            self._logging_unregister_callback = dfk_log_config.initialize_logging(log_dir=self.run_dir, log_name="parsl")
+            self._logging_unregister_callback = dfk_log_config.initialize_logging(log_dir=pathlib.Path(self.run_dir), log_name="parsl")
         elif config.initialize_logging is False:
             self.log_config = None
             self._logging_unregister_callback = None
         else:
             self.log_config = config.initialize_logging
-            self._logging_unregister_callback = self.log_config.initialize_logging(log_dir=self.run_dir, log_name="parsl")
+            self._logging_unregister_callback = self.log_config.initialize_logging(log_dir=pathlib.Path(self.run_dir), log_name="parsl")
 
         logger.info("Starting DataFlowKernel with config\n{}".format(config))
 

--- a/parsl/logconfigs/base.py
+++ b/parsl/logconfigs/base.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import abc
+import uuid
+from collections.abc import Callable
+
+
+class LogConfig(abc.ABC):
+    """Implementations of this class can initialize Parsl logging.
+
+    Parsl logging is built around Python's `logging` system, with
+    an Parsl-provided configuration system that allows multiple
+    configurations to be initialized and deinitialized within the
+    same process.
+
+    Configurations which might be shared between processes should expect to
+    be pickled/unpickled multiple times as they move around a Parsl
+    distributed system.
+
+    A log configuration is identified across the distributed system by
+    the `uuid` attribute. This is intended to allow code calling the
+    log_configuration class to only initialise a particular log configuration
+    once per process.
+    """
+
+    def __init__(self) -> None:
+        self.uuid = str(uuid.uuid4())
+
+    @abc.abstractmethod
+    def initialize_logging(self, *, log_dir: str, log_name: str) -> Callable[[], None]:
+        """Initialize logging in current process.
+
+        This should be implemented by users wanting to define their own log
+        configuration policies.
+
+        This should be called by Parsl components which which to initialize
+        logging according to a user supplied policy, rather than a hard-coded
+        log policy.
+
+        This should return a callback to uninitialize the logging initialized
+        by this call.
+        """
+        ...

--- a/parsl/logconfigs/base.py
+++ b/parsl/logconfigs/base.py
@@ -33,9 +33,9 @@ class LogConfig(abc.ABC):
         This should be implemented by users wanting to define their own log
         configuration policies.
 
-        This should be called by Parsl components which which to initialize
-        logging according to a user supplied policy, rather than a hard-coded
-        log policy.
+        This should be called by Parsl components to initialize logging
+        according to a user supplied policy, rather than a hard-coded log
+        policy.
 
         This should return a callback to uninitialize the logging initialized
         by this call.

--- a/parsl/logconfigs/base.py
+++ b/parsl/logconfigs/base.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-import uuid
 from collections.abc import Callable
 
 
@@ -16,15 +15,7 @@ class LogConfig(abc.ABC):
     Configurations which might be shared between processes should expect to
     be pickled/unpickled multiple times as they move around a Parsl
     distributed system.
-
-    A log configuration is identified across the distributed system by
-    the `uuid` attribute. This is intended to allow code calling the
-    log_configuration class to only initialise a particular log configuration
-    once per process.
     """
-
-    def __init__(self) -> None:
-        self.uuid = str(uuid.uuid4())
 
     @abc.abstractmethod
     def initialize_logging(self, *, log_dir: str, log_name: str) -> Callable[[], None]:

--- a/parsl/logconfigs/base.py
+++ b/parsl/logconfigs/base.py
@@ -9,7 +9,7 @@ class LogConfig(abc.ABC):
     """Implementations of this class can initialize Parsl logging.
 
     Parsl logging is built around Python's `logging` system, with
-    an Parsl-provided configuration system that allows multiple
+    a Parsl-provided configuration system that allows multiple
     configurations to be initialized and deinitialized within the
     same process.
 

--- a/parsl/logconfigs/base.py
+++ b/parsl/logconfigs/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import pathlib
 from collections.abc import Callable
 
 
@@ -18,7 +19,7 @@ class LogConfig(abc.ABC):
     """
 
     @abc.abstractmethod
-    def initialize_logging(self, *, log_dir: str, log_name: str) -> Callable[[], None]:
+    def initialize_logging(self, *, log_dir: pathlib.Path, log_name: str) -> Callable[[], None]:
         """Initialize logging in current process.
 
         This should be implemented by users wanting to define their own log

--- a/parsl/logconfigs/file.py
+++ b/parsl/logconfigs/file.py
@@ -1,0 +1,50 @@
+import logging
+import os
+from typing import Callable
+
+from parsl.log_utils import DEFAULT_FORMAT
+from parsl.logconfigs.base import LogConfig
+
+
+class FileLogging(LogConfig):
+    """A log configuration which configures traditional logging to files."""
+
+    def __init__(self, *, format_string: str = DEFAULT_FORMAT, level: int = logging.DEBUG):
+        super().__init__()
+        self.format_string = DEFAULT_FORMAT
+        self.level = level
+
+    def initialize_logging(self, *, log_dir: str, log_name: str) -> Callable[[], None]:
+
+        os.makedirs(log_dir, exist_ok=True)
+        filename = log_dir + "/" + log_name + ".log"
+
+        handler = logging.FileHandler(filename)
+        handler.setLevel(self.level)
+        formatter = logging.Formatter(self.format_string, datefmt='%Y-%m-%d %H:%M:%S')
+        handler.setFormatter(formatter)
+
+        logger = logging.getLogger("parsl")
+
+        if logger.level == logging.NOTSET:
+            logger.setLevel(self.level)
+        else:
+            logger.setLevel(min(logger.level, self.level))
+
+        logger.addHandler(handler)
+
+        # Concurrent.futures errors are also of interest, as exceptions
+        # which propagate out of the top of a callback are logged this way
+        # and then discarded. (see #240)
+        futures_logger = logging.getLogger("concurrent.futures")
+        if futures_logger.level == logging.NOTSET:
+            futures_logger.setLevel(self.level)
+        else:
+            futures_logger.setLevel(min(futures_logger.level, self.level))
+        futures_logger.addHandler(handler)
+
+        def unregister_callback():
+            logger.removeHandler(handler)
+            futures_logger.removeHandler(handler)
+
+        return unregister_callback

--- a/parsl/logconfigs/file.py
+++ b/parsl/logconfigs/file.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pathlib
 from typing import Callable
 
 from parsl.log_utils import DEFAULT_FORMAT
@@ -14,10 +15,10 @@ class FileLogging(LogConfig):
         self.format_string = DEFAULT_FORMAT
         self.level = level
 
-    def initialize_logging(self, *, log_dir: str, log_name: str) -> Callable[[], None]:
+    def initialize_logging(self, *, log_dir: pathlib.Path, log_name: str) -> Callable[[], None]:
 
         os.makedirs(log_dir, exist_ok=True)
-        filename = log_dir + "/" + log_name + ".log"
+        filename = log_dir.joinpath(log_name + ".log")
 
         handler = logging.FileHandler(filename)
         handler.setLevel(self.level)

--- a/parsl/logconfigs/file.py
+++ b/parsl/logconfigs/file.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import pathlib
 from typing import Callable
 
@@ -17,7 +16,7 @@ class FileLogging(LogConfig):
 
     def initialize_logging(self, *, log_dir: pathlib.Path, log_name: str) -> Callable[[], None]:
 
-        os.makedirs(log_dir, exist_ok=True)
+        log_dir.mkdir(exist_ok=True)
         filename = log_dir.joinpath(log_name + ".log")
 
         handler = logging.FileHandler(filename)

--- a/parsl/tests/configs/htex_local_alternate.py
+++ b/parsl/tests/configs/htex_local_alternate.py
@@ -25,6 +25,7 @@ from parsl.data_provider.zip import ZipFileStaging
 from parsl.dataflow.memoization import BasicMemoizer
 from parsl.executors import HighThroughputExecutor
 from parsl.launchers import SingleNodeLauncher
+from parsl.logconfigs.file import FileLogging
 from parsl.monitoring import MonitoringHub
 from parsl.providers import LocalProvider
 
@@ -62,7 +63,10 @@ def fresh_config():
                         resource_monitoring_interval=1,
         ),
         usage_tracking=3,
-        project_name="parsl htex_local_alternate test configuration"
+        project_name="parsl htex_local_alternate test configuration",
+
+        # level 1 is even more debuggy than logging.DEBUG
+        initialize_logging=FileLogging(level=1)
     )
 
 

--- a/parsl/tests/test_logging/test_initialize_logging.py
+++ b/parsl/tests/test_logging/test_initialize_logging.py
@@ -3,6 +3,7 @@ import pathlib
 import pytest
 
 import parsl
+from parsl.logconfigs.file import FileLogging
 
 
 @pytest.mark.local
@@ -17,3 +18,10 @@ def test_parsl_log_not_exists(tmpd_cwd):
     with parsl.load(parsl.Config(run_dir=str(tmpd_cwd), initialize_logging=False)):
         assert not (pathlib.Path(parsl.dfk().run_dir) / "parsl.log").exists(), \
             "With initialize_logging=False, parsl.log should not exist in rundir after startup"
+
+
+@pytest.mark.local
+def test_parsl_log_FileLogging(tmpd_cwd):
+    with parsl.load(parsl.Config(run_dir=str(tmpd_cwd), initialize_logging=FileLogging())):
+        assert (pathlib.Path(parsl.dfk().run_dir) / "parsl.log").exists(), \
+            "With FileLogging, parsl.log should exist in rundir after startup"


### PR DESCRIPTION
# Description

This is the first of a series of patches introducing a log configuration mechanism across various Parsl Python processes, intended to eventually allow richer configuration than the current ad-hoc mechanisms (such as `worker_debug` in the High Throughput Executor, and `initialize_logging` in `Config`)

This PR adds a new log configuration base class, `LogConfig`. Instances of this class can be passed to the DFK as part of Parsl configuration, and the DFK will use that instance to initialize logging rather than the previous hard coded `parsl.log`.

This log configuration is structured to be pickled to other processes, with the configured `LogConfig` retained to be used by other Parsl components at initialization. Future PRs will introduce those further uses.

This is quite similar to the logging system introduced into Academy in https://github.com/academy-agents/academy/pull/295

# Changed Behaviour

Nothing should change if not using the new configuration mechanism. Otherwise `parsl.log` equivalents will be initialized differently, according to the supplied configuration.

## Type of change

- New feature
