### PR TITLE
Remove a line mis-describing monitoring database startup

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -688,9 +688,6 @@ def dbm_starter(resource_msgs: mpq.Queue,
                 logging_level: int,
                 exit_event: mpe.Event) -> None:
     """Start the database manager process
-
-    The DFK should start this function. The args, kwargs match that of the monitoring config
-
     """
     setproctitle("parsl: monitoring database")
 


### PR DESCRIPTION
The DFK does not start the database manager. That happens as part of the MonitoringHub being started (itself started by the DFK).

The arguments to dbm_starter do not match the arguments to anything else.

# Changed Behaviour

none

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
