### PR TITLE
Allow disabling of both parsl and python version checks between IX and managers.

### DIFF
--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -102,8 +102,9 @@ class Interchange:
 
         _check_python_mismatch : bool
             If True, the interchange and worker managers must run the same version of
-            Python. Running different versions can cause inter-process communication
-            errors, so proceed with caution.
+            Python and Parsl. Running different versions can cause inter-process
+            communication errors, so proceed with caution.
+            Default: True
         """
         self.cert_dir = cert_dir
         self.logdir = logdir
@@ -404,7 +405,10 @@ class Interchange:
 
             python_mismatch: bool = ix_minor_py != mgr_minor_py
             parsl_mismatch: bool = ix_parsl_v != mgr_parsl_v
-            if parsl_mismatch or (self._check_python_mismatch and python_mismatch):
+            logger.warning(f"Yadu : {self._check_python_mismatch=}")
+            logger.warning(f"Yadu : {python_mismatch=} {ix_minor_py=} {mgr_minor_py=}")
+            logger.warning(f"Yadu : {parsl_mismatch=}  {ix_parsl_v=} {mgr_parsl_v=}")
+            if self._check_python_mismatch and (parsl_mismatch or python_mismatch):
                 kill_event.set()
                 vm_exc = VersionMismatch(
                     f"py.v={ix_minor_py} parsl.v={ix_parsl_v}",

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -405,9 +405,6 @@ class Interchange:
 
             python_mismatch: bool = ix_minor_py != mgr_minor_py
             parsl_mismatch: bool = ix_parsl_v != mgr_parsl_v
-            logger.warning(f"Yadu : {self._check_python_mismatch=}")
-            logger.warning(f"Yadu : {python_mismatch=} {ix_minor_py=} {mgr_minor_py=}")
-            logger.warning(f"Yadu : {parsl_mismatch=}  {ix_parsl_v=} {mgr_parsl_v=}")
             if self._check_python_mismatch and (parsl_mismatch or python_mismatch):
                 kill_event.set()
                 vm_exc = VersionMismatch(

--- a/parsl/tests/test_htex/test_interchange_exit_bad_registration.py
+++ b/parsl/tests/test_htex/test_interchange_exit_bad_registration.py
@@ -3,6 +3,7 @@ import os
 import pickle
 import platform
 import subprocess
+import sys
 import time
 
 import psutil
@@ -114,5 +115,122 @@ def test_exit_with_bad_registration(tmpd_cwd, try_assert):
     # See issue #3697 - ideally the interchange would exit cleanly, but it does not.
     # assert interchange_proc.poll() == 0, "Interchange exited with an error code, not 0"
 
+    task_channel.close()
+    context.term()
+
+
+@pytest.mark.local
+@pytest.mark.parametrize(
+    "worker_version_info", [
+    {"parsl_v": PARSL_VERSION,
+     "python_v": "0.0.0", # python_v mismatch
+     },
+    {"parsl_v": "0.0.0",  # parsl_v mismatch}
+     "python_v": "{}.{}.{}".format(sys.version_info.major,
+     sys.version_info.minor,
+     sys.version_info.micro)
+     },
+    {"parsl_v": "0.0.0",  # parsl_v mismatch and
+     "python_v": "0.0.0", # python_v mismatch
+     }]
+)
+def test_ignore_version_check_at_registration(tmpd_cwd, try_assert, worker_version_info):
+    """Test that the interchange will ignore version checks
+
+    Uses _check_python_version flag to indicate that version mismatches should
+    be ignored.
+    """
+
+    outgoing_q = zmq_pipes.TasksOutgoing(
+        "127.0.0.1", (49152, 65535), None
+    )
+    incoming_q = zmq_pipes.ResultsIncoming(
+        "127.0.0.1", (49152, 65535), None
+    )
+    command_client = zmq_pipes.CommandClient(
+        "127.0.0.1", (49152, 65535), None
+    )
+
+    interchange_config = {"client_address": "127.0.0.1",
+                          "client_ports": (outgoing_q.port,
+                                           incoming_q.port,
+                                           command_client.port),
+                          "interchange_address": "127.0.0.1",
+                          "worker_port": None,
+                          "worker_port_range": (50000, 60000),
+                          "hub_address": None,
+                          "hub_zmq_port": None,
+                          "logdir": tmpd_cwd,
+                          "heartbeat_threshold": 120,
+                          "poll_period": P_ms,
+                          "logging_level": logging.DEBUG,
+                          "cert_dir": None,
+                          "manager_selector": RandomManagerSelector(),
+                          "run_id": "test",
+                          "_check_python_mismatch": False,
+                          }
+
+    config_pickle = pickle.dumps(interchange_config)
+
+    interchange_proc = subprocess.Popen(DEFAULT_INTERCHANGE_LAUNCH_CMD, stdin=subprocess.PIPE)
+    stdin = interchange_proc.stdin
+    assert stdin is not None, "Popen should have created an IO object (vs default None) because of PIPE mode"
+
+    stdin.write(config_pickle)
+    stdin.flush()
+    stdin.close()
+
+    # wait for interchange to be alive, by waiting for the command thread to become
+    # responsive. if the interchange process didn't start enough to get the command
+    # thread running, this will time out.
+
+    worker_port = command_client.run("WORKER_BINDS", timeout_s=120)
+
+    # now we'll assume that if the interchange command thread is responding,
+    # then the worker polling code is also running and that the interchange has
+    # started successfully.
+
+    # send bad registration message as if from a new worker pool. The badness here
+    # is that the Python version does not match the real Python version - which
+    # unlike some other bad interchange messages, should cause the interchange
+    # to shut down.
+
+    msg = {'type': 'registration',
+           'worker_count': 1,
+           'uid': 'testuid',
+           'block_id': 0,
+           'start_time': time.time(),
+           'prefetch_capacity': 0,
+           'max_capacity': 1,
+           'os': platform.system(),
+           'hostname': platform.node(),
+           'dir': os.getcwd(),
+           'cpu_count': psutil.cpu_count(logical=False),
+           'total_memory': psutil.virtual_memory().total,
+           }.update(worker_version_info)
+
+
+    # connect to worker port and send this message.
+
+    context = zmq.Context()
+    channel_timeout = 10000  # in milliseconds
+    task_channel = context.socket(zmq.DEALER)
+    task_channel.setsockopt(zmq.LINGER, 0)
+    task_channel.setsockopt(zmq.IDENTITY, b'testid')
+
+    task_channel.set_hwm(0)
+    task_channel.setsockopt(zmq.SNDTIMEO, channel_timeout)
+    task_channel.connect(f"tcp://127.0.0.1:{worker_port}")
+
+    task_channel.send(pickle.dumps(msg))
+
+
+    # Run a command against the interchange to confirm that the interchange has
+    # not failed, this call will hang if the interchange exits early
+    output = command_client.run("MANAGERS", max_retries=0, timeout_s=1)
+    logging.warning(f"MANAGERS = {output=}")
+    # check that the interchange exits within some reasonable time
+
+    interchange_proc.terminate()
     task_channel.close()
     context.term()

--- a/parsl/tests/test_htex/test_interchange_exit_bad_registration.py
+++ b/parsl/tests/test_htex/test_interchange_exit_bad_registration.py
@@ -122,17 +122,17 @@ def test_exit_with_bad_registration(tmpd_cwd, try_assert):
 @pytest.mark.local
 @pytest.mark.parametrize(
     "worker_version_info", [
-    {"parsl_v": PARSL_VERSION,
-     "python_v": "0.0.0", # python_v mismatch
-     },
-    {"parsl_v": "0.0.0",  # parsl_v mismatch}
-     "python_v": "{}.{}.{}".format(sys.version_info.major,
-     sys.version_info.minor,
-     sys.version_info.micro)
-     },
-    {"parsl_v": "0.0.0",  # parsl_v mismatch and
-     "python_v": "0.0.0", # python_v mismatch
-     }]
+        {"parsl_v": PARSL_VERSION,
+         "python_v": "0.0.0",  # python_v mismatch
+         },
+        {"parsl_v": "0.0.0",  # parsl_v mismatch
+         "python_v": "{}.{}.{}".format(sys.version_info.major,
+                                       sys.version_info.minor,
+                                       sys.version_info.micro)
+         },
+        {"parsl_v": "0.0.0",  # parsl_v mismatch and
+         "python_v": "0.0.0",  # python_v mismatch
+         }]
 )
 def test_ignore_version_check_at_registration(tmpd_cwd, try_assert, worker_version_info):
     """Test that the interchange will ignore version checks
@@ -209,7 +209,6 @@ def test_ignore_version_check_at_registration(tmpd_cwd, try_assert, worker_versi
            'total_memory': psutil.virtual_memory().total,
            }.update(worker_version_info)
 
-
     # connect to worker port and send this message.
 
     context = zmq.Context()
@@ -223,7 +222,6 @@ def test_ignore_version_check_at_registration(tmpd_cwd, try_assert, worker_versi
     task_channel.connect(f"tcp://127.0.0.1:{worker_port}")
 
     task_channel.send(pickle.dumps(msg))
-
 
     # Run a command against the interchange to confirm that the interchange has
     # not failed, this call will hang if the interchange exits early


### PR DESCRIPTION
# Description

Reids work in #3951 added support for disabling the Python version checks between the interchange and manager using a private flag `_check_python_version`. This flag does not disable parsl version checks which means strict version matches are required between the components, which is troublesome in Globus Compute deployments.

This PR expands the scope of the `_check_python_version` flag to toggle version checks for both python and parsl versions. I considered adding an additional `_check_parsl_version` flag but decided against it due to the additional backwards compatibility headaches.

Here are two options:
1. Overload the existing `_check_python_mismatch` to also ignore parsl version mismatches.
```
MEP updated   Worker updated    Compatibility
       No                     No                  Status quo
       No                     Yes                 Status quo
       Yes                    No                  New behavior, version checks ignored
       Yes                    Yes                 New behavior, version checks ignored
```
Cons: Flag does more than what the name implies, (but it is hidden from users)

2. Add a new `_check_parsl_mismatch` flag.
```
MEP updated, Worker updated,  Compatibility
       No                     No                  Status quo
       No                     Yes                 Status quo
       Yes                    No                  Worker lanch fails: Unknown _check_parsl_mismatch flag
       Yes                    Yes                 New behavior, version checks ignored
```
Cons: This approach will be disruptive, because we'll need both admins and users to update the EP envs

# Changed Behaviour

This change does not affect Parsl users. Only GC uses this private flag AFAIK.
For GC users, when EP administrators update the parsl versions, users will no longer see VersionMismatch errors that terminate endpoints.

## Type of change

Choose which options apply, and delete the ones which do not apply.

- New feature
