### PR TITLE
Add more type annotations onto process worker pool

### DIFF
--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -19,7 +19,7 @@ from importlib.metadata import distributions
 from multiprocessing.context import SpawnProcess
 from multiprocessing.managers import DictProxy
 from multiprocessing.sharedctypes import Synchronized
-from typing import Callable, Dict, List, Optional, Sequence
+from typing import Callable, Dict, List, Optional, Sequence, Union
 
 import psutil
 import zmq
@@ -73,24 +73,24 @@ class Manager:
     """
     def __init__(self, *,
                  addresses: str,
-                 address_probe_timeout,
-                 port,
+                 address_probe_timeout: int,
+                 port: int,
                  cores_per_worker,
                  mem_per_worker: Optional[float],
                  max_workers_per_node,
-                 prefetch_capacity,
-                 uid,
-                 block_id,
-                 heartbeat_threshold,
-                 heartbeat_period,
-                 poll_period,
-                 cpu_affinity,
+                 prefetch_capacity: int,
+                 uid: str,
+                 block_id: str,
+                 heartbeat_threshold: int,
+                 heartbeat_period: int,
+                 poll_period: int,
+                 cpu_affinity: str,
                  enable_mpi_mode: bool = False,
                  mpi_launcher: str = "mpiexec",
                  available_accelerators: Sequence[str],
                  cert_dir: Optional[str],
                  drain_period: Optional[int],
-                 log_config: Optional[LogConfig]):
+                 log_config: Optional[LogConfig]) -> None:
         """
         Parameters
         ----------
@@ -297,7 +297,7 @@ class Manager:
         logger.debug("Sent drain")
 
     @wrap_with_logs
-    def interchange_communicator(self, pair_setup: threading.Event):
+    def interchange_communicator(self, pair_setup: threading.Event) -> None:
         """ Pull tasks from the incoming tasks zmq pipe onto the internal
         pending task queue
         """
@@ -376,7 +376,7 @@ class Manager:
                 self.drain_time = float('inf')
 
             poll_duration_s = max(0, next_interesting_event_time - time.time())
-            socks = dict(poller.poll(timeout=poll_duration_s * 1000))
+            socks = dict(poller.poll(timeout=math.floor(poll_duration_s * 1000)))
 
             if socks.get(ix_sock) == zmq.POLLIN:
                 pkl_msg = ix_sock.recv()
@@ -418,7 +418,7 @@ class Manager:
         logger.info("Exiting")
 
     @wrap_with_logs
-    def ferry_result(self, may_connect: threading.Event):
+    def ferry_result(self, may_connect: threading.Event) -> None:
         """ Listens on the pending_result_queue and ferries results to the interchange
          connected thread
         """
@@ -444,7 +444,7 @@ class Manager:
         notify_sock.close()
         logger.debug("Exiting")
 
-    def worker_watchdog(self, procs: dict[int, SpawnProcess]):
+    def worker_watchdog(self, procs: dict[int, SpawnProcess]) -> None:
         """Keeps workers alive."""
         logger.debug("Starting worker watchdog")
 
@@ -474,7 +474,7 @@ class Manager:
         logger.debug("Exiting")
 
     @wrap_with_logs
-    def handle_monitoring_messages(self):
+    def handle_monitoring_messages(self) -> None:
         """Transfer messages from the managed monitoring queue to the result queue.
 
         We separate the queues so that the result queue does not rely on a manager
@@ -500,7 +500,7 @@ class Manager:
 
         logger.debug("Exiting")
 
-    def start(self):
+    def start(self) -> None:
         """ Start the worker processes.
         """
         procs: dict[int, SpawnProcess] = {}
@@ -612,7 +612,7 @@ def update_resource_spec_env_vars(mpi_launcher: str, resource_spec: Dict, node_i
         os.environ[key] = prefix_table[key]
 
 
-def _init_mpi_env(mpi_launcher: str, resource_spec: Dict):
+def _init_mpi_env(mpi_launcher: str, resource_spec: Dict) -> None:
     for varname in resource_spec:
         envname = "PARSL_" + str(varname).upper()
         os.environ[envname] = str(resource_spec[varname])
@@ -644,7 +644,7 @@ def worker(
     log_config: LogConfig,
     debug: bool,
     mpi_launcher: str,
-):
+) -> None:
 
     if log_config:
         path = pathlib.Path(logdir) / f"block-{block_id}" / pool_id
@@ -749,7 +749,7 @@ def worker(
 
         logger.info(f'Pinned worker to accelerator: {accelerator}')
 
-    def manager_is_alive():
+    def manager_is_alive() -> bool:
         try:
             # This does not kill the process, but instead raises
             # an exception if the process doesn't exist
@@ -826,7 +826,7 @@ def worker(
 
 def get_arg_parser() -> argparse.ArgumentParser:
 
-    def strategyorlist(s: str):
+    def strategyorlist(s: str) -> Union[str, list]:
         s = s.lower()
         allowed_strategies = ("none", "block", "alternating", "block-reverse")
         if s in allowed_strategies:


### PR DESCRIPTION
These annotations don't need a lot of further work on the code. In one case, this PR adds a `math.floor` to round a floating point time to the next millisecond down.

This follows on from previous PRs #4114, #4113, #4110, #4111 which made related non-annotation tidyups.

(The final two missing type annotations which prevent mypy's disallow_typed_defs option being applied to process_worker_pool live in PR #4115 alongside this PR)

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
