### PR TITLE
Update comments in HTEX radio

### DIFF
--- a/parsl/monitoring/radios/htex.py
+++ b/parsl/monitoring/radios/htex.py
@@ -27,7 +27,7 @@ class HTEXRadioSender(MonitoringRadioSender):
         pass
 
     def send(self, message: object) -> None:
-        """ Sends a message to the UDP receiver
+        """ Sends a message via HTEX result channel.
 
         Parameter
         ---------
@@ -44,9 +44,7 @@ class HTEXRadioSender(MonitoringRadioSender):
         result_queue = parsl.executors.high_throughput.monitoring_info.result_queue
 
         # this message needs to go in the result queue tagged so that it is treated
-        # i) as a monitoring message by the interchange, and then further more treated
-        # as a RESOURCE_INFO message when received by monitoring (rather than a NODE_INFO
-        # which is the implicit default for messages from the interchange)
+        # as a monitoring message by the interchange.
 
         # for the interchange, the outer wrapper, this needs to be a dict:
 


### PR DESCRIPTION
Remove a reference to UDP from when this code was forked off from the UDP radio implementation.

Remove reference to tag types:
Monitoring messages at this point contain their own type tag, rather than the infrastructure adding a type tag. There is no need for this level of message transport to know anything about RESOURCE_INFO or NODE_INFO tags. This is something that was originally quite confused in the monitoring implementation but was rationalised over the years.

# Changed Behaviour

none

## Type of change

- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
