### PR TITLE
Add a docstring for JobStatusPoller.__init__

### DIFF
--- a/parsl/jobs/job_status_poller.py
+++ b/parsl/jobs/job_status_poller.py
@@ -9,9 +9,20 @@ logger = logging.getLogger(__name__)
 
 
 class JobStatusPoller(Timer):
+
     def __init__(self, *, strategy: Optional[str], max_idletime: float,
                  strategy_period: Union[float, int]) -> None:
+        """Initalize the poller.
 
+        strategy: str
+          names the scaling strategy to use
+
+        max_idletime: float, seconds
+          used by some scaling strategies to decide how long a block is idle
+
+        strategy_period: float|int, seconds
+          how often the scaling strategy should be executed
+        """
         # only executors which should be polled and which have a valid
         # provider should be added to this list: so it is safe to assume
         # that e.provider is not None for e in self._executors


### PR DESCRIPTION
Previously, the __init__ docstring was inherited from the superclass, Timer, which was wrong and confusing.

## Type of change

- Update to human readable text: Documentation/error messages/comments
