### PR TITLE
Add structured logging for add_executor

### DIFF
--- a/parsl/dataflow/dflow.py
+++ b/parsl/dataflow/dflow.py
@@ -1073,6 +1073,10 @@ class DataFlowKernel:
 
     def add_executors(self, executors: Sequence[ParslExecutor]) -> None:
         for executor in executors:
+            logger.info("Adding executor %s of type %s.%s", executor.label, type(executor).__module__, type(executor).__name__,
+                        extra={"parsl.executor.label": executor.label,
+                               "parsl.executor.type": type(executor).__module__ + "." + type(executor).__name__
+                               })
             executor.run_id = self.run_id
             executor.run_dir = self.run_dir
             executor.log_config = self.log_config

--- a/parsl/tests/sites/test_dynamic_executor.py
+++ b/parsl/tests/sites/test_dynamic_executor.py
@@ -38,8 +38,21 @@ def add(dur=0.01):
 
 
 @pytest.mark.local
-def test_dynamic_executor():
+def test_dynamic_executor(caplog):
     dfk = parsl.load()
+
+    expected_executors = {('threads', 'parsl.executors.threads.ThreadPoolExecutor')}
+
+    def check_expected_logs():
+        seen_executors = {(r.__dict__['parsl.executor.label'],
+                           r.__dict__['parsl.executor.type'])
+                          for r in caplog.records
+                          if 'parsl.executor.label' in r.__dict__ and
+                          'parsl.executor.type' in r.__dict__}
+        assert expected_executors <= seen_executors
+
+    check_expected_logs()
+
     tasks = [sleeper() for i in range(5)]
     results = [i.result() for i in tasks]
     print("Done with initial test. The results are", results)
@@ -50,6 +63,10 @@ def test_dynamic_executor():
         max_threads=4)
     ]
     dfk.add_executors(executors=thread_executors)
+
+    expected_executors = {('threads2', 'parsl.executors.threads.ThreadPoolExecutor')}
+    check_expected_logs()
+
     tasks = [cpu_stress() for i in range(8)]
     results = [i.result() for i in tasks]
     print("Successfully added thread executor and ran with it. The results are", results)
@@ -68,6 +85,10 @@ def test_dynamic_executor():
         )
     ]
     dfk.add_executors(executors=executors)
+
+    expected_executors.add(('htex_local', 'parsl.executors.high_throughput.executor.HighThroughputExecutor'))
+    check_expected_logs()
+
     tasks = [add() for i in range(10)]
     results = [i.result() for i in tasks]
     print("Successfully added htex executor and ran with it. The results are", results)


### PR DESCRIPTION
This is intended to help log analysis code understand what other information it might find (for example, the output of the work queue executor is very different to the output of the high throughput executor).

Although this call is exposed to the user for dynamic execution, it is more commonly used implicitly as part of initial DFK configuration. The test modified in this PR checks both of those paths.

# Changed Behaviour

more logs

## Type of change

- New feature
