### PR TITLE
Remove unused self.tasks_per_round in htex worker pool

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -235,8 +235,6 @@ class Manager:
 
         self.max_queue_size = self.prefetch_capacity + self.worker_count
 
-        self.tasks_per_round = 1
-
         self.heartbeat_period = heartbeat_period
         self.heartbeat_threshold = heartbeat_threshold
         self.poll_period = poll_period


### PR DESCRIPTION
This looks like it was introduced as part of mpix in

 commit 117431e88d315960badfa1fe20d5e36514fa2ca0
 Author: Yadu Nand B <yadudoc1729@gmail.com>
 Date:   Mon Sep 24 11:19:42 2018 -0500

In that commit, it is unused, and it looks like it has been cut and pasted into the present day htex, still unused.


# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
