### PR TITLE
Don't log a duplicate of configuration

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -670,7 +670,7 @@ class DataFlowKernel:
         try:
             executor = self.executors[executor_label]
         except Exception:
-            logger.exception("Task {} requested invalid executor {}: config is\n{}".format(task_id, executor_label, self._config))
+            logger.exception("Task {} requested invalid executor {}".format(task_id, executor_label))
             raise ValueError("Task {} requested invalid executor {}".format(task_id, executor_label))
 
         try_id = task_record['fail_count']


### PR DESCRIPTION
There's nothing special about this particular error that needs the config to be logged.

# Changed Behaviour

slightly less logging in some error situations -- the config is already logged at DFK initialization so there shouldn't be any information loss except when running without `INFO` level logging

## Type of change

- Update to human readable text: Documentation/error messages/comments
