### PR TITLE
Rename interchange HOLD_WORKER command to HOLD_MANAGER

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -646,7 +646,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         manager_id : str
             Manager id to be put on hold
         """
-        self.command_client.run("HOLD_WORKER;{}".format(manager_id))
+        self.command_client.run("HOLD_MANAGER;{}".format(manager_id))
         logger.debug("Sent hold request to manager: {}".format(manager_id))
 
     def outstanding(self) -> int:

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -259,10 +259,10 @@ class Interchange:
                     manager_id_str = manager_id.decode('utf-8')
                     reply[manager_id_str] = m["packages"]
 
-            elif command_req.startswith("HOLD_WORKER"):
+            elif command_req.startswith("HOLD_MANAGER"):
                 cmd, s_manager = command_req.split(';')
                 manager_id = s_manager.encode('utf-8')
-                logger.info("Received HOLD_WORKER for {!r}".format(manager_id))
+                logger.info("Received HOLD_MANAGER for {!r}".format(manager_id))
                 if manager_id in self._ready_managers:
                     m = self._ready_managers[manager_id]
                     m['active'] = False


### PR DESCRIPTION
# Changed Behaviour

Anyone implementing their own version of either side of the interchange protocol will be affected by the command changing name. This is not any normal user, but I have definitely done that in a research project.

# Fixes

Fixes #3839 

## Type of change

- Code maintenance/cleanup
