### PR TITLE
Add machine readable DFK-level task state logging

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -545,11 +545,15 @@ class DataFlowKernel:
         """
 
         with self.task_state_counts_lock:
+            extra = {"parsl.dfk": self.run_id,
+                     "parsl.task": task_record['id'],
+                     "parsl.task_state": new_state.name
+                     }
             if 'status' in task_record:
                 self.task_state_counts[task_record['status']] -= 1
-                logger.info(f"Task {task_record['id']} changing state from {task_record['status'].name} to {new_state.name}")
+                logger.info(f"Task {task_record['id']} changing state from {task_record['status'].name} to {new_state.name}", extra=extra)
             else:
-                logger.info(f"Task {task_record['id']} initializing state to {new_state.name}")
+                logger.info(f"Task {task_record['id']} initializing state to {new_state.name}", extra=extra)
 
             self.task_state_counts[new_state] += 1
             task_record['status'] = new_state

--- a/parsl/tests/test_logging/test_dfk_states.py
+++ b/parsl/tests/test_logging/test_dfk_states.py
@@ -20,14 +20,31 @@ def test_state_logs_success(caplog):
 
     # from the DFK logs, we wouldn't expect to see running or
     # running_done states as those exist only in the worker.
-    for s in ("pending", "launched", "exec_done", ):
-        assert s in caplog.text, f"Expected state {s} to be logged"
+
+    expected_states = {"pending", "launched", "exec_done"}
+
+    seen_states = {r.__dict__['parsl.task_state']
+                   for r in caplog.records
+                   if 'parsl.task_state' in r.__dict__}
+
+    assert expected_states <= seen_states, "every expected state should have been seen"
+
+    for s in expected_states:
+        assert s in caplog.text, f"Expected state {s} to be logged as text"
 
 
 @pytest.mark.local
 def test_state_logs_fail(caplog):
     with parsl.load():
-        noop().result()
+        fail().exception()
 
-    for s in ("pending", "launched", "failed", ):
-        assert s in caplog.text, f"Expected state {s} to be logged"
+    expected_states = {"pending", "launched", "failed"}
+
+    seen_states = {r.__dict__['parsl.task_state']
+                   for r in caplog.records
+                   if 'parsl.task_state' in r.__dict__}
+
+    assert expected_states <= seen_states, "every expected state should have been seen"
+
+    for s in expected_states:
+        assert s in caplog.text, f"Expected state {s} to be logged as text"


### PR DESCRIPTION
This PR adds extra= fields to existing task state change logs

Aligned with PR #4123, this is to help get all monitoring-observable info also observable via machine readable logs.

This PR does not make this happen for the running and running_ended states, which do not exist in the DFK part of the
distributed-quasi-state-machine. A future PR will add this into the worker side.

While testing this, I discovered that the test for failed logging was broken - by matching on text, it was finding the word "failed" elsewhere in the logs, rather than in the relevant record, and the test was not actually calling a failing app! The test now checks the new structured data which is less prone to this.

# Changed Behaviour

more info in logs

## Type of change

- New feature
