### PR TITLE
Fix some mypy warnings

### DIFF
--- a/parsl/tests/test_htex/test_managers_command.py
+++ b/parsl/tests/test_htex/test_managers_command.py
@@ -42,7 +42,8 @@ def test_connected_managers_packages():
     f = dummy()
     assert f.result() is None
 
-    htex: parsl.HighThroughputExecutor = parsl.dfk().executors['htex_local']
+    htex = parsl.dfk().executors['htex_local']
+    assert isinstance(htex, parsl.HighThroughputExecutor)
     managers_info_list = htex.connected_managers()
     managers_packages = htex.connected_managers_packages()
 

--- a/parsl/tests/unit/executors/high_throughput/test_process_worker_pool.py
+++ b/parsl/tests/unit/executors/high_throughput/test_process_worker_pool.py
@@ -2,6 +2,7 @@ import os
 import pickle
 import sys
 from argparse import ArgumentError
+from typing import Any, Dict
 from unittest import mock
 
 import pytest
@@ -86,9 +87,9 @@ def _always_raise(*a, **k):
 
 
 @pytest.mark.local
-def test_worker_dynamic_import_happy_path(tmpd_cwd):
+def test_worker_dynamic_import_happy_path(tmpd_cwd) -> None:
     import_str = f"{_always_raise.__module__}.{_always_raise.__name__}"
-    task_exec = {
+    task_exec: Dict[str, Any] = {
         "f": import_str,
         "a": (1, 2),
         "k": {"a": "b"},
@@ -145,7 +146,7 @@ def test_worker_dynamic_import_happy_path(tmpd_cwd):
 
 
 @pytest.mark.local
-def test_worker_bad_dynamic_import(tmpd_cwd):
+def test_worker_bad_dynamic_import(tmpd_cwd) -> None:
     req = {
         "task_id": 15,
         "context": {


### PR DESCRIPTION
Before this PR, mypy was noting that it saw these type annotations in the test suite, but was ignoring them.

This PR makes those warnings go away, a couple by enabling type checking in those tests. Another replaces an incorrect type annotation with a runtime assert that better asserts the expected behaviour.

```
MYPYPATH=/home/benc/parsl/src/parsl/mypy-stubs mypy parsl/
parsl/tests/unit/executors/high_throughput/test_process_worker_pool.py:141: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
parsl/tests/unit/executors/high_throughput/test_process_worker_pool.py:191: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
parsl/tests/test_htex/test_managers_command.py:45: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Success: no issues found in 464 source files
```

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
