### PR TITLE
Removed connected_workers command channel.

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -654,10 +654,6 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         and managers"""
         return len(self.tasks)
 
-    def connected_workers(self) -> int:
-        """Returns the count of workers across all connected managers"""
-        return self.command_client.run("WORKERS")
-
     def connected_managers(self) -> List[Dict[str, typing.Any]]:
         """Returns a list of dicts one for each connected managers.
         The dict contains info on manager(str:manager_id), block_id,

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -235,9 +235,6 @@ class Interchange:
             if command_req == "CONNECTED_BLOCKS":
                 reply = self.connected_block_history
 
-            elif command_req == "WORKERS":
-                reply = sum(m['worker_count'] for m in self._ready_managers.values())
-
             elif command_req == "MANAGERS":
                 reply = []
                 now = time.time()

--- a/parsl/tests/test_htex/test_command_concurrency_regression_1321.py
+++ b/parsl/tests/test_htex/test_command_concurrency_regression_1321.py
@@ -44,7 +44,6 @@ def blast(cc, e):
     target_end = time.monotonic() + DURATION_S
 
     while time.monotonic() < target_end:
-        cc.run("WORKERS")
         cc.run("MANGERs_PACKAGES")
         cc.run("CONNECTED_BLOCKS")
         cc.run("WORKER_BINDS")


### PR DESCRIPTION
The last/only use of connected_worker/the interchange WORKERS command was removed in PR #3991.

This PR removes it entirely.

This is part of command channel minimisation project, issue #4133

One manual test was already broken due to out of date API. This PR does not remove the use of connected_workers in that test. It continues to be broken due to at least the outdated API, now even more so.

```
$ python3 parsl/tests/manual_tests/test_memory_limits.py
Traceback (most recent call last):
  File "/home/benc/parsl/src/parsl/parsl/tests/manual_tests/test_memory_limits.py", line 79, in <module>
    x = test_simple(None)
        ^^^^^^^^^^^^^^^^^
  File "/home/benc/parsl/src/parsl/parsl/tests/manual_tests/test_memory_limits.py", line 23, in test_simple
    HighThroughputExecutor(
TypeError: HighThroughputExecutor.__init__() got an unexpected keyword argument 'suppress_failure'
```

# Changed Behaviour

none

## Type of change

- Code maintenance/cleanup
