### PR TITLE
Fix broken error reporting for bad htex worker pool addresses

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -72,7 +72,7 @@ class Manager:
 
     """
     def __init__(self, *,
-                 addresses,
+                 addresses: str,
                  address_probe_timeout,
                  port,
                  cores_per_worker,

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -169,11 +169,11 @@ class Manager:
         self.cert_dir = cert_dir
         self.zmq_context = curvezmq.ClientContext(self.cert_dir)
 
-        addresses = {tcp_url(a, port) for a in addresses.split(',')}
+        address_set = {tcp_url(a, port) for a in addresses.split(',')}
         try:
             self._ix_url = probe_addresses(
                 self.zmq_context,
-                addresses,
+                address_set,
                 timeout_ms=1_000 * address_probe_timeout,
                 identity=uid.encode('utf-8'),
             )


### PR DESCRIPTION
# Description

PR #4087 broke handling of error reporting when all addresses are bad for a HighThroughputExecutor worker pool.

#4087 rewrites the `addresses` variable to a new value, changing both the meaning of the contents and the Python-level type. This is fine in the happy path but directly below it, there is an `except` block that expects the original meaning and which itself raises an exception when executed.

I discovered this while working on the type annotations for process_worker_pool.py, and this PR contains one additional type annotation which led me to discover this bug.

This PR makes the #4087 change happen into a new variable, keeping the original `addresses` variable as is.

After #4087 and before this PR, this double exception appears:

```
    parsl.executors.errors.BadStateException: Executor htex_local failed due to: Error 1:
            Job is marked as MISSING since the workers failed to register to the executor. Check the stdout/stderr logs in the>
            EXIT CODE: 1
            STDERR: Traceback (most recent call last):
      File "/home/benc/parsl/virtualenv-3.12/bin/process_worker_pool.py", line 174, in __init__
        self._ix_url = probe_addresses(
                       ^^^^^^^^^^^^^^^^
      File "/home/benc/parsl/src/parsl/parsl/executors/high_throughput/probe.py", line 65, in probe_addresses
        raise ConnectionError(f"No viable ZMQ url from: {addys}")
    ConnectionError: No viable ZMQ url from: tcp://10.99.99.99:54512
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "/home/benc/parsl/virtualenv-3.12/bin/process_worker_pool.py", line 1001, in <module>
        manager = Manager(port=args.port,
                  ^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/benc/parsl/virtualenv-3.12/bin/process_worker_pool.py", line 181, in __init__
        addys = ", ".join(addresses.split(","))
                          ^^^^^^^^^^^^^^^
    AttributeError: 'set' object has no attribute 'split' 
```

After this PR, the 2nd `split` related exception is gone:

            Job is marked as MISSING since the workers failed to register to the executor. Check the stdout/stderr logs in the submit_scripts directory for more debug information
            EXIT CODE: 1
            STDERR: Traceback (most recent call last):
      File "/home/benc/parsl/virtualenv-3.12/bin/process_worker_pool.py", line 1001, in <module>
        manager = Manager(port=args.port,
                  ^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/benc/parsl/virtualenv-3.12/bin/process_worker_pool.py", line 174, in __init__
        self._ix_url = probe_addresses(
                       ^^^^^^^^^^^^^^^^
      File "/home/benc/parsl/src/parsl/parsl/executors/high_throughput/probe.py", line 65, in probe_addresses
        raise ConnectionError(f"No viable ZMQ url from: {addys}")
    ConnectionError: No viable ZMQ url from: tcp://10.99.99.99:54627
    
    and this line appears in the relevant manager log:
    
```
1779966328.741755 2026-05-28 11:05:28 MainProcess-7344 MainThread-139861403830080 parsl.executors.high_throughput.process_worker_pool:182 __init__ ERROR: Unable to connect to interchange; attempted addresses: 10.99.99.99
```

# Changed Behaviour

In the happy path, no change. in the error handling path, error reporting is neater.
This PR doesn't change when an error occurs or not.

## Type of change

- Bug fix
