### PR TITLE
Use structured object for HOLD_MANAGER

### DIFF
--- a/parsl/executors/high_throughput/executor.py
+++ b/parsl/executors/high_throughput/executor.py
@@ -646,7 +646,7 @@ class HighThroughputExecutor(BlockProviderExecutor, RepresentationMixin, UsageIn
         manager_id : str
             Manager id to be put on hold
         """
-        self.command_client.run("HOLD_MANAGER;{}".format(manager_id))
+        self.command_client.run(["HOLD_MANAGER", manager_id])
         logger.debug("Sent hold request to manager: {}".format(manager_id))
 
     def outstanding(self) -> int:

--- a/parsl/executors/high_throughput/interchange.py
+++ b/parsl/executors/high_throughput/interchange.py
@@ -259,9 +259,8 @@ class Interchange:
                     manager_id_str = manager_id.decode('utf-8')
                     reply[manager_id_str] = m["packages"]
 
-            elif command_req.startswith("HOLD_MANAGER"):
-                cmd, s_manager = command_req.split(';')
-                manager_id = s_manager.encode('utf-8')
+            elif isinstance(command_req, list) and len(command_req) == 2 and command_req[0] == "HOLD_MANAGER":
+                manager_id = command_req[1].encode('utf-8')
                 logger.info("Received HOLD_MANAGER for {!r}".format(manager_id))
                 if manager_id in self._ready_managers:
                     m = self._ready_managers[manager_id]


### PR DESCRIPTION
Command channel commands are pickleable Python objects, and do not need an ad-hoc string encoding for parameters.

This PR removes the only such an ad-hoc encoding and uses a Python-level tuple instead.

# Changed Behaviour

Like #4144 this will break things for anyone who has implemented their own custom interchange protocol-talker, but otherwise this should not be visible externally.

# Fixes

Fixes #3368 

## Type of change

- Code maintenance/cleanup
