### PR TITLE
Add a JSON format log file configuration

### DIFF
--- a/parsl/logconfigs/json.py
+++ b/parsl/logconfigs/json.py
@@ -1,0 +1,74 @@
+import json
+import logging
+import pathlib
+from typing import Any, Callable
+
+from parsl.logconfigs.base import LogConfig
+
+
+class JSONLogging(LogConfig):
+    """A log configuration which logs as JSON objects.
+
+    This configuration will write each log event as a JSON object into a
+    log file, one per line.
+    """
+
+    def __init__(self, *, level: int = logging.DEBUG):
+        super().__init__()
+        self.level = level
+
+    def initialize_logging(self, *, log_dir: pathlib.Path, log_name: str) -> Callable[[], None]:
+        log_dir.mkdir(exist_ok=True)
+
+        filename = log_dir.joinpath(log_name + ".jsonlog")
+
+        logger = logging.getLogger("")
+        if logger.level == logging.NOTSET:
+            logger.setLevel(self.level)
+        else:
+            logger.setLevel(min(logger.level, self.level))
+
+        handler = JSONHandler(filename)
+        handler.setLevel(self.level)
+        formatter = logging.Formatter("%(message)s", datefmt='%Y-%m-%d %H:%M:%S')
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+        def unregister_callback() -> None:
+            logger.removeHandler(handler)
+
+        return unregister_callback
+
+
+class JSONHandler(logging.Handler):
+    def __init__(self, filename: pathlib.Path, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.f = open(filename, "w")
+
+    def emit(self, record: logging.LogRecord) -> None:
+
+        d: dict[str, object] = {
+            "created": record.created,
+            "process": record.process,
+            "processName": record.processName,
+            "threadName": record.threadName,
+            "thread": record.thread,
+            "name": record.name,
+            "lineno": record.lineno,
+            "funcname": record.funcName,
+            "levelname": record.levelname,
+            "msg": record.msg,
+            "formatted": self.format(record)
+        }
+
+        for (k, v) in record.__dict__.items():
+            if k.startswith("parsl."):
+                try:
+                    d[k] = str(v)
+                except Exception as e:
+                    # present the exception rather than omitting
+                    d[k] = f"UNREPRESENTABLE: {e!r}"
+
+        json.dump(d, fp=self.f)
+        print("", file=self.f)
+        self.f.flush()

--- a/parsl/tests/configs/htex_local_alternate.py
+++ b/parsl/tests/configs/htex_local_alternate.py
@@ -25,7 +25,7 @@ from parsl.data_provider.zip import ZipFileStaging
 from parsl.dataflow.memoization import BasicMemoizer
 from parsl.executors import HighThroughputExecutor
 from parsl.launchers import SingleNodeLauncher
-from parsl.logconfigs.file import FileLogging
+from parsl.logconfigs.json import JSONLogging
 from parsl.monitoring import MonitoringHub
 from parsl.providers import LocalProvider
 
@@ -66,7 +66,7 @@ def fresh_config():
         project_name="parsl htex_local_alternate test configuration",
 
         # level 1 is even more debuggy than logging.DEBUG
-        initialize_logging=FileLogging(level=1)
+        initialize_logging=JSONLogging(level=1)
     )
 
 

--- a/parsl/tests/test_logging/test_initialize_logging.py
+++ b/parsl/tests/test_logging/test_initialize_logging.py
@@ -1,9 +1,12 @@
+import json
+import logging
 import pathlib
 
 import pytest
 
 import parsl
 from parsl.logconfigs.file import FileLogging
+from parsl.logconfigs.json import JSONLogging
 
 
 @pytest.mark.local
@@ -25,3 +28,32 @@ def test_parsl_log_FileLogging(tmpd_cwd):
     with parsl.load(parsl.Config(run_dir=str(tmpd_cwd), initialize_logging=FileLogging())):
         assert (pathlib.Path(parsl.dfk().run_dir) / "parsl.log").exists(), \
             "With FileLogging, parsl.log should exist in rundir after startup"
+
+
+@pytest.mark.local
+def test_parsl_log_JSONLogging(tmpd_cwd):
+    with parsl.load(parsl.Config(run_dir=str(tmpd_cwd), initialize_logging=JSONLogging())):
+        logger = logging.getLogger(__name__)
+        msg1 = "Test without extra"
+        msg2 = "Test with extra"
+
+        logger.info(msg1)
+        logger.info("Test with extra", extra={"parsl.somekey": "vv"})
+
+        logfile = pathlib.Path(parsl.dfk().run_dir) / "parsl.jsonlog"
+        assert logfile.exists(), \
+            "With JSONLogging, parsl.jsonlog should exist in rundir after startup"
+
+    # close down the DFK before attempt to read log file, so that there aren't any partial
+    # writes.
+    with open(logfile, "r") as f:
+        lines = f.readlines()
+
+        # we should parse every line as JSON, without Exceptions
+        parsed = [json.loads(line) for line in lines]
+
+        assert len([None for p in parsed if p['msg'] == msg1]) == 1, "msg1 should appear once"
+
+        msgs2 = [p for p in parsed if p['msg'] == msg2]
+        assert len(msgs2) == 1, "msg2 should appear once"
+        assert msgs2[0]['parsl.somekey'] == "vv", "extra key should have been stored in record"


### PR DESCRIPTION
This is intended for the class of users who regexp their logfiles.

Alongside this, further PRs will add in logging 'extra' dictionaries containing machine readable fields such as task IDs.

# Changed Behaviour

nothing when this new feature is not configured

## Type of change

- New feature
