### PR TITLE
Restrict HTEX max_workers_per_node to int

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -258,7 +258,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
                  worker_debug: bool = False,
                  cores_per_worker: float = 1.0,
                  mem_per_worker: Optional[float] = None,
-                 max_workers_per_node: Optional[Union[int, float]] = None,
+                 max_workers_per_node: Optional[int] = None,
                  cpu_affinity: str = 'none',
                  available_accelerators: Union[int, Sequence[str]] = (),
                  prefetch_capacity: int = 0,


### PR DESCRIPTION
Prior to this PR, it is annotated as also accepting a float in the type annotation (although not in the docstring).

This comes from prior to PR #3117 where the max_workers parameter used the floating point infinity value as a default/not-specified value.


PR #3117 changed that to use None for that marker value, and added Optional as a possible type annotation without removing float.

Any other float can result in error messages quite late in execution.

When I set max_workers_per_node=1.2 in
parsl/tests/configs/htex_local_alternate.py, this is what happens:

Before this PR:

Worker pools fail to start up (inside batch job, for example) with this stderr:

Traceback (most recent call last):
  File "/home/benc/parsl/virtualenv-3.12/bin/process_worker_pool.py", line 1005, in <module>
    else int(args.max_workers_per_node)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '1.2'


After this PR:

Construction of configuration object fails, near startup of the main workflow process, like this, with the source location pointing at the user's HighThroughputExecutor construction (the tests/configs/... entry)

parsl/tests/configs/htex_local_alternate.py:38: in fresh_config
    HighThroughputExecutor(
parsl/executors/high_throughput/executor.py:246: in __init__
    def __init__(self,
../../virtualenv-3.12/lib/python3.12/site-packages/typeguard/_functions.py:137: in check_argument_types
    check_type_internal(value, annotation, memo)
../../virtualenv-3.12/lib/python3.12/site-packages/typeguard/_checkers.py:960: in check_type_internal
    checker(value, origin_type, args, memo)
../../virtualenv-3.12/lib/python3.12/site-packages/typeguard/_checkers.py:427: in check_union
    raise TypeCheckError(f"did not match any element in the union:\n{formatted_errors}")
E   typeguard.TypeCheckError: argument "max_workers_per_node" (float) did not match any element in the union:
E     int: is not an instance of int
E     NoneType: is not an instance of NoneType


# Changed Behaviour

nothing in the happy path. earlier more focused error as described above when a float is used as max workers.

## Type of change

- Code maintenance/cleanup
