### PR TITLE
Simplify some workflow start and end time monitoring fields

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -133,8 +133,7 @@ class DataFlowKernel:
             self.monitoring.start(self.run_dir, self.config.run_dir, self.log_config)
             self.monitoring_radio = MultiprocessingQueueRadioSender(self.monitoring.resource_msgs)
 
-        self.time_began = datetime.datetime.now()
-        self.time_completed: Optional[datetime.datetime] = None
+        time_began = datetime.datetime.now()
 
         logger.info("Run id is: " + self.run_id)
 
@@ -155,7 +154,7 @@ class DataFlowKernel:
                 logger.debug("Could not choose a name automatically")
                 self.workflow_name = "unnamed"
 
-        self.workflow_version = str(self.time_began.replace(microsecond=0))
+        self.workflow_version = str(time_began.replace(microsecond=0))
         if self.monitoring is not None and self.monitoring.workflow_version is not None:
             self.workflow_version = self.monitoring.workflow_version
 
@@ -164,8 +163,7 @@ class DataFlowKernel:
                                                     sys.version_info.minor,
                                                     sys.version_info.micro),
                 'parsl_version': get_version(),
-                "time_began": self.time_began,
-                'time_completed': None,
+                "time_began": time_began,
                 'run_id': self.run_id,
                 'workflow_name': self.workflow_name,
                 'workflow_version': self.workflow_version,
@@ -1160,15 +1158,14 @@ class DataFlowKernel:
             logger.info(f"Shut down executor {executor.label}")
 
         logger.info("Terminated executors")
-        self.time_completed = datetime.datetime.now()
+        time_completed = datetime.datetime.now()
 
         if self.monitoring_radio:
             logger.info("Sending final monitoring message")
             self.monitoring_radio.send((MessageType.WORKFLOW_INFO,
                                        {'tasks_failed_count': self.task_state_counts[States.failed],
                                         'tasks_completed_count': self.task_state_counts[States.exec_done],
-                                        "time_began": self.time_began,
-                                        'time_completed': self.time_completed,
+                                        'time_completed': time_completed,
                                         'run_id': self.run_id, 'rundir': self.run_dir}))
 
         if self.monitoring:

--- a/parsl/tests/test_monitoring/test_basic.py
+++ b/parsl/tests/test_monitoring/test_basic.py
@@ -118,6 +118,10 @@ def row_counts_parametrized(tmpd_cwd, fresh_config):
         (c, ) = result.first()
         assert c == 0
 
+        result = connection.execute(text("SELECT COUNT(*) FROM workflow WHERE time_began IS NOT NULL AND time_completed IS NOT NULL"))
+        (c, ) = result.first()
+        assert c == 1, "start/end times should be populated"
+
         if isinstance(config.executors[0], HighThroughputExecutor):
             # The node table is specific to the HighThroughputExecutor
             # Two entries: one showing manager active, one inactive


### PR DESCRIPTION
The monitoring database does not need all fields to be present in a monitoring message, and generally when a field is missing it will have an SQL-schema defined default (if the corresponding database row is being created) or be left untouched (if the corresponding database row is being updated).

Because of this, there is no need to send time_began at the end (because it was already sent at the start) or a null-like time_completed (because that is the default behaviour)

And there is no need to keep these values as attributes across the lifetime of the DFK object:

time_completed will always be None except inside the closing method that both creates and uses the only non-None value of that attribute.

This PR adds a test that both values have been populated at the end of a workflow run.

# Changed Behaviour

should be no change to the monitoring database. people who are directly asking the DFK for the start time attribute will have to find some other way. I don't think anyone does that.

## Type of change

- Code maintenance/cleanup
