### PR TITLE
Remove unused self.max_queue_size in htex worker pool

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -233,8 +233,6 @@ class Manager:
             )
         self.ready_worker_count = SpawnContext.Value("i", 0)
 
-        self.max_queue_size = self.prefetch_capacity + self.worker_count
-
         self.tasks_per_round = 1
 
         self.heartbeat_period = heartbeat_period


### PR DESCRIPTION
The last use of this was removed in PR #3778.

The value of this variable is probably set incorrectly and there may have been a bug relating to that, before #3778. This variable was used after doing some of minimisations of worker count in a worker pool, but not all of them: limiting to the number of accelerators available did not happen until later. If that was a bug, it won't be any more because #3778 stopped this value being used entirely, so I haven't investigated further.

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
