### PR TITLE
Tidy type annotations and defaults for HTEX mem_per_worker

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -76,7 +76,7 @@ class Manager:
                  address_probe_timeout,
                  port,
                  cores_per_worker,
-                 mem_per_worker,
+                 mem_per_worker: Optional[float],
                  max_workers_per_node,
                  prefetch_capacity,
                  uid,
@@ -111,7 +111,7 @@ class Manager:
              cores to be assigned to each worker. Oversubscription is possible
              by setting cores_per_worker < 1.0.
 
-        mem_per_worker : float
+        mem_per_worker : optional float
              GB of memory required per worker. If this option is specified, the node manager
              will check the available memory at startup and limit the number of workers such that
              the there's sufficient memory for each worker. If set to None, memory on node is not
@@ -883,8 +883,7 @@ def get_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-m",
         "--mem_per_worker",
-        default=0,
-        help="GB of memory assigned to each worker process. Default=0, no assignment",
+        help="GB of memory assigned to each worker process. 'None' means no assignment.",
     )
     parser.add_argument(
         "-P",


### PR DESCRIPTION
Prior to this PR, there were two simultaneous defaults for this parameter, None and 0. This PR removes one of those defaults, keeping the one that is most commonly encountered by users.

This PR adds a checked type annotation and corrects the docstring type annotation to reflect that None is a valid value.

See PRs #2991 cpu affinity, #2973 start method which deal with multiple-default bugs, which motivates my desire to remove unused defaults on internal APIs.

This is a tidyup driven by work on worker pool type annotations.

# Changed Behaviour

No change when worker pool command lines are generated by default Parsl. Crafters of custom command lines might find that they need to add `-m None` if they weren't doing so before.

## Type of change

- Code maintenance/cleanup
