### PR TITLE
Add a no-op log configuration for profiling and not-logging

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -195,6 +195,7 @@ Logging
     :nosignatures:
 
     parsl.logconfigs.base.LogConfig
+    parsl.logconfigs.noop.NoopLogging
 
 Monitoring
 ==========

--- a/parsl/logconfigs/noop.py
+++ b/parsl/logconfigs/noop.py
@@ -1,0 +1,20 @@
+import pathlib
+from typing import Callable
+
+from parsl.logconfigs.base import LogConfig
+
+
+class NoopLogging(LogConfig):
+    """A log configuration which doesn't configure any logging.
+
+    This is intended to help with benchmarking, but can also be used to
+    configure an environment with no logging from any LogConfig aware
+    component.
+    """
+
+    def initialize_logging(self, *, log_dir: pathlib.Path, log_name: str) -> Callable[[], None]:
+
+        def unregister_callback() -> None:
+            pass
+
+        return unregister_callback

--- a/parsl/tests/test_logging/test_initialize_logging.py
+++ b/parsl/tests/test_logging/test_initialize_logging.py
@@ -7,6 +7,7 @@ import pytest
 import parsl
 from parsl.logconfigs.file import FileLogging
 from parsl.logconfigs.json import JSONLogging
+from parsl.logconfigs.noop import NoopLogging
 
 
 @pytest.mark.local
@@ -21,6 +22,13 @@ def test_parsl_log_not_exists(tmpd_cwd):
     with parsl.load(parsl.Config(run_dir=str(tmpd_cwd), initialize_logging=False)):
         assert not (pathlib.Path(parsl.dfk().run_dir) / "parsl.log").exists(), \
             "With initialize_logging=False, parsl.log should not exist in rundir after startup"
+
+
+@pytest.mark.local
+def test_parsl_log_Noop_not_exists(tmpd_cwd):
+    with parsl.load(parsl.Config(run_dir=str(tmpd_cwd), initialize_logging=NoopLogging())):
+        assert not (pathlib.Path(parsl.dfk().run_dir) / "parsl.log").exists(), \
+            "With NoopLogging, parsl.log should not exist in rundir after startup"
 
 
 @pytest.mark.local


### PR DESCRIPTION
This is mostly intended to help with benchmarking the core logging infrastructure (so that the whole logging infrastructure is initialised except an actual Handler), but you can also use it to help have no logging in an LogConfig-aware component.

# Changed Behaviour

none

## Type of change

- New feature