### PR TITLE
Fix and test format string in file log configuration

### DIFF
--- a/parsl/logconfigs/file.py
+++ b/parsl/logconfigs/file.py
@@ -11,7 +11,7 @@ class FileLogging(LogConfig):
 
     def __init__(self, *, format_string: str = DEFAULT_FORMAT, level: int = logging.DEBUG):
         super().__init__()
-        self.format_string = DEFAULT_FORMAT
+        self.format_string = format_string
         self.level = level
 
     def initialize_logging(self, *, log_dir: pathlib.Path, log_name: str) -> Callable[[], None]:

--- a/parsl/tests/test_logging/test_initialize_logging.py
+++ b/parsl/tests/test_logging/test_initialize_logging.py
@@ -25,3 +25,16 @@ def test_parsl_log_FileLogging(tmpd_cwd):
     with parsl.load(parsl.Config(run_dir=str(tmpd_cwd), initialize_logging=FileLogging())):
         assert (pathlib.Path(parsl.dfk().run_dir) / "parsl.log").exists(), \
             "With FileLogging, parsl.log should exist in rundir after startup"
+
+
+@pytest.mark.local
+def test_parsl_log_FileLogging_format(tmpd_cwd):
+    msg = "XXXYYY %(message)s"
+    with parsl.load(parsl.Config(run_dir=str(tmpd_cwd), initialize_logging=FileLogging(format_string=msg))):
+        logfile = pathlib.Path(parsl.dfk().run_dir) / "parsl.log"
+        assert logfile.exists(), \
+            "With FileLogging, parsl.log should exist in rundir after startup"
+    with open(logfile, "r") as f:
+        ls = f.readlines()
+        assert len(ls) >= 1, "logfile should contain lines"
+        assert ls[0].startswith("XXXYYY "), "logged lines should match format string"


### PR DESCRIPTION
# Changed Behaviour

The format_string parameter was ignored in code introduced in PR #4091. After this PR, it is not ignored.

## Type of change

- Bug fix
