### PR TITLE
Tidyup references and asserts around decoding tagged message

### DIFF
--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -576,16 +576,13 @@ class DatabaseManager:
         if x[0] in [MessageType.WORKFLOW_INFO, MessageType.TASK_INFO]:
             self.pending_priority_queue.put(cast(Any, x))
         elif x[0] == MessageType.RESOURCE_INFO:
-            body = x[1]
-            self.pending_resource_queue.put(body)
+            self.pending_resource_queue.put(x[1])
         elif x[0] == MessageType.NODE_INFO:
-            assert len(x) == 2, "expected NODE_INFO tuple to have exactly two elements"
-
             logger.debug("Will put {} to pending node queue".format(x[1]))
             self.pending_node_queue.put(x[1])
         elif x[0] == MessageType.BLOCK_INFO:
             logger.debug("Will put {} to pending block queue".format(x[1]))
-            self.pending_block_queue.put(x[-1])
+            self.pending_block_queue.put(x[1])
         else:
             logger.error("Discarding message of unknown type {}".format(x[0]))
 


### PR DESCRIPTION
The message is already asserted to be length 2 so remove another duplicate assert.

In this two-element case, x[-1] is the same as x[1] so make that consistent across all cases.

One case uses an intermediate variable where others don't. Make that consistent across all cases too.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
