### PR TITLE
Use LogConfig mechanism for HighThroughputExecutor worker pools

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import os
 import pickle
 import subprocess
 import threading
@@ -51,6 +52,7 @@ DEFAULT_LAUNCH_CMD = ("process_worker_pool.py {debug} {max_workers_per_node} "
                       "--port={worker_port} "
                       "--cert_dir {cert_dir} "
                       "--logdir={logdir} "
+                      "--logconf={logconf} "
                       "--block_id={{block_id}} "
                       "--hb_period={heartbeat_period} "
                       "{address_probe_timeout_string} "
@@ -423,6 +425,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
                                        poll_period=self.poll_period,
                                        cert_dir=self.cert_dir,
                                        logdir=self.worker_logdir,
+                                       logconf=self.logconf_path,
                                        cpu_affinity=self.cpu_affinity,
                                        enable_mpi_mode=enable_mpi_opts,
                                        mpi_launcher=self.mpi_launcher,
@@ -445,6 +448,16 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
                 "encrypted attribute is set to False. You must either change cert_dir to "
                 "None or encrypted to True."
             )
+
+        if self.log_config:
+            log_config_dir = os.path.join(self.logdir, "log_config")
+            os.makedirs(log_config_dir, mode=0o700, exist_ok=True)
+
+            self.logconf_path = os.path.join(log_config_dir, "log_config.pkl")
+            with open(self.logconf_path, "wb") as f:
+                pickle.dump(self.log_config, f)
+        else:
+            self.logconf_path = None
 
         self.outgoing_q = zmq_pipes.TasksOutgoing(
             self.loopback_address, self.interchange_port_range, self.cert_dir

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -6,6 +6,7 @@ import logging
 import math
 import multiprocessing
 import os
+import pathlib
 import pickle
 import platform
 import queue
@@ -38,6 +39,7 @@ from parsl.executors.high_throughput.mpi_resource_management import (
 )
 from parsl.executors.high_throughput.probe import probe_addresses
 from parsl.log_utils import set_file_logger
+from parsl.logconfigs.base import LogConfig
 from parsl.multiprocessing import SpawnContext
 from parsl.process_loggers import wrap_with_logs
 from parsl.serialize import serialize
@@ -87,7 +89,8 @@ class Manager:
                  mpi_launcher: str = "mpiexec",
                  available_accelerators: Sequence[str],
                  cert_dir: Optional[str],
-                 drain_period: Optional[int]):
+                 drain_period: Optional[int],
+                 log_config: Optional[LogConfig]):
         """
         Parameters
         ----------
@@ -160,6 +163,8 @@ class Manager:
         logger.info("Manager initializing")
 
         self._start_time = time.time()
+
+        self.log_config = log_config
 
         self.cert_dir = cert_dir
         self.zmq_context = curvezmq.ClientContext(self.cert_dir)
@@ -595,6 +600,7 @@ class Manager:
                 self.heartbeat_period,
                 os.getpid(),
                 args.logdir,
+                self.log_config,
                 args.debug,
                 self.mpi_launcher,
             ),
@@ -639,11 +645,17 @@ def worker(
     task_queue_timeout: int,
     manager_pid: int,
     logdir: str,
+    log_config: LogConfig,
     debug: bool,
     mpi_launcher: str,
 ):
-    set_file_logger('{}/block-{}/{}/worker_{}.log'.format(logdir, block_id, pool_id, worker_id),
-                    level=logging.DEBUG if debug else logging.INFO)
+
+    if log_config:
+        path = pathlib.Path(logdir) / f"block-{block_id}" / pool_id
+        log_config.initialize_logging(log_dir=path, log_name=f"worker_{worker_id}")
+    else:
+        set_file_logger('{}/block-{}/{}/worker_{}.log'.format(logdir, block_id, pool_id, worker_id),
+                        level=logging.DEBUG if debug else logging.INFO)
 
     # Store worker ID as an environment variable
     os.environ['PARSL_WORKER_RANK'] = str(worker_id)
@@ -848,6 +860,12 @@ def get_arg_parser() -> argparse.ArgumentParser:
         help="Process worker pool log directory",
     )
     parser.add_argument(
+        "-L",
+        "--logconf",
+        default=None,
+        help="Path to pickled log configuration object, default=None",
+    )
+    parser.add_argument(
         "-u",
         "--uid",
         default=str(uuid.uuid4()).split('-')[-1],
@@ -938,17 +956,29 @@ if __name__ == "__main__":
     parser = get_arg_parser()
     args = parser.parse_args()
 
-    os.makedirs(os.path.join(args.logdir, "block-{}".format(args.block_id), args.uid), exist_ok=True)
+    if args.logconf is None or args.logconf == "None":
+        os.makedirs(os.path.join(args.logdir, "block-{}".format(args.block_id), args.uid), exist_ok=True)
 
-    set_file_logger(
-        f'{args.logdir}/block-{args.block_id}/{args.uid}/manager.log',
-        level=logging.DEBUG if args.debug is True else logging.INFO
-    )
+        set_file_logger(
+            f'{args.logdir}/block-{args.block_id}/{args.uid}/manager.log',
+            level=logging.DEBUG if args.debug is True else logging.INFO
+        )
+        logconf = None
+    else:
+        with open(args.logconf, "rb") as f:
+            # This deliberately does not make the path directory. Creating directories
+            # can be extremely expensive on shared filesystems, and avoiding this for
+            # logging is a specific use case for this log configurability.
+            path = os.path.join(args.logdir, "block-{}".format(args.block_id), args.uid)
+            logconf = pickle.load(f)
+            logconf.initialize_logging(log_dir=pathlib.Path(path), log_name="manager")
+
     logger.info(
         f"\n  Python version: {sys.version}"
         f"\n  Debug logging: {args.debug}"
         f"\n  Certificates dir: {args.cert_dir}"
         f"\n  Log dir: {args.logdir}"
+        f"\n  Log config path: {args.logconf}"
         f"\n  Manager ID: {args.uid}"
         f"\n  Block ID: {args.block_id}"
         f"\n  cores_per_worker: {args.cores_per_worker}"
@@ -988,7 +1018,8 @@ if __name__ == "__main__":
                           enable_mpi_mode=args.enable_mpi_mode,
                           mpi_launcher=args.mpi_launcher,
                           available_accelerators=args.available_accelerators,
-                          cert_dir=None if args.cert_dir == "None" else args.cert_dir)
+                          cert_dir=None if args.cert_dir == "None" else args.cert_dir,
+                          log_config=logconf)
         manager.start()
 
     except Exception:

--- a/parsl/logconfigs/file.py
+++ b/parsl/logconfigs/file.py
@@ -16,7 +16,7 @@ class FileLogging(LogConfig):
 
     def initialize_logging(self, *, log_dir: pathlib.Path, log_name: str) -> Callable[[], None]:
 
-        log_dir.mkdir(exist_ok=True)
+        log_dir.mkdir(exist_ok=True, parents=True)
         filename = log_dir.joinpath(log_name + ".log")
 
         handler = logging.FileHandler(filename)

--- a/parsl/logconfigs/json.py
+++ b/parsl/logconfigs/json.py
@@ -18,7 +18,7 @@ class JSONLogging(LogConfig):
         self.level = level
 
     def initialize_logging(self, *, log_dir: pathlib.Path, log_name: str) -> Callable[[], None]:
-        log_dir.mkdir(exist_ok=True)
+        log_dir.mkdir(exist_ok=True, parents=True)
 
         filename = log_dir.joinpath(log_name + ".jsonlog")
 

--- a/parsl/tests/test_htex/test_log_config.py
+++ b/parsl/tests/test_htex/test_log_config.py
@@ -7,6 +7,11 @@ from parsl.executors.high_throughput.executor import HighThroughputExecutor
 from parsl.logconfigs.file import FileLogging
 
 
+@parsl.python_app
+def noop_app():
+    pass
+
+
 @pytest.mark.local
 def test_interchange_log_default(tmpd_cwd):
     with parsl.load(parsl.Config(run_dir=str(tmpd_cwd),
@@ -16,7 +21,7 @@ def test_interchange_log_default(tmpd_cwd):
 
 
 @pytest.mark.local
-def test_interchange_log_fileconfig(tmpd_cwd):
+def test_log_fileconfig(tmpd_cwd):
     # this arbitrary token should flow via the format_string parameter into the
     # resulting text-format log file, and the test will check it arrives there.
     token = "XXXXYYYYY"
@@ -24,11 +29,31 @@ def test_interchange_log_fileconfig(tmpd_cwd):
     with parsl.load(parsl.Config(initialize_logging=FileLogging(format_string=msg),
                                  run_dir=str(tmpd_cwd),
                                  executors=[HighThroughputExecutor(label="htex")])):
-        logfile = pathlib.Path(parsl.dfk().run_dir) / "htex" / "interchange.log"
-        assert logfile.exists(), \
-            "interchange.log should exist after startup"
+        # ensure that enough has started to run a task - so that includes everything
+        # all the way to a worker, on the task execution path
+        noop_app().result()
 
-    with open(logfile, "r") as f:
-        ls = f.readlines()
-        assert len(ls) >= 1, "There should be at least one log entry"
-        assert ls[0].startswith(token), "Log entry should be formatted with token from format_string parameter"
+        interchange_logfile = pathlib.Path(parsl.dfk().run_dir) / "htex" / "interchange.log"
+
+        # assume in this configuration that there is only one subdirectory of block-0,
+        # and that it is the directory for a started worker pool.
+        pool_dir = next((pathlib.Path(parsl.dfk().run_dir) / "htex" / "block-0").iterdir())
+        manager_logfile = pool_dir / "manager.log"
+        worker_logfile = pool_dir / "worker_0.log"
+
+        assert interchange_logfile.exists(), \
+            "interchange.log should exist after startup"
+        assert manager_logfile.exists(), \
+            "a manager log file should exist after startup"
+        assert worker_logfile.exists(), \
+            "a worker log file should exist after startup"
+
+    def check_file(logfile: pathlib.Path):
+        with open(logfile, "r") as f:
+            ls = f.readlines()
+            assert len(ls) >= 1, f"There should be at least one log entry in {logfile}"
+            assert ls[0].startswith(token), f"Log entry in {logfile} should be formatted with token from format_string parameter"
+
+    check_file(interchange_logfile)
+    check_file(manager_logfile)
+    check_file(worker_logfile)

--- a/parsl/tests/unit/executors/high_throughput/test_process_worker_pool.py
+++ b/parsl/tests/unit/executors/high_throughput/test_process_worker_pool.py
@@ -131,6 +131,7 @@ def test_worker_dynamic_import_happy_path(tmpd_cwd):
             task_queue_timeout=0,
             manager_pid=os.getpid(),
             logdir=str(tmpd_cwd),
+            log_config=None,
             debug=True,
             mpi_launcher="",
         )
@@ -180,6 +181,7 @@ def test_worker_bad_dynamic_import(tmpd_cwd):
             task_queue_timeout=0,
             manager_pid=os.getpid(),
             logdir=str(tmpd_cwd),
+            log_config=None,
             debug=True,
             mpi_launcher="",
         )


### PR DESCRIPTION
This follows on from the same for the interchange in PR #4103

Log configurations are passed via file, in the same way as certificate configurations, and so in situations where filesystems force encrypted=False, you should expect to not be able to use log configurations.

This PR modifies the directory creation behaviour of the two file-based configurations, so that they will create parent directories too. This is needed because workers put logs in a deeper hierarchy than other places where log configuration is used.

# Changed Behaviour

DFK-level log configuration introduced in PR #4091 will be respected inside htex workers.

## Type of change

- New feature