### PR TITLE
Type-related on worker count restrictions in htex worker pool

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -75,9 +75,9 @@ class Manager:
                  addresses: str,
                  address_probe_timeout,
                  port,
-                 cores_per_worker,
+                 cores_per_worker: float,
                  mem_per_worker: Optional[float],
-                 max_workers_per_node,
+                 max_workers_per_node: Optional[int],
                  prefetch_capacity,
                  uid,
                  block_id,
@@ -117,7 +117,7 @@ class Manager:
              the there's sufficient memory for each worker. If set to None, memory on node is not
              considered in the determination of workers to be launched on node by the manager.
 
-        max_workers_per_node : int | float
+        max_workers_per_node : optional int
              Caps the maximum number of workers that can be launched.
 
         prefetch_capacity : int
@@ -204,14 +204,20 @@ class Manager:
         self.max_workers_per_node = max_workers_per_node
         self.prefetch_capacity = prefetch_capacity
 
-        mem_slots = max_workers_per_node
+        # self.worker_count will initially based on core count, and then will
+        # optionally be reduced by the other worker count restricting actions.
+        # This has the effect of computing the minimum of whichever restrictions
+        # were supplied.
+
+        self.worker_count: int = math.floor(cores_on_node / cores_per_worker)
+
         # Avoid a divide by 0 error.
         if mem_per_worker and mem_per_worker > 0:
             mem_slots = math.floor(available_mem_on_node / mem_per_worker)
+            self.worker_count = min(self.worker_count, mem_slots)
 
-        self.worker_count: int = min(max_workers_per_node,
-                                     mem_slots,
-                                     math.floor(cores_on_node / cores_per_worker))
+        if max_workers_per_node:
+            self.worker_count = min(self.worker_count, max_workers_per_node)
 
         self._mp_manager = SpawnContext.Manager()  # Starts a server process
         self._tasks_in_progress = self._mp_manager.dict()
@@ -889,8 +895,8 @@ def get_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--max_workers_per_node",
-        default=float('inf'),
-        help="Caps the maximum workers that can be launched, default:infinity",
+        default=None,
+        help="Caps the maximum workers that can be launched, default: no cap",
     )
     parser.add_argument(
         "-p",
@@ -1001,7 +1007,7 @@ if __name__ == "__main__":
                           cores_per_worker=float(args.cores_per_worker),
                           mem_per_worker=None if args.mem_per_worker == 'None' else float(args.mem_per_worker),
                           max_workers_per_node=(
-                              args.max_workers_per_node if args.max_workers_per_node == float('inf')
+                              None if args.max_workers_per_node is None
                               else int(args.max_workers_per_node)
                           ),
                           prefetch_capacity=int(args.prefetch_capacity),


### PR DESCRIPTION
Previous to this, the worker count variables were a combination of integers and floats, but the only float used was +inf, as a marker to indicate a particular restriction wasn't applied.

Added individually, the type checker does not care about type annotations added onto max workers per node and cores per worker (because there remain enough implicit Anys) by this PR.

But when both added, there is/was a conflict:

parsl/executors/high_throughput/process_worker_pool.py:212: error: Incompatible types in assignment (expression has type "int | float", variable has type "int")  [assignment]

The revealed types for the three parameters of this min statement are:

        self.worker_count: int = min(max_workers_per_node,
                                     mem_slots,
                                     math.floor(cores_on_node / cores_per_worker))

parsl/executors/high_throughput/process_worker_pool.py:212: note: Revealed type is "builtins.int | builtins.float"
parsl/executors/high_throughput/process_worker_pool.py:213: note: Revealed type is "builtins.int | builtins.float"
parsl/executors/high_throughput/process_worker_pool.py:214: note: Revealed type is "builtins.int"

When calculating the worker count, this minimum should probably be over ints not floats.

So why are the first two int|float?

i) max_workers_per_node can be a float here solely for the +infinity value that is used to flag that it is unspecified.

ii) mem_slots can be a float solely because it is initialized to the value of max_workers_per_node and then potentially adjusted to an int after computation.

The cores_on_node/cores_per_worker is the only non-optional piece of this minimization.

The other two components of the min either do nothing (if they're +inf) or they reduce the worker count further. (that's what happens to *any* additional parameter to a min!)

This PR reworks the calculation to something more like a semi-group with `min` as the operation:

Start with the only definite limit (cores_on_node / cores_per_worker) and then optionally apply further limits (there are three further restrictions) when they apply using `min`.

When previously a float +inf was passed to min, that overall had a no-op effect (because it will always be larger than cores_on_node/cores_per_worker, for sensible values of that calculation). Those two cases are now handled by `if` statements: in one case, mem_slots, the `if` statement already existed!

TODO: ^ validate cores_on_node/cores_per_worker?

TODO: how to test?

# Description

Please include a summary of the change and (optionally) which issue is fixed. Please also include
relevant motivation and context.

# Changed Behaviour

Which existing user workflows or functionality will behave differently after this PR?

# Fixes

Fixes # (issue)

## Type of change

Choose which options apply, and delete the ones which do not apply.

- Bug fix
- New feature
- Update to human readable text: Documentation/error messages/comments
- Code maintenance/cleanup
