### PR TITLE
Prepare for Python 3.15 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
   main-test-suite:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15.0-beta.1"]
     runs-on: ubuntu-24.04
     timeout-minutes: 60
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,6 @@ import parsl
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'nbsphinx',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
@@ -47,8 +46,6 @@ url = 'https://raw.githubusercontent.com/Parsl/parsl-tutorial/master/1-parsl-int
 r = requests.get(url)
 with open(os.path.join(os.path.dirname(__file__), '1-parsl-introduction.ipynb'), 'wb') as f:
     f.write(r.content)
-
-nbsphinx_execute = 'never'
 
 def linkcode_resolve(domain, info):
     if domain != 'py':

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,7 +105,6 @@ Table of Contents
    :maxdepth: 2
 
    quickstart
-   1-parsl-introduction.ipynb
    userguide/index
    userguide/glossary
    faq

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -228,7 +228,6 @@ There are several options for following the tutorial:
 
 1. Use `Binder <https://mybinder.org/v2/gh/Parsl/parsl-tutorial/master>`_  to follow the tutorial online without installing or writing any code locally. 
 2. Clone the `Parsl tutorial repository <https://github.com/Parsl/parsl-tutorial>`_ using a local Parsl installation.
-3. Read through the online `tutorial documentation XXXXXX.
 
 
 Usage Tracking

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -228,7 +228,7 @@ There are several options for following the tutorial:
 
 1. Use `Binder <https://mybinder.org/v2/gh/Parsl/parsl-tutorial/master>`_  to follow the tutorial online without installing or writing any code locally. 
 2. Clone the `Parsl tutorial repository <https://github.com/Parsl/parsl-tutorial>`_ using a local Parsl installation.
-3. Read through the online `tutorial documentation <1-parsl-introduction.html>`_.
+3. Read through the online `tutorial documentation XXXXXX.
 
 
 Usage Tracking

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ typeguard>=2.10,!=3.*,<5
 
 
 typing-extensions>=4.6,<5
-dill
+git+https://github.com/uqfoundation/dill@37d2bf717ac7ac110f06be5210f989847959c2cd
 tblib
 requests
 sortedcontainers

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ extras_require = {
     'kubernetes' : ['kubernetes'],
     'docs' : [
         'ipython<=8.6.0',
-        'nbsphinx',
         'sphinx>=7.4,<8',
         'sphinx_rtd_theme'
     ],

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@ from setuptools import find_packages, setup
 with open('parsl/version.py') as f:
     exec(f.read())
 
-with open('requirements.txt') as f:
-    install_requires = f.readlines()
+install_requires = []
 
 extras_require = {
     'monitoring' : [

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,6 @@ pandas
 pytest>=7.4.0,<8
 pytest-cov
 pytest-random-order
-nbsphinx
 sphinx_rtd_theme
 mypy==1.18.2
 types-mock


### PR DESCRIPTION
test against 3.15.0-beta.1 to start flushing out what has changed/is broken.

this PR should lead to fix PRs as needed, upstream issues/PRs, and eventually the addition of 3.15 as a CI target in master.

## Type of change

- New feature
