### PR TITLE
Checkout full history in release process for release suppression

### DIFF
--- a/.github/workflows/python-publish-to-testpypi.yml
+++ b/.github/workflows/python-publish-to-testpypi.yml
@@ -32,6 +32,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-tags: true
+        fetch-depth: 0
 
     - name: Check if this commit is already released
       id: already_released


### PR DESCRIPTION
PR #2617 introduced a block to abort release if no changes had been made since the previous release. It does that by asking if the current master branch head commit already has a release tag. However, the preceeding checkout step by default performs a shallow tag-free checkout which does not contain enough history to make that query.

This PR changes the checkout to get the whole history and tag collection.

This is awkward to test the whole way through: I can test the pieces but the full integrated flow makes an actual release, which i) I don't want to do midweek, and ii) when I'm paying enough attention to Parsl to work on this, that means I'm making PRs that get merged and don't exercise this path. So there's a multi-week (multi-year!) round trip in testing the final deployed behaviour.

# Changed Behaviour

maybe no-changes-no-release behaviour will work now?

## Type of change

- Bug fix
