### PR TITLE
Force typed definitions for parsl.logconfigs

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -60,6 +60,11 @@ disallow_any_decorated = True
 [mypy-parsl.jobs.*]
 disallow_untyped_defs = True
 
+[mypy-parsl.logconfigs.*]
+disallow_untyped_defs = True
+disallow_any_expr = True
+disallow_any_decorated = True
+
 [mypy-parsl.providers.base.*]
 disallow_untyped_decorators = True
 check_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -62,7 +62,6 @@ disallow_untyped_defs = True
 
 [mypy-parsl.logconfigs.*]
 disallow_untyped_defs = True
-disallow_any_expr = True
 disallow_any_decorated = True
 
 [mypy-parsl.providers.base.*]

--- a/parsl/logconfigs/file.py
+++ b/parsl/logconfigs/file.py
@@ -43,7 +43,7 @@ class FileLogging(LogConfig):
             futures_logger.setLevel(min(futures_logger.level, self.level))
         futures_logger.addHandler(handler)
 
-        def unregister_callback():
+        def unregister_callback() -> None:
             logger.removeHandler(handler)
             futures_logger.removeHandler(handler)
 


### PR DESCRIPTION
This is a new subtree so we can make it typed from the start.

# Changed Behaviour

nothing user facing - tighter developer facing checking.

## Type of change

- Code maintenance/cleanup
