### PR TITLE
Make log initialization ref-counted

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -43,7 +43,11 @@ from parsl.executors.base import ParslExecutor
 from parsl.executors.status_handling import BlockProviderExecutor
 from parsl.executors.threads import ThreadPoolExecutor
 from parsl.jobs.job_status_poller import JobStatusPoller
-from parsl.logconfigs.base import LogConfig, oneshot_initialize_logging
+from parsl.logconfigs.base import (
+    LogConfig,
+    oneshot_initialize_logging,
+    oneshot_uninitialize_logging,
+)
 from parsl.logconfigs.file import FileLogging
 from parsl.monitoring import MonitoringHub
 from parsl.monitoring.errors import RadioRequiredError
@@ -108,10 +112,13 @@ class DataFlowKernel:
             self.log_config = None
             self._logging_unregister_callback = None
         else:
+            c = config.initialize_logging
+            assert c is not None, "type of initialize_logging was not properly narrowed to LogConfig"
             self.log_config = config.initialize_logging
-            self._logging_unregister_callback = oneshot_initialize_logging(log_config=self.log_config,
-                                                                           log_dir=pathlib.Path(self.run_dir),
-                                                                           log_name="parsl")
+            oneshot_initialize_logging(log_config=c,
+                                       log_dir=pathlib.Path(self.run_dir),
+                                       log_name="parsl")
+            self._logging_unregister_callback = lambda: oneshot_uninitialize_logging(log_config=c)
 
         logger.info("Starting DataFlowKernel with config\n%r", config)
 

--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -43,7 +43,7 @@ from parsl.executors.base import ParslExecutor
 from parsl.executors.status_handling import BlockProviderExecutor
 from parsl.executors.threads import ThreadPoolExecutor
 from parsl.jobs.job_status_poller import JobStatusPoller
-from parsl.logconfigs.base import LogConfig
+from parsl.logconfigs.base import LogConfig, oneshot_initialize_logging
 from parsl.logconfigs.file import FileLogging
 from parsl.monitoring import MonitoringHub
 from parsl.monitoring.errors import RadioRequiredError
@@ -109,7 +109,9 @@ class DataFlowKernel:
             self._logging_unregister_callback = None
         else:
             self.log_config = config.initialize_logging
-            self._logging_unregister_callback = self.log_config.initialize_logging(log_dir=pathlib.Path(self.run_dir), log_name="parsl")
+            self._logging_unregister_callback = oneshot_initialize_logging(log_config=self.log_config,
+                                                                           log_dir=pathlib.Path(self.run_dir),
+                                                                           log_name="parsl")
 
         logger.info("Starting DataFlowKernel with config\n%r", config)
 

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -20,7 +20,7 @@ from parsl.executors.high_throughput.errors import ManagerLost, VersionMismatch
 from parsl.executors.high_throughput.manager_record import ManagerRecord
 from parsl.executors.high_throughput.manager_selector import ManagerSelector
 from parsl.log_utils import set_file_logger
-from parsl.logconfigs.base import LogConfig
+from parsl.logconfigs.base import LogConfig, oneshot_initialize_logging
 from parsl.monitoring.message_type import MessageType
 from parsl.monitoring.radios.base import MonitoringRadioSender
 from parsl.monitoring.radios.zmq import ZMQRadioSender
@@ -114,7 +114,7 @@ class Interchange:
         os.makedirs(self.logdir, exist_ok=True)
 
         if log_config:
-            log_config.initialize_logging(log_dir=pathlib.Path(self.logdir), log_name="interchange")
+            oneshot_initialize_logging(log_config=log_config, log_dir=pathlib.Path(self.logdir), log_name="interchange")
             # discard the returned callback because the interchange doesn't usually do
             # a normal shutdown
         else:

--- a/parsl/executors/high_throughput/process_worker_pool.py
+++ b/parsl/executors/high_throughput/process_worker_pool.py
@@ -39,7 +39,7 @@ from parsl.executors.high_throughput.mpi_resource_management import (
 )
 from parsl.executors.high_throughput.probe import probe_addresses
 from parsl.log_utils import set_file_logger
-from parsl.logconfigs.base import LogConfig
+from parsl.logconfigs.base import LogConfig, oneshot_initialize_logging
 from parsl.multiprocessing import SpawnContext
 from parsl.process_loggers import wrap_with_logs
 from parsl.serialize import serialize
@@ -648,7 +648,7 @@ def worker(
 
     if log_config:
         path = pathlib.Path(logdir) / f"block-{block_id}" / pool_id
-        log_config.initialize_logging(log_dir=path, log_name=f"worker_{worker_id}")
+        oneshot_initialize_logging(log_config=log_config, log_dir=path, log_name=f"worker_{worker_id}")
     else:
         set_file_logger('{}/block-{}/{}/worker_{}.log'.format(logdir, block_id, pool_id, worker_id),
                         level=logging.DEBUG if debug else logging.INFO)
@@ -966,7 +966,7 @@ if __name__ == "__main__":
             # logging is a specific use case for this log configurability.
             path = os.path.join(args.logdir, "block-{}".format(args.block_id), args.uid)
             logconf = pickle.load(f)
-            logconf.initialize_logging(log_dir=pathlib.Path(path), log_name="manager")
+            oneshot_initialize_logging(log_config=logconf, log_dir=pathlib.Path(path), log_name="manager")
 
     logger.info(
         f"\n  Python version: {sys.version}"

--- a/parsl/logconfigs/base.py
+++ b/parsl/logconfigs/base.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 import abc
+import logging
 import pathlib
+import threading
+import uuid
 from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
 
 
 class LogConfig(abc.ABC):
@@ -17,6 +22,9 @@ class LogConfig(abc.ABC):
     be pickled/unpickled multiple times as they move around a Parsl
     distributed system.
     """
+
+    def __init__(self) -> None:
+        self.uuid = uuid.uuid4()
 
     @abc.abstractmethod
     def initialize_logging(self, *, log_dir: pathlib.Path, log_name: str) -> Callable[[], None]:
@@ -33,3 +41,77 @@ class LogConfig(abc.ABC):
         by this call.
         """
         ...
+
+
+class _ConfigReference:
+    def __init__(self, uninit_callback: Callable) -> None:
+        self.uninit_callback = uninit_callback
+        self.count: int = 1
+
+
+# This holds the collection of initialized configurations for the current
+# Python interpreter. It is scoped at the interpreter level because that is
+# the scope of Python `logging` module log configuration.
+_initialized_log_contexts: dict[uuid.UUID, _ConfigReference] = {}
+_initialized_log_context_lock: threading.Lock = threading.Lock()
+
+
+def oneshot_initialize_logging(*, log_config: LogConfig, log_dir: pathlib.Path, log_name: str) -> Callable:
+    """Initialized the LogConfig if it is not currently initialized.
+
+    This is scoped per-interpreter, the same as the global state for the
+    Python logging module.
+
+    A first oneshot_initialize_logging for any given LogConfig will call
+    the initialize_logging method of that config. Subsequent calls will
+    be reference counted, but not cause a reinitialization.
+
+    Calling the callback will decrease the reference count, and when that
+    count reaches zero, the LogConfig will be uninitialized via its own
+    callback.
+
+    The API syntax mimics the syntax of the LogConfig abstract class, with
+    these reference counting semantics added on top.
+
+    The intention is to allow a log configuration to be initialized by
+    multiple pieces of Parsl without duplicating logs: for example, when
+    using the thread pool executor, a task does not need the global log
+    configuration to be initialized (again) because the task runs in the
+    same process as the DFK; but in, for example, the Work Queue executor
+    (at least now), there is no per-worker log configuration, and the task
+    *does* need to initialize logging. This reference counting is the
+    mechanism by which that different behaviour can occur.
+
+    There is an ambiguity on the use of log_name and log_dir across multiple
+    initializations: the name and directory of the first initialization
+    will be used and the name and directory of subsequent initializations
+    will be ignored.
+    """
+    with _initialized_log_context_lock:
+        if log_config.uuid in _initialized_log_contexts:
+            _initialized_log_contexts[log_config.uuid].count += 1
+            logger.debug('Configuration %r already initialized', log_config)
+        else:
+            logger.debug('Initializing %r', log_config)
+            _initialized_log_contexts[log_config.uuid] = _ConfigReference(
+                log_config.initialize_logging(log_dir=log_dir, log_name=log_name)
+            )
+            assert callable(_initialized_log_contexts[log_config.uuid].uninit_callback), (
+                f'Log config {log_config} should have returned a callable on initialization'
+            )
+            logger.debug('Initialized %r', log_config)
+
+        assert log_config.uuid in _initialized_log_contexts
+
+    def uninit() -> None:
+        with _initialized_log_context_lock:
+            assert log_config.uuid in _initialized_log_contexts, f"log context for {log_config} not found, perhaps too many uninitializations"
+            assert _initialized_log_contexts[log_config.uuid].count >= 1, \
+                f"log context for {log_config} has bad reference count {_initialized_log_contexts[log_config.uuid].count}"
+            _initialized_log_contexts[log_config.uuid].count -= 1
+            if _initialized_log_contexts[log_config.uuid].count < 1:
+                logger.debug('All references removed for %r', log_config)
+                _initialized_log_contexts[log_config.uuid].uninit_callback()
+                del _initialized_log_contexts[log_config.uuid]
+
+    return uninit

--- a/parsl/logconfigs/base.py
+++ b/parsl/logconfigs/base.py
@@ -56,7 +56,7 @@ _initialized_log_contexts: dict[uuid.UUID, _ConfigReference] = {}
 _initialized_log_context_lock: threading.Lock = threading.Lock()
 
 
-def oneshot_initialize_logging(*, log_config: LogConfig, log_dir: pathlib.Path, log_name: str) -> Callable:
+def oneshot_initialize_logging(*, log_config: LogConfig, log_dir: pathlib.Path, log_name: str) -> None:
     """Initialized the LogConfig if it is not currently initialized.
 
     This is scoped per-interpreter, the same as the global state for the
@@ -105,15 +105,14 @@ def oneshot_initialize_logging(*, log_config: LogConfig, log_dir: pathlib.Path, 
 
         assert log_config.uuid in _initialized_log_contexts
 
-    def uninit() -> None:
-        with _initialized_log_context_lock:
-            assert log_config.uuid in _initialized_log_contexts, f"log context for {log_config} not found, perhaps too many uninitializations"
-            assert _initialized_log_contexts[log_config.uuid].count >= 1, \
-                f"log context for {log_config} has bad reference count {_initialized_log_contexts[log_config.uuid].count}"
-            _initialized_log_contexts[log_config.uuid].count -= 1
-            if _initialized_log_contexts[log_config.uuid].count < 1:
-                logger.debug('All references removed for %r', log_config)
-                _initialized_log_contexts[log_config.uuid].uninit_callback()
-                del _initialized_log_contexts[log_config.uuid]
 
-    return uninit
+def oneshot_uninitialize_logging(*, log_config: LogConfig) -> None:
+    with _initialized_log_context_lock:
+        assert log_config.uuid in _initialized_log_contexts, f"log context for {log_config} not found, perhaps too many uninitializations"
+        assert _initialized_log_contexts[log_config.uuid].count >= 1, \
+            f"log context for {log_config} has bad reference count {_initialized_log_contexts[log_config.uuid].count}"
+        _initialized_log_contexts[log_config.uuid].count -= 1
+        if _initialized_log_contexts[log_config.uuid].count < 1:
+            logger.debug('All references removed for %r', log_config)
+            _initialized_log_contexts[log_config.uuid].uninit_callback()
+            del _initialized_log_contexts[log_config.uuid]

--- a/parsl/logconfigs/base.py
+++ b/parsl/logconfigs/base.py
@@ -90,7 +90,9 @@ def oneshot_initialize_logging(*, log_config: LogConfig, log_dir: pathlib.Path, 
     with _initialized_log_context_lock:
         if log_config.uuid in _initialized_log_contexts:
             _initialized_log_contexts[log_config.uuid].count += 1
-            logger.debug('Configuration %r already initialized', log_config)
+            logger.debug('Configuration %r already initialized, now with %s references',
+                         log_config,
+                         _initialized_log_contexts[log_config.uuid].count)
         else:
             logger.debug('Initializing %r', log_config)
             _initialized_log_contexts[log_config.uuid] = _ConfigReference(

--- a/parsl/monitoring/db_manager.py
+++ b/parsl/monitoring/db_manager.py
@@ -14,7 +14,7 @@ import typeguard
 from parsl.dataflow.states import States
 from parsl.errors import OptionalModuleMissing
 from parsl.log_utils import set_file_logger
-from parsl.logconfigs.base import LogConfig
+from parsl.logconfigs.base import LogConfig, oneshot_initialize_logging
 from parsl.monitoring.message_type import MessageType
 from parsl.monitoring.types import MonitoringMessage, TaggedMonitoringMessage
 from parsl.process_loggers import wrap_with_logs
@@ -296,7 +296,7 @@ class DatabaseManager:
         self.run_dir = run_dir
 
         if log_config:
-            log_config.initialize_logging(log_dir=pathlib.Path(self.run_dir), log_name="database_manager")
+            oneshot_initialize_logging(log_config=log_config, log_dir=pathlib.Path(self.run_dir), log_name="database_manager")
         else:
             os.makedirs(self.run_dir, exist_ok=True)
 

--- a/parsl/tests/test_logging/test_oneshot.py
+++ b/parsl/tests/test_logging/test_oneshot.py
@@ -54,7 +54,7 @@ def test_nested(tmpd_cwd):
 
 @pytest.mark.local
 def test_sequential(tmpd_cwd):
-    """Test that if a log context can be released completely, and then reinitialized."""
+    """Test that a log context can be released completely, and then reinitialized."""
     lc = Mock(spec=b.LogConfig)
     lc.uuid = uuid.uuid4()
 

--- a/parsl/tests/test_logging/test_oneshot.py
+++ b/parsl/tests/test_logging/test_oneshot.py
@@ -16,13 +16,13 @@ def test_simple(tmpd_cwd):
     assert b._initialized_log_contexts == {}, "precondition"
 
     lc.initialize_logging.assert_not_called()
-    uninit = b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_simple")
+    b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_simple")
     lc.initialize_logging.assert_called()
 
     cb = b._initialized_log_contexts[lc.uuid].uninit_callback
 
     cb.assert_not_called()
-    uninit()
+    b.oneshot_uninitialize_logging(log_config=lc)
     cb.assert_called()
 
     assert b._initialized_log_contexts == {}, "back to satisfying the precondition"
@@ -35,41 +35,18 @@ def test_nested(tmpd_cwd):
 
     assert b._initialized_log_contexts == {}, "precondition"
 
-    uninit = b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_nested_1")
+    b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_nested_1")
     lc.initialize_logging.assert_called_once()
 
-    uninit2 = b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_nested_2")
+    b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_nested_2")
     lc.initialize_logging.assert_called_once()
 
     cb = b._initialized_log_contexts[lc.uuid].uninit_callback
 
     cb.assert_not_called()
-    uninit2()
+    b.oneshot_uninitialize_logging(log_config=lc)
     cb.assert_not_called()
-    uninit()
-    cb.assert_called()
-
-    assert b._initialized_log_contexts == {}, "back to satisfying the precondition"
-
-
-@pytest.mark.local
-def test_overlap(tmpd_cwd):
-    lc = Mock()
-    lc.uuid = uuid.uuid4()
-
-    assert b._initialized_log_contexts == {}, "precondition"
-
-    uninit = b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_overlap_1")
-    cb = b._initialized_log_contexts[lc.uuid].uninit_callback
-    lc.initialize_logging.assert_called_once()
-
-    uninit2 = b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_overlap_2")
-    lc.initialize_logging.assert_called_once()
-
-    cb.assert_not_called()
-    uninit()
-    cb.assert_not_called()
-    uninit2()
+    b.oneshot_uninitialize_logging(log_config=lc)
     cb.assert_called()
 
     assert b._initialized_log_contexts == {}, "back to satisfying the precondition"
@@ -83,16 +60,16 @@ def test_sequential(tmpd_cwd):
 
     assert b._initialized_log_contexts == {}, "precondition"
 
-    uninit1 = b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_nested_1")
+    b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_nested_1")
     lc.initialize_logging.assert_called_once()
     cb = b._initialized_log_contexts[lc.uuid].uninit_callback
     cb.assert_not_called()
-    uninit1()
+    b.oneshot_uninitialize_logging(log_config=lc)
     cb.assert_called()
 
     assert b._initialized_log_contexts == {}, "back to satisfying the precondition, between uses"
 
-    uninit2 = b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_nested_2")
+    b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_nested_2")
     assert lc.initialize_logging.call_count == 2, "Should have been initialized once per block"
 
     cb2 = b._initialized_log_contexts[lc.uuid].uninit_callback
@@ -101,7 +78,7 @@ def test_sequential(tmpd_cwd):
     # When writing this test, cb2 is a reused mock, `cb2 is cb`, but that isn't
     # a requirement of the API.
     c = cb2.call_count
-    uninit2()
+    b.oneshot_uninitialize_logging(log_config=lc)
     assert cb2.call_count == c + 1
 
     assert b._initialized_log_contexts == {}, "back to satisfying the precondition"
@@ -125,15 +102,44 @@ def test_nested_pickle(tmpd_cwd):
     p = pickle.dumps(lc_orig)
 
     assert lc_orig.uuid not in b._initialized_log_contexts
-    uninit = b.oneshot_initialize_logging(log_config=pickle.loads(p), log_dir=tmpd_cwd, log_name="test_nested_1")
+    lc_1 = pickle.loads(p)
+    b.oneshot_initialize_logging(log_config=lc_1, log_dir=tmpd_cwd, log_name="test_nested_1")
 
     assert lc_orig.uuid in b._initialized_log_contexts
-    uninit2 = b.oneshot_initialize_logging(log_config=pickle.loads(p), log_dir=tmpd_cwd, log_name="test_nested_2")
+    lc_2 = pickle.loads(p)
+    b.oneshot_initialize_logging(log_config=lc_2, log_dir=tmpd_cwd, log_name="test_nested_2")
 
     assert lc_orig.uuid in b._initialized_log_contexts
 
-    uninit2()
+    b.oneshot_uninitialize_logging(log_config=lc_2)
     assert lc_orig.uuid in b._initialized_log_contexts
 
-    uninit()
+    b.oneshot_uninitialize_logging(log_config=lc_1)
+    assert lc_orig.uuid not in b._initialized_log_contexts
+
+
+@pytest.mark.local
+def test_overlap_pickle(tmpd_cwd):
+
+    # this config will never be exposed to the log system except after passing
+    # through pickle via two different paths, to generate different "remote-like"
+    # objects.
+    lc_orig = NestedPickleTestConfig()
+
+    p = pickle.dumps(lc_orig)
+
+    assert lc_orig.uuid not in b._initialized_log_contexts
+    lc_1 = pickle.loads(p)
+    b.oneshot_initialize_logging(log_config=lc_1, log_dir=tmpd_cwd, log_name="test_nested_1")
+
+    assert lc_orig.uuid in b._initialized_log_contexts
+    lc_2 = pickle.loads(p)
+    b.oneshot_initialize_logging(log_config=lc_2, log_dir=tmpd_cwd, log_name="test_nested_2")
+
+    assert lc_orig.uuid in b._initialized_log_contexts
+
+    b.oneshot_uninitialize_logging(log_config=lc_2)
+    assert lc_orig.uuid in b._initialized_log_contexts
+
+    b.oneshot_uninitialize_logging(log_config=lc_1)
     assert lc_orig.uuid not in b._initialized_log_contexts

--- a/parsl/tests/test_logging/test_oneshot.py
+++ b/parsl/tests/test_logging/test_oneshot.py
@@ -1,0 +1,139 @@
+import pickle
+import unittest
+import uuid
+from unittest.mock import Mock
+
+import pytest
+
+import parsl.logconfigs.base as b
+
+
+@pytest.mark.local
+def test_simple(tmpd_cwd):
+    lc = Mock()
+    lc.uuid = uuid.uuid4()
+
+    assert b._initialized_log_contexts == {}, "precondition"
+
+    lc.initialize_logging.assert_not_called()
+    uninit = b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_simple")
+    lc.initialize_logging.assert_called()
+
+    cb = b._initialized_log_contexts[lc.uuid].uninit_callback
+
+    cb.assert_not_called()
+    uninit()
+    cb.assert_called()
+
+    assert b._initialized_log_contexts == {}, "back to satisfying the precondition"
+
+
+@pytest.mark.local
+def test_nested(tmpd_cwd):
+    lc = Mock()
+    lc.uuid = uuid.uuid4()
+
+    assert b._initialized_log_contexts == {}, "precondition"
+
+    uninit = b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_nested_1")
+    lc.initialize_logging.assert_called_once()
+
+    uninit2 = b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_nested_2")
+    lc.initialize_logging.assert_called_once()
+
+    cb = b._initialized_log_contexts[lc.uuid].uninit_callback
+
+    cb.assert_not_called()
+    uninit2()
+    cb.assert_not_called()
+    uninit()
+    cb.assert_called()
+
+    assert b._initialized_log_contexts == {}, "back to satisfying the precondition"
+
+
+@pytest.mark.local
+def test_overlap(tmpd_cwd):
+    lc = Mock()
+    lc.uuid = uuid.uuid4()
+
+    assert b._initialized_log_contexts == {}, "precondition"
+
+    uninit = b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_overlap_1")
+    cb = b._initialized_log_contexts[lc.uuid].uninit_callback
+    lc.initialize_logging.assert_called_once()
+
+    uninit2 = b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_overlap_2")
+    lc.initialize_logging.assert_called_once()
+
+    cb.assert_not_called()
+    uninit()
+    cb.assert_not_called()
+    uninit2()
+    cb.assert_called()
+
+    assert b._initialized_log_contexts == {}, "back to satisfying the precondition"
+
+
+@pytest.mark.local
+def test_sequential(tmpd_cwd):
+    """Test that if a log context can be released completely, and then reinitialized."""
+    lc = Mock()
+    lc.uuid = uuid.uuid4()
+
+    assert b._initialized_log_contexts == {}, "precondition"
+
+    uninit1 = b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_nested_1")
+    lc.initialize_logging.assert_called_once()
+    cb = b._initialized_log_contexts[lc.uuid].uninit_callback
+    cb.assert_not_called()
+    uninit1()
+    cb.assert_called()
+
+    assert b._initialized_log_contexts == {}, "back to satisfying the precondition, between uses"
+
+    uninit2 = b.oneshot_initialize_logging(log_config=lc, log_dir=tmpd_cwd, log_name="test_nested_2")
+    assert lc.initialize_logging.call_count == 2, "Should have been initialized once per block"
+
+    cb2 = b._initialized_log_contexts[lc.uuid].uninit_callback
+
+    # There is no requirement that cb2 be a fresh callback (mock) or be re-used.
+    # When writing this test, cb2 is a reused mock, `cb2 is cb`, but that isn't
+    # a requirement of the API.
+    c = cb2.call_count
+    uninit2()
+    assert cb2.call_count == c + 1
+
+    assert b._initialized_log_contexts == {}, "back to satisfying the precondition"
+
+
+class NestedPickleTestConfig(b.LogConfig):
+    def initialize_logging(self, *args, **kwargs):
+        def de():
+            pass
+        return de
+
+
+@pytest.mark.local
+def test_nested_pickle(tmpd_cwd):
+
+    # this config will never be exposed to the log system except after passing
+    # through pickle via two different paths, to generate different "remote-like"
+    # objects.
+    lc_orig = NestedPickleTestConfig()
+
+    p = pickle.dumps(lc_orig)
+
+    assert lc_orig.uuid not in b._initialized_log_contexts
+    uninit = b.oneshot_initialize_logging(log_config=pickle.loads(p), log_dir=tmpd_cwd, log_name="test_nested_1")
+
+    assert lc_orig.uuid in b._initialized_log_contexts
+    uninit2 = b.oneshot_initialize_logging(log_config=pickle.loads(p), log_dir=tmpd_cwd, log_name="test_nested_2")
+
+    assert lc_orig.uuid in b._initialized_log_contexts
+
+    uninit2()
+    assert lc_orig.uuid in b._initialized_log_contexts
+
+    uninit()
+    assert lc_orig.uuid not in b._initialized_log_contexts

--- a/parsl/tests/test_logging/test_oneshot.py
+++ b/parsl/tests/test_logging/test_oneshot.py
@@ -10,7 +10,7 @@ import parsl.logconfigs.base as b
 
 @pytest.mark.local
 def test_simple(tmpd_cwd):
-    lc = Mock()
+    lc = Mock(spec=b.LogConfig)
     lc.uuid = uuid.uuid4()
 
     assert b._initialized_log_contexts == {}, "precondition"
@@ -30,7 +30,7 @@ def test_simple(tmpd_cwd):
 
 @pytest.mark.local
 def test_nested(tmpd_cwd):
-    lc = Mock()
+    lc = Mock(spec=b.LogConfig)
     lc.uuid = uuid.uuid4()
 
     assert b._initialized_log_contexts == {}, "precondition"
@@ -55,7 +55,7 @@ def test_nested(tmpd_cwd):
 @pytest.mark.local
 def test_sequential(tmpd_cwd):
     """Test that if a log context can be released completely, and then reinitialized."""
-    lc = Mock()
+    lc = Mock(spec=b.LogConfig)
     lc.uuid = uuid.uuid4()
 
     assert b._initialized_log_contexts == {}, "precondition"


### PR DESCRIPTION
This PR brings in a feature that I didn't include in the initial Parsl log configuration work, but that I did over in the Academy equivalent of this work.

This PR introduces a distributed identity to log config objects (using a UUID) so that they may be serialised and deserialised by various paths and retain their identity.

This identity is then used to reference count the same configuration being initialized in a Python interpreter by multiple paths, so that a particular configuration is only initialized once, but kept alive for as along as someone needs it.

The motivating usecase in Parsl is:

When running tasks via htex, the htex code is LogConfig aware and will initialize each worker with the DFK log configuration (PR #4107), and in the thread pool executor, tasks will run in the main process which will already have the DFK log configuration initialized. But when running in some arbitrary not-LogConfig aware executor, Parsl will need to wrap tasks in the same way that it wraps tasks for monitoring (a future PR).

This reference counting is the mechanism by which both of those initializations can happen without actually duplicating the initializations.

# Changed Behaviour

none

## Type of change

- New feature
