### PR TITLE
Tighten checks around MPIExecutor provider.launcher accesses

### DIFF
--- a/parsl/executors/high_throughput/mpi_executor.py
+++ b/parsl/executors/high_throughput/mpi_executor.py
@@ -103,7 +103,10 @@ class MPIExecutor(HighThroughputExecutor):
 
         self.max_workers_per_block = max_workers_per_block
 
-        if not isinstance(self.provider.launcher, SimpleLauncher):
+        assert isinstance(self.provider, ExecutionProvider), \
+            "HTEX initialization should always make self.provider a provider"
+
+        if not hasattr(self.provider, 'launcher') or not isinstance(self.provider.launcher, SimpleLauncher):
             raise TypeError("mpi_mode requires the provider to be configured to use a SimpleLauncher")
 
         if mpi_launcher not in VALID_LAUNCHERS:


### PR DESCRIPTION
i) assert that self.provider is actually a provider - it can potentially be None in the general executor interface, but not in the htex implementation.

This reveals another type error, that an ExecutionProvider does not always have a launcher attribute.

So

ii) check if that attribute is there.

This does not change happy path behaviour but is more aggressive and explicit about what is expected in not-happy paths.

It is possible that it would make sense to not use a launcher at all for providers which do not have launchers -- but that's not the current behaviour, and this PR is not intended to develop MPI further, only to make type-checking stronger and more explicit.

This was discovered through ongoing work to make ParslExecutor.provider be type-checked.

# Changed Behaviour

different error handling. happy path should be unchanged.

## Type of change

- Code maintenance/cleanup
