### PR TITLE
Add type annotation to executor.provider, and consequences

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -299,6 +299,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
 
         mem_slots = self.max_workers_per_node
         cpu_slots = self.max_workers_per_node
+        assert self.provider is not None, "htex always has a provider"
         if hasattr(self.provider, 'mem_per_node') and \
                 self.provider.mem_per_node is not None and \
                 mem_per_worker is not None and \
@@ -878,6 +879,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         # Potential issue with multiple threads trying to remove the same blocks
         to_kill = [self.blocks_to_job_id[bid] for bid in block_ids_to_kill if bid in self.blocks_to_job_id]
 
+        assert self.provider is not None, "htex always has a provider"
         r = self.provider.cancel(to_kill)
         job_ids = self._filter_scale_in_ids(to_kill, r)
 

--- a/parsl/executors/high_throughput/mpi_executor.py
+++ b/parsl/executors/high_throughput/mpi_executor.py
@@ -103,7 +103,10 @@ class MPIExecutor(HighThroughputExecutor):
 
         self.max_workers_per_block = max_workers_per_block
 
-        if not isinstance(self.provider.launcher, SimpleLauncher):
+        assert isinstance(self.provider, ExecutionProvider), \
+            "HTEX initialization should always make self.provider a provider"
+
+        if not hasattr(self.provider, 'launcher') or not isinstance(self.provider.launcher, SimpleLauncher):
             raise TypeError("mpi_mode requires the provider to be configured to use a SimpleLauncher")
 
         if mpi_launcher not in VALID_LAUNCHERS:

--- a/parsl/executors/status_handling.py
+++ b/parsl/executors/status_handling.py
@@ -98,12 +98,12 @@ class BlockProviderExecutor(ParslExecutor):
         if self.monitoring_messages:
             self.submit_monitoring_radio = MultiprocessingQueueRadioSender(self.monitoring_messages)
 
-    def _make_status_dict(self, block_ids: List[str], status_list: List[JobStatus]) -> Dict[str, JobStatus]:
-        """Given a list of block ids and a list of corresponding status strings,
+    def _make_status_dict(self, block_ids: Sequence[str], status_list: Sequence[JobStatus]) -> Dict[str, JobStatus]:
+        """Given a sequence of block ids and a sequence of corresponding status strings,
         returns a dictionary mapping each block id to the corresponding status
 
-        :param block_ids: the list of block ids
-        :param status_list: the list of job status strings
+        :param block_ids: the sequence of block ids
+        :param status_list: the sequence of job status strings
         :return: the resulting dictionary
         """
         if len(block_ids) != len(status_list):
@@ -179,7 +179,7 @@ class BlockProviderExecutor(ParslExecutor):
         return self._tasks
 
     @property
-    def provider(self):
+    def provider(self) -> Optional[ExecutionProvider]:
         return self._provider
 
     def _filter_scale_in_ids(self, to_kill: Sequence[Any], killed: Sequence[bool]) -> Sequence[Any]:
@@ -200,8 +200,8 @@ class BlockProviderExecutor(ParslExecutor):
     def scale_out_facade(self, n: int) -> List[str]:
         """Scales out the number of blocks by "blocks"
         """
-        if not self.provider:
-            raise ScalingFailed(self, "No execution provider available")
+        assert self.provider is not None, \
+            "scale_out_facade should only be called on executors with a valid provider"
         block_ids = []
         monitoring_status_changes = {}
         logger.info("%s Scaling out by %d blocks", self._scale_prefix, n)
@@ -260,6 +260,9 @@ class BlockProviderExecutor(ParslExecutor):
             return []
 
     def _launch_block(self, block_id: str) -> Any:
+        assert self.provider is not None, \
+            "_launch_block should only be called on executors with a valid provider"
+
         launch_cmd = self._get_launch_command(block_id)
         job_name = f"parsl.{self.label}.block-{block_id}"
         logger.debug("%s Submitting to provider with job_name %s", self._scale_prefix, job_name)

--- a/parsl/jobs/error_handlers.py
+++ b/parsl/jobs/error_handlers.py
@@ -13,6 +13,7 @@ def noop_error_handler(executor: status_handling.BlockProviderExecutor, status: 
 
 def simple_error_handler(executor: status_handling.BlockProviderExecutor, status: Dict[str, JobStatus], threshold: int = 3) -> None:
     (total_jobs, failed_jobs) = _count_jobs(status)
+    assert executor.provider is not None, "error handlers should only be called on executors which have a provider"
     if hasattr(executor.provider, "init_blocks"):
         threshold = max(1, executor.provider.init_blocks)
 

--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -11,7 +11,12 @@ logger = logging.getLogger(__name__)
 class JobStatusPoller(Timer):
     def __init__(self, *, strategy: Optional[str], max_idletime: float,
                  strategy_period: Union[float, int]) -> None:
+
+        # only executors which should be polled and which have a valid
+        # provider should be added to this list: so it is safe to assume
+        # that e.provider is not None for e in self._executors
         self._executors: List[BlockProviderExecutor] = []
+
         self._strategy = Strategy(strategy=strategy,
                                   max_idletime=max_idletime)
         super().__init__(self.poll, interval=strategy_period, name="JobStatusPoller")
@@ -27,6 +32,8 @@ class JobStatusPoller(Timer):
     def add_executors(self, executors: Sequence[BlockProviderExecutor]) -> None:
         for executor in executors:
             if executor.status_polling_interval > 0:
+                assert executor.provider is not None, \
+                    "BlockProviderExecutor.status_polling_interval implementation guarantee: None => status_polling_interval == 0"
                 logger.debug("Adding executor {}".format(executor.label))
                 self._executors.append(executor)
         self._strategy.add_executors(executors)

--- a/parsl/jobs/strategy.py
+++ b/parsl/jobs/strategy.py
@@ -153,6 +153,8 @@ class Strategy:
         """
         for executor in executors:
             if self.executors[executor.label]['first']:
+                assert executor.provider is not None, \
+                    "strategy must only be called with executors that have a provider."
                 logger.debug(f"strategy_init_only: scaling out {executor.provider.init_blocks} initial blocks for {executor.label}")
                 executor.scale_out_facade(executor.provider.init_blocks)
                 self.executors[executor.label]['first'] = False
@@ -184,6 +186,8 @@ class Strategy:
         logger.debug(f"general strategy starting with strategy_type {strategy_type} for {len(executors)} executors")
 
         for executor in executors:
+            assert executor.provider is not None, \
+                "strategy must only be called with executors that have a provider."
             label = executor.label
             prefix = f"[Scaling executor {label}]"
 

--- a/parsl/providers/base.py
+++ b/parsl/providers/base.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABCMeta, abstractmethod, abstractproperty
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional, Sequence
 
 from parsl.jobs.states import JobStatus
 
@@ -94,7 +94,7 @@ class ExecutionProvider(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def status(self, job_ids: List[object]) -> List[JobStatus]:
+    def status(self, job_ids: Sequence[object]) -> Sequence[JobStatus]:
         ''' Get the status of a list of jobs identified by the job identifiers
         returned from the submit request.
 
@@ -112,7 +112,7 @@ class ExecutionProvider(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def cancel(self, job_ids: List[object]) -> List[bool]:
+    def cancel(self, job_ids: Sequence[object]) -> Sequence[bool]:
         ''' Cancels the resources identified by the job_ids provided by the user.
 
         Args:

--- a/parsl/tests/manual_tests/test_worker_count.py
+++ b/parsl/tests/manual_tests/test_worker_count.py
@@ -16,6 +16,7 @@ from parsl.executors import HighThroughputExecutor
 from parsl.tests.manual_tests.htex_local import config
 
 assert isinstance(config.executors[0], HighThroughputExecutor)
+assert config.executors[0].provider is not None, "htex always has a provider"
 config.executors[0].cores_per_worker = CORES_PER_WORKER
 config.executors[0].provider.init_blocks = 1
 

--- a/parsl/tests/test_htex/mpi/test_bad_mpi_config.py
+++ b/parsl/tests/test_htex/mpi/test_bad_mpi_config.py
@@ -45,4 +45,6 @@ def test_correct_launcher_with_mpi_mode(mpi_launcher: str):
         provider=SlurmProvider(launcher=SimpleLauncher()),
     )
 
+    assert executor.provider is not None, "htex always has a provider"
+    assert hasattr(executor.provider, 'launcher'), "supplied provider has a launcher attribute"
     assert isinstance(executor.provider.launcher, SimpleLauncher)

--- a/parsl/tests/test_htex/test_htex.py
+++ b/parsl/tests/test_htex/test_htex.py
@@ -24,6 +24,8 @@ def htex(encrypted: bool, tmpd_cwd):
     htex = HighThroughputExecutor(encrypted=encrypted)
     htex.max_workers_per_node = 1
     htex.run_dir = tmpd_cwd
+
+    assert htex.provider is not None, "htex always has a provider"
     htex.provider.script_dir = tmpd_cwd
 
     yield htex


### PR DESCRIPTION
The basic point of this PR is to add a type annotation to the provider attribute of executors.

This brings up 23 type errors, mostly to do with provider sometimes being optional and sometimes not, with at-distance reasoning about whether it is optional at any particular point.

This PR addresses them as follows:

1. Resolved by following suggestion and using Sequence in the definition of cancel and submit - the input list is read only, and sequence is the correct thing to do there.

```
parsl/executors/status_handling.py:254: error: Argument 1 to "cancel" of "ExecutionProvider" has incompatible type "list[str]"; expected "list[object]"  [arg-type]
parsl/executors/status_handling.py:254: note: "list" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
parsl/executors/status_handling.py:254: note: Consider using "Sequence" instead, which is covariant

parsl/executors/high_throughput/executor.py:881: error: Argument 1 to "cancel" of "ExecutionProvider" has incompatible type "list[str]"; expected "list[object]"  [arg-type]
parsl/executors/high_throughput/executor.py:881: note: "list" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
parsl/executors/high_throughput/executor.py:881: note: Consider using "Sequence" instead, which is covariant
```


2. Strategy/job related type check errors are protected by a check earlier on if the provider is specified. This PR adds asserts to express that at-distance reasoning. This PR isn't adding any *new* reasoning. It is expressing existing reasoning that was not written down.

```
parsl/jobs/error_handlers.py:17: error: Item "None" of "ExecutionProvider | None" has no attribute "init_blocks"  [union-attr]
parsl/executors/status_handling.py:266: error: Item "None" of "ExecutionProvider | None" has no attribute "submit"  [union-attr]
parsl/jobs/strategy.py:156: error: Item "None" of "ExecutionProvider | None" has no attribute "init_blocks"  [union-attr]
parsl/jobs/strategy.py:157: error: Item "None" of "ExecutionProvider | None" has no attribute "init_blocks"  [union-attr]
parsl/jobs/strategy.py:197: error: Item "None" of "ExecutionProvider | None" has no attribute "init_blocks"  [union-attr]
parsl/jobs/strategy.py:198: error: Item "None" of "ExecutionProvider | None" has no attribute "init_blocks"  [union-attr]
parsl/jobs/strategy.py:208: error: Item "None" of "ExecutionProvider | None" has no attribute "min_blocks"  [union-attr]
parsl/jobs/strategy.py:209: error: Item "None" of "ExecutionProvider | None" has no attribute "max_blocks"  [union-attr]
parsl/jobs/strategy.py:212: error: Item "None" of "ExecutionProvider | None" has no attribute "nodes_per_block"  [union-attr]
parsl/jobs/strategy.py:213: error: Item "None" of "ExecutionProvider | None" has no attribute "parallelism"  [union-attr]
```

4. In htex, there is always a provider (because there's a default of LocalProvider that is used when `None` is supplied as provider), so assert that fact.

```
parsl/executors/high_throughput/executor.py:303: error: Item "None" of "ExecutionProvider | None" has no attribute "mem_per_node"  [union-attr]
parsl/executors/high_throughput/executor.py:306: error: Item "None" of "ExecutionProvider | None" has no attribute "mem_per_node"  [union-attr]
parsl/executors/high_throughput/executor.py:308: error: Item "None" of "ExecutionProvider | None" has no attribute "cores_per_node"  [union-attr]
parsl/executors/high_throughput/executor.py:309: error: Item "None" of "ExecutionProvider | None" has no attribute "cores_per_node"  [union-attr]
parsl/executors/high_throughput/executor.py:881: error: Item "None" of "ExecutionProvider | None" has no attribute "cancel"  [union-attr]
```

5. These should have been covered by other PR https://github.com/Parsl/parsl/pull/4129

```
parsl/executors/high_throughput/mpi_executor.py:106: error: Item "ExecutionProvider" of "ExecutionProvider | None" has no attribute "launcher"  [union-attr]
parsl/executors/high_throughput/mpi_executor.py:106: error: Item "None" of "ExecutionProvider | None" has no attribute "launcher"  [union-attr]
```

6. Assert expected setup.

```
parsl/tests/manual_tests/test_worker_count.py:20: error: Item "None" of "ExecutionProvider | None" has no attribute "init_blocks"  [union-attr]
parsl/tests/unit/executors/high_throughput/test_process_worker_pool.py:141: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
parsl/tests/unit/executors/high_throughput/test_process_worker_pool.py:191: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
parsl/tests/test_htex/test_managers_command.py:45: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
parsl/tests/test_htex/test_htex.py:27: error: Item "None" of "ExecutionProvider | None" has no attribute "script_dir"  [union-attr]
parsl/tests/test_htex/mpi/test_bad_mpi_config.py:48: error: Item "ExecutionProvider" of "ExecutionProvider | None" has no attribute "launcher"  [union-attr]
parsl/tests/test_htex/mpi/test_bad_mpi_config.py:48: error: Item "None" of "ExecutionProvider | None" has no attribute "launcher"  [union-attr]
```

# Changed Behaviour

none - many asserts added but they should not be firing (because they're asserts!)

## Type of change

- Code maintenance/cleanup
