### PR TITLE
Implement LogConfig handling for monitoring database manager

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -130,7 +130,7 @@ class DataFlowKernel:
         self.monitoring_radio = None
 
         if self.monitoring:
-            self.monitoring.start(self.run_dir, self.config.run_dir)
+            self.monitoring.start(self.run_dir, self.config.run_dir, self.log_config)
             self.monitoring_radio = MultiprocessingQueueRadioSender(self.monitoring.resource_msgs)
 
         self.time_began = datetime.datetime.now()

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -3,6 +3,7 @@ import logging
 import multiprocessing.queues as mpq
 import multiprocessing.synchronize as mpe
 import os
+import pathlib
 import queue
 import threading
 import time
@@ -13,6 +14,7 @@ import typeguard
 from parsl.dataflow.states import States
 from parsl.errors import OptionalModuleMissing
 from parsl.log_utils import set_file_logger
+from parsl.logconfigs.base import LogConfig
 from parsl.monitoring.message_type import MessageType
 from parsl.monitoring.types import MonitoringMessage, TaggedMonitoringMessage
 from parsl.process_loggers import wrap_with_logs
@@ -283,6 +285,7 @@ class DatabaseManager:
                  db_url: str = 'sqlite:///runinfo/monitoring.db',
                  run_dir: str = '.',
                  logging_level: int = logging.INFO,
+                 log_config: Optional[LogConfig] = None,
                  batching_interval: float = 1,
                  batching_threshold: float = 99999,
                  exit_event: mpe.Event
@@ -291,10 +294,14 @@ class DatabaseManager:
         self.workflow_end = False
         self.workflow_start_message: Optional[MonitoringMessage] = None
         self.run_dir = run_dir
-        os.makedirs(self.run_dir, exist_ok=True)
 
-        set_file_logger(f"{self.run_dir}/database_manager.log", level=logging_level,
-                        format_string="%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s] [%(threadName)s %(thread)d] %(message)s")
+        if log_config:
+            log_config.initialize_logging(log_dir=pathlib.Path(self.run_dir), log_name="database_manager")
+        else:
+            os.makedirs(self.run_dir, exist_ok=True)
+
+            set_file_logger(f"{self.run_dir}/database_manager.log", level=logging_level,
+                            format_string="%(asctime)s.%(msecs)03d %(name)s:%(lineno)d [%(levelname)s] [%(threadName)s %(thread)d] %(message)s")
 
         logger.info("Initializing Database Manager process")
 
@@ -692,7 +699,8 @@ def dbm_starter(resource_msgs: mpq.Queue,
                 db_url: str,
                 run_dir: str,
                 logging_level: int,
-                exit_event: mpe.Event) -> None:
+                exit_event: mpe.Event,
+                log_config: Optional[LogConfig]) -> None:
     """Start the database manager process
     """
     setproctitle("parsl: monitoring database")
@@ -701,7 +709,8 @@ def dbm_starter(resource_msgs: mpq.Queue,
         dbm = DatabaseManager(db_url=db_url,
                               run_dir=run_dir,
                               logging_level=logging_level,
-                              exit_event=exit_event)
+                              exit_event=exit_event,
+                              log_config=log_config)
         logger.info("Starting dbm in dbm starter")
         dbm.start(resource_msgs)
     except KeyboardInterrupt:

--- a/parsl/monitoring/monitoring.py
+++ b/parsl/monitoring/monitoring.py
@@ -9,6 +9,7 @@ from typing import Any, Optional, Union
 
 import typeguard
 
+from parsl.logconfigs.base import LogConfig
 from parsl.monitoring.types import TaggedMonitoringMessage
 from parsl.multiprocessing import (
     SpawnEvent,
@@ -114,7 +115,7 @@ class MonitoringHub(RepresentationMixin):
         self.resource_monitoring_enabled = resource_monitoring_enabled
         self.resource_monitoring_interval = resource_monitoring_interval
 
-    def start(self, dfk_run_dir: str, config_run_dir: Union[str, os.PathLike]) -> None:
+    def start(self, dfk_run_dir: str, config_run_dir: Union[str, os.PathLike], log_config: Optional[LogConfig]) -> None:
 
         logger.debug("Starting MonitoringHub")
 
@@ -137,6 +138,7 @@ class MonitoringHub(RepresentationMixin):
                                              "logging_level": logging.DEBUG if self.monitoring_debug else logging.INFO,
                                              "db_url": self.logging_endpoint,
                                              "exit_event": self.dbm_exit_event,
+                                             "log_config": log_config,
                                              },
                                      name="Monitoring-DBM-Process",
                                      daemon=True,

--- a/parsl/tests/test_monitoring/test_log_config.py
+++ b/parsl/tests/test_monitoring/test_log_config.py
@@ -1,0 +1,36 @@
+import pathlib
+
+import pytest
+
+import parsl
+from parsl.config import Config
+from parsl.executors import ThreadPoolExecutor
+from parsl.logconfigs.json import JSONLogging
+from parsl.monitoring import MonitoringHub
+
+
+def config(*, run_dir):
+    c = Config(executors=[ThreadPoolExecutor()],
+               monitoring=MonitoringHub(),
+               run_dir=str(run_dir))
+    return c
+
+
+def config_log(*, run_dir, log_config):
+    c = Config(executors=[ThreadPoolExecutor()],
+               monitoring=MonitoringHub(),
+               run_dir=str(run_dir),
+               initialize_logging=log_config)
+    return c
+
+
+@pytest.mark.local
+def test_log_default_config(tmpd_cwd, try_assert):
+    with parsl.load(config(run_dir=tmpd_cwd)):
+        try_assert(lambda: (pathlib.Path(parsl.dfk().run_dir) / "database_manager.log").exists())
+
+
+@pytest.mark.local
+def test_log_json_config(tmpd_cwd, try_assert):
+    with parsl.load(config_log(run_dir=tmpd_cwd, log_config=JSONLogging())):
+        try_assert(lambda: (pathlib.Path(parsl.dfk().run_dir) / "database_manager.jsonlog").exists())


### PR DESCRIPTION
DFK-supplied log configuration will now be used to configure the monitoring database logs.

As an example, one of the tests introduced by this PR makes the database log to a JSON format log.

This does for the monitoring database process what PR #4103 does for the High Throughput Executor intechange.

# Changed Behaviour

The monitoring db manager will log differently when there is a DFK supplied log configuration. The `monitoring_debug` flag will be ignored in that case. That flag is still used when no log configuration is supplied, to configure how the default logging works.

## Type of change

- New feature
