### PR TITLE
Fix test race condition on whether worker 0 has started

### DIFF
--- a/parsl/tests/test_htex/test_log_config.py
+++ b/parsl/tests/test_htex/test_log_config.py
@@ -28,7 +28,7 @@ def test_log_fileconfig(tmpd_cwd):
     msg = f"{token} %(message)s"
     with parsl.load(parsl.Config(initialize_logging=FileLogging(format_string=msg),
                                  run_dir=str(tmpd_cwd),
-                                 executors=[HighThroughputExecutor(label="htex")])):
+                                 executors=[HighThroughputExecutor(label="htex", max_workers_per_node=1)])):
         # ensure that enough has started to run a task - so that includes everything
         # all the way to a worker, on the task execution path
         noop_app().result()
@@ -36,7 +36,8 @@ def test_log_fileconfig(tmpd_cwd):
         interchange_logfile = pathlib.Path(parsl.dfk().run_dir) / "htex" / "interchange.log"
 
         # assume in this configuration that there is only one subdirectory of block-0,
-        # and that it is the directory for a started worker pool.
+        # that it is the directory for a started worker pool, and that the worker that completed
+        # the above app invocation is worker 0 (the only worker).
         pool_dir = next((pathlib.Path(parsl.dfk().run_dir) / "htex" / "block-0").iterdir())
         manager_logfile = pool_dir / "manager.log"
         worker_logfile = pool_dir / "worker_0.log"


### PR DESCRIPTION
There's no guarantee that all workers (and so specificlly worker 0) has started by the time that the test task completes: one worker must have started, in order to perform the task, but the others might not have got as far yet.

This PR forces there to be a single worker, which will be worker 0, and which will have started enough to do logging by the time the test task completes.

I have observed this race in Github Actions (in downloaded log artefacts), but not in my development environment.

# Changed Behaviour

test should be less race prone.

## Type of change

- Bug fix
